### PR TITLE
Reduce the scope pollution in DPD::buf4_sort

### DIFF
--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -117,7 +117,6 @@ namespace psi {
 
 int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum, const std::string& label) {
     dpdbuf4 OutBuf;
-    long int rowtot, coltot, core_total, maxrows;
     int Grow, Gcol;
     int out_rows_per_bucket, out_nbuckets, out_rows_left, out_row_start, n;
     int in_rows_per_bucket, in_nbuckets, in_rows_left, in_row_start, m;
@@ -133,11 +132,12 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
     buf4_init(&OutBuf, outfilenum, my_irrep, pqnum, rsnum, pqnum, rsnum, 0, label);
 
     /* select in-core vs. out-of-core algorithms */
-    core_total = 0;
     int incore = 1;
     {
+        long int core_total = 0;
         for (int h = 0; h < nirreps; h++) {
-            coltot = InBuf->params->coltot[h ^ my_irrep];
+            const long int coltot = InBuf->params->coltot[h ^ my_irrep];
+            long int maxrows;
             if (coltot) {
                 maxrows = DPD_BIGNUM / coltot;
                 if (maxrows < 1) {
@@ -146,7 +146,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                 }
             } else
                 maxrows = DPD_BIGNUM;
-            rowtot = InBuf->params->rowtot[h];
+            long int rowtot = InBuf->params->rowtot[h];
             for (; rowtot > maxrows; rowtot -= maxrows) {
                 if (core_total > (core_total + 2 * maxrows * coltot))
                     incore = 0;

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -117,7 +117,7 @@ namespace psi {
 int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum,
                    const std::string& label) {
     dpdbuf4 OutBuf;
-    int in_rows_per_bucket, in_nbuckets, in_rows_left, in_row_start, m;
+    int in_nbuckets, in_rows_left, in_row_start, m;
     int rows_per_bucket, nbuckets, rows_left;
 
     const int nirreps = InBuf->params->nirreps;
@@ -385,9 +385,12 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                             const int Gcol = Grow ^ my_irrep;        /*Gcol = Gqs*/
 
                             /* determine how many rows of InBuf we can store in the other half of the core */
-                            in_rows_per_bucket = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);
-                            if (in_rows_per_bucket > InBuf->params->rowtot[Grow])
-                                in_rows_per_bucket = InBuf->params->rowtot[Grow];
+                            const int in_rows_per_bucket = [&InBuf, Gcol, Grow] {
+                                int irpb = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);
+                                if (irpb > InBuf->params->rowtot[Grow]) irpb = InBuf->params->rowtot[Grow];
+                                return irpb;
+                            }();
+
                             in_nbuckets = (int)ceil((double)InBuf->params->rowtot[Grow] / (double)in_rows_per_bucket);
                             if (in_nbuckets == 1)
                                 in_rows_left = in_rows_per_bucket;
@@ -464,9 +467,12 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                             const int Gcol = Grow ^ my_irrep;
 
                             /* determine how many rows of InBuf we can store in the other half of the core */
-                            in_rows_per_bucket = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);
-                            if (in_rows_per_bucket > InBuf->params->rowtot[Grow])
-                                in_rows_per_bucket = InBuf->params->rowtot[Grow];
+                            const int in_rows_per_bucket = [&InBuf, Gcol, Grow] {
+                                int irpb = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);
+                                if (irpb > InBuf->params->rowtot[Grow]) irpb = InBuf->params->rowtot[Grow];
+                                return irpb;
+                            }();
+
                             in_nbuckets = (int)ceil((double)InBuf->params->rowtot[Grow] / (double)in_rows_per_bucket);
                             if (in_nbuckets == 1)
                                 in_rows_left = in_rows_per_bucket;
@@ -617,9 +623,12 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                             const int Gcol = Grow ^ my_irrep;
 
                             /* determine how many rows of InBuf we can store in the other half of the core */
-                            in_rows_per_bucket = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);
-                            if (in_rows_per_bucket > InBuf->params->rowtot[Grow])
-                                in_rows_per_bucket = InBuf->params->rowtot[Grow];
+                            const int in_rows_per_bucket = [&InBuf, Gcol, Grow] {
+                                int irpb = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);
+                                if (irpb > InBuf->params->rowtot[Grow]) irpb = InBuf->params->rowtot[Grow];
+                                return irpb;
+                            }();
+
                             in_nbuckets = (int)ceil((double)InBuf->params->rowtot[Grow] / (double)in_rows_per_bucket);
                             if (in_nbuckets == 1)
                                 in_rows_left = in_rows_per_bucket;
@@ -694,9 +703,12 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                             const int Gcol = Grow ^ my_irrep;
 
                             /* determine how many rows of InBuf we can store in the other half of the core */
-                            in_rows_per_bucket = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);
-                            if (in_rows_per_bucket > InBuf->params->rowtot[Grow])
-                                in_rows_per_bucket = InBuf->params->rowtot[Grow];
+                            const int in_rows_per_bucket = [&InBuf, Gcol, Grow] {
+                                int irpb = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);
+                                if (irpb > InBuf->params->rowtot[Grow]) irpb = InBuf->params->rowtot[Grow];
+                                return irpb;
+                            }();
+
                             in_nbuckets = (int)ceil((double)InBuf->params->rowtot[Grow] / (double)in_rows_per_bucket);
                             if (in_nbuckets == 1)
                                 in_rows_left = in_rows_per_bucket;
@@ -1653,10 +1665,12 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     const int out_rows_left =
                         (out_nbuckets == 1) ? out_rows_per_bucket : OutBuf.params->rowtot[Gpq] % out_rows_per_bucket;
 
-                    in_rows_per_bucket =
-                        (dpd_memfree() - InBuf->params->coltot[Gpq]) / (2 * InBuf->params->coltot[Gpq]);
-                    if (in_rows_per_bucket > InBuf->params->rowtot[Grs])
-                        in_rows_per_bucket = InBuf->params->rowtot[Grs];
+                    const int in_rows_per_bucket = [&InBuf, Gpq, Grs] {
+                        int irpb = (dpd_memfree() - InBuf->params->coltot[Gpq]) / (2 * InBuf->params->coltot[Gpq]);
+                        if (irpb > InBuf->params->rowtot[Grs]) irpb = InBuf->params->rowtot[Grs];
+                        return irpb;
+                    }();
+
                     in_nbuckets = (int)ceil((double)InBuf->params->rowtot[Grs] / (double)in_rows_per_bucket);
                     if (in_nbuckets == 1)
                         in_rows_left = in_rows_per_bucket;

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -117,7 +117,7 @@ namespace psi {
 
 int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum, const std::string& label) {
     dpdbuf4 OutBuf;
-    int out_rows_per_bucket, out_nbuckets, out_rows_left, out_row_start, n;
+    int out_nbuckets, out_rows_left, out_row_start, n;
     int in_rows_per_bucket, in_nbuckets, in_rows_left, in_row_start, m;
     int rows_per_bucket, nbuckets, rows_left;
 
@@ -363,9 +363,12 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                 for (int Gpq = 0; Gpq < nirreps; Gpq++) {
                     const int Grs = Gpq ^ my_irrep;
 
-                    out_rows_per_bucket = dpd_memfree() / (2 * OutBuf.params->coltot[Grs]);
-                    if (out_rows_per_bucket > OutBuf.params->rowtot[Gpq])
-                        out_rows_per_bucket = OutBuf.params->rowtot[Gpq];
+                    const int out_rows_per_bucket = [&OutBuf, Grs, Gpq]{
+                        int orpb = dpd_memfree() / (2 * OutBuf.params->coltot[Grs]);
+                        if (orpb > OutBuf.params->rowtot[Gpq]) orpb = OutBuf.params->rowtot[Gpq];
+                        return orpb;
+                    }();
+
                     out_nbuckets = (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)out_rows_per_bucket);
                     if (out_nbuckets == 1)
                         out_rows_left = out_rows_per_bucket;
@@ -592,9 +595,12 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                     const int Grs = Gpq ^ my_irrep;
 
                     /* determine how many rows of OutBuf we can store in half of the core */
-                    out_rows_per_bucket = dpd_memfree() / (2 * OutBuf.params->coltot[Grs]);
-                    if (out_rows_per_bucket > OutBuf.params->rowtot[Gpq])
-                        out_rows_per_bucket = OutBuf.params->rowtot[Gpq];
+                    const int out_rows_per_bucket = [&OutBuf, Grs, Gpq]{
+                        int orpb = dpd_memfree() / (2 * OutBuf.params->coltot[Grs]);
+                        if (orpb > OutBuf.params->rowtot[Gpq]) orpb = OutBuf.params->rowtot[Gpq];
+                        return orpb;
+                    }();
+
                     out_nbuckets = (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)out_rows_per_bucket);
                     if (out_nbuckets == 1)
                         out_rows_left = out_rows_per_bucket;
@@ -1635,10 +1641,12 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                 for (int Gpq = 0; Gpq < nirreps; Gpq++) {
                     const int Grs = Gpq ^ my_irrep;
 
-                    out_rows_per_bucket =
-                        (dpd_memfree() - OutBuf.params->coltot[Grs]) / (2 * OutBuf.params->coltot[Grs]);
-                    if (out_rows_per_bucket > OutBuf.params->rowtot[Gpq])
-                        out_rows_per_bucket = OutBuf.params->rowtot[Gpq];
+                    const int out_rows_per_bucket = [&OutBuf, Grs, Gpq]{
+                        int orpb = (dpd_memfree() - OutBuf.params->coltot[Grs]) / (2 * OutBuf.params->coltot[Grs]);
+                        if (orpb > OutBuf.params->rowtot[Gpq]) orpb = OutBuf.params->rowtot[Gpq];
+                        return orpb;
+                    }();
+
                     out_nbuckets = (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)out_rows_per_bucket);
                     if (out_nbuckets == 1)
                         out_rows_left = out_rows_per_bucket;

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -117,7 +117,7 @@ namespace psi {
 int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum,
                    const std::string& label) {
     dpdbuf4 OutBuf;
-    int out_nbuckets, out_rows_left, out_row_start, n;
+    int out_row_start, n;
     int in_rows_per_bucket, in_nbuckets, in_rows_left, in_row_start, m;
     int rows_per_bucket, nbuckets, rows_left;
 
@@ -369,11 +369,10 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                         return orpb;
                     }();
 
-                    out_nbuckets = (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)out_rows_per_bucket);
-                    if (out_nbuckets == 1)
-                        out_rows_left = out_rows_per_bucket;
-                    else
-                        out_rows_left = OutBuf.params->rowtot[Gpq] % out_rows_per_bucket;
+                    const int out_nbuckets =
+                        (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)out_rows_per_bucket);
+                    const int out_rows_left =
+                        (out_nbuckets == 1) ? out_rows_per_bucket : OutBuf.params->rowtot[Gpq] % out_rows_per_bucket;
 
                     /* allocate space for the bucket of rows */
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, out_rows_per_bucket);
@@ -601,11 +600,10 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                         return orpb;
                     }();
 
-                    out_nbuckets = (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)out_rows_per_bucket);
-                    if (out_nbuckets == 1)
-                        out_rows_left = out_rows_per_bucket;
-                    else
-                        out_rows_left = OutBuf.params->rowtot[Gpq] % out_rows_per_bucket;
+                    const int out_nbuckets =
+                        (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)out_rows_per_bucket);
+                    const int out_rows_left =
+                        (out_nbuckets == 1) ? out_rows_per_bucket : OutBuf.params->rowtot[Gpq] % out_rows_per_bucket;
 
                     /* allocate space for the bucket of rows */
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, out_rows_per_bucket);
@@ -1647,11 +1645,10 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                         return orpb;
                     }();
 
