### PR TITLE
PR template and dlpno test fix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,11 @@
 ## Description
 <!-- Provide a brief description of the PR's purpose here. -->
 
+## API & Changelog Entry
+<!-- Suggest notable points or changes in API that should be recorded in release notes. -->
+- [ ] RN 1
+- [ ] RN 2
+
 ## Todos
 <!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
 - [ ] Feature1

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,17 @@
 ## Description
 <!-- Provide a brief description of the PR's purpose here. -->
 
-## API & Changelog Entry
-<!-- Suggest notable points or changes in API that should be recorded in release notes. -->
+
+## User API & Changelog headlines
+<!-- A bullet-point format description of how this PR affects the user.
+     This is detined for the release notes. May be empty. -->
 - [ ] RN 1
 - [ ] RN 2
 
-## Todos
-<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
+## Dev notes & details
+<!-- A bullet-point format description of what this PR does "at a glance."
+     Target audience is code reviewers and other devs skimming PRs.
+     Should be more technical than user notes. Should never be empty. -->
 - [ ] Feature1
 - [ ] Feature2
 

--- a/tests/dlpnomp2-2/input.dat
+++ b/tests/dlpnomp2-2/input.dat
@@ -7,6 +7,8 @@ ref_dfmp2_tot            =    -76.3632013590074              #TEST
                                                
 ref_dlpnomp2_corl        =     -0.2983320108291              #TEST
 ref_dlpnomp2_tot         =    -76.3631796087154              #TEST
+ref_dlpnomp2_corl += 0.000020259  # after https://github.com/psi4/psi4/pull/2707
+ref_dlpnomp2_tot  += 0.000020259  # after https://github.com/psi4/psi4/pull/2707
 
 molecule h2o {
 O


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] Put back separate section for API/RN headlines in PR template
- [x] Looks like the dlpno fix in #2707 slightly broke a test. Zach has confirmed this is the reasonable fix. Only showed up in quad-zeta cbs step

## Checklist
- [ ] ~Tests added for any new features~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