-                    out_nbuckets = (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)out_rows_per_bucket);
-                    if (out_nbuckets == 1)
-                        out_rows_left = out_rows_per_bucket;
-                    else
-                        out_rows_left = OutBuf.params->rowtot[Gpq] % out_rows_per_bucket;
+                    const int out_nbuckets =
+                        (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)out_rows_per_bucket);
+                    const int out_rows_left =
+                        (out_nbuckets == 1) ? out_rows_per_bucket : OutBuf.params->rowtot[Gpq] % out_rows_per_bucket;
 
                     in_rows_per_bucket =
                         (dpd_memfree() - InBuf->params->coltot[Gpq]) / (2 * InBuf->params->coltot[Gpq]);

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -117,8 +117,6 @@ namespace psi {
 int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum,
                    const std::string& label) {
     dpdbuf4 OutBuf;
-    int nbuckets, rows_left;
-
     const int nirreps = InBuf->params->nirreps;
     const int my_irrep = InBuf->file.my_irrep;
 
@@ -264,11 +262,9 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
 
                     if (!rows_per_bucket) dpd_error("buf4_sort_pqsr: Not enough memory for one row!", "outfile");
 
-                    nbuckets = (int)ceil(((double)InBuf->params->rowtot[Gpq]) / ((double)rows_per_bucket));
-                    if (nbuckets == 1)
-                        rows_left = rows_per_bucket;
-                    else
-                        rows_left = InBuf->params->rowtot[Gpq] % rows_per_bucket;
+                    const int nbuckets = (int)ceil(((double)InBuf->params->rowtot[Gpq]) / ((double)rows_per_bucket));
+                    const int rows_left =
+                        (nbuckets == 1) ? rows_per_bucket : InBuf->params->rowtot[Gpq] % rows_per_bucket;
 
                     buf4_mat_irrep_init_block(InBuf, Gpq, rows_per_bucket);
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, rows_per_bucket);
@@ -938,11 +934,9 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                         return rpb;
                     }();
 
-                    nbuckets = (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)rows_per_bucket);
-                    if (nbuckets == 1)
-                        rows_left = rows_per_bucket;
-                    else
-                        rows_left = OutBuf.params->rowtot[Gpq] % rows_per_bucket;
+                    const int nbuckets = (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)rows_per_bucket);
+                    const int rows_left =
+                        (nbuckets == 1) ? rows_per_bucket : OutBuf.params->rowtot[Gpq] % rows_per_bucket;
 
                     /* allocate space for the bucket of rows */
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, rows_per_bucket);
@@ -1066,11 +1060,9 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                         return rpb;
                     }();
 
-                    nbuckets = (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)rows_per_bucket);
-                    if (nbuckets == 1)
-                        rows_left = rows_per_bucket;
-                    else
-                        rows_left = OutBuf.params->rowtot[Gpq] % rows_per_bucket;
+                    const int nbuckets = (int)ceil((double)OutBuf.params->rowtot[Gpq] / (double)rows_per_bucket);
+                    const int rows_left =
+                        (nbuckets == 1) ? rows_per_bucket : OutBuf.params->rowtot[Gpq] % rows_per_bucket;
 
                     /* allocate space for the bucket of rows */
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, rows_per_bucket);

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -333,7 +333,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
 
                             /* Irreps on the source */
                             const int Gpr = Gp ^ Gr;
-                            Gqs = Gq ^ Gs;
+                            const int Gqs = Gq ^ Gs;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;
@@ -561,8 +561,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Gps = Gp ^ Gs;
-                            Gqr = Gq ^ Gr;
+                            const int Gps = Gp ^ Gs;
+                            const int Gqr = Gq ^ Gr;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;
@@ -637,7 +637,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                                         const int s = OutBuf.params->colorb[Grs][rs][1];
                                         const int Gr = OutBuf.params->rsym[r];
                                         const int Gs = Grs ^ Gr;
-                                        Gps = Gp ^ Gs;
+                                        const int Gps = Gp ^ Gs;
 
                                         if (Gps == Grow) {
                                             const int ps = InBuf->params->rowidx[p][s] - in_row_start;
@@ -664,7 +664,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                                         const int s = OutBuf.params->colorb[Grs][rs][1];
                                         const int Gr = OutBuf.params->rsym[r];
                                         const int Gs = Grs ^ Gr;
-                                        Gps = Gp ^ Gs;
+                                        const int Gps = Gp ^ Gs;
 
                                         if (Gps == Grow) {
                                             const int ps = InBuf->params->rowidx[p][s] - in_row_start;
@@ -714,7 +714,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                                         const int s = OutBuf.params->colorb[Grs][rs][1];
                                         const int Gr = OutBuf.params->rsym[r];
                                         const int Gs = Grs ^ Gr;
-                                        Gps = Gp ^ Gs;
+                                        const int Gps = Gp ^ Gs;
 
                                         if (Gps == Grow) {
                                             const int ps = InBuf->params->rowidx[p][s] - in_row_start;
@@ -741,7 +741,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                                         const int s = OutBuf.params->colorb[Grs][rs][1];
                                         const int Gr = OutBuf.params->rsym[r];
                                         const int Gs = Grs ^ Gr;
-                                        Gps = Gp ^ Gs;
+                                        const int Gps = Gp ^ Gs;
 
                                         if (Gps == Grow) {
                                             const int ps = InBuf->params->rowidx[p][s] - in_row_start;
@@ -788,7 +788,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                             const int Gs = Gr ^ r_irrep;
 
                             const int Gpr = Gp ^ Gr;
-                            Gsq = Gs ^ Gq;
+                            const int Gsq = Gs ^ Gq;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;
@@ -840,8 +840,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Gps = Gp ^ Gs;
-                            Grq = Gr ^ Gq;
+                            const int Gps = Gp ^ Gs;
+                            const int Grq = Gr ^ Gq;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;
@@ -1160,8 +1160,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Grp = Gr ^ Gp;
-                            Gqs = Gq ^ Gs;
+                            const int Grp = Gr ^ Gp;
+                            const int Gqs = Gq ^ Gs;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;
@@ -1213,8 +1213,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Gsp = Gs ^ Gp;
-                            Gqr = Gq ^ Gr;
+                            const int Gsp = Gs ^ Gp;
+                            const int Gqr = Gq ^ Gr;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;
@@ -1265,8 +1265,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Grp = Gr ^ Gp;
-                            Gsq = Gs ^ Gq;
+                            const int Grp = Gr ^ Gp;
+                            const int Gsq = Gs ^ Gq;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;
@@ -1317,8 +1317,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Gsp = Gs ^ Gp;
-                            Grq = Gr ^ Gq;
+                            const int Gsp = Gs ^ Gp;
+                            const int Grq = Gr ^ Gq;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;
@@ -1370,8 +1370,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Grq = Gr ^ Gq;
-                            Gps = Gp ^ Gs;
+                            const int Grq = Gr ^ Gq;
+                            const int Gps = Gp ^ Gs;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;
@@ -1423,7 +1423,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Gsq = Gs ^ Gq;
+                            const int Gsq = Gs ^ Gq;
                             const int Gpr = Gp ^ Gr;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
@@ -1476,8 +1476,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Gqr = Gq ^ Gr;
-                            Gps = Gp ^ Gs;
+                            const int Gqr = Gq ^ Gr;
+                            const int Gps = Gp ^ Gs;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;
@@ -1529,7 +1529,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Gqs = Gq ^ Gs;
+                            const int Gqs = Gq ^ Gs;
                             const int Gpr = Gp ^ Gr;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
@@ -1722,8 +1722,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Gsq = Gs ^ Gq;
-                            Grp = Gr ^ Gp;
+                            const int Gsq = Gs ^ Gq;
+                            const int Grp = Gr ^ Gp;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;
@@ -1855,8 +1855,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Gqr = Gq ^ Gr;
-                            Gsp = Gs ^ Gp;
+                            const int Gqr = Gq ^ Gr;
+                            const int Gsp = Gs ^ Gp;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;
@@ -1908,8 +1908,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         for (int Gr = 0; Gr < nirreps; Gr++) {
                             const int Gs = Gr ^ r_irrep;
 
-                            Gqs = Gq ^ Gs;
-                            Grp = Gr ^ Gp;
+                            const int Gqs = Gq ^ Gs;
+                            const int Grp = Gr ^ Gp;
 
                             for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
                                 const int P = OutBuf.params->poff[Gp] + p;

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -117,7 +117,6 @@ namespace psi {
 
 int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum, const std::string& label) {
     dpdbuf4 OutBuf;
-    int Grow, Gcol;
     int out_rows_per_bucket, out_nbuckets, out_rows_left, out_row_start, n;
     int in_rows_per_bucket, in_nbuckets, in_rows_left, in_row_start, m;
     int rows_per_bucket, nbuckets, rows_left;
@@ -379,8 +378,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                     for (n = 0; n < (out_rows_left ? out_nbuckets - 1 : out_nbuckets); n++) {
                         out_row_start = n * out_rows_per_bucket;
 
-                        for (Grow = 0; Grow < nirreps; Grow++) { /*Grow = Gpr*/
-                            Gcol = Grow ^ my_irrep;              /*Gcol = Gqs*/
+                        for (int Grow = 0; Grow < nirreps; Grow++) { /*Grow = Gpr*/
+                            const int Gcol = Grow ^ my_irrep;              /*Gcol = Gqs*/
 
                             /* determine how many rows of InBuf we can store in the other half of the core */
                             in_rows_per_bucket = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);
@@ -458,8 +457,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                     if (out_rows_left) {
                         out_row_start = n * out_rows_per_bucket;
 
-                        for (Grow = 0; Grow < nirreps; Grow++) {
-                            Gcol = Grow ^ my_irrep;
+                        for (int Grow = 0; Grow < nirreps; Grow++) {
+                            const int Gcol = Grow ^ my_irrep;
 
                             /* determine how many rows of InBuf we can store in the other half of the core */
                             in_rows_per_bucket = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);
@@ -608,8 +607,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                     for (n = 0; n < (out_rows_left ? out_nbuckets - 1 : out_nbuckets); n++) {
                         out_row_start = n * out_rows_per_bucket;
 
-                        for (Grow = 0; Grow < nirreps; Grow++) {
-                            Gcol = Grow ^ my_irrep;
+                        for (int Grow = 0; Grow < nirreps; Grow++) {
+                            const int Gcol = Grow ^ my_irrep;
 
                             /* determine how many rows of InBuf we can store in the other half of the core */
                             in_rows_per_bucket = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);
@@ -685,8 +684,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                     if (out_rows_left) {
                         out_row_start = n * out_rows_per_bucket;
 
-                        for (Grow = 0; Grow < nirreps; Grow++) {
-                            Gcol = Grow ^ my_irrep;
+                        for (int Grow = 0; Grow < nirreps; Grow++) {
+                            const int Gcol = Grow ^ my_irrep;
 
                             /* determine how many rows of InBuf we can store in the other half of the core */
                             in_rows_per_bucket = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -41,7 +41,6 @@
 #include <cstdlib>
 #include <cmath>
 
-using std::string;
 namespace psi {
 
 /*
@@ -115,7 +114,8 @@ namespace psi {
 ** spqr: IC     ** sprq: IC
 ** -RAK, Nov. 2005*/
 
-int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum, const std::string& label) {
+int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum,
+                   const std::string& label) {
     dpdbuf4 OutBuf;
     int out_nbuckets, out_rows_left, out_row_start, n;
     int in_rows_per_bucket, in_nbuckets, in_rows_left, in_row_start, m;
@@ -363,7 +363,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                 for (int Gpq = 0; Gpq < nirreps; Gpq++) {
                     const int Grs = Gpq ^ my_irrep;
 
-                    const int out_rows_per_bucket = [&OutBuf, Grs, Gpq]{
+                    const int out_rows_per_bucket = [&OutBuf, Grs, Gpq] {
                         int orpb = dpd_memfree() / (2 * OutBuf.params->coltot[Grs]);
                         if (orpb > OutBuf.params->rowtot[Gpq]) orpb = OutBuf.params->rowtot[Gpq];
                         return orpb;
@@ -382,7 +382,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                         out_row_start = n * out_rows_per_bucket;
 
                         for (int Grow = 0; Grow < nirreps; Grow++) { /*Grow = Gpr*/
-                            const int Gcol = Grow ^ my_irrep;              /*Gcol = Gqs*/
+                            const int Gcol = Grow ^ my_irrep;        /*Gcol = Gqs*/
 
                             /* determine how many rows of InBuf we can store in the other half of the core */
                             in_rows_per_bucket = dpd_memfree() / (2 * InBuf->params->coltot[Gcol]);
@@ -595,7 +595,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                     const int Grs = Gpq ^ my_irrep;
 
                     /* determine how many rows of OutBuf we can store in half of the core */
-                    const int out_rows_per_bucket = [&OutBuf, Grs, Gpq]{
+                    const int out_rows_per_bucket = [&OutBuf, Grs, Gpq] {
                         int orpb = dpd_memfree() / (2 * OutBuf.params->coltot[Grs]);
                         if (orpb > OutBuf.params->rowtot[Gpq]) orpb = OutBuf.params->rowtot[Gpq];
                         return orpb;
@@ -1641,7 +1641,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
                 for (int Gpq = 0; Gpq < nirreps; Gpq++) {
                     const int Grs = Gpq ^ my_irrep;
 
-                    const int out_rows_per_bucket = [&OutBuf, Grs, Gpq]{
+                    const int out_rows_per_bucket = [&OutBuf, Grs, Gpq] {
                         int orpb = (dpd_memfree() - OutBuf.params->coltot[Grs]) / (2 * OutBuf.params->coltot[Grs]);
                         if (orpb > OutBuf.params->rowtot[Gpq]) orpb = OutBuf.params->rowtot[Gpq];
                         return orpb;
@@ -1691,7 +1691,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
 
                             for (int pq = 0; pq < (n == out_nbuckets - 1 ? out_rows_left : out_rows_per_bucket); pq++) {
                                 const int PQ = pq + n * out_rows_per_bucket;
-                                for (int RS = 0; RS < (m == in_nbuckets - 1 ? in_rows_left : in_rows_per_bucket); RS++) {
+                                for (int RS = 0; RS < (m == in_nbuckets - 1 ? in_rows_left : in_rows_per_bucket);
+                                     RS++) {
                                     const int rs = RS + m * in_rows_per_bucket;
                                     OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Grs][RS][PQ];
                                 }
@@ -1970,7 +1971,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
     return 0;
 }
 
-int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, string pq, string rs, const std::string& label) {
+int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices index, const std::string pq,
+                   const std::string rs, const std::string& label) {
     return buf4_sort(InBuf, outfilenum, index, pairnum(pq), pairnum(rs), label);
 }
 

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -117,7 +117,7 @@ namespace psi {
 int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum,
                    const std::string& label) {
     dpdbuf4 OutBuf;
-    int in_nbuckets, in_rows_left, in_row_start, m;
+    int in_row_start, m;
     int rows_per_bucket, nbuckets, rows_left;
 
     const int nirreps = InBuf->params->nirreps;
@@ -391,11 +391,11 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                                 return irpb;
                             }();
 
-                            in_nbuckets = (int)ceil((double)InBuf->params->rowtot[Grow] / (double)in_rows_per_bucket);
-                            if (in_nbuckets == 1)
-                                in_rows_left = in_rows_per_bucket;
-                            else
-                                in_rows_left = InBuf->params->rowtot[Grow] % in_rows_per_bucket;
+                            const int in_nbuckets =
+                                (int)ceil((double)InBuf->params->rowtot[Grow] / (double)in_rows_per_bucket);
+                            const int in_rows_left = (in_nbuckets == 1)
+                                                         ? in_rows_per_bucket
+                                                         : InBuf->params->rowtot[Grow] % in_rows_per_bucket;
 
                             /* allocate space for the bucket of rows */
                             buf4_mat_irrep_init_block(InBuf, Grow, in_rows_per_bucket);
@@ -473,11 +473,11 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                                 return irpb;
                             }();
 
-                            in_nbuckets = (int)ceil((double)InBuf->params->rowtot[Grow] / (double)in_rows_per_bucket);
-                            if (in_nbuckets == 1)
-                                in_rows_left = in_rows_per_bucket;
-                            else
-                                in_rows_left = InBuf->params->rowtot[Grow] % in_rows_per_bucket;
+                            const int in_nbuckets =
+                                (int)ceil((double)InBuf->params->rowtot[Grow] / (double)in_rows_per_bucket);
+                            const int in_rows_left = (in_nbuckets == 1)
+                                                         ? in_rows_per_bucket
+                                                         : InBuf->params->rowtot[Grow] % in_rows_per_bucket;
 
                             /* allocate space for the bucket of rows */
                             buf4_mat_irrep_init_block(InBuf, Grow, in_rows_per_bucket);
@@ -629,11 +629,11 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                                 return irpb;
                             }();
 
-                            in_nbuckets = (int)ceil((double)InBuf->params->rowtot[Grow] / (double)in_rows_per_bucket);
-                            if (in_nbuckets == 1)
-                                in_rows_left = in_rows_per_bucket;
-                            else
-                                in_rows_left = InBuf->params->rowtot[Grow] % in_rows_per_bucket;
+                            const int in_nbuckets =
+                                (int)ceil((double)InBuf->params->rowtot[Grow] / (double)in_rows_per_bucket);
+                            const int in_rows_left = (in_nbuckets == 1)
+                                                         ? in_rows_per_bucket
+                                                         : InBuf->params->rowtot[Grow] % in_rows_per_bucket;
 
                             /* allocate space for the bucket of rows */
                             buf4_mat_irrep_init_block(InBuf, Grow, in_rows_per_bucket);
@@ -709,11 +709,11 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                                 return irpb;
                             }();
 
-                            in_nbuckets = (int)ceil((double)InBuf->params->rowtot[Grow] / (double)in_rows_per_bucket);
-                            if (in_nbuckets == 1)
-                                in_rows_left = in_rows_per_bucket;
-                            else
-                                in_rows_left = InBuf->params->rowtot[Grow] % in_rows_per_bucket;
+                            const int in_nbuckets =
+                                (int)ceil((double)InBuf->params->rowtot[Grow] / (double)in_rows_per_bucket);
+                            const int in_rows_left = (in_nbuckets == 1)
+                                                         ? in_rows_per_bucket
+                                                         : InBuf->params->rowtot[Grow] % in_rows_per_bucket;
 
                             /* allocate space for the bucket of rows */
                             buf4_mat_irrep_init_block(InBuf, Grow, in_rows_per_bucket);
@@ -1671,11 +1671,9 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                         return irpb;
                     }();
 
-                    in_nbuckets = (int)ceil((double)InBuf->params->rowtot[Grs] / (double)in_rows_per_bucket);
-                    if (in_nbuckets == 1)
-                        in_rows_left = in_rows_per_bucket;
-                    else
-                        in_rows_left = InBuf->params->rowtot[Grs] % in_rows_per_bucket;
+                    const int in_nbuckets = (int)ceil((double)InBuf->params->rowtot[Grs] / (double)in_rows_per_bucket);
+                    const int in_rows_left =
+                        (in_nbuckets == 1) ? in_rows_per_bucket : InBuf->params->rowtot[Grs] % in_rows_per_bucket;
 
 #ifdef DPD_DEBUG
                     outfile->Printf(stdout, "Gpq = %d\n", Gpq);

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -117,7 +117,7 @@ namespace psi {
 int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum,
                    const std::string& label) {
     dpdbuf4 OutBuf;
-    int in_row_start, m;
+
     int rows_per_bucket, nbuckets, rows_left;
 
     const int nirreps = InBuf->params->nirreps;
@@ -401,8 +401,9 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                             buf4_mat_irrep_init_block(InBuf, Grow, in_rows_per_bucket);
 
                             /* pqrs <- prqs */
+                            int m;
                             for (m = 0; m < (in_rows_left ? in_nbuckets - 1 : in_nbuckets); m++) {
-                                in_row_start = m * in_rows_per_bucket;
+                                const int in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_per_bucket);
 
                                 for (int pq = 0; pq < out_rows_per_bucket; pq++) {
@@ -429,7 +430,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                                 }
                             }
                             if (in_rows_left) {
-                                in_row_start = m * in_rows_per_bucket;
+                                const int in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_left);
 
                                 /* pqrs <- prqs */
@@ -483,8 +484,9 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                             buf4_mat_irrep_init_block(InBuf, Grow, in_rows_per_bucket);
 
                             /* pqrs <- prqs */
+                            int m;
                             for (m = 0; m < (in_rows_left ? in_nbuckets - 1 : in_nbuckets); m++) {
-                                in_row_start = m * in_rows_per_bucket;
+                                const int in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_per_bucket);
 
                                 for (int pq = 0; pq < out_rows_left; pq++) {
@@ -511,7 +513,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                                 }
                             }
                             if (in_rows_left) {
-                                in_row_start = m * in_rows_per_bucket;
+                                const int in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_left);
 
                                 for (int pq = 0; pq < out_rows_left; pq++) {
@@ -638,8 +640,9 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                             /* allocate space for the bucket of rows */
                             buf4_mat_irrep_init_block(InBuf, Grow, in_rows_per_bucket);
 
+                            int m;
                             for (m = 0; m < (in_rows_left ? in_nbuckets - 1 : in_nbuckets); m++) {
-                                in_row_start = m * in_rows_per_bucket;
+                                const int in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_per_bucket);
 
                                 for (int pq = 0; pq < out_rows_per_bucket; pq++) {
@@ -666,7 +669,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                                 }
                             }
                             if (in_rows_left) {
-                                in_row_start = m * in_rows_per_bucket;
+                                const int in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_left);
 
                                 for (int pq = 0; pq < out_rows_per_bucket; pq++) {
@@ -718,8 +721,9 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                             /* allocate space for the bucket of rows */
                             buf4_mat_irrep_init_block(InBuf, Grow, in_rows_per_bucket);
 
+                            int m;
                             for (m = 0; m < (in_rows_left ? in_nbuckets - 1 : in_nbuckets); m++) {
-                                in_row_start = m * in_rows_per_bucket;
+                                const int in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_per_bucket);
 
                                 for (int pq = 0; pq < out_rows_left; pq++) {
@@ -746,7 +750,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                                 }
                             }
                             if (in_rows_left) {
-                                in_row_start = m * in_rows_per_bucket;
+                                const int in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_left);
 
                                 for (int pq = 0; pq < out_rows_left; pq++) {
@@ -942,8 +946,9 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     for (n = 0; n < (rows_left ? nbuckets - 1 : nbuckets); n++) {
                         out_row_start = n * rows_per_bucket;
 
+                        int m;
                         for (m = 0; m < (rows_left ? nbuckets - 1 : nbuckets); m++) {
-                            in_row_start = m * rows_per_bucket;
+                            const int in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_per_bucket);
                             for (int pq = 0; pq < rows_per_bucket; pq++) {
                                 /* check to see if this row is contained in the current input-bucket */
@@ -956,9 +961,8 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                                 }
                             }
                         }
-
                         if (rows_left) {
-                            in_row_start = m * rows_per_bucket;
+                            const int in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_left);
                             for (int pq = 0; pq < rows_per_bucket; pq++) {
                                 /* check to see if this row is contained in the current input-bucket */
@@ -978,8 +982,9 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     if (rows_left) {
                         out_row_start = n * rows_per_bucket;
 
+                        int m;
                         for (m = 0; m < (rows_left ? nbuckets - 1 : nbuckets); m++) {
-                            in_row_start = m * rows_per_bucket;
+                            const int in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_per_bucket);
                             for (int pq = 0; pq < rows_left; pq++) {
                                 /* check to see if this row is contained in the current input-bucket */
@@ -992,9 +997,8 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                                 }
                             }
                         }
-
                         if (rows_left) {
-                            in_row_start = m * rows_per_bucket;
+                            const int in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_left);
                             for (int pq = 0; pq < rows_left; pq++) {
                                 /* check to see if this row is contained in the current input-bucket */
@@ -1066,8 +1070,9 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     for (n = 0; n < (rows_left ? nbuckets - 1 : nbuckets); n++) {
                         out_row_start = n * rows_per_bucket;
 
+                        int m;
                         for (m = 0; m < (rows_left ? nbuckets - 1 : nbuckets); m++) {
-                            in_row_start = m * rows_per_bucket;
+                            const int in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_per_bucket);
 
                             for (int pq = 0; pq < rows_per_bucket; pq++) {
@@ -1086,7 +1091,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                             }
                         }
                         if (rows_left) {
-                            in_row_start = m * rows_per_bucket;
+                            const int in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_left);
 
                             for (int pq = 0; pq < rows_per_bucket; pq++) {
@@ -1111,8 +1116,9 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     if (rows_left) {
                         out_row_start = n * rows_per_bucket;
 
+                        int m;
                         for (m = 0; m < (rows_left ? nbuckets - 1 : nbuckets); m++) {
-                            in_row_start = m * rows_per_bucket;
+                            const int in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_per_bucket);
 
                             for (int pq = 0; pq < rows_left; pq++) {
@@ -1131,7 +1137,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                             }
                         }
                         if (rows_left) {
-                            in_row_start = m * rows_per_bucket;
+                            const int in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_left);
 
                             for (int pq = 0; pq < rows_left; pq++) {
@@ -1696,8 +1702,8 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     for (int n = 0; n < out_nbuckets; n++) {
                         const int out_row_start = n * out_rows_per_bucket;
 
-                        for (m = 0; m < in_nbuckets; m++) {
-                            in_row_start = m * in_rows_per_bucket;
+                        for (int m = 0; m < in_nbuckets; m++) {
+                            const int in_row_start = m * in_rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Grs, in_row_start,
                                                     (m == in_nbuckets - 1 ? in_rows_left : in_rows_per_bucket));
 

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -117,7 +117,6 @@ namespace psi {
 int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum,
                    const std::string& label) {
     dpdbuf4 OutBuf;
-    int n;
     int in_rows_per_bucket, in_nbuckets, in_rows_left, in_row_start, m;
     int rows_per_bucket, nbuckets, rows_left;
 
@@ -272,6 +271,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     buf4_mat_irrep_init_block(InBuf, Gpq, rows_per_bucket);
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, rows_per_bucket);
 
+                    int n;
                     for (n = 0; n < (rows_left ? nbuckets - 1 : nbuckets); n++) {
                         buf4_mat_irrep_rd_block(InBuf, Gpq, n * rows_per_bucket, rows_per_bucket);
 
@@ -377,6 +377,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     /* allocate space for the bucket of rows */
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, out_rows_per_bucket);
 
+                    int n;
                     for (n = 0; n < (out_rows_left ? out_nbuckets - 1 : out_nbuckets); n++) {
                         const int out_row_start = n * out_rows_per_bucket;
 
@@ -608,6 +609,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     /* allocate space for the bucket of rows */
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, out_rows_per_bucket);
 
+                    int n;
                     for (n = 0; n < (out_rows_left ? out_nbuckets - 1 : out_nbuckets); n++) {
                         const int out_row_start = n * out_rows_per_bucket;
 
@@ -924,7 +926,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, rows_per_bucket);
                     buf4_mat_irrep_init_block(InBuf, Gpq, rows_per_bucket);
 
-                    int out_row_start;
+                    int out_row_start, n;
                     for (n = 0; n < (rows_left ? nbuckets - 1 : nbuckets); n++) {
                         out_row_start = n * rows_per_bucket;
 
@@ -1048,7 +1050,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, rows_per_bucket);
                     buf4_mat_irrep_init_block(InBuf, Gpq, rows_per_bucket);
 
-                    int out_row_start;
+                    int out_row_start, n;
                     for (n = 0; n < (rows_left ? nbuckets - 1 : nbuckets); n++) {
                         out_row_start = n * rows_per_bucket;
 
@@ -1679,7 +1681,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, out_rows_per_bucket);
                     buf4_mat_irrep_init_block(InBuf, Grs, in_rows_per_bucket);
 
-                    for (n = 0; n < out_nbuckets; n++) {
+                    for (int n = 0; n < out_nbuckets; n++) {
                         const int out_row_start = n * out_rows_per_bucket;
 
                         for (m = 0; m < in_nbuckets; m++) {

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -117,7 +117,7 @@ namespace psi {
 int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum,
                    const std::string& label) {
     dpdbuf4 OutBuf;
-    int out_row_start, n;
+    int n;
     int in_rows_per_bucket, in_nbuckets, in_rows_left, in_row_start, m;
     int rows_per_bucket, nbuckets, rows_left;
 
@@ -378,7 +378,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, out_rows_per_bucket);
 
                     for (n = 0; n < (out_rows_left ? out_nbuckets - 1 : out_nbuckets); n++) {
-                        out_row_start = n * out_rows_per_bucket;
+                        const int out_row_start = n * out_rows_per_bucket;
 
                         for (int Grow = 0; Grow < nirreps; Grow++) { /*Grow = Gpr*/
                             const int Gcol = Grow ^ my_irrep;        /*Gcol = Gqs*/
@@ -457,7 +457,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                         buf4_mat_irrep_wrt_block(&OutBuf, Gpq, out_row_start, out_rows_per_bucket);
                     }
                     if (out_rows_left) {
-                        out_row_start = n * out_rows_per_bucket;
+                        const int out_row_start = n * out_rows_per_bucket;
 
                         for (int Grow = 0; Grow < nirreps; Grow++) {
                             const int Gcol = Grow ^ my_irrep;
@@ -609,7 +609,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, out_rows_per_bucket);
 
                     for (n = 0; n < (out_rows_left ? out_nbuckets - 1 : out_nbuckets); n++) {
-                        out_row_start = n * out_rows_per_bucket;
+                        const int out_row_start = n * out_rows_per_bucket;
 
                         for (int Grow = 0; Grow < nirreps; Grow++) {
                             const int Gcol = Grow ^ my_irrep;
@@ -686,7 +686,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                         buf4_mat_irrep_wrt_block(&OutBuf, Gpq, out_row_start, out_rows_per_bucket);
                     }
                     if (out_rows_left) {
-                        out_row_start = n * out_rows_per_bucket;
+                        const int out_row_start = n * out_rows_per_bucket;
 
                         for (int Grow = 0; Grow < nirreps; Grow++) {
                             const int Gcol = Grow ^ my_irrep;
@@ -924,6 +924,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, rows_per_bucket);
                     buf4_mat_irrep_init_block(InBuf, Gpq, rows_per_bucket);
 
+                    int out_row_start;
                     for (n = 0; n < (rows_left ? nbuckets - 1 : nbuckets); n++) {
                         out_row_start = n * rows_per_bucket;
 
@@ -1047,6 +1048,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     buf4_mat_irrep_init_block(&OutBuf, Gpq, rows_per_bucket);
                     buf4_mat_irrep_init_block(InBuf, Gpq, rows_per_bucket);
 
+                    int out_row_start;
                     for (n = 0; n < (rows_left ? nbuckets - 1 : nbuckets); n++) {
                         out_row_start = n * rows_per_bucket;
 
@@ -1136,7 +1138,6 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     }
 
                     buf4_mat_irrep_wrt_block(&OutBuf, Gpq, out_row_start, rows_left);
-
                     buf4_mat_irrep_close_block(InBuf, Gpq, rows_per_bucket);
                     buf4_mat_irrep_close_block(&OutBuf, Gpq, rows_per_bucket);
 
@@ -1679,7 +1680,7 @@ int DPD::buf4_sort(dpdbuf4* InBuf, const int outfilenum, const enum indices inde
                     buf4_mat_irrep_init_block(InBuf, Grs, in_rows_per_bucket);
 
                     for (n = 0; n < out_nbuckets; n++) {
-                        out_row_start = n * out_rows_per_bucket;
+                        const int out_row_start = n * out_rows_per_bucket;
 
                         for (m = 0; m < in_nbuckets; m++) {
                             in_row_start = m * in_rows_per_bucket;

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -136,27 +136,27 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
     core_total = 0;
     int incore = 1;
     {
-    for (int h = 0; h < nirreps; h++) {
-        coltot = InBuf->params->coltot[h ^ my_irrep];
-        if (coltot) {
-            maxrows = DPD_BIGNUM / coltot;
-            if (maxrows < 1) {
-                outfile->Printf("\nLIBDPD Error: too many rows in buf4_sort_axpy.\n");
-                dpd_error("buf4_sort_axpy", "outfile");
+        for (int h = 0; h < nirreps; h++) {
+            coltot = InBuf->params->coltot[h ^ my_irrep];
+            if (coltot) {
+                maxrows = DPD_BIGNUM / coltot;
+                if (maxrows < 1) {
+                    outfile->Printf("\nLIBDPD Error: too many rows in buf4_sort_axpy.\n");
+                    dpd_error("buf4_sort_axpy", "outfile");
+                }
+            } else
+                maxrows = DPD_BIGNUM;
+            rowtot = InBuf->params->rowtot[h];
+            for (; rowtot > maxrows; rowtot -= maxrows) {
+                if (core_total > (core_total + 2 * maxrows * coltot))
+                    incore = 0;
+                else
+                    core_total += 2 * maxrows * coltot;
             }
-        } else
-            maxrows = DPD_BIGNUM;
-        rowtot = InBuf->params->rowtot[h];
-        for (; rowtot > maxrows; rowtot -= maxrows) {
-            if (core_total > (core_total + 2 * maxrows * coltot))
-                incore = 0;
-            else
-                core_total += 2 * maxrows * coltot;
+            if (core_total > (core_total + 2 * rowtot * coltot)) incore = 0;
+            core_total += 2 * rowtot * coltot;
         }
-        if (core_total > (core_total + 2 * rowtot * coltot)) incore = 0;
-        core_total += 2 * rowtot * coltot;
-    }
-    if (core_total > dpd_memfree()) incore = 0;
+        if (core_total > dpd_memfree()) incore = 0;
     }
 
 #ifdef DPD_DEBUG

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -116,10 +116,7 @@ namespace psi {
 ** -RAK, Nov. 2005*/
 
 int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum, int rsnum, const std::string& label) {
-    int h, nirreps, row, col, my_irrep, r_irrep;
-    int p, q, r, s, P, Q, R, S, pq, rs, sr, pr, qs, qp, rq, qr, ps, sp, rp, sq;
-    int PQ, RS;
-    int Gp, Gq, Gr, Gs, Gpq, Grs, Gpr, Gqs, Grq, Gqr, Gps, Gsp, Grp, Gsq;
+    int Gqs, Grq, Gqr, Gps, Gsp, Grp, Gsq;
     dpdbuf4 OutBuf;
     int incore;
     long int rowtot, coltot, core_total, maxrows;
@@ -128,8 +125,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
     int in_rows_per_bucket, in_nbuckets, in_rows_left, in_row_start, m;
     int rows_per_bucket, nbuckets, rows_left;
 
-    nirreps = InBuf->params->nirreps;
-    my_irrep = InBuf->file.my_irrep;
+    const int nirreps = InBuf->params->nirreps;
+    const int my_irrep = InBuf->file.my_irrep;
 
 #ifdef DPD_TIMER
     timer_on("buf4_sort");
@@ -140,7 +137,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
     /* select in-core vs. out-of-core algorithms */
     incore = 1;
     core_total = 0;
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         coltot = InBuf->params->coltot[h ^ my_irrep];
         if (coltot) {
             maxrows = DPD_BIGNUM / coltot;
@@ -218,7 +215,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
 
     /* Init input and output buffers and read in all blocks of the input */
     if (incore) {
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             buf4_mat_irrep_init(&OutBuf, h);
             buf4_mat_irrep_init(InBuf, h);
             buf4_mat_irrep_rd(InBuf, h);
@@ -239,20 +236,20 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
 
             /* p->p; q->q; s->r; r->s = pqsr */
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
-                        p = OutBuf.params->roworb[h][pq][0];
-                        q = OutBuf.params->roworb[h][pq][1];
+                    for (int pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
+                        const int p = OutBuf.params->roworb[h][pq][0];
+                        const int q = OutBuf.params->roworb[h][pq][1];
 
-                        row = InBuf->params->rowidx[p][q];
+                        const int row = InBuf->params->rowidx[p][q];
 
-                        for (rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
-                            r = OutBuf.params->colorb[r_irrep][rs][0];
-                            s = OutBuf.params->colorb[r_irrep][rs][1];
+                        for (int rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
+                            const int r = OutBuf.params->colorb[r_irrep][rs][0];
+                            const int s = OutBuf.params->colorb[r_irrep][rs][1];
 
-                            sr = InBuf->params->colidx[s][r];
+                            const int sr = InBuf->params->colidx[s][r];
 
                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[h][row][sr];
                         }
@@ -260,8 +257,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                 }
             } else { /* out-of-core pqsr -> pqrs */
 
-                for (Gpq = 0; Gpq < nirreps; Gpq++) {
-                    Grs = Gpq ^ my_irrep;
+                for (int Gpq = 0; Gpq < nirreps; Gpq++) {
+                    const int Grs = Gpq ^ my_irrep;
                     rows_per_bucket = dpd_memfree() / 2 / InBuf->params->coltot[Grs];
 
                     if (rows_per_bucket > InBuf->params->rowtot[Gpq]) rows_per_bucket = InBuf->params->rowtot[Gpq];
@@ -279,12 +276,12 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                     for (n = 0; n < (rows_left ? nbuckets - 1 : nbuckets); n++) {
                         buf4_mat_irrep_rd_block(InBuf, Gpq, n * rows_per_bucket, rows_per_bucket);
 
-                        for (pq = 0; pq < rows_per_bucket; pq++) {
-                            for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                r = OutBuf.params->colorb[Grs][rs][0];
-                                s = OutBuf.params->colorb[Grs][rs][1];
+                        for (int pq = 0; pq < rows_per_bucket; pq++) {
+                            for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                const int r = OutBuf.params->colorb[Grs][rs][0];
+                                const int s = OutBuf.params->colorb[Grs][rs][1];
 
-                                sr = InBuf->params->colidx[s][r];
+                                const int sr = InBuf->params->colidx[s][r];
 
                                 OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Gpq][pq][sr];
                             }
@@ -295,12 +292,12 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                     if (rows_left) {
                         buf4_mat_irrep_rd_block(InBuf, Gpq, n * rows_per_bucket, rows_left);
 
-                        for (pq = 0; pq < rows_left; pq++) {
-                            for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                r = OutBuf.params->colorb[Grs][rs][0];
-                                s = OutBuf.params->colorb[Grs][rs][1];
+                        for (int pq = 0; pq < rows_left; pq++) {
+                            for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                const int r = OutBuf.params->colorb[Grs][rs][0];
+                                const int s = OutBuf.params->colorb[Grs][rs][1];
 
-                                sr = InBuf->params->colidx[s][r];
+                                const int sr = InBuf->params->colidx[s][r];
 
                                 OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Gpq][pq][sr];
                             }
@@ -327,32 +324,32 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
 
             /* p->p; r->q; q->r; s->s = prqs */
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             /* Irreps on the source */
-                            Gpr = Gp ^ Gr;
+                            const int Gpr = Gp ^ Gr;
                             Gqs = Gq ^ Gs;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        pr = InBuf->params->rowidx[P][R];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int pr = InBuf->params->rowidx[P][R];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            qs = InBuf->params->colidx[Q][S];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int qs = InBuf->params->colidx[Q][S];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Gpr][pr][qs];
                                         }
@@ -364,8 +361,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                 }
             } else { /* pqrs <- prqs */
 
-                for (Gpq = 0; Gpq < nirreps; Gpq++) {
-                    Grs = Gpq ^ my_irrep;
+                for (int Gpq = 0; Gpq < nirreps; Gpq++) {
+                    const int Grs = Gpq ^ my_irrep;
 
                     out_rows_per_bucket = dpd_memfree() / (2 * OutBuf.params->coltot[Grs]);
                     if (out_rows_per_bucket > OutBuf.params->rowtot[Gpq])
@@ -403,23 +400,23 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                                 in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_per_bucket);
 
-                                for (pq = 0; pq < out_rows_per_bucket; pq++) {
-                                    p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                    q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                    Gp = OutBuf.params->psym[p];
-                                    Gq = Gpq ^ Gp;
-                                    for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                        r = OutBuf.params->colorb[Grs][rs][0];
-                                        s = OutBuf.params->colorb[Grs][rs][1];
-                                        Gr = OutBuf.params->rsym[r];
-                                        Gs = Grs ^ Gr;
-                                        Gpr = Gp ^ Gr;
+                                for (int pq = 0; pq < out_rows_per_bucket; pq++) {
+                                    const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                    const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                    const int Gp = OutBuf.params->psym[p];
+                                    const int Gq = Gpq ^ Gp;
+                                    for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                        const int r = OutBuf.params->colorb[Grs][rs][0];
+                                        const int s = OutBuf.params->colorb[Grs][rs][1];
+                                        const int Gr = OutBuf.params->rsym[r];
+                                        const int Gs = Grs ^ Gr;
+                                        const int Gpr = Gp ^ Gr;
 
                                         if (Gpr == Grow) {
-                                            pr = InBuf->params->rowidx[p][r] - in_row_start;
+                                            const int pr = InBuf->params->rowidx[p][r] - in_row_start;
                                             /* check if the current value is in the current in_bucket or not */
                                             if (pr >= 0 && pr < in_rows_per_bucket) {
-                                                qs = InBuf->params->colidx[q][s];
+                                                const int qs = InBuf->params->colidx[q][s];
                                                 OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Grow][pr][qs];
                                             }
                                         }
@@ -431,23 +428,23 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_left);
 
                                 /* pqrs <- prqs */
-                                for (pq = 0; pq < out_rows_per_bucket; pq++) {
-                                    p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                    q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                    Gp = OutBuf.params->psym[p];
-                                    Gq = Gpq ^ Gp;
-                                    for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                        r = OutBuf.params->colorb[Grs][rs][0];
-                                        s = OutBuf.params->colorb[Grs][rs][1];
-                                        Gr = OutBuf.params->rsym[r];
-                                        Gs = Grs ^ Gr;
-                                        Gpr = Gp ^ Gr;
+                                for (int pq = 0; pq < out_rows_per_bucket; pq++) {
+                                    const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                    const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                    const int Gp = OutBuf.params->psym[p];
+                                    const int Gq = Gpq ^ Gp;
+                                    for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                        const int r = OutBuf.params->colorb[Grs][rs][0];
+                                        const int s = OutBuf.params->colorb[Grs][rs][1];
+                                        const int Gr = OutBuf.params->rsym[r];
+                                        const int Gs = Grs ^ Gr;
+                                        const int Gpr = Gp ^ Gr;
 
                                         if (Gpr == Grow) {
-                                            pr = InBuf->params->rowidx[p][r] - in_row_start;
+                                            const int pr = InBuf->params->rowidx[p][r] - in_row_start;
                                             /* check if the current value is in core or not */
                                             if (pr >= 0 && pr < in_rows_left) {
-                                                qs = InBuf->params->colidx[q][s];
+                                                const int qs = InBuf->params->colidx[q][s];
                                                 OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Grow][pr][qs];
                                             }
                                         }
@@ -482,23 +479,23 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                                 in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_per_bucket);
 
-                                for (pq = 0; pq < out_rows_left; pq++) {
-                                    p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                    q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                    Gp = OutBuf.params->psym[p];
-                                    Gq = Gpq ^ Gp;
-                                    for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                        r = OutBuf.params->colorb[Grs][rs][0];
-                                        s = OutBuf.params->colorb[Grs][rs][1];
-                                        Gr = OutBuf.params->rsym[r];
-                                        Gs = Grs ^ Gr;
-                                        Gpr = Gp ^ Gr;
+                                for (int pq = 0; pq < out_rows_left; pq++) {
+                                    const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                    const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                    const int Gp = OutBuf.params->psym[p];
+                                    const int Gq = Gpq ^ Gp;
+                                    for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                        const int r = OutBuf.params->colorb[Grs][rs][0];
+                                        const int s = OutBuf.params->colorb[Grs][rs][1];
+                                        const int Gr = OutBuf.params->rsym[r];
+                                        const int Gs = Grs ^ Gr;
+                                        const int Gpr = Gp ^ Gr;
 
                                         if (Gpr == Grow) {
-                                            pr = InBuf->params->rowidx[p][r] - in_row_start;
+                                            const int pr = InBuf->params->rowidx[p][r] - in_row_start;
                                             /* check if the current value is in the current in_bucket or not */
                                             if (pr >= 0 && pr < in_rows_per_bucket) {
-                                                qs = InBuf->params->colidx[q][s];
+                                                const int qs = InBuf->params->colidx[q][s];
                                                 OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Grow][pr][qs];
                                             }
                                         }
@@ -509,23 +506,23 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                                 in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_left);
 
-                                for (pq = 0; pq < out_rows_left; pq++) {
-                                    p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                    q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                    Gp = OutBuf.params->psym[p];
-                                    Gq = Gpq ^ Gp;
-                                    for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                        r = OutBuf.params->colorb[Grs][rs][0];
-                                        s = OutBuf.params->colorb[Grs][rs][1];
-                                        Gr = OutBuf.params->rsym[r];
-                                        Gs = Grs ^ Gr;
-                                        Gpr = Gp ^ Gr;
+                                for (int pq = 0; pq < out_rows_left; pq++) {
+                                    const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                    const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                    const int Gp = OutBuf.params->psym[p];
+                                    const int Gq = Gpq ^ Gp;
+                                    for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                        const int r = OutBuf.params->colorb[Grs][rs][0];
+                                        const int s = OutBuf.params->colorb[Grs][rs][1];
+                                        const int Gr = OutBuf.params->rsym[r];
+                                        const int Gs = Grs ^ Gr;
+                                        const int Gpr = Gp ^ Gr;
 
                                         if (Gpr == Grow) {
-                                            pr = InBuf->params->rowidx[p][r] - in_row_start;
+                                            const int pr = InBuf->params->rowidx[p][r] - in_row_start;
                                             /* check if the current value is in core or not */
                                             if (pr >= 0 && pr < in_rows_left) {
-                                                qs = InBuf->params->colidx[q][s];
+                                                const int qs = InBuf->params->colidx[q][s];
                                                 OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Grow][pr][qs];
                                             }
                                         }
@@ -557,31 +554,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* p->p; r->q; s->r; q->s = psqr */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Gps = Gp ^ Gs;
                             Gqr = Gq ^ Gr;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        qr = InBuf->params->colidx[Q][R];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int qr = InBuf->params->colidx[Q][R];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            ps = InBuf->params->rowidx[P][S];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int ps = InBuf->params->rowidx[P][S];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Gps][ps][qr];
                                         }
@@ -592,8 +589,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                     }
                 }
             } else {
-                for (Gpq = 0; Gpq < nirreps; Gpq++) {
-                    Grs = Gpq ^ my_irrep;
+                for (int Gpq = 0; Gpq < nirreps; Gpq++) {
+                    const int Grs = Gpq ^ my_irrep;
 
                     /* determine how many rows of OutBuf we can store in half of the core */
                     out_rows_per_bucket = dpd_memfree() / (2 * OutBuf.params->coltot[Grs]);
@@ -631,24 +628,23 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                                 in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_per_bucket);
 
-                                for (pq = 0; pq < out_rows_per_bucket; pq++) {
-                                    p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                    q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                    Gp = OutBuf.params->psym[p];
-                                    Gq = Gpq ^ Gp;
-                                    for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                        r = OutBuf.params->colorb[Grs][rs][0];
-                                        s = OutBuf.params->colorb[Grs][rs][1];
-                                        Gr = OutBuf.params->rsym[r];
-                                        Gs = Grs ^ Gr;
-
+                                for (int pq = 0; pq < out_rows_per_bucket; pq++) {
+                                    const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                    const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                    const int Gp = OutBuf.params->psym[p];
+                                    const int Gq = Gpq ^ Gp;
+                                    for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                        const int r = OutBuf.params->colorb[Grs][rs][0];
+                                        const int s = OutBuf.params->colorb[Grs][rs][1];
+                                        const int Gr = OutBuf.params->rsym[r];
+                                        const int Gs = Grs ^ Gr;
                                         Gps = Gp ^ Gs;
 
                                         if (Gps == Grow) {
-                                            ps = InBuf->params->rowidx[p][s] - in_row_start;
+                                            const int ps = InBuf->params->rowidx[p][s] - in_row_start;
                                             /* check if the current value is in the current in_bucket or not */
                                             if (ps >= 0 && ps < in_rows_per_bucket) {
-                                                qr = InBuf->params->colidx[q][r];
+                                                const int qr = InBuf->params->colidx[q][r];
                                                 OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Grow][ps][qr];
                                             }
                                         }
@@ -659,24 +655,23 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                                 in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_left);
 
-                                for (pq = 0; pq < out_rows_per_bucket; pq++) {
-                                    p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                    q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                    Gp = OutBuf.params->psym[p];
-                                    Gq = Gpq ^ Gp;
-                                    for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                        r = OutBuf.params->colorb[Grs][rs][0];
-                                        s = OutBuf.params->colorb[Grs][rs][1];
-                                        Gr = OutBuf.params->rsym[r];
-                                        Gs = Grs ^ Gr;
-
+                                for (int pq = 0; pq < out_rows_per_bucket; pq++) {
+                                    const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                    const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                    const int Gp = OutBuf.params->psym[p];
+                                    const int Gq = Gpq ^ Gp;
+                                    for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                        const int r = OutBuf.params->colorb[Grs][rs][0];
+                                        const int s = OutBuf.params->colorb[Grs][rs][1];
+                                        const int Gr = OutBuf.params->rsym[r];
+                                        const int Gs = Grs ^ Gr;
                                         Gps = Gp ^ Gs;
 
                                         if (Gps == Grow) {
-                                            ps = InBuf->params->rowidx[p][s] - in_row_start;
+                                            const int ps = InBuf->params->rowidx[p][s] - in_row_start;
                                             /* check if the current value is in core or not */
                                             if (ps >= 0 && ps < in_rows_left) {
-                                                qr = InBuf->params->colidx[q][r];
+                                                const int qr = InBuf->params->colidx[q][r];
                                                 OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Grow][ps][qr];
                                             }
                                         }
@@ -710,24 +705,23 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                                 in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_per_bucket);
 
-                                for (pq = 0; pq < out_rows_left; pq++) {
-                                    p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                    q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                    Gp = OutBuf.params->psym[p];
-                                    Gq = Gpq ^ Gp;
-                                    for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                        r = OutBuf.params->colorb[Grs][rs][0];
-                                        s = OutBuf.params->colorb[Grs][rs][1];
-                                        Gr = OutBuf.params->rsym[r];
-                                        Gs = Grs ^ Gr;
-
+                                for (int pq = 0; pq < out_rows_left; pq++) {
+                                    const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                    const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                    const int Gp = OutBuf.params->psym[p];
+                                    const int Gq = Gpq ^ Gp;
+                                    for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                        const int r = OutBuf.params->colorb[Grs][rs][0];
+                                        const int s = OutBuf.params->colorb[Grs][rs][1];
+                                        const int Gr = OutBuf.params->rsym[r];
+                                        const int Gs = Grs ^ Gr;
                                         Gps = Gp ^ Gs;
 
                                         if (Gps == Grow) {
-                                            ps = InBuf->params->rowidx[p][s] - in_row_start;
+                                            const int ps = InBuf->params->rowidx[p][s] - in_row_start;
                                             /* check if the current value is in the current in_bucket or not */
                                             if (ps >= 0 && ps < in_rows_per_bucket) {
-                                                qr = InBuf->params->colidx[q][r];
+                                                const int qr = InBuf->params->colidx[q][r];
                                                 OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Grow][ps][qr];
                                             }
                                         }
@@ -738,24 +732,23 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                                 in_row_start = m * in_rows_per_bucket;
                                 buf4_mat_irrep_rd_block(InBuf, Grow, in_row_start, in_rows_left);
 
-                                for (pq = 0; pq < out_rows_left; pq++) {
-                                    p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                    q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                    Gp = OutBuf.params->psym[p];
-                                    Gq = Gpq ^ Gp;
-                                    for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                        r = OutBuf.params->colorb[Grs][rs][0];
-                                        s = OutBuf.params->colorb[Grs][rs][1];
-                                        Gr = OutBuf.params->rsym[r];
-                                        Gs = Grs ^ Gr;
-
+                                for (int pq = 0; pq < out_rows_left; pq++) {
+                                    const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                    const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                    const int Gp = OutBuf.params->psym[p];
+                                    const int Gq = Gpq ^ Gp;
+                                    for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                        const int r = OutBuf.params->colorb[Grs][rs][0];
+                                        const int s = OutBuf.params->colorb[Grs][rs][1];
+                                        const int Gr = OutBuf.params->rsym[r];
+                                        const int Gs = Grs ^ Gr;
                                         Gps = Gp ^ Gs;
 
                                         if (Gps == Grow) {
-                                            ps = InBuf->params->rowidx[p][s] - in_row_start;
+                                            const int ps = InBuf->params->rowidx[p][s] - in_row_start;
                                             /* check if the current value is in core or not */
                                             if (ps >= 0 && ps < in_rows_left) {
-                                                qr = InBuf->params->colidx[q][r];
+                                                const int qr = InBuf->params->colidx[q][r];
                                                 OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Grow][ps][qr];
                                             }
                                         }
@@ -787,31 +780,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* p->p; s->q; q->r; r->s = prsq */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
-                            Gpr = Gp ^ Gr;
+                            const int Gpr = Gp ^ Gr;
                             Gsq = Gs ^ Gq;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        pr = InBuf->params->rowidx[P][R];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int pr = InBuf->params->rowidx[P][R];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            sq = InBuf->params->colidx[S][Q];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int sq = InBuf->params->colidx[S][Q];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Gpr][pr][sq];
                                         }
@@ -840,31 +833,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* p->p; s->q; r->r; q->s = psrq */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Gps = Gp ^ Gs;
                             Grq = Gr ^ Gq;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        rq = InBuf->params->colidx[R][Q];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int rq = InBuf->params->colidx[R][Q];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            ps = InBuf->params->rowidx[P][S];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int ps = InBuf->params->rowidx[P][S];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Gps][ps][rq];
                                         }
@@ -893,27 +886,27 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* q->p; p->q; r->r; s->s = qprs */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
-                        p = OutBuf.params->roworb[h][pq][0];
-                        q = OutBuf.params->roworb[h][pq][1];
-                        qp = InBuf->params->rowidx[q][p];
+                    for (int pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
+                        const int p = OutBuf.params->roworb[h][pq][0];
+                        const int q = OutBuf.params->roworb[h][pq][1];
+                        const int qp = InBuf->params->rowidx[q][p];
 
-                        for (rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
-                            r = OutBuf.params->colorb[r_irrep][rs][0];
-                            s = OutBuf.params->colorb[r_irrep][rs][1];
+                        for (int rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
+                            const int r = OutBuf.params->colorb[r_irrep][rs][0];
+                            const int s = OutBuf.params->colorb[r_irrep][rs][1];
 
-                            col = InBuf->params->colidx[r][s];
+                            const int col = InBuf->params->colidx[r][s];
 
                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[h][qp][col];
                         }
                     }
                 }
             } else {
-                for (Gpq = 0; Gpq < nirreps; Gpq++) {
-                    Grs = Gpq ^ my_irrep;
+                for (int Gpq = 0; Gpq < nirreps; Gpq++) {
+                    const int Grs = Gpq ^ my_irrep;
 
                     /* determine how many rows of OutBuf/InBuf we can store in half the core */
                     rows_per_bucket = dpd_memfree() / (2 * OutBuf.params->coltot[Grs]);
@@ -934,11 +927,11 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                         for (m = 0; m < (rows_left ? nbuckets - 1 : nbuckets); m++) {
                             in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_per_bucket);
-                            for (pq = 0; pq < rows_per_bucket; pq++) {
+                            for (int pq = 0; pq < rows_per_bucket; pq++) {
                                 /* check to see if this row is contained in the current input-bucket */
-                                p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                qp = InBuf->params->rowidx[q][p] - in_row_start;
+                                const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                const int qp = InBuf->params->rowidx[q][p] - in_row_start;
                                 if (qp >= 0 && qp < rows_per_bucket) {
                                     C_DCOPY(OutBuf.params->coltot[Grs], InBuf->matrix[Gpq][qp], 1,
                                             OutBuf.matrix[Gpq][pq], 1);
@@ -949,11 +942,11 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                         if (rows_left) {
                             in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_left);
-                            for (pq = 0; pq < rows_per_bucket; pq++) {
+                            for (int pq = 0; pq < rows_per_bucket; pq++) {
                                 /* check to see if this row is contained in the current input-bucket */
-                                p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                qp = InBuf->params->rowidx[q][p] - in_row_start;
+                                const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                const int qp = InBuf->params->rowidx[q][p] - in_row_start;
                                 if (qp >= 0 && qp < rows_left) {
                                     C_DCOPY(OutBuf.params->coltot[Grs], InBuf->matrix[Gpq][qp], 1,
                                             OutBuf.matrix[Gpq][pq], 1);
@@ -970,11 +963,11 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                         for (m = 0; m < (rows_left ? nbuckets - 1 : nbuckets); m++) {
                             in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_per_bucket);
-                            for (pq = 0; pq < rows_left; pq++) {
+                            for (int pq = 0; pq < rows_left; pq++) {
                                 /* check to see if this row is contained in the current input-bucket */
-                                p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                qp = InBuf->params->rowidx[q][p] - in_row_start;
+                                const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                const int qp = InBuf->params->rowidx[q][p] - in_row_start;
                                 if (qp >= 0 && qp < rows_per_bucket) {
                                     C_DCOPY(OutBuf.params->coltot[Grs], InBuf->matrix[Gpq][qp], 1,
                                             OutBuf.matrix[Gpq][pq], 1);
@@ -985,11 +978,11 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                         if (rows_left) {
                             in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_left);
-                            for (pq = 0; pq < rows_left; pq++) {
+                            for (int pq = 0; pq < rows_left; pq++) {
                                 /* check to see if this row is contained in the current input-bucket */
-                                p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                qp = InBuf->params->rowidx[q][p] - in_row_start;
+                                const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                const int qp = InBuf->params->rowidx[q][p] - in_row_start;
                                 if (qp >= 0 && qp < rows_left) {
                                     C_DCOPY(OutBuf.params->coltot[Grs], InBuf->matrix[Gpq][qp], 1,
                                             OutBuf.matrix[Gpq][pq], 1);
@@ -1017,26 +1010,26 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* q->p; p->q; s->r; r->s = qpsr */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
-                        p = OutBuf.params->roworb[h][pq][0];
-                        q = OutBuf.params->roworb[h][pq][1];
-                        qp = InBuf->params->rowidx[q][p];
+                    for (int pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
+                        const int p = OutBuf.params->roworb[h][pq][0];
+                        const int q = OutBuf.params->roworb[h][pq][1];
+                        const int qp = InBuf->params->rowidx[q][p];
 
-                        for (rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
-                            r = OutBuf.params->colorb[r_irrep][rs][0];
-                            s = OutBuf.params->colorb[r_irrep][rs][1];
-                            sr = InBuf->params->colidx[s][r];
+                        for (int rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
+                            const int r = OutBuf.params->colorb[r_irrep][rs][0];
+                            const int s = OutBuf.params->colorb[r_irrep][rs][1];
+                            const int sr = InBuf->params->colidx[s][r];
 
                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[h][qp][sr];
                         }
                     }
                 }
             } else {
-                for (Gpq = 0; Gpq < nirreps; Gpq++) {
-                    Grs = Gpq ^ my_irrep;
+                for (int Gpq = 0; Gpq < nirreps; Gpq++) {
+                    const int Grs = Gpq ^ my_irrep;
 
                     /* determine how many rows of OutBuf/InBuf we can store in half the core */
                     rows_per_bucket = dpd_memfree() / (2 * OutBuf.params->coltot[Grs]);
@@ -1058,16 +1051,16 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                             in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_per_bucket);
 
-                            for (pq = 0; pq < rows_per_bucket; pq++) {
+                            for (int pq = 0; pq < rows_per_bucket; pq++) {
                                 /* check to see if this row is contained in the current input-bucket */
-                                p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                qp = InBuf->params->rowidx[q][p] - in_row_start;
+                                const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                const int qp = InBuf->params->rowidx[q][p] - in_row_start;
                                 if (qp >= 0 && qp < rows_per_bucket) {
-                                    for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                        r = OutBuf.params->colorb[Grs][rs][0];
-                                        s = OutBuf.params->colorb[Grs][rs][1];
-                                        sr = InBuf->params->colidx[s][r];
+                                    for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                        const int r = OutBuf.params->colorb[Grs][rs][0];
+                                        const int s = OutBuf.params->colorb[Grs][rs][1];
+                                        const int sr = InBuf->params->colidx[s][r];
                                         OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Gpq][qp][sr];
                                     }
                                 }
@@ -1077,16 +1070,16 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                             in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_left);
 
-                            for (pq = 0; pq < rows_per_bucket; pq++) {
+                            for (int pq = 0; pq < rows_per_bucket; pq++) {
                                 /* check to see if this row is contained in the current input-bucket */
-                                p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                qp = InBuf->params->rowidx[q][p] - in_row_start;
+                                const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                const int qp = InBuf->params->rowidx[q][p] - in_row_start;
                                 if (qp >= 0 && qp < rows_left) {
-                                    for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                        r = OutBuf.params->colorb[Grs][rs][0];
-                                        s = OutBuf.params->colorb[Grs][rs][1];
-                                        sr = InBuf->params->colidx[s][r];
+                                    for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                        const int r = OutBuf.params->colorb[Grs][rs][0];
+                                        const int s = OutBuf.params->colorb[Grs][rs][1];
+                                        const int sr = InBuf->params->colidx[s][r];
                                         OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Gpq][qp][sr];
                                     }
                                 }
@@ -1103,16 +1096,16 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                             in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_per_bucket);
 
-                            for (pq = 0; pq < rows_left; pq++) {
+                            for (int pq = 0; pq < rows_left; pq++) {
                                 /* check to see if this row is contained in the current input-bucket */
-                                p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                qp = InBuf->params->rowidx[q][p] - in_row_start;
+                                const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                const int qp = InBuf->params->rowidx[q][p] - in_row_start;
                                 if (qp >= 0 && qp < rows_per_bucket) {
-                                    for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                        r = OutBuf.params->colorb[Grs][rs][0];
-                                        s = OutBuf.params->colorb[Grs][rs][1];
-                                        sr = InBuf->params->colidx[s][r];
+                                    for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                        const int r = OutBuf.params->colorb[Grs][rs][0];
+                                        const int s = OutBuf.params->colorb[Grs][rs][1];
+                                        const int sr = InBuf->params->colidx[s][r];
                                         OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Gpq][qp][sr];
                                     }
                                 }
@@ -1122,16 +1115,16 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                             in_row_start = m * rows_per_bucket;
                             buf4_mat_irrep_rd_block(InBuf, Gpq, in_row_start, rows_left);
 
-                            for (pq = 0; pq < rows_left; pq++) {
+                            for (int pq = 0; pq < rows_left; pq++) {
                                 /* check to see if this row is contained in the current input-bucket */
-                                p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
-                                q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
-                                qp = InBuf->params->rowidx[q][p] - in_row_start;
+                                const int p = OutBuf.params->roworb[Gpq][pq + out_row_start][0];
+                                const int q = OutBuf.params->roworb[Gpq][pq + out_row_start][1];
+                                const int qp = InBuf->params->rowidx[q][p] - in_row_start;
                                 if (qp >= 0 && qp < rows_left) {
-                                    for (rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
-                                        r = OutBuf.params->colorb[Grs][rs][0];
-                                        s = OutBuf.params->colorb[Grs][rs][1];
-                                        sr = InBuf->params->colidx[s][r];
+                                    for (int rs = 0; rs < OutBuf.params->coltot[Grs]; rs++) {
+                                        const int r = OutBuf.params->colorb[Grs][rs][0];
+                                        const int s = OutBuf.params->colorb[Grs][rs][1];
+                                        const int sr = InBuf->params->colidx[s][r];
                                         OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Gpq][qp][sr];
                                     }
                                 }
@@ -1160,31 +1153,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* q->p; r->q; p->r; s->s = rpqs */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Grp = Gr ^ Gp;
                             Gqs = Gq ^ Gs;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        rp = InBuf->params->rowidx[R][P];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int rp = InBuf->params->rowidx[R][P];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            qs = InBuf->params->colidx[Q][S];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int qs = InBuf->params->colidx[Q][S];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Grp][rp][qs];
                                         }
@@ -1213,31 +1206,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* q->p; r->q; s->r; p->s = spqr */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Gsp = Gs ^ Gp;
                             Gqr = Gq ^ Gr;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        qr = InBuf->params->colidx[Q][R];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int qr = InBuf->params->colidx[Q][R];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            sp = InBuf->params->rowidx[S][P];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int sp = InBuf->params->rowidx[S][P];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Gsp][sp][qr];
                                         }
@@ -1265,31 +1258,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* q->p; s->q; p->r; r->s = rpsq */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Grp = Gr ^ Gp;
                             Gsq = Gs ^ Gq;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        rp = InBuf->params->rowidx[R][P];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int rp = InBuf->params->rowidx[R][P];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            sq = InBuf->params->colidx[S][Q];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int sq = InBuf->params->colidx[S][Q];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Grp][rp][sq];
                                         }
@@ -1317,31 +1310,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
 
             /* q->p; s->q; r->r; p->s = sprq */
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Gsp = Gs ^ Gp;
                             Grq = Gr ^ Gq;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        rq = InBuf->params->colidx[R][Q];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int rq = InBuf->params->colidx[R][Q];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            sp = InBuf->params->rowidx[S][P];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int sp = InBuf->params->rowidx[S][P];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Gsp][sp][rq];
                                         }
@@ -1370,31 +1363,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* r->p; q->q; p->r; s->s = rqps */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Grq = Gr ^ Gq;
                             Gps = Gp ^ Gs;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        rq = InBuf->params->rowidx[R][Q];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int rq = InBuf->params->rowidx[R][Q];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            ps = InBuf->params->colidx[P][S];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int ps = InBuf->params->colidx[P][S];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Grq][rq][ps];
                                         }
@@ -1423,31 +1416,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* r->p; q->q; s->r; p->s = sqpr */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Gsq = Gs ^ Gq;
-                            Gpr = Gp ^ Gr;
+                            const int Gpr = Gp ^ Gr;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        pr = InBuf->params->colidx[P][R];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int pr = InBuf->params->colidx[P][R];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            sq = InBuf->params->rowidx[S][Q];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int sq = InBuf->params->rowidx[S][Q];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Gsq][sq][pr];
                                         }
@@ -1476,31 +1469,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* r->p; p->q; q->r; s->s = qrps */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Gqr = Gq ^ Gr;
                             Gps = Gp ^ Gs;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        qr = InBuf->params->rowidx[Q][R];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int qr = InBuf->params->rowidx[Q][R];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            ps = InBuf->params->colidx[P][S];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int ps = InBuf->params->colidx[P][S];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Gqr][qr][ps];
                                         }
@@ -1529,31 +1522,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* r->p; p->q; s->r; q->s = qspr */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Gqs = Gq ^ Gs;
-                            Gpr = Gp ^ Gr;
+                            const int Gpr = Gp ^ Gr;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        pr = InBuf->params->colidx[P][R];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int pr = InBuf->params->colidx[P][R];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            qs = InBuf->params->rowidx[Q][S];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int qs = InBuf->params->rowidx[Q][S];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Gqs][qs][pr];
                                         }
@@ -1582,20 +1575,20 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* r->p; s->q; q->r; p->s = srpq */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
-                        p = OutBuf.params->roworb[h][pq][0];
-                        q = OutBuf.params->roworb[h][pq][1];
+                    for (int pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
+                        const int p = OutBuf.params->roworb[h][pq][0];
+                        const int q = OutBuf.params->roworb[h][pq][1];
 
-                        col = InBuf->params->colidx[p][q];
+                        const int col = InBuf->params->colidx[p][q];
 
-                        for (rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
-                            r = OutBuf.params->colorb[r_irrep][rs][0];
-                            s = OutBuf.params->colorb[r_irrep][rs][1];
+                        for (int rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
+                            const int r = OutBuf.params->colorb[r_irrep][rs][0];
+                            const int s = OutBuf.params->colorb[r_irrep][rs][1];
 
-                            row = InBuf->params->rowidx[s][r];
+                            const int row = InBuf->params->rowidx[s][r];
 
                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[h][row][col];
                         }
@@ -1620,28 +1613,28 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* r->p; s->q; p->r; q->s = rspq */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
-                        p = OutBuf.params->roworb[h][pq][0];
-                        q = OutBuf.params->roworb[h][pq][1];
+                    for (int pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
+                        const int p = OutBuf.params->roworb[h][pq][0];
+                        const int q = OutBuf.params->roworb[h][pq][1];
 
-                        col = InBuf->params->colidx[p][q];
+                        const int col = InBuf->params->colidx[p][q];
 
-                        for (rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
-                            r = OutBuf.params->colorb[r_irrep][rs][0];
-                            s = OutBuf.params->colorb[r_irrep][rs][1];
+                        for (int rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
+                            const int r = OutBuf.params->colorb[r_irrep][rs][0];
+                            const int s = OutBuf.params->colorb[r_irrep][rs][1];
 
-                            row = InBuf->params->rowidx[r][s];
+                            const int row = InBuf->params->rowidx[r][s];
 
                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[r_irrep][row][col];
                         }
                     }
                 }
             } else {
-                for (Gpq = 0; Gpq < nirreps; Gpq++) {
-                    Grs = Gpq ^ my_irrep;
+                for (int Gpq = 0; Gpq < nirreps; Gpq++) {
+                    const int Grs = Gpq ^ my_irrep;
 
                     out_rows_per_bucket =
                         (dpd_memfree() - OutBuf.params->coltot[Grs]) / (2 * OutBuf.params->coltot[Grs]);
@@ -1689,10 +1682,10 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
                             buf4_mat_irrep_rd_block(InBuf, Grs, in_row_start,
                                                     (m == in_nbuckets - 1 ? in_rows_left : in_rows_per_bucket));
 
-                            for (pq = 0; pq < (n == out_nbuckets - 1 ? out_rows_left : out_rows_per_bucket); pq++) {
-                                PQ = pq + n * out_rows_per_bucket;
-                                for (RS = 0; RS < (m == in_nbuckets - 1 ? in_rows_left : in_rows_per_bucket); RS++) {
-                                    rs = RS + m * in_rows_per_bucket;
+                            for (int pq = 0; pq < (n == out_nbuckets - 1 ? out_rows_left : out_rows_per_bucket); pq++) {
+                                const int PQ = pq + n * out_rows_per_bucket;
+                                for (int RS = 0; RS < (m == in_nbuckets - 1 ? in_rows_left : in_rows_per_bucket); RS++) {
+                                    const int rs = RS + m * in_rows_per_bucket;
                                     OutBuf.matrix[Gpq][pq][rs] = InBuf->matrix[Grs][RS][PQ];
                                 }
                             }
@@ -1722,31 +1715,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* s->p; q->q; r->r; p->s = sqrp */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Gsq = Gs ^ Gq;
                             Grp = Gr ^ Gp;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        rp = InBuf->params->colidx[R][P];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int rp = InBuf->params->colidx[R][P];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            sq = InBuf->params->rowidx[S][Q];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int sq = InBuf->params->rowidx[S][Q];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Gsq][sq][rp];
                                         }
@@ -1780,20 +1773,20 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* s->p; r->q; q->r; p->s = srqp */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
-                        p = OutBuf.params->roworb[h][pq][0];
-                        q = OutBuf.params->roworb[h][pq][1];
+                    for (int pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
+                        const int p = OutBuf.params->roworb[h][pq][0];
+                        const int q = OutBuf.params->roworb[h][pq][1];
 
-                        col = InBuf->params->colidx[q][p];
+                        const int col = InBuf->params->colidx[q][p];
 
-                        for (rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
-                            r = OutBuf.params->colorb[r_irrep][rs][0];
-                            s = OutBuf.params->colorb[r_irrep][rs][1];
+                        for (int rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
+                            const int r = OutBuf.params->colorb[r_irrep][rs][0];
+                            const int s = OutBuf.params->colorb[r_irrep][rs][1];
 
-                            row = InBuf->params->rowidx[s][r];
+                            const int row = InBuf->params->rowidx[s][r];
 
                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[r_irrep][row][col];
                         }
@@ -1817,20 +1810,20 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* s->p; r->q; p->r; q->s = rsqp */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
-                        p = OutBuf.params->roworb[h][pq][0];
-                        q = OutBuf.params->roworb[h][pq][1];
+                    for (int pq = 0; pq < OutBuf.params->rowtot[h]; pq++) {
+                        const int p = OutBuf.params->roworb[h][pq][0];
+                        const int q = OutBuf.params->roworb[h][pq][1];
 
-                        col = InBuf->params->colidx[q][p];
+                        const int col = InBuf->params->colidx[q][p];
 
-                        for (rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
-                            r = OutBuf.params->colorb[r_irrep][rs][0];
-                            s = OutBuf.params->colorb[r_irrep][rs][1];
+                        for (int rs = 0; rs < OutBuf.params->coltot[r_irrep]; rs++) {
+                            const int r = OutBuf.params->colorb[r_irrep][rs][0];
+                            const int s = OutBuf.params->colorb[r_irrep][rs][1];
 
-                            row = InBuf->params->rowidx[r][s];
+                            const int row = InBuf->params->rowidx[r][s];
 
                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[h][row][col];
                         }
@@ -1855,31 +1848,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* s->p; p->q; q->r; r->s = qrsp */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Gqr = Gq ^ Gr;
                             Gsp = Gs ^ Gp;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        qr = InBuf->params->rowidx[Q][R];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int qr = InBuf->params->rowidx[Q][R];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            sp = InBuf->params->colidx[S][P];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int sp = InBuf->params->colidx[S][P];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Gqr][qr][sp];
                                         }
@@ -1908,31 +1901,31 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
             /* s->p; p->q; r->r; q->s = qsrp */
 
             if (incore) {
-                for (h = 0; h < nirreps; h++) {
-                    r_irrep = h ^ my_irrep;
+                for (int h = 0; h < nirreps; h++) {
+                    const int r_irrep = h ^ my_irrep;
 
-                    for (Gp = 0; Gp < nirreps; Gp++) {
-                        Gq = Gp ^ h;
-                        for (Gr = 0; Gr < nirreps; Gr++) {
-                            Gs = Gr ^ r_irrep;
+                    for (int Gp = 0; Gp < nirreps; Gp++) {
+                        const int Gq = Gp ^ h;
+                        for (int Gr = 0; Gr < nirreps; Gr++) {
+                            const int Gs = Gr ^ r_irrep;
 
                             Gqs = Gq ^ Gs;
                             Grp = Gr ^ Gp;
 
-                            for (p = 0; p < OutBuf.params->ppi[Gp]; p++) {
-                                P = OutBuf.params->poff[Gp] + p;
-                                for (q = 0; q < OutBuf.params->qpi[Gq]; q++) {
-                                    Q = OutBuf.params->qoff[Gq] + q;
-                                    pq = OutBuf.params->rowidx[P][Q];
+                            for (int p = 0; p < OutBuf.params->ppi[Gp]; p++) {
+                                const int P = OutBuf.params->poff[Gp] + p;
+                                for (int q = 0; q < OutBuf.params->qpi[Gq]; q++) {
+                                    const int Q = OutBuf.params->qoff[Gq] + q;
+                                    const int pq = OutBuf.params->rowidx[P][Q];
 
-                                    for (r = 0; r < OutBuf.params->rpi[Gr]; r++) {
-                                        R = OutBuf.params->roff[Gr] + r;
-                                        rp = InBuf->params->colidx[R][P];
+                                    for (int r = 0; r < OutBuf.params->rpi[Gr]; r++) {
+                                        const int R = OutBuf.params->roff[Gr] + r;
+                                        const int rp = InBuf->params->colidx[R][P];
 
-                                        for (s = 0; s < OutBuf.params->spi[Gs]; s++) {
-                                            S = OutBuf.params->soff[Gs] + s;
-                                            rs = OutBuf.params->colidx[R][S];
-                                            qs = InBuf->params->rowidx[Q][S];
+                                        for (int s = 0; s < OutBuf.params->spi[Gs]; s++) {
+                                            const int S = OutBuf.params->soff[Gs] + s;
+                                            const int rs = OutBuf.params->colidx[R][S];
+                                            const int qs = InBuf->params->rowidx[Q][S];
 
                                             OutBuf.matrix[h][pq][rs] = InBuf->matrix[Gqs][qs][rp];
                                         }
@@ -1954,7 +1947,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
     }
 
     if (incore) {
-        for (h = 0; h < nirreps; h++) {
+        for (int h = 0; h < nirreps; h++) {
             buf4_mat_irrep_wrt(&OutBuf, h);
             buf4_mat_irrep_close(&OutBuf, h);
             buf4_mat_irrep_close(InBuf, h);

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -115,8 +115,7 @@ namespace psi {
 ** spqr: IC     ** sprq: IC
 ** -RAK, Nov. 2005*/
 
-int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum, int rsnum, const std::string& label) {
-    int Gqs, Grq, Gqr, Gps, Gsp, Grp, Gsq;
+int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum, const std::string& label) {
     dpdbuf4 OutBuf;
     int incore;
     long int rowtot, coltot, core_total, maxrows;

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -135,6 +135,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
     /* select in-core vs. out-of-core algorithms */
     core_total = 0;
     int incore = 1;
+    {
     for (int h = 0; h < nirreps; h++) {
         coltot = InBuf->params->coltot[h ^ my_irrep];
         if (coltot) {
@@ -156,6 +157,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
         core_total += 2 * rowtot * coltot;
     }
     if (core_total > dpd_memfree()) incore = 0;
+    }
 
 #ifdef DPD_DEBUG
     if (incore == 0) {

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -117,7 +117,6 @@ namespace psi {
 
 int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum, const std::string& label) {
     dpdbuf4 OutBuf;
-    int incore;
     long int rowtot, coltot, core_total, maxrows;
     int Grow, Gcol;
     int out_rows_per_bucket, out_nbuckets, out_rows_left, out_row_start, n;
@@ -134,8 +133,8 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices inde
     buf4_init(&OutBuf, outfilenum, my_irrep, pqnum, rsnum, pqnum, rsnum, 0, label);
 
     /* select in-core vs. out-of-core algorithms */
-    incore = 1;
     core_total = 0;
+    int incore = 1;
     for (int h = 0; h < nirreps; h++) {
         coltot = InBuf->params->coltot[h ^ my_irrep];
         if (coltot) {

--- a/psi4/src/psi4/libdpd/dpd.h
+++ b/psi4/src/psi4/libdpd/dpd.h
@@ -114,7 +114,7 @@ struct dpdbuf4 {
     int **col_offset;
     double ***matrix;
 
-    int axpy_matrix(const Matrix& MatX, double alpha);
+    int axpy_matrix(const Matrix &MatX, double alpha);
     int zero();
 };
 
@@ -152,7 +152,7 @@ struct dpdfile2 {
     int incore;
     double ***matrix;
 
-    int axpy_matrix(const Matrix& MatX, double alpha);
+    int axpy_matrix(const Matrix &MatX, double alpha);
     int zero();
 };
 
@@ -351,7 +351,7 @@ class PSI_API DPD {
 
     int trace42_13(dpdbuf4 *A, dpdfile2 *B, int transb, double alpha, double beta);
 
-    int file2_init(dpdfile2 *File, int filenum, int irrep, int pnum, int qnum, const std::string& label);
+    int file2_init(dpdfile2 *File, int filenum, int irrep, int pnum, int qnum, const std::string &label);
     int file2_close(dpdfile2 *File);
     int file2_mat_init(dpdfile2 *File);
     int file2_mat_close(dpdfile2 *File);
@@ -385,10 +385,11 @@ class PSI_API DPD {
     int file4_mat_irrep_wrt_block(dpdfile4 *File, int irrep, int start_pq, int num_pq);
 
     int buf4_init(dpdbuf4 *Buf, int inputfile, int irrep, int pqnum, int rsnum, int file_pqnum, int file_rsnum,
-                  int anti, const std::string& label);
+                  int anti, const std::string &label);
     int buf4_init(dpdbuf4 *Buf, int inputfile, int irrep, std::string pq, std::string rs, std::string file_pq,
-                  std::string file_rs, int anti, const std::string& label);
-    int buf4_init(dpdbuf4 *Buf, int inputfile, int irrep, std::string pq, std::string rs, int anti, const std::string& label);
+                  std::string file_rs, int anti, const std::string &label);
+    int buf4_init(dpdbuf4 *Buf, int inputfile, int irrep, std::string pq, std::string rs, int anti,
+                  const std::string &label);
     int pairnum(std::string);
     double buf4_trace(dpdbuf4 *Buf);
     int buf4_close(dpdbuf4 *Buf);
@@ -397,10 +398,11 @@ class PSI_API DPD {
     int buf4_mat_irrep_rd(dpdbuf4 *Buf, int irrep);
     int buf4_mat_irrep_wrt(dpdbuf4 *Buf, int irrep);
     int buf4_print(dpdbuf4 *Buf, std::string out_fname, int print_data);
-    int buf4_copy(dpdbuf4 *InBuf, int outfilenum, const std::string& label);
-    int buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum, int rsnum, const std::string& label);
-    int buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, std::string pq, std::string rs,
-                  const std::string& label);
+    int buf4_copy(dpdbuf4 *InBuf, int outfilenum, const std::string &label);
+    int buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices index, const int pqnum, const int rsnum,
+                  const std::string &label);
+    int buf4_sort(dpdbuf4 *InBuf, const int outfilenum, const enum indices index, const std::string pq,
+                  const std::string rs, const std::string &label);
     int buf4_sort_ooc(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum, int rsnum, const char *label);
     int buf4_sort_axpy(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum, int rsnum, const char *label,
                        double alpha);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
`DPD::buf4_sort(...)` is not exactly easy on the eyes. This PR attempts to improve that by reducing the scope pollution of the main scope of the function. Const is now used wherever appropriate.

The `int` variables are suspect when it comes to overflowing, but this PR intends to be purely a cleanup that does not change any behavior, so all types are preserved as-is, modulo the addition of `const` qualifiers.

Squash merge may be a good idea for this PR.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [ ] Make `DPD::buf4_sort(...)` slightly easier to read/debug

## Checklist
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)
- [ ] Compiles with -Wshadow -Werror=shadow

## Status
- [ ] Ready for review
- [ ] Ready for merge
