### PR TITLE
Clean `ccenergy/rotate` (1/2)

### DIFF
--- a/psi4/src/psi4/cc/ccwave.h
+++ b/psi4/src/psi4/cc/ccwave.h
@@ -120,7 +120,7 @@ class CCEnergyWavefunction : public Wavefunction {
     void cachedone_uhf(int **cachelist);
 
     /* Brueckner */
-    int rotate();
+    bool rotate();
     double **fock_build(double **D);
 
     /* CC2 / CC3 */

--- a/tests/cc15/output.ref
+++ b/tests/cc15/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.7a1.dev59 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {moinfo4} ad3533b dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Monday, 12 September 2022 03:03PM
 
-    Process ID:  12475
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 30094
+    Host:       jonathons-mbp.wireless.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -46,29 +59,29 @@ energy("bccd(t)")
 escf = -76.021997876298414 #TEST
 ebccd = -76.228456597086762 #TEST
 ebccd_t = -76.231452929871523 #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 6, "SCF energy") #TEST
-compare_values(ebccd, get_variable("CCSD TOTAL ENERGY"), 6, "B-CCD energy") #TEST
-compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 6, "B-CCD(T) energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 6, "SCF energy") #TEST
+compare_values(ebccd, variable("CCSD TOTAL ENERGY"), 6, "B-CCD energy") #TEST
+compare_values(ebccd_t, variable("CCSD(T) TOTAL ENERGY"), 6, "B-CCD(T) energy") #TEST
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:13 2017
+Scratch directory: /tmp/
+
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:03:55 2022
 
    => Loading Basis Set <=
 
     Name: 6-31G**
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   140 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
-    atoms 2-3 entry H          line    35 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
-
-    There are an even number of electrons - assuming singlet.
-    Specify the multiplicity in the molecule input block.
+    atoms 1   entry O          line   149 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/6-31gss.gbs 
+    atoms 2-3 entry H          line    44 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/6-31gss.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -82,15 +95,15 @@ compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 6, "B-CCD(T) energ
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.067578587269    15.994914619560
-           H          0.000000000000    -0.759129912147     0.536260610269     1.007825032070
-           H          0.000000000000     0.759129912147     0.536260610269     1.007825032070
+         O            0.000000000000     0.000000000000    -0.067578587279    15.994914619570
+         H            0.000000000000    -0.759129912147     0.536260610260     1.007825032230
+         H            0.000000000000     0.759129912147     0.536260610260     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.82761  B =     14.51273  C =      9.29167 [cm^-1]
-  Rotational constants: A = 774292.15647  B = 435080.73208  C = 278557.26010 [MHz]
-  Nuclear repulsion =    9.077238153630930
+  Rotational constants: A = 774292.16226  B = 435080.73532  C = 278557.26218 [MHz]
+  Nuclear repulsion =    9.077238189310194
 
   Charge       = 0
   Multiplicity = 1
@@ -107,30 +120,17 @@ compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 6, "B-CCD(T) energ
   Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: 6-31G**
     Blend: 6-31G**
     Number of shells: 12
-    Number of basis function: 25
+    Number of basis functions: 25
     Number of Cartesian functions: 25
     Spherical Harmonics?: false
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        12      12       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      25      25       5       5       5       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -149,40 +149,58 @@ compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 6, "B-CCD(T) energ
   Using 105950 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.2308645666E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 2.1501314989E-02.
+  Reciprocal condition number of the overlap matrix is 4.8539442250E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        12      12 
+     A2         2       2 
+     B1         4       4 
+     B2         7       7 
+   -------------------------
+    Total      25      25
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -75.95492261751966   -7.59549e+01   1.14488e-01 
-   @RHF iter   1:   -75.97837615968200   -2.34535e-02   2.17692e-02 
-   @RHF iter   2:   -76.01219021646442   -3.38141e-02   1.14813e-02 DIIS
-   @RHF iter   3:   -76.02158202461503   -9.39181e-03   1.55978e-03 DIIS
-   @RHF iter   4:   -76.02196350344684   -3.81479e-04   4.25856e-04 DIIS
-   @RHF iter   5:   -76.02199704584848   -3.35424e-05   6.17940e-05 DIIS
-   @RHF iter   6:   -76.02199785623192   -8.10383e-07   7.71295e-06 DIIS
-   @RHF iter   7:   -76.02199786797981   -1.17479e-08   7.44815e-07 DIIS
-   @RHF iter   8:   -76.02199786811084   -1.31038e-10   1.89640e-07 DIIS
-   @RHF iter   9:   -76.02199786812271   -1.18661e-11   3.57448e-08 DIIS
-   @RHF iter  10:   -76.02199786812304   -3.26850e-13   2.53291e-09 DIIS
+   @RHF iter SAD:   -75.50729373443478   -7.55073e+01   0.00000e+00 
+   @RHF iter   1:   -75.95231123128877   -4.45017e-01   2.80327e-02 DIIS/ADIIS
+   @RHF iter   2:   -76.00295317475184   -5.06419e-02   1.63838e-02 DIIS/ADIIS
+   @RHF iter   3:   -76.02144234460296   -1.84892e-02   2.10489e-03 DIIS/ADIIS
+   @RHF iter   4:   -76.02197436238164   -5.32018e-04   3.72203e-04 DIIS/ADIIS
+   @RHF iter   5:   -76.02199691392222   -2.25515e-05   6.36020e-05 DIIS
+   @RHF iter   6:   -76.02199784301769   -9.29095e-07   9.96049e-06 DIIS
+   @RHF iter   7:   -76.02199786790561   -2.48879e-08   1.47609e-06 DIIS
+   @RHF iter   8:   -76.02199786848800   -5.82389e-10   3.28554e-07 DIIS
+   @RHF iter   9:   -76.02199786852113   -3.31255e-11   5.76953e-08 DIIS
+   @RHF iter  10:   -76.02199786852192   -7.95808e-13   5.50818e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -202,50 +220,49 @@ compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 6, "B-CCD(T) energ
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
+    NA   [     3,    0,    1,    1 ]
+    NB   [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:   -76.02199786812304
+  @RHF Final Energy:   -76.02199786852192
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.0772381536309297
-    One-Electron Energy =                -122.8800884171156724
-    Two-Electron Energy =                  37.7808523953616984
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0219978681230373
+    Nuclear Repulsion Energy =              9.0772381893101937
+    One-Electron Energy =                -122.8800884952867563
+    Two-Electron Energy =                  37.7808524374546408
+    Total Energy =                        -76.0219978685219218
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0051
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.1315
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.8736     Total:     0.8736
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     2.2205     Total:     2.2205
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.1315042            1.0051312            0.8736270
+ Magnitude           :                                                    0.8736270
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:34:13 2017
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:03:56 2022
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.55 seconds =       0.01 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.55 seconds =       0.01 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -259,19 +276,19 @@ Total time:
       Number of basis functions:        25
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  12    2    4    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 13665 non-zero two-electron integrals.
+      Computed 13617 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:13 2017
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:03:56 2022
 
 
 	Wfn Parameters:
@@ -296,7 +313,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -332,7 +349,7 @@ Total time:
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -61.28292597722126
+	Frozen core energy     =    -61.28292598577755
 
 	Size of irrep 0 of <ab|cd> integrals:      0.017 (MW) /      0.135 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.005 (MW) /      0.041 (MB)
@@ -352,243 +369,30 @@ Total time:
 	Size of irrep 3 of tijab amplitudes:       0.000 (MW) /      0.004 (MB)
 	Total:                                     0.002 (MW) /      0.014 (MB)
 
-	Nuclear Rep. energy          =      9.07723815363093
-	SCF energy                   =    -76.02199786812304
-	One-electron energy          =    -41.44174889462249
-	Two-electron energy          =     17.62543885008984
-	Reference energy             =    -76.02199786812298
+	Nuclear Rep. energy          =      9.07723818931019
+	SCF energy                   =    -76.02199786852192
+	One-electron energy          =    -41.44174893861597
+	Two-electron energy          =     17.62543886656143
+	Reference energy             =    -76.02199786852189
 
-*** tstop() called on psinet at Mon May 15 15:34:13 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.43 seconds =       0.01 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:13 2017
-
-            **************************
-            *                        *
-            *        CCENERGY        *
-            *                        *
-            **************************
-
-    Nuclear Rep. energy (wfn)     =    9.077238153630930
-    SCF energy          (wfn)     =  -76.021997868123037
-    Reference energy    (file100) =  -76.021997868122980
-
-    Input parameters:
-    -----------------
-    Wave function   =     BCCD_T
-    Reference wfn   =     RHF
-    Brueckner       =     Yes
-    Brueckner conv. =     1.0e-04
-    Memory (Mbytes) =     524.3
-    Maxiter         =     50
-    R_Convergence   =     1.0e-07
-    E_Convergence   =     1.0e-06
-    Restart         =     Yes
-    DIIS            =     Yes
-    AO Basis        =     NONE
-    ABCD            =     NEW
-    Cache Level     =     2
-    Cache Type      =     LOW
-    Print Level     =     1
-    Num. of threads =     1
-    # Amps to Print =     10
-    Print MP2 Amps? =     No
-    Analyze T2 Amps =     No
-    Print Pair Ener =     No
-    Local CC        =     No
-    SCS-MP2         =     False
-    SCSN-MP2        =     False
-    SCS-CCSD        =     False
-
-MP2 correlation energy -0.1976444003982516
-                Solving CC Amplitude Equations
-                ------------------------------
-  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
-  ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.197644400398251    0.000e+00    0.000000    0.000000    0.000000    0.110440
-     1        -0.202143300845404    2.740e-02    0.005039    0.008933    0.008933    0.117248
-     2        -0.206071522257421    9.799e-03    0.005789    0.010403    0.010403    0.122665
-     3        -0.206590664343121    2.784e-03    0.006384    0.011997    0.011997    0.124078
-     4        -0.206595699622500    6.510e-04    0.006448    0.012319    0.012319    0.124300
-     5        -0.206609970180567    2.065e-04    0.006492    0.012517    0.012517    0.124343
-     6        -0.206606031434682    6.471e-05    0.006508    0.012588    0.012588    0.124329
-     7        -0.206605503548151    1.560e-05    0.006512    0.012607    0.012607    0.124327
-     8        -0.206605474034672    2.911e-06    0.006512    0.012610    0.012610    0.124326
-     9        -0.206605399193867    6.983e-07    0.006512    0.012610    0.012610    0.124326
-    10        -0.206605418838738    1.484e-07    0.006512    0.012610    0.012610    0.124326
-    11        -0.206605417458158    2.901e-08    0.006512    0.012610    0.012610    0.124326
-
-    Iterations converged.
-
-
-    Largest TIA Amplitudes:
-              1   0         0.0109876183
-              2  11        -0.0066311228
-              3  14        -0.0063228408
-              3  18         0.0053909635
-              3  16         0.0049042276
-              0   2         0.0042702460
-              1   5         0.0040627309
-              0   0        -0.0025360448
-              0   7         0.0023966479
-              1   1         0.0022623018
-
-    Largest TIjAb Amplitudes:
-      2   2  11  11        -0.0519230108
-      3   3  14  14        -0.0394264800
-      1   1   2   2        -0.0299245502
-      3   3  15  15        -0.0287611328
-      1   2   2  11         0.0252619250
-      2   1  11   2         0.0252619250
-      2   3  11  16        -0.0248488617
-      3   2  16  11        -0.0248488617
-      3   3  16  16        -0.0246375907
-      2   3  11  14        -0.0244629926
-
-    SCF energy       (wfn)                    =  -76.021997868123037
-    Reference energy (file100)                =  -76.021997868122980
-
-    Opposite-spin MP2 correlation energy      =   -0.148071803353867
-    Same-spin MP2 correlation energy          =   -0.049572597044384
-    MP2 correlation energy                    =   -0.197644400398252
-      * MP2 total energy                      =  -76.219642268521227
-
-    Opposite-spin CCSD correlation energy     =   -0.162686593640668
-    Same-spin CCSD correlation energy         =   -0.043918824012867
-    CCSD correlation energy                   =   -0.206605417458158
-      * CCSD total energy                     =  -76.228603285581144
-
-    Rotating orbitals.  Maximum T1 =  0.010987618258
-
-*** tstop() called on psinet at Mon May 15 15:34:14 2017
-Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.49 seconds =       0.01 minutes
-	system time =       0.25 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Brueckner convergence check: False
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:14 2017
-
-
-	Wfn Parameters:
-	--------------------
-	Wavefunction         = BCCD_T
-	Number of irreps     = 4
-	Number of MOs        = 25
-	Number of active MOs = 24
-	AO-Basis             = NONE
-	Semicanonical        = false
-	Reference            = RHF
-	Print Level          = 1
-
-	IRREP	# MOs	# FZDC	# DOCC	# SOCC	# VIRT	# FZVR
-	-----	-----	------	------	------	------	------
-	 A1	   12	    1	    2	    0	    9	    0
-	 A2	   2	    0	    0	    0	    2	    0
-	 B1	   4	    0	    1	    0	    3	    0
-	 B2	   7	    0	    1	    0	    6	    0
-	Transforming integrals...
-	IWL integrals will be retained.
-	(OO|OO)...
-	Presorting SO-basis two-electron integrals.
-	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
-	Starting first half-transformation.
-	Sorting half-transformed integrals.
-	First half integral transformation complete.
-	Starting second half-transformation.
-	Two-electron integral transformation complete.
-	(OO|OV)...
-	Starting second half-transformation.
-	Two-electron integral transformation complete.
-	(OO|VV)...
-	Starting second half-transformation.
-	Two-electron integral transformation complete.
-	(OV|OO)...
-	Starting first half-transformation.
-	Sorting half-transformed integrals.
-	First half integral transformation complete.
-	Starting second half-transformation.
-	Two-electron integral transformation complete.
-	(OV|OV)...
-	Starting second half-transformation.
-	Two-electron integral transformation complete.
-	(OV|VV)...
-	Starting second half-transformation.
-	Two-electron integral transformation complete.
-	(VV|OO)...
-	Starting first half-transformation.
-	Sorting half-transformed integrals.
-	First half integral transformation complete.
-	Starting second half-transformation.
-	Two-electron integral transformation complete.
-	(VV|OV)...
-	Starting second half-transformation.
-	Two-electron integral transformation complete.
-	(VV|VV)...
-	Starting second half-transformation.
-	Two-electron integral transformation complete.
-	Frozen core energy     =    -61.28292597722136
-
-	Size of irrep 0 of <ab|cd> integrals:      0.017 (MW) /      0.135 (MB)
-	Size of irrep 1 of <ab|cd> integrals:      0.005 (MW) /      0.041 (MB)
-	Size of irrep 2 of <ab|cd> integrals:      0.006 (MW) /      0.049 (MB)
-	Size of irrep 3 of <ab|cd> integrals:      0.014 (MW) /      0.115 (MB)
-	Total:                                     0.043 (MW) /      0.341 (MB)
-
-	Size of irrep 0 of <ia|bc> integrals:      0.004 (MW) /      0.028 (MB)
-	Size of irrep 1 of <ia|bc> integrals:      0.001 (MW) /      0.007 (MB)
-	Size of irrep 2 of <ia|bc> integrals:      0.001 (MW) /      0.011 (MB)
-	Size of irrep 3 of <ia|bc> integrals:      0.003 (MW) /      0.022 (MB)
-	Total:                                     0.009 (MW) /      0.068 (MB)
-
-	Size of irrep 0 of tijab amplitudes:       0.001 (MW) /      0.006 (MB)
-	Size of irrep 1 of tijab amplitudes:       0.000 (MW) /      0.001 (MB)
-	Size of irrep 2 of tijab amplitudes:       0.000 (MW) /      0.002 (MB)
-	Size of irrep 3 of tijab amplitudes:       0.000 (MW) /      0.004 (MB)
-	Total:                                     0.002 (MW) /      0.014 (MB)
-
-	Nuclear Rep. energy          =      9.07723815363093
-	SCF energy                   =    -76.02199786812304
-	One-electron energy          =    -41.37683424827949
-	Two-electron energy          =     17.56156436046423
-	Reference energy             =    -76.02095771140569
-
-*** tstop() called on psinet at Mon May 15 15:34:14 2017
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:03:56 2022
 Module time:
 	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.52 seconds =       0.01 minutes
-	system time =       0.27 seconds =       0.00 minutes
+	user time   =       0.59 seconds =       0.01 minutes
+	system time =       0.28 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:14 2017
-
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.077238153630930
-    SCF energy          (wfn)     =  -76.228603285581144
-    Reference energy    (file100) =  -76.020957711405686
+    Nuclear Rep. energy (wfn)     =    9.077238189310194
+    SCF energy          (wfn)     =  -76.021997868521922
+    Reference energy    (file100) =  -76.021997868521893
 
     Input parameters:
     -----------------
@@ -617,81 +421,71 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-    Using old T1 amplitudes.
-    Using old T2 amplitudes.
-
-MP2 correlation energy -0.2004780645961007
+MP2 correlation energy -0.1976444000050879
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.206619919216377    0.000e+00    0.006512    0.012610    0.012610    0.124326
-     1        -0.208158711013838    1.791e-02    0.001416    0.002628    0.002628    0.125201
-     2        -0.207540969627652    3.231e-03    0.000796    0.001620    0.001620    0.124451
-     3        -0.207503266261805    1.389e-03    0.000697    0.001343    0.001343    0.124281
-     4        -0.207489383820808    4.047e-04    0.000705    0.001319    0.001319    0.124214
-     5        -0.207487869372639    1.398e-04    0.000717    0.001300    0.001300    0.124205
-     6        -0.207489059623687    2.668e-05    0.000719    0.001293    0.001293    0.124209
-     7        -0.207489524266288    5.614e-06    0.000719    0.001290    0.001290    0.124210
-     8        -0.207489602278927    1.033e-06    0.000719    0.001290    0.001290    0.124211
-     9        -0.207489624469080    2.069e-07    0.000719    0.001289    0.001289    0.124211
-    10        -0.207489626453358    4.396e-08    0.000719    0.001289    0.001289    0.124211
+     0        -0.197644400005088    0.000e+00    0.000000    0.000000    0.000000    0.110440
+     1        -0.202143300670428    2.740e-02    0.005039    0.008933    0.008933    0.117248
+     2        -0.206071522183078    9.799e-03    0.005789    0.010403    0.010403    0.122665
+     3        -0.206590664420656    2.784e-03    0.006384    0.011997    0.011997    0.124078
+     4        -0.206595699651339    6.510e-04    0.006448    0.012319    0.012319    0.124300
+     5        -0.206609970208928    2.065e-04    0.006492    0.012517    0.012517    0.124343
+     6        -0.206606031450935    6.471e-05    0.006508    0.012588    0.012588    0.124329
+     7        -0.206605503563163    1.560e-05    0.006512    0.012607    0.012607    0.124327
+     8        -0.206605474049577    2.911e-06    0.006512    0.012610    0.012610    0.124326
+     9        -0.206605399208762    6.983e-07    0.006512    0.012610    0.012610    0.124326
+    10        -0.206605418853634    1.484e-07    0.006512    0.012610    0.012610    0.124326
+    11        -0.206605417473054    2.901e-08    0.006512    0.012610    0.012610    0.124326
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              3  14         0.0010671415
-              2  11         0.0008203113
-              1   0        -0.0007805339
-              3  16         0.0006195013
-              1   1        -0.0005972784
-              0   0         0.0005007926
-              1   2        -0.0004670430
-              3  15         0.0003648862
-              0   2        -0.0003286311
-              0   3        -0.0002743905
+              1   0         0.0109876380
+              2  11        -0.0066311221
+              3  14        -0.0063228363
+              3  18         0.0053909633
+              3  16         0.0049042313
+              0   2         0.0042702450
+              1   5         0.0040627299
+              0   0        -0.0025360432
+              0   7         0.0023966481
+              1   1         0.0022623078
 
     Largest TIjAb Amplitudes:
-      2   2  11  11        -0.0518604742
-      3   3  14  14        -0.0396128121
-      3   3  15  15        -0.0286102246
-      1   1   2   2        -0.0283454165
-      2   3  11  16        -0.0247639978
-      3   2  16  11        -0.0247639978
-      3   3  16  16        -0.0245348844
-      2   3  11  14        -0.0244863038
-      3   2  14  11        -0.0244863038
-      1   2   2  11         0.0243032641
+      2   2  11  11        -0.0519230107
+      3   3  14  14        -0.0394264793
+      1   1   2   2        -0.0299245497
+      3   3  15  15        -0.0287611326
+      1   2   2  11         0.0252619247
+      2   1  11   2         0.0252619247
+      2   3  11  16        -0.0248488617
+      3   2  16  11        -0.0248488617
+      3   3  16  16        -0.0246375908
+      2   3  11  14        -0.0244629925
 
-    SCF energy       (wfn)                    =  -76.228603285581144
-    Reference energy (file100)                =  -76.020957711405686
+    SCF energy       (wfn)                    =  -76.021997868521922
+    Reference energy (file100)                =  -76.021997868521893
 
-    Opposite-spin MP2 correlation energy      =   -0.149551680362525
-    Same-spin MP2 correlation energy          =   -0.049953421922438
-    MP2 correlation energy                    =   -0.200478064596101
-      * MP2 total energy                      =  -76.221435776001783
+    Opposite-spin MP2 correlation energy      =   -0.148071803063593
+    Same-spin MP2 correlation energy          =   -0.049572596941495
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.197644400005088
+      * MP2 total energy                      =  -76.219642268526982
 
-    Opposite-spin CCSD correlation energy     =   -0.163426974013336
-    Same-spin CCSD correlation energy         =   -0.044001389867505
-    CCSD correlation energy                   =   -0.207489626453358
-      * CCSD total energy                     =  -76.228447337859038
+    Opposite-spin CCSD correlation energy     =   -0.162686593467293
+    Same-spin CCSD correlation energy         =   -0.043918824005761
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.206605417473054
+      * CCSD total energy                     =  -76.228603285994950
 
-    Rotating orbitals.  Maximum T1 =  0.001067141455
-
-*** tstop() called on psinet at Mon May 15 15:34:14 2017
-Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.60 seconds =       0.01 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
+    Rotating orbitals.  Maximum T1 =  0.010987637996
 Brueckner convergence check: False
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:14 2017
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:03:57 2022
 
 
 	Wfn Parameters:
@@ -716,7 +510,7 @@ Brueckner convergence check: False
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -752,7 +546,7 @@ Brueckner convergence check: False
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -61.28292597722136
+	Frozen core energy     =    -61.28292598577755
 
 	Size of irrep 0 of <ab|cd> integrals:      0.017 (MW) /      0.135 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.005 (MW) /      0.041 (MB)
@@ -772,34 +566,30 @@ Brueckner convergence check: False
 	Size of irrep 3 of tijab amplitudes:       0.000 (MW) /      0.004 (MB)
 	Total:                                     0.002 (MW) /      0.014 (MB)
 
-	Nuclear Rep. energy          =      9.07723815363093
-	SCF energy                   =    -76.22860328558114
-	One-electron energy          =    -41.39374643500425
-	Two-electron energy          =     17.57837291290405
-	Reference energy             =    -76.02106134569064
+	Nuclear Rep. energy          =      9.07723818931019
+	SCF energy                   =    -76.02199786852192
+	One-electron energy          =    -41.37683207197099
+	Two-electron energy          =     17.56156222599536
+	Reference energy             =    -76.02095764244298
 
-*** tstop() called on psinet at Mon May 15 15:34:14 2017
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:03:58 2022
 Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.61 seconds =       0.01 minutes
-	system time =       0.44 seconds =       0.01 minutes
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:14 2017
-
+Total time:
+	user time   =       0.78 seconds =       0.01 minutes
+	system time =       0.96 seconds =       0.02 minutes
+	total time  =          3 seconds =       0.05 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.077238153630930
-    SCF energy          (wfn)     =  -76.228447337859038
-    Reference energy    (file100) =  -76.021061345690640
+    Nuclear Rep. energy (wfn)     =    9.077238189310194
+    SCF energy          (wfn)     =  -76.228603285994950
+    Reference energy    (file100) =  -76.020957642442980
 
     Input parameters:
     -----------------
@@ -831,77 +621,70 @@ Total time:
     Using old T1 amplitudes.
     Using old T2 amplitudes.
 
-MP2 correlation energy -0.2002715760711746
+MP2 correlation energy -0.2004781909020278
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.207387297333163    0.000e+00    0.000719    0.001289    0.001289    0.124211
-     1        -0.207363629168777    2.974e-03    0.000240    0.000407    0.000407    0.124166
-     2        -0.207394104554025    4.230e-04    0.000149    0.000232    0.000232    0.124209
-     3        -0.207395141263082    1.227e-04    0.000164    0.000266    0.000266    0.124215
-     4        -0.207397532941981    2.751e-05    0.000166    0.000275    0.000275    0.124220
-     5        -0.207397345237096    9.152e-06    0.000167    0.000277    0.000277    0.124220
-     6        -0.207397330492946    2.583e-06    0.000167    0.000277    0.000277    0.124220
-     7        -0.207397333934165    7.991e-07    0.000167    0.000277    0.000277    0.124220
-     8        -0.207397330534088    1.421e-07    0.000167    0.000277    0.000277    0.124220
-     9        -0.207397331412633    2.812e-08    0.000167    0.000277    0.000277    0.124220
+     0        -0.206619914808704    0.000e+00    0.006512    0.012610    0.012610    0.124326
+     1        -0.208158793535685    1.791e-02    0.001416    0.002628    0.002628    0.125201
+     2        -0.207541032949529    3.231e-03    0.000796    0.001620    0.001620    0.124451
+     3        -0.207503330353830    1.389e-03    0.000697    0.001343    0.001343    0.124281
+     4        -0.207489447803939    4.048e-04    0.000705    0.001319    0.001319    0.124214
+     5        -0.207487933461680    1.398e-04    0.000717    0.001300    0.001300    0.124205
+     6        -0.207489123797215    2.668e-05    0.000719    0.001293    0.001293    0.124209
+     7        -0.207489588461266    5.614e-06    0.000719    0.001290    0.001290    0.124210
+     8        -0.207489666475798    1.033e-06    0.000719    0.001290    0.001290    0.124211
+     9        -0.207489688666307    2.069e-07    0.000719    0.001290    0.001290    0.124211
+    10        -0.207489690650637    4.397e-08    0.000719    0.001290    0.001290    0.124211
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              2  11        -0.0002242087
-              3  14        -0.0002139716
-              3  16        -0.0001535120
-              1   0         0.0001487744
-              1   1         0.0001455427
-              1   2         0.0001355524
-              0   0        -0.0001095349
-              3  15        -0.0000784652
-              0   3         0.0000757666
-              0   2         0.0000756055
+              3  14         0.0010673859
+              2  11         0.0008204413
+              1   0        -0.0007811608
+              3  16         0.0006193543
+              1   1        -0.0005974060
+              0   0         0.0005009493
+              1   2        -0.0004670627
+              3  15         0.0003649546
+              0   2        -0.0003286907
+              0   3        -0.0002743550
 
     Largest TIjAb Amplitudes:
-      2   2  11  11        -0.0518687460
-      3   3  14  14        -0.0395680660
-      1   1   2   2        -0.0287466420
-      3   3  15  15        -0.0286312440
-      2   3  11  16        -0.0247759629
-      3   2  16  11        -0.0247759629
-      3   3  16  16        -0.0245606627
-      1   2   2  11         0.0245488477
-      2   1  11   2         0.0245488477
-      2   3  11  14        -0.0244702937
+      2   2  11  11        -0.0518604717
+      3   3  14  14        -0.0396128182
+      3   3  15  15        -0.0286102188
+      1   1   2   2        -0.0283453564
+      2   3  11  16        -0.0247639955
+      3   2  16  11        -0.0247639955
+      3   3  16  16        -0.0245348816
+      2   3  11  14        -0.0244863044
+      3   2  14  11        -0.0244863044
+      1   2   2  11         0.0243032270
 
-    SCF energy       (wfn)                    =  -76.228447337859038
-    Reference energy (file100)                =  -76.021061345690640
+    SCF energy       (wfn)                    =  -76.228603285994950
+    Reference energy (file100)                =  -76.020957642442980
 
-    Opposite-spin MP2 correlation energy      =   -0.149499802353775
-    Same-spin MP2 correlation energy          =   -0.049951729795314
-    MP2 correlation energy                    =   -0.200271576071175
-      * MP2 total energy                      =  -76.221332921761814
+    Opposite-spin MP2 correlation energy      =   -0.149551730659386
+    Same-spin MP2 correlation energy          =   -0.049953433682497
+    Singles MP2 correlation energy            =   -0.000973026560145
+    MP2 correlation energy                    =   -0.200478190902028
+      * MP2 total energy                      =  -76.221435833345012
 
-    Opposite-spin CCSD correlation energy     =   -0.163402268432671
-    Same-spin CCSD correlation energy         =   -0.044003139044644
-    CCSD correlation energy                   =   -0.207397331412633
-      * CCSD total energy                     =  -76.228458677103276
+    Opposite-spin CCSD correlation energy     =   -0.163426997553750
+    Same-spin CCSD correlation energy         =   -0.044001391613448
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.207489690650637
+      * CCSD total energy                     =  -76.228447333093612
 
-    Rotating orbitals.  Maximum T1 =  0.000224208671
-
-*** tstop() called on psinet at Mon May 15 15:34:14 2017
-Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.68 seconds =       0.01 minutes
-	system time =       0.56 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
+    Rotating orbitals.  Maximum T1 =  0.001067385882
 Brueckner convergence check: False
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:14 2017
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:03:58 2022
 
 
 	Wfn Parameters:
@@ -926,7 +709,7 @@ Brueckner convergence check: False
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -962,7 +745,7 @@ Brueckner convergence check: False
 	(VV|VV)...
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -61.28292597722136
+	Frozen core energy     =    -61.28292598577755
 
 	Size of irrep 0 of <ab|cd> integrals:      0.017 (MW) /      0.135 (MB)
 	Size of irrep 1 of <ab|cd> integrals:      0.005 (MW) /      0.041 (MB)
@@ -982,34 +765,30 @@ Brueckner convergence check: False
 	Size of irrep 3 of tijab amplitudes:       0.000 (MW) /      0.004 (MB)
 	Total:                                     0.002 (MW) /      0.014 (MB)
 
-	Nuclear Rep. energy          =      9.07723815363093
-	SCF energy                   =    -76.22844733785904
-	One-electron energy          =    -41.38964002793375
-	Two-electron energy          =     17.57428380426301
-	Reference energy             =    -76.02104404726117
+	Nuclear Rep. energy          =      9.07723818931019
+	SCF energy                   =    -76.22860328599495
+	One-electron energy          =    -41.39374705929632
+	Two-electron energy          =     17.57837350644641
+	Reference energy             =    -76.02106134931726
 
-*** tstop() called on psinet at Mon May 15 15:34:14 2017
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:03:59 2022
 Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.69 seconds =       0.01 minutes
-	system time =       0.59 seconds =       0.01 minutes
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:14 2017
-
+Total time:
+	user time   =       0.96 seconds =       0.02 minutes
+	system time =       1.61 seconds =       0.03 minutes
+	total time  =          4 seconds =       0.07 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.077238153630930
-    SCF energy          (wfn)     =  -76.228458677103276
-    Reference energy    (file100) =  -76.021044047261171
+    Nuclear Rep. energy (wfn)     =    9.077238189310194
+    SCF energy          (wfn)     =  -76.228447333093612
+    Reference energy    (file100) =  -76.021061349317264
 
     Input parameters:
     -----------------
@@ -1041,77 +820,263 @@ Total time:
     Using old T1 amplitudes.
     Using old T2 amplitudes.
 
-MP2 correlation energy -0.2003086154798928
+MP2 correlation energy -0.2002715691710808
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.207412880654714    0.000e+00    0.000167    0.000277    0.000277    0.124220
-     1        -0.207418858982063    7.046e-04    0.000059    0.000097    0.000097    0.124228
-     2        -0.207412614061857    9.867e-05    0.000036    0.000057    0.000057    0.124220
-     3        -0.207412535137756    2.461e-05    0.000039    0.000064    0.000064    0.124219
-     4        -0.207412051297091    5.130e-06    0.000040    0.000065    0.000065    0.124218
-     5        -0.207412091193105    1.594e-06    0.000040    0.000066    0.000066    0.124218
-     6        -0.207412093004189    4.284e-07    0.000040    0.000066    0.000066    0.124218
-     7        -0.207412091967648    1.480e-07    0.000040    0.000066    0.000066    0.124218
-     8        -0.207412092561001    3.049e-08    0.000040    0.000066    0.000066    0.124218
+     0        -0.207387314412295    0.000e+00    0.000719    0.001290    0.001290    0.124211
+     1        -0.207363602633358    2.975e-03    0.000240    0.000407    0.000407    0.124166
+     2        -0.207394098387950    4.231e-04    0.000149    0.000232    0.000232    0.124209
+     3        -0.207395137128569    1.228e-04    0.000164    0.000266    0.000266    0.124215
+     4        -0.207397529935610    2.753e-05    0.000166    0.000275    0.000275    0.124220
+     5        -0.207397342186007    9.161e-06    0.000167    0.000277    0.000277    0.124220
+     6        -0.207397327406126    2.586e-06    0.000167    0.000277    0.000277    0.124220
+     7        -0.207397330844135    7.996e-07    0.000167    0.000277    0.000277    0.124220
+     8        -0.207397327441016    1.421e-07    0.000167    0.000277    0.000277    0.124220
+     9        -0.207397328319505    2.813e-08    0.000167    0.000277    0.000277    0.124220
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              2  11         0.0000542361
-              3  14         0.0000502003
-              3  16         0.0000374274
-              1   1        -0.0000349955
-              1   0        -0.0000340879
-              1   2        -0.0000332309
-              0   0         0.0000262070
-              0   3        -0.0000184361
-              0   2        -0.0000181246
-              3  15         0.0000177248
+              2  11        -0.0002242440
+              3  14        -0.0002140181
+              3  16        -0.0001535383
+              1   0         0.0001488093
+              1   1         0.0001455673
+              1   2         0.0001355697
+              0   0        -0.0001095572
+              3  15        -0.0000784809
+              0   3         0.0000757784
+              0   2         0.0000756187
 
     Largest TIjAb Amplitudes:
-      2   2  11  11        -0.0518669771
-      3   3  14  14        -0.0395788781
-      1   1   2   2        -0.0286552615
-      3   3  15  15        -0.0286265549
-      2   3  11  16        -0.0247728321
-      3   2  16  11        -0.0247728321
-      3   3  16  16        -0.0245539997
-      1   2   2  11         0.0244931826
-      2   1  11   2         0.0244931826
-      2   3  11  14        -0.0244744387
+      2   2  11  11        -0.0518687463
+      3   3  14  14        -0.0395680641
+      1   1   2   2        -0.0287466548
+      3   3  15  15        -0.0286312447
+      2   3  11  16        -0.0247759634
+      3   2  16  11        -0.0247759634
+      3   3  16  16        -0.0245606636
+      1   2   2  11         0.0245488555
+      2   1  11   2         0.0245488555
+      2   3  11  14        -0.0244702931
 
-    SCF energy       (wfn)                    =  -76.228458677103276
-    Reference energy (file100)                =  -76.021044047261171
+    SCF energy       (wfn)                    =  -76.228447333093612
+    Reference energy (file100)                =  -76.021061349317264
 
-    Opposite-spin MP2 correlation energy      =   -0.149508911940018
-    Same-spin MP2 correlation energy          =   -0.049951604516017
-    MP2 correlation energy                    =   -0.200308615479893
-      * MP2 total energy                      =  -76.221352662741069
+    Opposite-spin MP2 correlation energy      =   -0.149499800082713
+    Same-spin MP2 correlation energy          =   -0.049951729643765
+    Singles MP2 correlation energy            =   -0.000820039444602
+    MP2 correlation energy                    =   -0.200271569171081
+      * MP2 total energy                      =  -76.221332918488343
 
-    Opposite-spin CCSD correlation energy     =   -0.163407004655562
-    Same-spin CCSD correlation energy         =   -0.044002967426786
-    CCSD correlation energy                   =   -0.207412092561001
-      * CCSD total energy                     =  -76.228456139822171
+    Opposite-spin CCSD correlation energy     =   -0.163402267077727
+    Same-spin CCSD correlation energy         =   -0.044003139041255
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.207397328319505
+      * CCSD total energy                     =  -76.228458677636766
 
-    Brueckner orbitals converged.  Maximum T1 =  0.000054236134
+    Rotating orbitals.  Maximum T1 =  0.000224243978
+Brueckner convergence check: False
 
-*** tstop() called on psinet at Mon May 15 15:34:14 2017
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:03:59 2022
+
+
+	Wfn Parameters:
+	--------------------
+	Wavefunction         = BCCD_T
+	Number of irreps     = 4
+	Number of MOs        = 25
+	Number of active MOs = 24
+	AO-Basis             = NONE
+	Semicanonical        = false
+	Reference            = RHF
+	Print Level          = 1
+
+	IRREP	# MOs	# FZDC	# DOCC	# SOCC	# VIRT	# FZVR
+	-----	-----	------	------	------	------	------
+	 A1	   12	    1	    2	    0	    9	    0
+	 A2	   2	    0	    0	    0	    2	    0
+	 B1	   4	    0	    1	    0	    3	    0
+	 B2	   7	    0	    1	    0	    6	    0
+	Transforming integrals...
+	IWL integrals will be retained.
+	(OO|OO)...
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Constructing frozen core operators
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OO)...
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OO)...
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	Frozen core energy     =    -61.28292598577755
+
+	Size of irrep 0 of <ab|cd> integrals:      0.017 (MW) /      0.135 (MB)
+	Size of irrep 1 of <ab|cd> integrals:      0.005 (MW) /      0.041 (MB)
+	Size of irrep 2 of <ab|cd> integrals:      0.006 (MW) /      0.049 (MB)
+	Size of irrep 3 of <ab|cd> integrals:      0.014 (MW) /      0.115 (MB)
+	Total:                                     0.043 (MW) /      0.341 (MB)
+
+	Size of irrep 0 of <ia|bc> integrals:      0.004 (MW) /      0.028 (MB)
+	Size of irrep 1 of <ia|bc> integrals:      0.001 (MW) /      0.007 (MB)
+	Size of irrep 2 of <ia|bc> integrals:      0.001 (MW) /      0.011 (MB)
+	Size of irrep 3 of <ia|bc> integrals:      0.003 (MW) /      0.022 (MB)
+	Total:                                     0.009 (MW) /      0.068 (MB)
+
+	Size of irrep 0 of tijab amplitudes:       0.001 (MW) /      0.006 (MB)
+	Size of irrep 1 of tijab amplitudes:       0.000 (MW) /      0.001 (MB)
+	Size of irrep 2 of tijab amplitudes:       0.000 (MW) /      0.002 (MB)
+	Size of irrep 3 of tijab amplitudes:       0.000 (MW) /      0.004 (MB)
+	Total:                                     0.002 (MW) /      0.014 (MB)
+
+	Nuclear Rep. energy          =      9.07723818931019
+	SCF energy                   =    -76.22844733309361
+	One-electron energy          =    -41.38963993168113
+	Two-electron energy          =     17.57428368112209
+	Reference energy             =    -76.02104404702639
+
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:04:00 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.75 seconds =       0.01 minutes
-	system time =       0.71 seconds =       0.01 minutes
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.11 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       1.11 seconds =       0.02 minutes
+	system time =       2.19 seconds =       0.04 minutes
+	total time  =          5 seconds =       0.08 minutes
+            **************************
+            *                        *
+            *        CCENERGY        *
+            *                        *
+            **************************
+
+    Nuclear Rep. energy (wfn)     =    9.077238189310194
+    SCF energy          (wfn)     =  -76.228458677636766
+    Reference energy    (file100) =  -76.021044047026393
+
+    Input parameters:
+    -----------------
+    Wave function   =     BCCD_T
+    Reference wfn   =     RHF
+    Brueckner       =     Yes
+    Brueckner conv. =     1.0e-04
+    Memory (Mbytes) =     524.3
+    Maxiter         =     50
+    R_Convergence   =     1.0e-07
+    E_Convergence   =     1.0e-06
+    Restart         =     Yes
+    DIIS            =     Yes
+    AO Basis        =     NONE
+    ABCD            =     NEW
+    Cache Level     =     2
+    Cache Type      =     LOW
+    Print Level     =     1
+    Num. of threads =     1
+    # Amps to Print =     10
+    Print MP2 Amps? =     No
+    Analyze T2 Amps =     No
+    Print Pair Ener =     No
+    Local CC        =     No
+    SCS-MP2         =     False
+    SCSN-MP2        =     False
+    SCS-CCSD        =     False
+
+    Using old T1 amplitudes.
+    Using old T2 amplitudes.
+
+MP2 correlation energy -0.2003086165197985
+                Solving CC Amplitude Equations
+                ------------------------------
+  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
+  ----     ---------------------    ---------   ----------  ----------  ----------   --------
+     0        -0.207412880513287    0.000e+00    0.000167    0.000277    0.000277    0.124220
+     1        -0.207418860744414    7.047e-04    0.000059    0.000098    0.000098    0.124228
+     2        -0.207412614473225    9.868e-05    0.000036    0.000057    0.000057    0.124220
+     3        -0.207412535504921    2.462e-05    0.000039    0.000064    0.000064    0.124219
+     4        -0.207412051560339    5.131e-06    0.000040    0.000065    0.000065    0.124218
+     5        -0.207412091464014    1.594e-06    0.000040    0.000066    0.000066    0.124218
+     6        -0.207412093275525    4.285e-07    0.000040    0.000066    0.000066    0.124218
+     7        -0.207412092238784    1.480e-07    0.000040    0.000066    0.000066    0.124218
+     8        -0.207412092832266    3.050e-08    0.000040    0.000066    0.000066    0.124218
+
+    Iterations converged.
+
+
+    Largest TIA Amplitudes:
+              2  11         0.0000542457
+              3  14         0.0000502095
+              3  16         0.0000374340
+              1   1        -0.0000350018
+              1   0        -0.0000340943
+              1   2        -0.0000332366
+              0   0         0.0000262118
+              0   3        -0.0000184393
+              0   2        -0.0000181278
+              3  15         0.0000177281
+
+    Largest TIjAb Amplitudes:
+      2   2  11  11        -0.0518669770
+      3   3  14  14        -0.0395788780
+      1   1   2   2        -0.0286552574
+      3   3  15  15        -0.0286265547
+      2   3  11  16        -0.0247728320
+      3   2  16  11        -0.0247728320
+      3   3  16  16        -0.0245539995
+      1   2   2  11         0.0244931800
+      2   1  11   2         0.0244931800
+      2   3  11  14        -0.0244744388
+
+    SCF energy       (wfn)                    =  -76.228458677636766
+    Reference energy (file100)                =  -76.021044047026393
+
+    Opposite-spin MP2 correlation energy      =   -0.149508912015885
+    Same-spin MP2 correlation energy          =   -0.049951604451994
+    Singles MP2 correlation energy            =   -0.000848100051919
+    MP2 correlation energy                    =   -0.200308616519799
+      * MP2 total energy                      =  -76.221352663546199
+
+    Opposite-spin CCSD correlation energy     =   -0.163407004539869
+    Same-spin CCSD correlation energy         =   -0.044002967407708
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.207412092832266
+      * CCSD total energy                     =  -76.228456139858665
+
+    Brueckner orbitals converged.  Maximum T1 =  0.000054245670
 Brueckner convergence check: True
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:14 2017
-
             **************************
             *                        *
             *        CCTRIPLES       *
@@ -1122,34 +1087,27 @@ Brueckner convergence check: True
     Wave function   =    BCCD_T
     Reference wfn   =      RHF
 
-    Nuclear Rep. energy (wfn)                =    9.077238153630930
-    SCF energy          (wfn)                =  -76.228458677103276
-    Reference energy    (file100)            =  -76.021044047261171
-    CCSD energy         (file100)            =   -0.207412092561001
-    Total CCSD energy   (file100)            =  -76.228456139822171
+    Nuclear Rep. energy (wfn)                =    9.077238189310194
+    SCF energy          (wfn)                =  -76.228458677636766
+    Reference energy    (file100)            =  -76.021044047026393
+    CCSD energy         (file100)            =   -0.207412092832266
+    Total CCSD energy   (file100)            =  -76.228456139858665
 
     Number of ijk index combinations:               20
-    Memory available in words        :        65536000
-    ~Words needed per explicit thread:            2916
+    Memory available in words               :        65536000
+    Approx. words needed per explicit thread:            2916
     Number of threads for explicit ijk threading:    1
 
     MKL num_threads set to 1 for explicit threading.
 
-    (T) energy                                =   -0.002996772606313
-      * CCSD(T) total energy                  =  -76.231452912428480
+    (T) energy                                =   -0.002996772675488
+      * CCSD(T) total energy                  =  -76.231452912534152
 
+    SCF energy............................................................................PASSED
+    B-CCD energy..........................................................................PASSED
+    B-CCD(T) energy.......................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:34:14 2017
-Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.76 seconds =       0.01 minutes
-	system time =       0.72 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-	SCF energy........................................................PASSED
-	B-CCD energy......................................................PASSED
-	B-CCD(T) energy...................................................PASSED
+    Psi4 stopped on: Monday, 12 September 2022 03:04PM
+    Psi4 wall time for execution: 0:00:05.52
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc16/output.ref
+++ b/tests/cc16/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.7a1.dev59 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {moinfo4} ad3533b dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:34PM
+    Psi4 started on: Monday, 12 September 2022 03:07PM
 
-    Process ID:  12503
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 30836
+    Host:       jonathons-mbp.wireless.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -50,9 +63,9 @@ energy("bccd(t)")
 escf = -38.917378694797030 #TEST
 ebccd = -39.030833895315020 #TEST
 ebccd_t = -39.032691827829460 #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
-compare_values(ebccd, get_variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
-compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ebccd, variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
+compare_values(ebccd_t, variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
 
 
 # We should obtain the same result as above, but start with different orbitals
@@ -65,26 +78,29 @@ energy("bccd(t)")
 escf = -38.91341670976116 #TEST
 ebccd = -39.030807046983838 #TEST
 ebccd_t = -39.032665163463861 #TEST
-compare_values(escf, get_variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
-compare_values(ebccd, get_variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
-compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
+compare_values(escf, variable("SCF TOTAL ENERGY"), 7, "SCF energy") #TEST
+compare_values(ebccd, variable("CCSD TOTAL ENERGY"), 7, "B-CCD energy") #TEST
+compare_values(ebccd_t, variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energy") #TEST
 --------------------------------------------------------------------------
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:14 2017
+Scratch directory: /tmp/
+
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:07:25 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry C          line   130 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry C          line   138 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -98,15 +114,15 @@ compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energ
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.000000000000     0.000000000000    -0.091864689759    12.000000000000
-           H          0.000000000000    -0.895527070192     0.546908561523     1.007825032070
-           H          0.000000000000     0.895527070192     0.546908561523     1.007825032070
+         C            0.000000000000     0.000000000000    -0.091864689772    12.000000000000
+         H            0.000000000000    -0.895527070192     0.546908561510     1.007825032230
+         H            0.000000000000     0.895527070192     0.546908561510     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     23.93977  B =     10.42855  C =      7.26416 [cm^-1]
-  Rotational constants: A = 717696.14844  B = 312640.05804  C = 217774.12469 [MHz]
-  Nuclear repulsion =    6.068298005568229
+  Rotational constants: A = 717696.15382  B = 312640.06037  C = 217774.12632 [MHz]
+  Nuclear repulsion =    6.068298029420463
 
   Charge       = 0
   Multiplicity = 3
@@ -120,33 +136,20 @@ compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energ
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        11      11       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      24      24       5       3       3       2
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -165,48 +168,66 @@ compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energ
   Using 90300 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.9429630952E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  Minimum eigenvalue in the overlap matrix is 2.6725919994E-02.
+  Reciprocal condition number of the overlap matrix is 8.2894136923E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        11      11 
+     A2         2       2 
+     B1         4       4 
+     B2         7       7 
+   -------------------------
+    Total      24      24
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @UHF iter   1:   -38.31961105999222   -3.83196e+01   7.93567e-02 
-   @UHF iter   2:   -38.88101600456736   -5.61405e-01   1.58957e-02 DIIS
-   @UHF iter   3:   -38.91270296738568   -3.16870e-02   3.91910e-03 DIIS
-   @UHF iter   4:   -38.91662354907334   -3.92058e-03   1.48823e-03 DIIS
-   @UHF iter   5:   -38.91730228395677   -6.78735e-04   4.44253e-04 DIIS
-   @UHF iter   6:   -38.91737258063895   -7.02967e-05   1.17907e-04 DIIS
-   @UHF iter   7:   -38.91737754549431   -4.96486e-06   4.91546e-05 DIIS
-   @UHF iter   8:   -38.91737856026896   -1.01477e-06   1.75671e-05 DIIS
-   @UHF iter   9:   -38.91737868936088   -1.29092e-07   2.94888e-06 DIIS
-   @UHF iter  10:   -38.91737869216924   -2.80836e-09   5.22485e-07 DIIS
-   @UHF iter  11:   -38.91737869225076   -8.15135e-11   6.46134e-08 DIIS
-   @UHF iter  12:   -38.91737869225199   -1.23634e-12   1.63998e-08 DIIS
-   @UHF iter  13:   -38.91737869225209   -9.23706e-14   2.84225e-09 DIIS
+   @UHF iter SAD:   -38.17324740294831   -3.81732e+01   0.00000e+00 
+   @UHF iter   1:   -38.90234369081280   -7.29096e-01   9.18281e-03 ADIIS/DIIS
+   @UHF iter   2:   -38.91513874101257   -1.27951e-02   2.96594e-03 ADIIS/DIIS
+   @UHF iter   3:   -38.91704192221886   -1.90318e-03   9.12227e-04 ADIIS/DIIS
+   @UHF iter   4:   -38.91728769227932   -2.45770e-04   4.46390e-04 ADIIS/DIIS
+   @UHF iter   5:   -38.91736714064813   -7.94484e-05   1.57015e-04 ADIIS/DIIS
+   @UHF iter   6:   -38.91737800453870   -1.08639e-05   3.99078e-05 DIIS
+   @UHF iter   7:   -38.91737866710700   -6.62568e-07   8.99030e-06 DIIS
+   @UHF iter   8:   -38.91737869146958   -2.43626e-08   1.73779e-06 DIIS
+   @UHF iter   9:   -38.91737869233110   -8.61519e-10   4.12144e-07 DIIS
+   @UHF iter  10:   -38.91737869238194   -5.08464e-11   6.23767e-08 DIIS
+   @UHF iter  11:   -38.91737869238312   -1.17950e-12   1.38186e-08 DIIS
+   @UHF iter  12:   -38.91737869238319   -6.39488e-14   2.41469e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   1.210199601E-02
+   @Spin Contamination Metric:   1.210199553E-02
    @S^2 Expected:                2.000000000E+00
    @S^2 Observed:                2.012101996E+00
    @S   Expected:                1.000000000E+00
    @S   Observed:                1.000000000E+00
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
@@ -241,22 +262,17 @@ compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energ
              A1    A2    B1    B2 
     DOCC [     2,    0,    0,    1 ]
     SOCC [     1,    0,    1,    0 ]
+    NA   [     3,    0,    1,    1 ]
+    NB   [     2,    0,    0,    1 ]
 
-  Energy converged.
-
-  @UHF Final Energy:   -38.91737869225209
+  @UHF Final Energy:   -38.91737869238319
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              6.0682980055682290
-    One-Electron Energy =                 -63.7147359432526983
-    Two-Electron Energy =                  18.7290592454323850
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -38.9173786922520861
-
+    Nuclear Repulsion Energy =              6.0682980294204629
+    One-Electron Energy =                 -63.7147359964043787
+    Two-Electron Energy =                  18.7290592746007327
+    Total Energy =                        -38.9173786923831813
 
   UHF NO Occupations:
   HONO-2 :    2 A1 1.9967234
@@ -268,33 +284,37 @@ compare_values(ebccd_t, get_variable("CCSD(T) TOTAL ENERGY"), 7, "B-CCD(T) energ
   LUNO+3 :    6 A1 0.0000000
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0254
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.7742
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.2512     Total:     0.2512
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.6386     Total:     0.6386
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.7741869            1.0254202            0.2512333
+ Magnitude           :                                                    0.2512333
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:34:14 2017
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:07:26 2022
 Module time:
-	user time   =       0.17 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.65 seconds =       0.01 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.17 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.65 seconds =       0.01 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -308,19 +328,19 @@ Total time:
       Number of basis functions:        24
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  11    2    4    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 11581 non-zero two-electron integrals.
+      Computed 11412 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:14 2017
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:07:26 2022
 
 
 	Wfn Parameters:
@@ -345,7 +365,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting AA/AB first half-transformation.
 	Sorting AA/AB half-transformed integrals.
 	Starting BB first half-transformation.
@@ -405,7 +425,7 @@ Total time:
 	Starting AB second half-transformation.
 	Starting BB second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -34.28292990220937
+	Frozen core energy     =    -34.28292990976122
 
 	Size of irrep 0 of <AB|CD> integrals:      0.002 (MW) /      0.018 (MB)
 	Size of irrep 1 of <AB|CD> integrals:      0.001 (MW) /      0.009 (MB)
@@ -455,37 +475,33 @@ Total time:
 	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
 	Total:                                     0.001 (MW) /      0.007 (MB)
 
-	Nuclear Rep. energy          =      6.06829800556823
-	SCF energy                   =    -38.91737869225209
-	One-electron energy          =    -17.65765447137572
-	Two-electron (AA) energy     =      2.57509466472492
-	Two-electron (BB) energy     =      0.37129588806088
-	Two-electron (AB) energy     =      4.00851712297898
-	Two-electron energy          =      6.95490767576478
-	Reference energy             =    -38.91737869225209
+	Nuclear Rep. energy          =      6.06829802942046
+	SCF energy                   =    -38.91737869238319
+	One-electron energy          =    -17.65765449730041
+	Two-electron (AA) energy     =      2.57509466662178
+	Two-electron (BB) energy     =      0.37129588895724
+	Two-electron (AB) energy     =      4.00851712967900
+	Two-electron energy          =      6.95490768525802
+	Reference energy             =    -38.91737869238315
 
-*** tstop() called on psinet at Mon May 15 15:34:14 2017
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:07:26 2022
 Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       0.04 seconds =       0.00 minutes
+	system time =       0.14 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.24 seconds =       0.00 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:14 2017
-
+	user time   =       0.72 seconds =       0.01 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    6.068298005568229
-    SCF energy          (wfn)     =  -38.917378692252086
-    Reference energy    (file100) =  -38.917378692252086
+    Nuclear Rep. energy (wfn)     =    6.068298029420463
+    SCF energy          (wfn)     =  -38.917378692383188
+    Reference energy    (file100) =  -38.917378692383146
 
     Input parameters:
     -----------------
@@ -514,116 +530,108 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.0933741741227911
+MP2 correlation energy -0.0933741740885756
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.093374174122791    0.000e+00    0.000000    0.000000    0.000000    0.000000
-     1        -0.108367774301765    3.751e-02    0.005754    0.000000    0.000000    0.000000
-     2        -0.113018776661563    1.456e-02    0.010163    0.000000    0.000000    0.000000
-     3        -0.113459332761070    5.372e-03    0.012606    0.000000    0.000000    0.000000
-     4        -0.113499511602377    1.599e-03    0.013206    0.000000    0.000000    0.000000
-     5        -0.113497624751186    4.167e-04    0.013208    0.000000    0.000000    0.000000
-     6        -0.113502746108534    1.492e-04    0.013181    0.000000    0.000000    0.000000
-     7        -0.113503232524088    5.440e-05    0.013163    0.000000    0.000000    0.000000
-     8        -0.113502998485573    1.454e-05    0.013158    0.000000    0.000000    0.000000
-     9        -0.113503202400279    3.837e-06    0.013157    0.000000    0.000000    0.000000
-    10        -0.113503207414140    1.239e-06    0.013157    0.000000    0.000000    0.000000
-    11        -0.113503188053256    2.954e-07    0.013157    0.000000    0.000000    0.000000
-    12        -0.113503190870829    7.378e-08    0.013157    0.000000    0.000000    0.000000
+     0        -0.093374174088576    0.000e+00    0.000000    0.000000    0.000000    0.000000
+     1        -0.108367774326550    3.751e-02    0.005754    0.000000    0.000000    0.000000
+     2        -0.113018776853798    1.456e-02    0.010163    0.000000    0.000000    0.000000
+     3        -0.113459332991378    5.372e-03    0.012606    0.000000    0.000000    0.000000
+     4        -0.113499511817718    1.599e-03    0.013206    0.000000    0.000000    0.000000
+     5        -0.113497624965326    4.167e-04    0.013208    0.000000    0.000000    0.000000
+     6        -0.113502746323270    1.492e-04    0.013181    0.000000    0.000000    0.000000
+     7        -0.113503232739133    5.440e-05    0.013163    0.000000    0.000000    0.000000
+     8        -0.113502998700685    1.454e-05    0.013158    0.000000    0.000000    0.000000
+     9        -0.113503202615423    3.837e-06    0.013157    0.000000    0.000000    0.000000
+    10        -0.113503207629278    1.239e-06    0.013157    0.000000    0.000000    0.000000
+    11        -0.113503188268390    2.954e-07    0.013157    0.000000    0.000000    0.000000
+    12        -0.113503191085963    7.378e-08    0.013157    0.000000    0.000000    0.000000
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              0   0        -0.0059636581
-              3  13        -0.0056516143
-              0   2        -0.0053935943
-              2  10        -0.0044561490
-              0   1         0.0044350160
-              3  17         0.0042852723
-              2  11        -0.0042448479
-              3  14         0.0042101634
-              1   1        -0.0034173371
-              1   4        -0.0033686487
+              0   0        -0.0059636556
+              3  13        -0.0056516155
+              0   2        -0.0053935968
+              2  10        -0.0044561239
+              0   1         0.0044350178
+              3  17         0.0042852707
+              2  11        -0.0042448452
+              3  14         0.0042101758
+              1   1        -0.0034173526
+              1   4        -0.0033686502
 
     Largest Tia Amplitudes:
-              0   0         0.0201452109
-              0   2         0.0107988674
-              1  17         0.0098852888
-              1  15         0.0065406861
-              1  19         0.0061024994
-              0   6        -0.0055552756
-              0   4        -0.0049635051
+              0   0         0.0201452220
+              0   2         0.0107988725
+              1  17         0.0098852891
+              1  15         0.0065406843
+              1  19         0.0061024998
+              0   6        -0.0055552745
+              0   4        -0.0049635049
               0   5        -0.0037496402
               1  20         0.0032845292
-              0   1         0.0032433637
+              0   1         0.0032433629
 
     Largest TIJAB Amplitudes:
-      2   1  10   1        -0.0308557391
-      3   2   8   2         0.0236639445
-      2   1  11   4        -0.0219938275
-      3   2  15  10        -0.0209441349
-      3   2  13  10        -0.0206888759
-      3   1  13   1        -0.0197544672
-      3   1  15   1        -0.0197110358
-      2   1  10   2        -0.0174364587
-      3   1  14   4         0.0154956107
-      3   1  14   2        -0.0154785737
+      2   1  10   1        -0.0308557388
+      3   2   8   2         0.0236639442
+      2   1  11   4        -0.0219938274
+      3   2  15  10        -0.0209441347
+      3   2  13  10        -0.0206888757
+      3   1  13   1        -0.0197544675
+      3   1  15   1        -0.0197110359
+      2   1  10   2        -0.0174364584
+      3   1  14   4         0.0154956104
+      3   1  14   2        -0.0154785734
 
     Largest Tijab Amplitudes:
-      1   0  11   9        -0.0103470596
-      1   0  16   1        -0.0077445034
-      1   0  16   0         0.0077432788
-      1   0  16   3        -0.0073290799
-      1   0  15   0        -0.0068380361
-      1   0  17   0        -0.0067539264
+      1   0  11   9        -0.0103470598
+      1   0  16   1        -0.0077445035
+      1   0  16   0         0.0077432792
+      1   0  16   3        -0.0073290800
+      1   0  15   0        -0.0068380363
+      1   0  17   0        -0.0067539266
       1   0  15   1        -0.0065839734
       1   0  17   4         0.0062753803
-      1   0  15   4         0.0060796695
+      1   0  15   4         0.0060796696
       1   0  12   9        -0.0046160238
 
     Largest TIjAb Amplitudes:
       3   1  15  17        -0.0339535080
-      3   1  13  15        -0.0325218245
-      2   0   2  11        -0.0318513747
-      3   1  13  17        -0.0297956092
-      3   1   2   2        -0.0291344809
-      3   1  14  16        -0.0279571659
-      2   1  10  17        -0.0258519226
-      1   0   4   0        -0.0257907968
-      3   1  15  15        -0.0257324462
-      2   1  10  15        -0.0255403271
+      3   1  13  15        -0.0325218243
+      2   0   2  11        -0.0318513746
+      3   1  13  17        -0.0297956089
+      3   1   2   2        -0.0291344806
+      3   1  14  16        -0.0279571658
+      2   1  10  17        -0.0258519223
+      1   0   4   0        -0.0257907975
+      3   1  15  15        -0.0257324461
+      2   1  10  15        -0.0255403268
 
-    SCF energy       (wfn)                    =  -38.917378692252086
-    Reference energy (file100)                =  -38.917378692252086
+    SCF energy       (wfn)                    =  -38.917378692383188
+    Reference energy (file100)                =  -38.917378692383146
 
-    Opposite-spin MP2 correlation energy      =   -0.072262427887151
-    Same-spin MP2 correlation energy          =   -0.021111746235639
-    MP2 correlation energy                    =   -0.093374174122791
-      * MP2 total energy                      =  -39.010752866374879
+    Opposite-spin MP2 correlation energy      =   -0.072262427878367
+    Same-spin MP2 correlation energy          =   -0.021111746210209
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.093374174088576
+      * MP2 total energy                      =  -39.010752866471719
 
-    Opposite-spin CCSD correlation energy     =   -0.090689856015225
-    Same-spin CCSD correlation energy         =   -0.022813334969562
-    CCSD correlation energy                   =   -0.113503190870829
-      * CCSD total energy                     =  -39.030881883122916
+    Opposite-spin CCSD correlation energy     =   -0.090689856241992
+    Same-spin CCSD correlation energy         =   -0.022813334843971
+    Singles CCSD correlation energy           =   -0.000000000000000
+    CCSD correlation energy                   =   -0.113503191085963
+      * CCSD total energy                     =  -39.030881883469107
 
-    Rotating orbitals.  Maximum T1 =  0.020145210943
-
-*** tstop() called on psinet at Mon May 15 15:34:15 2017
-Module time:
-	user time   =       0.16 seconds =       0.00 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.40 seconds =       0.01 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
+    Rotating orbitals.  Maximum T1 =  0.020145221993
 Brueckner convergence check: False
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:15 2017
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:07:27 2022
 
 
 	Wfn Parameters:
@@ -648,7 +656,7 @@ Brueckner convergence check: False
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting AA/AB first half-transformation.
 	Sorting AA/AB half-transformed integrals.
 	Starting BB first half-transformation.
@@ -708,7 +716,7 @@ Brueckner convergence check: False
 	Starting AB second half-transformation.
 	Starting BB second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -34.28292990220937
+	Frozen core energy     =    -34.28292990976122
 
 	Size of irrep 0 of <AB|CD> integrals:      0.002 (MW) /      0.018 (MB)
 	Size of irrep 1 of <AB|CD> integrals:      0.001 (MW) /      0.009 (MB)
@@ -758,37 +766,33 @@ Brueckner convergence check: False
 	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
 	Total:                                     0.001 (MW) /      0.007 (MB)
 
-	Nuclear Rep. energy          =      6.06829800556823
-	SCF energy                   =    -38.91737869225209
-	One-electron energy          =    -17.66345423762118
-	Two-electron (AA) energy     =      2.56587646588223
-	Two-electron (BB) energy     =      0.37475988483797
-	Two-electron (AB) energy     =      4.02085535969958
-	Two-electron energy          =      6.96149171041978
-	Reference energy             =    -38.91659442384254
+	Nuclear Rep. energy          =      6.06829802942046
+	SCF energy                   =    -38.91737869238319
+	One-electron energy          =    -17.66345641883911
+	Two-electron (AA) energy     =      2.56587628639254
+	Two-electron (BB) energy     =      0.37476038453360
+	Two-electron (AB) energy     =      4.02085740490812
+	Two-electron energy          =      6.96149407583426
+	Reference energy             =    -38.91659422334561
 
-*** tstop() called on psinet at Mon May 15 15:34:15 2017
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:07:28 2022
 Module time:
-	user time   =       0.04 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.44 seconds =       0.01 minutes
-	system time =       0.35 seconds =       0.01 minutes
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.15 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:15 2017
-
+Total time:
+	user time   =       1.00 seconds =       0.02 minutes
+	system time =       1.07 seconds =       0.02 minutes
+	total time  =          3 seconds =       0.05 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    6.068298005568229
-    SCF energy          (wfn)     =  -39.030881883122916
-    Reference energy    (file100) =  -38.916594423842540
+    Nuclear Rep. energy (wfn)     =    6.068298029420463
+    SCF energy          (wfn)     =  -39.030881883469107
+    Reference energy    (file100) =  -38.916594223345605
 
     Input parameters:
     -----------------
@@ -819,116 +823,108 @@ Total time:
 
     Using old T1 amplitudes.
     Using old T2 amplitudes.
-MP2 correlation energy -0.0952131344166589
+MP2 correlation energy -0.0952134328266539
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.113562360233688    0.000e+00    0.013157    0.000000    0.000000    0.000000
-     1        -0.114585688986726    1.985e-02    0.005873    0.000000    0.000000    0.000000
-     2        -0.114368768772942    6.090e-03    0.002933    0.000000    0.000000    0.000000
-     3        -0.114254311348899    2.409e-03    0.001312    0.000000    0.000000    0.000000
-     4        -0.114237022296276    6.306e-04    0.000950    0.000000    0.000000    0.000000
-     5        -0.114237684293414    1.380e-04    0.000934    0.000000    0.000000    0.000000
-     6        -0.114237169168213    4.048e-05    0.000938    0.000000    0.000000    0.000000
-     7        -0.114237082393813    1.122e-05    0.000939    0.000000    0.000000    0.000000
-     8        -0.114237058726917    2.913e-06    0.000939    0.000000    0.000000    0.000000
-     9        -0.114237065738375    9.165e-07    0.000939    0.000000    0.000000    0.000000
-    10        -0.114237076836320    3.237e-07    0.000939    0.000000    0.000000    0.000000
-    11        -0.114237082996487    1.206e-07    0.000939    0.000000    0.000000    0.000000
-    12        -0.114237083071840    3.663e-08    0.000939    0.000000    0.000000    0.000000
+     0        -0.113562353462805    0.000e+00    0.013157    0.000000    0.000000    0.000000
+     1        -0.114585893602078    1.986e-02    0.005872    0.000000    0.000000    0.000000
+     2        -0.114368968923713    6.091e-03    0.002932    0.000000    0.000000    0.000000
+     3        -0.114254505093330    2.409e-03    0.001311    0.000000    0.000000    0.000000
+     4        -0.114237214446287    6.307e-04    0.000949    0.000000    0.000000    0.000000
+     5        -0.114237877039240    1.380e-04    0.000934    0.000000    0.000000    0.000000
+     6        -0.114237362030886    4.048e-05    0.000937    0.000000    0.000000    0.000000
+     7        -0.114237275305412    1.122e-05    0.000938    0.000000    0.000000    0.000000
+     8        -0.114237251657565    2.914e-06    0.000939    0.000000    0.000000    0.000000
+     9        -0.114237258678822    9.167e-07    0.000939    0.000000    0.000000    0.000000
+    10        -0.114237269782322    3.238e-07    0.000939    0.000000    0.000000    0.000000
+    11        -0.114237275944582    1.206e-07    0.000939    0.000000    0.000000    0.000000
+    12        -0.114237276019852    3.663e-08    0.000939    0.000000    0.000000    0.000000
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              3  15        -0.0009686988
-              3  13        -0.0008728378
-              3  14         0.0007240166
-              2  10        -0.0006412824
-              2  11        -0.0005851660
-              1   2        -0.0005566533
-              1   4        -0.0005065585
-              1   1        -0.0004555551
-              0   3         0.0003912211
-              0   1         0.0003398181
+              3  15        -0.0009688525
+              3  13        -0.0008728604
+              3  14         0.0007240236
+              2  10        -0.0006413819
+              2  11        -0.0005852344
+              1   2        -0.0005567089
+              1   4        -0.0005066286
+              1   1        -0.0004556043
+              0   3         0.0003912992
+              0   1         0.0003397590
 
     Largest Tia Amplitudes:
-              1  17         0.0005019607
-              1  15         0.0004129606
-              0   0         0.0004073951
-              0   1         0.0003385629
-              0   4        -0.0003113329
-              0   2         0.0002937303
-              0   3         0.0001945979
-              1  20         0.0000905173
-              0   8        -0.0000749946
-              1  18         0.0000746103
+              1  17         0.0005013128
+              1  15         0.0004125112
+              0   0         0.0004032718
+              0   1         0.0003379433
+              0   4        -0.0003103316
+              0   2         0.0002915363
+              0   3         0.0001946175
+              1  20         0.0000903077
+              1  18         0.0000746053
+              0   8        -0.0000744360
 
     Largest TIJAB Amplitudes:
-      2   1  10   1        -0.0304573942
-      3   2   8   2         0.0234177807
-      2   1  11   4        -0.0218971098
-      3   2  15  10        -0.0209209839
-      3   2  13  10        -0.0206142494
-      3   1  13   1        -0.0197567045
-      3   1  15   1        -0.0196544018
-      2   1  10   2        -0.0180768820
-      3   1  14   2        -0.0155374163
-      3   1  14   4         0.0154400782
+      2   1  10   1        -0.0304573109
+      3   2   8   2         0.0234177263
+      2   1  11   4        -0.0218970899
+      3   2  15  10        -0.0209209908
+      3   2  13  10        -0.0206142410
+      3   1  13   1        -0.0197567066
+      3   1  15   1        -0.0196543981
+      2   1  10   2        -0.0180770218
+      3   1  14   2        -0.0155374280
+      3   1  14   4         0.0154400697
 
     Largest Tijab Amplitudes:
       1   0  11   9        -0.0103617444
-      1   0  16   1        -0.0078209753
-      1   0  16   0         0.0076952187
-      1   0  16   3        -0.0073251234
-      1   0  15   0        -0.0069212298
-      1   0  17   0        -0.0068140150
-      1   0  15   1        -0.0064970215
-      1   0  17   4         0.0062507361
-      1   0  15   4         0.0060700733
-      1   0  12   9        -0.0046175427
+      1   0  16   1        -0.0078209951
+      1   0  16   0         0.0076951999
+      1   0  16   3        -0.0073251199
+      1   0  15   0        -0.0069212497
+      1   0  17   0        -0.0068140267
+      1   0  15   1        -0.0064970025
+      1   0  17   4         0.0062507359
+      1   0  15   4         0.0060700693
+      1   0  12   9        -0.0046175449
 
     Largest TIjAb Amplitudes:
-      3   1  15  17        -0.0338659994
-      3   1  13  15        -0.0325208949
-      2   0   2  11        -0.0314995907
-      3   1  13  17        -0.0296790367
-      3   1   2   2        -0.0289509902
-      3   1  14  16        -0.0279443622
-      3   1  15  15        -0.0258102174
-      2   1  10  17        -0.0257471645
-      1   0   4   0        -0.0256659707
-      2   1  10  15        -0.0255803048
+      3   1  15  17        -0.0338659899
+      3   1  13  15        -0.0325208774
+      2   0   2  11        -0.0314995124
+      3   1  13  17        -0.0296790151
+      3   1   2   2        -0.0289510126
+      3   1  14  16        -0.0279443703
+      3   1  15  15        -0.0258102168
+      2   1  10  17        -0.0257471655
+      1   0   4   0        -0.0256659335
+      2   1  10  15        -0.0255803058
 
-    SCF energy       (wfn)                    =  -39.030881883122916
-    Reference energy (file100)                =  -38.916594423842540
+    SCF energy       (wfn)                    =  -39.030881883469107
+    Reference energy (file100)                =  -38.916594223345605
 
-    Opposite-spin MP2 correlation energy      =   -0.073488551104551
-    Same-spin MP2 correlation energy          =   -0.021211334599110
-    MP2 correlation energy                    =   -0.095213134416659
-      * MP2 total energy                      =  -39.011807558259200
+    Opposite-spin MP2 correlation energy      =   -0.073488704419976
+    Same-spin MP2 correlation energy          =   -0.021211345261070
+    Singles MP2 correlation energy            =   -0.000513383145608
+    MP2 correlation energy                    =   -0.095213432826654
+      * MP2 total energy                      =  -39.011807656172259
 
-    Opposite-spin CCSD correlation energy     =   -0.091416840873124
-    Same-spin CCSD correlation energy         =   -0.022832067595435
-    CCSD correlation energy                   =   -0.114237083071840
-      * CCSD total energy                     =  -39.030831506914382
+    Opposite-spin CCSD correlation energy     =   -0.091416933892584
+    Same-spin CCSD correlation energy         =   -0.022832066505541
+    Singles CCSD correlation energy           =    0.000011724378273
+    CCSD correlation energy                   =   -0.114237276019852
+      * CCSD total energy                     =  -39.030831499365455
 
-    Rotating orbitals.  Maximum T1 =  0.000968698840
-
-*** tstop() called on psinet at Mon May 15 15:34:15 2017
-Module time:
-	user time   =       0.16 seconds =       0.00 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.60 seconds =       0.01 minutes
-	system time =       0.58 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
+    Rotating orbitals.  Maximum T1 =  0.000968852524
 Brueckner convergence check: False
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:15 2017
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:07:31 2022
 
 
 	Wfn Parameters:
@@ -953,7 +949,7 @@ Brueckner convergence check: False
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting AA/AB first half-transformation.
 	Sorting AA/AB half-transformed integrals.
 	Starting BB first half-transformation.
@@ -1013,7 +1009,7 @@ Brueckner convergence check: False
 	Starting AB second half-transformation.
 	Starting BB second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -34.28292990220939
+	Frozen core energy     =    -34.28292990976122
 
 	Size of irrep 0 of <AB|CD> integrals:      0.002 (MW) /      0.018 (MB)
 	Size of irrep 1 of <AB|CD> integrals:      0.001 (MW) /      0.009 (MB)
@@ -1063,476 +1059,448 @@ Brueckner convergence check: False
 	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
 	Total:                                     0.001 (MW) /      0.007 (MB)
 
-	Nuclear Rep. energy          =      6.06829800556823
-	SCF energy                   =    -39.03088188312292
-	One-electron energy          =    -17.66229277020776
-	Two-electron (AA) energy     =      2.56414461813523
-	Two-electron (BB) energy     =      0.37496240642497
-	Two-electron (AB) energy     =      4.02125075819789
-	Two-electron energy          =      6.96035778275809
-	Reference energy             =    -38.91656688409083
+	Nuclear Rep. energy          =      6.06829802942046
+	SCF energy                   =    -39.03088188346911
+	One-electron energy          =    -17.66229231431970
+	Two-electron (AA) energy     =      2.56414428557933
+	Two-electron (BB) energy     =      0.37496240359380
+	Two-electron (AB) energy     =      4.02125062217716
+	Two-electron energy          =      6.96035731135028
+	Reference energy             =    -38.91656688331017
 
-*** tstop() called on psinet at Mon May 15 15:34:15 2017
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:07:31 2022
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.62 seconds =       0.01 minutes
-	system time =       0.62 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:15 2017
-
-            **************************
-            *                        *
-            *        CCENERGY        *
-            *                        *
-            **************************
-
-    Nuclear Rep. energy (wfn)     =    6.068298005568229
-    SCF energy          (wfn)     =  -39.030831506914382
-    Reference energy    (file100) =  -38.916566884090834
-
-    Input parameters:
-    -----------------
-    Wave function   =     BCCD_T
-    Reference wfn   =     UHF
-    Brueckner       =     Yes
-    Brueckner conv. =     1.0e-04
-    Memory (Mbytes) =     524.3
-    Maxiter         =     50
-    R_Convergence   =     1.0e-07
-    E_Convergence   =     1.0e-06
-    Restart         =     Yes
-    DIIS            =     Yes
-    AO Basis        =     NONE
-    ABCD            =     NEW
-    Cache Level     =     2
-    Cache Type      =     LRU
-    Print Level     =     1
-    Num. of threads =     1
-    # Amps to Print =     10
-    Print MP2 Amps? =     No
-    Analyze T2 Amps =     No
-    Print Pair Ener =     No
-    Local CC        =     No
-    SCS-MP2         =     False
-    SCSN-MP2        =     False
-    SCS-CCSD        =     False
-
-    Using old T1 amplitudes.
-    Using old T2 amplitudes.
-MP2 correlation energy -0.0952390452458518
-                Solving CC Amplitude Equations
-                ------------------------------
-  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
-  ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.114254475818519    0.000e+00    0.000939    0.000000    0.000000    0.000000
-     1        -0.114268823862760    1.515e-03    0.000444    0.000000    0.000000    0.000000
-     2        -0.114272916766936    4.471e-04    0.000245    0.000000    0.000000    0.000000
-     3        -0.114269452560857    1.749e-04    0.000133    0.000000    0.000000    0.000000
-     4        -0.114267611703297    4.115e-05    0.000107    0.000000    0.000000    0.000000
-     5        -0.114267412070358    9.228e-06    0.000105    0.000000    0.000000    0.000000
-     6        -0.114267325581735    2.707e-06    0.000105    0.000000    0.000000    0.000000
-     7        -0.114267291353680    8.359e-07    0.000104    0.000000    0.000000    0.000000
-     8        -0.114267284719698    2.245e-07    0.000104    0.000000    0.000000    0.000000
-     9        -0.114267284111533    6.584e-08    0.000104    0.000000    0.000000    0.000000
-
-    Iterations converged.
-
-
-    Largest TIA Amplitudes:
-              1   4         0.0000338132
-              1   1         0.0000329665
-              2  11         0.0000258702
-              2  10         0.0000249333
-              3  14         0.0000243125
-              1   2        -0.0000236994
-              0   2        -0.0000178081
-              3  15        -0.0000139189
-              3  13        -0.0000123424
-              0   5        -0.0000109033
-
-    Largest Tia Amplitudes:
-              1  17         0.0001342850
-              0   0         0.0001179863
-              1  15         0.0001127119
-              0   4        -0.0000742590
-              0   1         0.0000528251
-              0   2         0.0000523625
-              1  16        -0.0000430639
-              1  20         0.0000274722
-              0   8        -0.0000271484
-              0   5         0.0000170327
-
-    Largest TIJAB Amplitudes:
-      2   1  10   1        -0.0304624689
-      3   2   8   2         0.0234206276
-      2   1  11   4        -0.0218953864
-      3   2  15  10        -0.0209187928
-      3   2  13  10        -0.0206108952
-      3   1  13   1        -0.0197547759
-      3   1  15   1        -0.0196519367
-      2   1  10   2        -0.0180692255
-      3   1  14   2        -0.0155338996
-      3   1  14   4         0.0154403825
-
-    Largest Tijab Amplitudes:
-      1   0  11   9        -0.0103673867
-      1   0  16   1        -0.0078202123
-      1   0  16   0         0.0077015580
-      1   0  16   3        -0.0073294361
-      1   0  15   0        -0.0069233807
-      1   0  17   0        -0.0068203719
-      1   0  15   1        -0.0065008723
-      1   0  17   4         0.0062489206
-      1   0  15   4         0.0060738022
-      1   0  12   9        -0.0046150992
-
-    Largest TIjAb Amplitudes:
-      3   1  15  17        -0.0338633236
-      3   1  13  15        -0.0325332390
-      2   0   2  11        -0.0315106072
-      3   1  13  17        -0.0296749733
-      3   1   2   2        -0.0288691869
-      3   1  14  16        -0.0279354643
-      3   1  15  15        -0.0258260889
-      2   1  10  17        -0.0257350367
-      1   0   4   0        -0.0256824768
-      2   1  10  15        -0.0255925427
-
-    SCF energy       (wfn)                    =  -39.030831506914382
-    Reference energy (file100)                =  -38.916566884090834
-
-    Opposite-spin MP2 correlation energy      =   -0.073525360293419
-    Same-spin MP2 correlation energy          =   -0.021203286692914
-    MP2 correlation energy                    =   -0.095239045245852
-      * MP2 total energy                      =  -39.011805929336688
-
-    Opposite-spin CCSD correlation energy     =   -0.091443357275180
-    Same-spin CCSD correlation energy         =   -0.022827097981713
-    CCSD correlation energy                   =   -0.114267284111533
-      * CCSD total energy                     =  -39.030834168202368
-
-    Rotating orbitals.  Maximum T1 =  0.000134284979
-
-*** tstop() called on psinet at Mon May 15 15:34:16 2017
-Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.73 seconds =       0.01 minutes
-	system time =       0.78 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-Brueckner convergence check: False
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:16 2017
-
-
-	Wfn Parameters:
-	--------------------
-	Wavefunction         = BCCD_T
-	Number of irreps     = 4
-	Number of MOs        = 24
-	Number of active MOs = 23
-	AO-Basis             = NONE
-	Semicanonical        = false
-	Reference            = UHF
-	Print Level          = 1
-
-	IRREP	# MOs	# FZDC	# DOCC	# SOCC	# VIRT	# FZVR
-	-----	-----	------	------	------	------	------
-	 A1	   11	    1	    1	    1	    8	    0
-	 A2	   2	    0	    0	    0	    2	    0
-	 B1	   4	    0	    0	    1	    3	    0
-	 B2	   7	    0	    1	    0	    6	    0
-	Transforming integrals...
-	IWL integrals will be retained.
-	(OO|OO)...
-	Presorting SO-basis two-electron integrals.
-	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
-	Starting AA/AB first half-transformation.
-	Sorting AA/AB half-transformed integrals.
-	Starting BB first half-transformation.
-	Sorting BB half-transformed integrals.
-	First half integral transformation complete.
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OO|OV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OO|VV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OV|OO)...
-	Starting AA/AB first half-transformation.
-	Sorting AA/AB half-transformed integrals.
-	Starting BB first half-transformation.
-	Sorting BB half-transformed integrals.
-	First half integral transformation complete.
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OV|OV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OV|VV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(VV|OO)...
-	Starting AA/AB first half-transformation.
-	Sorting AA/AB half-transformed integrals.
-	Starting BB first half-transformation.
-	Sorting BB half-transformed integrals.
-	First half integral transformation complete.
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(VV|OV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(VV|VV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	Frozen core energy     =    -34.28292990220937
-
-	Size of irrep 0 of <AB|CD> integrals:      0.002 (MW) /      0.018 (MB)
-	Size of irrep 1 of <AB|CD> integrals:      0.001 (MW) /      0.009 (MB)
-	Size of irrep 2 of <AB|CD> integrals:      0.001 (MW) /      0.010 (MB)
-	Size of irrep 3 of <AB|CD> integrals:      0.003 (MW) /      0.023 (MB)
-	Total:                                     0.008 (MW) /      0.061 (MB)
-
-	Size of irrep 0 of <ab|cd> integrals:      0.003 (MW) /      0.027 (MB)
-	Size of irrep 1 of <ab|cd> integrals:      0.002 (MW) /      0.014 (MB)
-	Size of irrep 2 of <ab|cd> integrals:      0.002 (MW) /      0.018 (MB)
-	Size of irrep 3 of <ab|cd> integrals:      0.004 (MW) /      0.031 (MB)
-	Total:                                     0.011 (MW) /      0.090 (MB)
-
-	Size of irrep 0 of <Ab|Cd> integrals:      0.015 (MW) /      0.123 (MB)
-	Size of irrep 1 of <Ab|Cd> integrals:      0.006 (MW) /      0.046 (MB)
-	Size of irrep 2 of <Ab|Cd> integrals:      0.007 (MW) /      0.055 (MB)
-	Size of irrep 3 of <Ab|Cd> integrals:      0.013 (MW) /      0.108 (MB)
-	Total:                                     0.041 (MW) /      0.332 (MB)
-
-	Size of irrep 0 of <IA|BC> integrals:      0.003 (MW) /      0.023 (MB)
-	Size of irrep 1 of <IA|BC> integrals:      0.001 (MW) /      0.007 (MB)
-	Size of irrep 2 of <IA|BC> integrals:      0.001 (MW) /      0.009 (MB)
-	Size of irrep 3 of <IA|BC> integrals:      0.002 (MW) /      0.019 (MB)
-	Total:                                     0.007 (MW) /      0.058 (MB)
-
-	Size of irrep 0 of <ia|bc> integrals:      0.002 (MW) /      0.016 (MB)
-	Size of irrep 1 of <ia|bc> integrals:      0.001 (MW) /      0.004 (MB)
-	Size of irrep 2 of <ia|bc> integrals:      0.001 (MW) /      0.005 (MB)
-	Size of irrep 3 of <ia|bc> integrals:      0.002 (MW) /      0.015 (MB)
-	Total:                                     0.005 (MW) /      0.040 (MB)
-
-	Size of irrep 0 of <Ia|Bc> integrals:      0.003 (MW) /      0.028 (MB)
-	Size of irrep 1 of <Ia|Bc> integrals:      0.001 (MW) /      0.009 (MB)
-	Size of irrep 2 of <Ia|Bc> integrals:      0.002 (MW) /      0.013 (MB)
-	Size of irrep 3 of <Ia|Bc> integrals:      0.003 (MW) /      0.021 (MB)
-	Total:                                     0.009 (MW) /      0.070 (MB)
-
-	Size of irrep 0 of <iA|bC> integrals:      0.002 (MW) /      0.014 (MB)
-	Size of irrep 1 of <iA|bC> integrals:      0.000 (MW) /      0.003 (MB)
-	Size of irrep 2 of <iA|bC> integrals:      0.000 (MW) /      0.003 (MB)
-	Size of irrep 3 of <iA|bC> integrals:      0.002 (MW) /      0.013 (MB)
-	Total:                                     0.004 (MW) /      0.033 (MB)
-
-	Size of irrep 0 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
-	Size of irrep 1 of tIjAb amplitudes:       0.000 (MW) /      0.001 (MB)
-	Size of irrep 2 of tIjAb amplitudes:       0.000 (MW) /      0.001 (MB)
-	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
-	Total:                                     0.001 (MW) /      0.007 (MB)
-
-	Nuclear Rep. energy          =      6.06829800556823
-	SCF energy                   =    -39.03083150691438
-	One-electron energy          =    -17.66256204976909
-	Two-electron (AA) energy     =      2.56415668305190
-	Two-electron (BB) energy     =      0.37500214006983
-	Two-electron (AB) energy     =      4.02147463763076
-	Two-electron energy          =      6.96063346075249
-	Reference energy             =    -38.91656048565774
-
-*** tstop() called on psinet at Mon May 15 15:34:16 2017
-Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.76 seconds =       0.01 minutes
-	system time =       0.82 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:16 2017
-
-            **************************
-            *                        *
-            *        CCENERGY        *
-            *                        *
-            **************************
-
-    Nuclear Rep. energy (wfn)     =    6.068298005568229
-    SCF energy          (wfn)     =  -39.030834168202368
-    Reference energy    (file100) =  -38.916560485657740
-
-    Input parameters:
-    -----------------
-    Wave function   =     BCCD_T
-    Reference wfn   =     UHF
-    Brueckner       =     Yes
-    Brueckner conv. =     1.0e-04
-    Memory (Mbytes) =     524.3
-    Maxiter         =     50
-    R_Convergence   =     1.0e-07
-    E_Convergence   =     1.0e-06
-    Restart         =     Yes
-    DIIS            =     Yes
-    AO Basis        =     NONE
-    ABCD            =     NEW
-    Cache Level     =     2
-    Cache Type      =     LRU
-    Print Level     =     1
-    Num. of threads =     1
-    # Amps to Print =     10
-    Print MP2 Amps? =     No
-    Analyze T2 Amps =     No
-    Print Pair Ener =     No
-    Local CC        =     No
-    SCS-MP2         =     False
-    SCSN-MP2        =     False
-    SCS-CCSD        =     False
-
-    Using old T1 amplitudes.
-    Using old T2 amplitudes.
-MP2 correlation energy -0.0952479866362604
-                Solving CC Amplitude Equations
-                ------------------------------
-  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
-  ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.114269799702286    0.000e+00    0.000104    0.000000    0.000000    0.000000
-     1        -0.114274403761374    1.984e-04    0.000045    0.000000    0.000000    0.000000
-     2        -0.114273885628603    4.580e-05    0.000027    0.000000    0.000000    0.000000
-     3        -0.114273586527636    2.090e-05    0.000016    0.000000    0.000000    0.000000
-     4        -0.114273427463777    4.427e-06    0.000014    0.000000    0.000000    0.000000
-     5        -0.114273365409018    1.048e-06    0.000014    0.000000    0.000000    0.000000
-     6        -0.114273353355555    3.278e-07    0.000014    0.000000    0.000000    0.000000
-     7        -0.114273350695541    1.037e-07    0.000014    0.000000    0.000000    0.000000
-     8        -0.114273350010298    3.022e-08    0.000014    0.000000    0.000000    0.000000
-
-    Iterations converged.
-
-
-    Largest TIA Amplitudes:
-              3  13        -0.0000165776
-              3  15        -0.0000162281
-              2  10        -0.0000117685
-              1   2        -0.0000092313
-              1   1        -0.0000086119
-              0   3         0.0000079076
-              0   0        -0.0000067978
-              3  14         0.0000066499
-              1   0        -0.0000055147
-              1   4        -0.0000054815
-
-    Largest Tia Amplitudes:
-              0   0        -0.0000040168
-              1  15        -0.0000025472
-              0   4         0.0000018685
-              1  17        -0.0000015497
-              0   3         0.0000015475
-              0   6         0.0000010735
-              1  16        -0.0000008707
-              0   1        -0.0000006474
-              1  19        -0.0000006150
-              1  18         0.0000004638
-
-    Largest TIJAB Amplitudes:
-      2   1  10   1        -0.0304559908
-      3   2   8   2         0.0234168139
-      2   1  11   4        -0.0218943173
-      3   2  15  10        -0.0209198191
-      3   2  13  10        -0.0206101139
-      3   1  13   1        -0.0197548087
-      3   1  15   1        -0.0196521029
-      2   1  10   2        -0.0180801188
-      3   1  14   2        -0.0155346376
-      3   1  14   4         0.0154407613
-
-    Largest Tijab Amplitudes:
-      1   0  11   9        -0.0103672378
-      1   0  16   1        -0.0078210308
-      1   0  16   0         0.0077006631
-      1   0  16   3        -0.0073294896
-      1   0  15   0        -0.0069239985
-      1   0  17   0        -0.0068210061
-      1   0  15   1        -0.0065000692
-      1   0  17   4         0.0062490393
-      1   0  15   4         0.0060737747
-      1   0  12   9        -0.0046156433
-
-    Largest TIjAb Amplitudes:
-      3   1  15  17        -0.0338636767
-      3   1  13  15        -0.0325316699
-      2   0   2  11        -0.0315049091
-      3   1  13  17        -0.0296732983
-      3   1   2   2        -0.0288706529
-      3   1  14  16        -0.0279362335
-      3   1  15  15        -0.0258268020
-      2   1  10  17        -0.0257352304
-      1   0   4   0        -0.0256799008
-      2   1  10  15        -0.0255928325
-
-    SCF energy       (wfn)                    =  -39.030834168202368
-    Reference energy (file100)                =  -38.916560485657740
-
-    Opposite-spin MP2 correlation energy      =   -0.073530432357751
-    Same-spin MP2 correlation energy          =   -0.021202989138661
-    MP2 correlation energy                    =   -0.095247986636260
-      * MP2 total energy                      =  -39.011808472294000
-
-    Opposite-spin CCSD correlation energy     =   -0.091446678719889
-    Same-spin CCSD correlation energy         =   -0.022826626778596
-    CCSD correlation energy                   =   -0.114273350010298
-      * CCSD total energy                     =  -39.030833835668041
-
-    Brueckner orbitals converged.  Maximum T1 =  0.000016577568
-
-*** tstop() called on psinet at Mon May 15 15:34:16 2017
-Module time:
-	user time   =       0.08 seconds =       0.00 minutes
+	user time   =       0.05 seconds =       0.00 minutes
 	system time =       0.12 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.84 seconds =       0.01 minutes
-	system time =       0.94 seconds =       0.02 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       1.33 seconds =       0.02 minutes
+	system time =       1.98 seconds =       0.03 minutes
+	total time  =          6 seconds =       0.10 minutes
+            **************************
+            *                        *
+            *        CCENERGY        *
+            *                        *
+            **************************
+
+    Nuclear Rep. energy (wfn)     =    6.068298029420463
+    SCF energy          (wfn)     =  -39.030831499365455
+    Reference energy    (file100) =  -38.916566883310175
+
+    Input parameters:
+    -----------------
+    Wave function   =     BCCD_T
+    Reference wfn   =     UHF
+    Brueckner       =     Yes
+    Brueckner conv. =     1.0e-04
+    Memory (Mbytes) =     524.3
+    Maxiter         =     50
+    R_Convergence   =     1.0e-07
+    E_Convergence   =     1.0e-06
+    Restart         =     Yes
+    DIIS            =     Yes
+    AO Basis        =     NONE
+    ABCD            =     NEW
+    Cache Level     =     2
+    Cache Type      =     LRU
+    Print Level     =     1
+    Num. of threads =     1
+    # Amps to Print =     10
+    Print MP2 Amps? =     No
+    Analyze T2 Amps =     No
+    Print Pair Ener =     No
+    Local CC        =     No
+    SCS-MP2         =     False
+    SCSN-MP2        =     False
+    SCS-CCSD        =     False
+
+    Using old T1 amplitudes.
+    Using old T2 amplitudes.
+MP2 correlation energy -0.0952390434148898
+                Solving CC Amplitude Equations
+                ------------------------------
+  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
+  ----     ---------------------    ---------   ----------  ----------  ----------   --------
+     0        -0.114254571227213    0.000e+00    0.000939    0.000000    0.000000    0.000000
+     1        -0.114268783166124    1.516e-03    0.000444    0.000000    0.000000    0.000000
+     2        -0.114272899814047    4.466e-04    0.000244    0.000000    0.000000    0.000000
+     3        -0.114269453217090    1.747e-04    0.000133    0.000000    0.000000    0.000000
+     4        -0.114267613852320    4.113e-05    0.000107    0.000000    0.000000    0.000000
+     5        -0.114267413758413    9.217e-06    0.000105    0.000000    0.000000    0.000000
+     6        -0.114267327216332    2.704e-06    0.000105    0.000000    0.000000    0.000000
+     7        -0.114267292933408    8.353e-07    0.000105    0.000000    0.000000    0.000000
+     8        -0.114267286263238    2.246e-07    0.000105    0.000000    0.000000    0.000000
+     9        -0.114267285650016    6.596e-08    0.000105    0.000000    0.000000    0.000000
+
+    Iterations converged.
+
+
+    Largest TIA Amplitudes:
+              1   4         0.0000339413
+              1   1         0.0000330868
+              2  11         0.0000259983
+              2  10         0.0000250786
+              3  14         0.0000241902
+              1   2        -0.0000236041
+              0   2        -0.0000177640
+              3  15        -0.0000137286
+              3  13        -0.0000121629
+              0   5        -0.0000109109
+
+    Largest Tia Amplitudes:
+              1  17         0.0001343400
+              0   0         0.0001180139
+              1  15         0.0001127755
+              0   4        -0.0000742737
+              0   1         0.0000528322
+              0   2         0.0000523646
+              1  16        -0.0000430840
+              1  20         0.0000274813
+              0   8        -0.0000271533
+              0   5         0.0000170363
+
+    Largest TIJAB Amplitudes:
+      2   1  10   1        -0.0304624751
+      3   2   8   2         0.0234206313
+      2   1  11   4        -0.0218953871
+      3   2  15  10        -0.0209187915
+      3   2  13  10        -0.0206108952
+      3   1  13   1        -0.0197547754
+      3   1  15   1        -0.0196519361
+      2   1  10   2        -0.0180692152
+      3   1  14   2        -0.0155338984
+      3   1  14   4         0.0154403822
+
+    Largest Tijab Amplitudes:
+      1   0  11   9        -0.0103673880
+      1   0  16   1        -0.0078202116
+      1   0  16   0         0.0077015599
+      1   0  16   3        -0.0073294369
+      1   0  15   0        -0.0069233807
+      1   0  17   0        -0.0068203726
+      1   0  15   1        -0.0065008737
+      1   0  17   4         0.0062489201
+      1   0  15   4         0.0060738029
+      1   0  12   9        -0.0046150983
+
+    Largest TIjAb Amplitudes:
+      3   1  15  17        -0.0338633226
+      3   1  13  15        -0.0325332424
+      2   0   2  11        -0.0315106139
+      3   1  13  17        -0.0296749737
+      3   1   2   2        -0.0288691699
+      3   1  14  16        -0.0279354619
+      3   1  15  15        -0.0258260911
+      2   1  10  17        -0.0257350343
+      1   0   4   0        -0.0256824820
+      2   1  10  15        -0.0255925447
+
+    SCF energy       (wfn)                    =  -39.030831499365455
+    Reference energy (file100)                =  -38.916566883310175
+
+    Opposite-spin MP2 correlation energy      =   -0.073525363212934
+    Same-spin MP2 correlation energy          =   -0.021203285142043
+    Singles MP2 correlation energy            =   -0.000510395059913
+    MP2 correlation energy                    =   -0.095239043414890
+      * MP2 total energy                      =  -39.011805926725067
+
+    Opposite-spin CCSD correlation energy     =   -0.091443359663813
+    Same-spin CCSD correlation energy         =   -0.022827097232666
+    Singles CCSD correlation energy           =    0.000003171246463
+    CCSD correlation energy                   =   -0.114267285650016
+      * CCSD total energy                     =  -39.030834168960190
+
+    Rotating orbitals.  Maximum T1 =  0.000134339962
+Brueckner convergence check: False
+
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:07:31 2022
+
+
+	Wfn Parameters:
+	--------------------
+	Wavefunction         = BCCD_T
+	Number of irreps     = 4
+	Number of MOs        = 24
+	Number of active MOs = 23
+	AO-Basis             = NONE
+	Semicanonical        = false
+	Reference            = UHF
+	Print Level          = 1
+
+	IRREP	# MOs	# FZDC	# DOCC	# SOCC	# VIRT	# FZVR
+	-----	-----	------	------	------	------	------
+	 A1	   11	    1	    1	    1	    8	    0
+	 A2	   2	    0	    0	    0	    2	    0
+	 B1	   4	    0	    0	    1	    3	    0
+	 B2	   7	    0	    1	    0	    6	    0
+	Transforming integrals...
+	IWL integrals will be retained.
+	(OO|OO)...
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Constructing frozen core operators
+	Starting AA/AB first half-transformation.
+	Sorting AA/AB half-transformed integrals.
+	Starting BB first half-transformation.
+	Sorting BB half-transformed integrals.
+	First half integral transformation complete.
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|OV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|VV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OO)...
+	Starting AA/AB first half-transformation.
+	Sorting AA/AB half-transformed integrals.
+	Starting BB first half-transformation.
+	Sorting BB half-transformed integrals.
+	First half integral transformation complete.
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|VV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OO)...
+	Starting AA/AB first half-transformation.
+	Sorting AA/AB half-transformed integrals.
+	Starting BB first half-transformation.
+	Sorting BB half-transformed integrals.
+	First half integral transformation complete.
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|VV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	Frozen core energy     =    -34.28292990976122
+
+	Size of irrep 0 of <AB|CD> integrals:      0.002 (MW) /      0.018 (MB)
+	Size of irrep 1 of <AB|CD> integrals:      0.001 (MW) /      0.009 (MB)
+	Size of irrep 2 of <AB|CD> integrals:      0.001 (MW) /      0.010 (MB)
+	Size of irrep 3 of <AB|CD> integrals:      0.003 (MW) /      0.023 (MB)
+	Total:                                     0.008 (MW) /      0.061 (MB)
+
+	Size of irrep 0 of <ab|cd> integrals:      0.003 (MW) /      0.027 (MB)
+	Size of irrep 1 of <ab|cd> integrals:      0.002 (MW) /      0.014 (MB)
+	Size of irrep 2 of <ab|cd> integrals:      0.002 (MW) /      0.018 (MB)
+	Size of irrep 3 of <ab|cd> integrals:      0.004 (MW) /      0.031 (MB)
+	Total:                                     0.011 (MW) /      0.090 (MB)
+
+	Size of irrep 0 of <Ab|Cd> integrals:      0.015 (MW) /      0.123 (MB)
+	Size of irrep 1 of <Ab|Cd> integrals:      0.006 (MW) /      0.046 (MB)
+	Size of irrep 2 of <Ab|Cd> integrals:      0.007 (MW) /      0.055 (MB)
+	Size of irrep 3 of <Ab|Cd> integrals:      0.013 (MW) /      0.108 (MB)
+	Total:                                     0.041 (MW) /      0.332 (MB)
+
+	Size of irrep 0 of <IA|BC> integrals:      0.003 (MW) /      0.023 (MB)
+	Size of irrep 1 of <IA|BC> integrals:      0.001 (MW) /      0.007 (MB)
+	Size of irrep 2 of <IA|BC> integrals:      0.001 (MW) /      0.009 (MB)
+	Size of irrep 3 of <IA|BC> integrals:      0.002 (MW) /      0.019 (MB)
+	Total:                                     0.007 (MW) /      0.058 (MB)
+
+	Size of irrep 0 of <ia|bc> integrals:      0.002 (MW) /      0.016 (MB)
+	Size of irrep 1 of <ia|bc> integrals:      0.001 (MW) /      0.004 (MB)
+	Size of irrep 2 of <ia|bc> integrals:      0.001 (MW) /      0.005 (MB)
+	Size of irrep 3 of <ia|bc> integrals:      0.002 (MW) /      0.015 (MB)
+	Total:                                     0.005 (MW) /      0.040 (MB)
+
+	Size of irrep 0 of <Ia|Bc> integrals:      0.003 (MW) /      0.028 (MB)
+	Size of irrep 1 of <Ia|Bc> integrals:      0.001 (MW) /      0.009 (MB)
+	Size of irrep 2 of <Ia|Bc> integrals:      0.002 (MW) /      0.013 (MB)
+	Size of irrep 3 of <Ia|Bc> integrals:      0.003 (MW) /      0.021 (MB)
+	Total:                                     0.009 (MW) /      0.070 (MB)
+
+	Size of irrep 0 of <iA|bC> integrals:      0.002 (MW) /      0.014 (MB)
+	Size of irrep 1 of <iA|bC> integrals:      0.000 (MW) /      0.003 (MB)
+	Size of irrep 2 of <iA|bC> integrals:      0.000 (MW) /      0.003 (MB)
+	Size of irrep 3 of <iA|bC> integrals:      0.002 (MW) /      0.013 (MB)
+	Total:                                     0.004 (MW) /      0.033 (MB)
+
+	Size of irrep 0 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
+	Size of irrep 1 of tIjAb amplitudes:       0.000 (MW) /      0.001 (MB)
+	Size of irrep 2 of tIjAb amplitudes:       0.000 (MW) /      0.001 (MB)
+	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
+	Total:                                     0.001 (MW) /      0.007 (MB)
+
+	Nuclear Rep. energy          =      6.06829802942046
+	SCF energy                   =    -39.03083149936545
+	One-electron energy          =    -17.66256217973037
+	Two-electron (AA) energy     =      2.56415671958394
+	Two-electron (BB) energy     =      0.37500214914182
+	Two-electron (AB) energy     =      4.02147470682345
+	Two-electron energy          =      6.96063357554921
+	Reference energy             =    -38.91656048452192
+
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:07:31 2022
+Module time:
+	user time   =       0.04 seconds =       0.00 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.52 seconds =       0.03 minutes
+	system time =       2.49 seconds =       0.04 minutes
+	total time  =          6 seconds =       0.10 minutes
+            **************************
+            *                        *
+            *        CCENERGY        *
+            *                        *
+            **************************
+
+    Nuclear Rep. energy (wfn)     =    6.068298029420463
+    SCF energy          (wfn)     =  -39.030834168960190
+    Reference energy    (file100) =  -38.916560484521916
+
+    Input parameters:
+    -----------------
+    Wave function   =     BCCD_T
+    Reference wfn   =     UHF
+    Brueckner       =     Yes
+    Brueckner conv. =     1.0e-04
+    Memory (Mbytes) =     524.3
+    Maxiter         =     50
+    R_Convergence   =     1.0e-07
+    E_Convergence   =     1.0e-06
+    Restart         =     Yes
+    DIIS            =     Yes
+    AO Basis        =     NONE
+    ABCD            =     NEW
+    Cache Level     =     2
+    Cache Type      =     LRU
+    Print Level     =     1
+    Num. of threads =     1
+    # Amps to Print =     10
+    Print MP2 Amps? =     No
+    Analyze T2 Amps =     No
+    Print Pair Ener =     No
+    Local CC        =     No
+    SCS-MP2         =     False
+    SCSN-MP2        =     False
+    SCS-CCSD        =     False
+
+    Using old T1 amplitudes.
+    Using old T2 amplitudes.
+MP2 correlation energy -0.0952479884884709
+                Solving CC Amplitude Equations
+                ------------------------------
+  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
+  ----     ---------------------    ---------   ----------  ----------  ----------   --------
+     0        -0.114269799387977    0.000e+00    0.000105    0.000000    0.000000    0.000000
+     1        -0.114274405558658    1.988e-04    0.000045    0.000000    0.000000    0.000000
+     2        -0.114273886243730    4.578e-05    0.000027    0.000000    0.000000    0.000000
+     3        -0.114273587440475    2.089e-05    0.000016    0.000000    0.000000    0.000000
+     4        -0.114273428499738    4.430e-06    0.000014    0.000000    0.000000    0.000000
+     5        -0.114273366418358    1.048e-06    0.000014    0.000000    0.000000    0.000000
+     6        -0.114273354338926    3.280e-07    0.000014    0.000000    0.000000    0.000000
+     7        -0.114273351676705    1.037e-07    0.000014    0.000000    0.000000    0.000000
+     8        -0.114273350991624    3.025e-08    0.000014    0.000000    0.000000    0.000000
+
+    Iterations converged.
+
+
+    Largest TIA Amplitudes:
+              3  13        -0.0000165933
+              3  15        -0.0000162431
+              2  10        -0.0000117884
+              1   2        -0.0000092371
+              1   1        -0.0000086291
+              0   3         0.0000079169
+              0   0        -0.0000068054
+              3  14         0.0000066504
+              1   0        -0.0000055204
+              1   4        -0.0000054930
+
+    Largest Tia Amplitudes:
+              0   0        -0.0000040444
+              1  15        -0.0000025734
+              0   4         0.0000018861
+              1  17        -0.0000015790
+              0   3         0.0000015444
+              0   6         0.0000010731
+              1  16        -0.0000008633
+              0   1        -0.0000006600
+              1  19        -0.0000006160
+              1  18         0.0000004636
+
+    Largest TIJAB Amplitudes:
+      2   1  10   1        -0.0304559893
+      3   2   8   2         0.0234168131
+      2   1  11   4        -0.0218943171
+      3   2  15  10        -0.0209198193
+      3   2  13  10        -0.0206101137
+      3   1  13   1        -0.0197548086
+      3   1  15   1        -0.0196521030
+      2   1  10   2        -0.0180801215
+      3   1  14   2        -0.0155346379
+      3   1  14   4         0.0154407614
+
+    Largest Tijab Amplitudes:
+      1   0  11   9        -0.0103672377
+      1   0  16   1        -0.0078210310
+      1   0  16   0         0.0077006628
+      1   0  16   3        -0.0073294896
+      1   0  15   0        -0.0069239985
+      1   0  17   0        -0.0068210062
+      1   0  15   1        -0.0065000689
+      1   0  17   4         0.0062490393
+      1   0  15   4         0.0060737747
+      1   0  12   9        -0.0046156435
+
+    Largest TIjAb Amplitudes:
+      3   1  15  17        -0.0338636770
+      3   1  13  15        -0.0325316689
+      2   0   2  11        -0.0315049076
+      3   1  13  17        -0.0296732977
+      3   1   2   2        -0.0288706539
+      3   1  14  16        -0.0279362337
+      3   1  15  15        -0.0258268019
+      2   1  10  17        -0.0257352306
+      1   0   4   0        -0.0256798999
+      2   1  10  15        -0.0255928323
+
+    SCF energy       (wfn)                    =  -39.030834168960190
+    Reference energy (file100)                =  -38.916560484521916
+
+    Opposite-spin MP2 correlation energy      =   -0.073530433044360
+    Same-spin MP2 correlation energy          =   -0.021202989208460
+    Singles MP2 correlation energy            =   -0.000514566235651
+    MP2 correlation energy                    =   -0.095247988488471
+      * MP2 total energy                      =  -39.011808473010390
+
+    Opposite-spin CCSD correlation energy     =   -0.091446679030866
+    Same-spin CCSD correlation energy         =   -0.022826626757284
+    Singles CCSD correlation energy           =   -0.000000045203474
+    CCSD correlation energy                   =   -0.114273350991624
+      * CCSD total energy                     =  -39.030833835513540
+
+    Brueckner orbitals converged.  Maximum T1 =  0.000016593319
 Brueckner convergence check: True
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:16 2017
-
             **************************
             *                        *
             *        CCTRIPLES       *
@@ -1543,53 +1511,46 @@ Brueckner convergence check: True
     Wave function   =    BCCD_T
     Reference wfn   =      UHF
 
-    Nuclear Rep. energy (wfn)                =    6.068298005568229
-    SCF energy          (wfn)                =  -39.030834168202368
-    Reference energy    (file100)            =  -38.916560485657740
-    CCSD energy         (file100)            =   -0.114273350010298
-    Total CCSD energy   (file100)            =  -39.030833835668041
+    Nuclear Rep. energy (wfn)                =    6.068298029420463
+    SCF energy          (wfn)                =  -39.030834168960190
+    Reference energy    (file100)            =  -38.916560484521916
+    CCSD energy         (file100)            =   -0.114273350991624
+    Total CCSD energy   (file100)            =  -39.030833835513540
 
     Number of ijk index combinations:
     Spin Case AAA:                                   4
     Spin Case BBB:                                   0
     Spin Case AAB:                                  12
     Spin Case ABB:                                   4
-    AAA (T) energy                             =   -0.000061271910275
+    AAA (T) energy                             =   -0.000061271908732
     BBB (T) energy                             =    0.000000000000000
-    AAB (T) energy                             =   -0.001407493346526
-    ABB (T) energy                             =   -0.000389211929948
-    (T) energy                                   =   -0.001857977186749
-      * CCSD(T) total energy                     =  -39.032691812854786
+    AAB (T) energy                             =   -0.001407493393359
+    ABB (T) energy                             =   -0.000389211960741
+    (T) energy                                   =   -0.001857977262832
+      * CCSD(T) total energy                     =  -39.032691812776370
 
+    SCF energy............................................................................PASSED
+    B-CCD energy..........................................................................PASSED
+    B-CCD(T) energy.......................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:34:16 2017
-Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.85 seconds =       0.01 minutes
-	system time =       0.96 seconds =       0.02 minutes
-	total time  =          2 seconds =       0.03 minutes
-	SCF energy........................................................PASSED
-	B-CCD energy......................................................PASSED
-	B-CCD(T) energy...................................................PASSED
+Scratch directory: /tmp/
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:16 2017
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:07:32 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry C          line   130 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
-    atoms 2-3 entry H          line    20 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1   entry C          line   138 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                              ROHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -1603,15 +1564,15 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           C          0.000000000000     0.000000000000    -0.091864689759    12.000000000000
-           H          0.000000000000    -0.895527070192     0.546908561523     1.007825032070
-           H          0.000000000000     0.895527070192     0.546908561523     1.007825032070
+         C            0.000000000000     0.000000000000    -0.091864689772    12.000000000000
+         H            0.000000000000    -0.895527070192     0.546908561510     1.007825032230
+         H            0.000000000000     0.895527070192     0.546908561510     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     23.93977  B =     10.42855  C =      7.26416 [cm^-1]
-  Rotational constants: A = 717696.14844  B = 312640.05804  C = 217774.12469 [MHz]
-  Nuclear repulsion =    6.068298005568228
+  Rotational constants: A = 717696.15382  B = 312640.06037  C = 217774.12632 [MHz]
+  Nuclear repulsion =    6.068298029420463
 
   Charge       = 0
   Multiplicity = 3
@@ -1625,33 +1586,20 @@ Total time:
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-08
   Density threshold  = 1.00e-08
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: CC-PVDZ
     Blend: CC-PVDZ
     Number of shells: 12
-    Number of basis function: 24
+    Number of basis functions: 24
     Number of Cartesian functions: 25
     Spherical Harmonics?: true
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        11      11       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      24      24       5       3       3       2
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -1670,40 +1618,58 @@ Total time:
   Using 90300 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.9429630952E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  Minimum eigenvalue in the overlap matrix is 2.6725919994E-02.
+  Reciprocal condition number of the overlap matrix is 8.2894136923E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        11      11 
+     A2         2       2 
+     B1         4       4 
+     B2         7       7 
+   -------------------------
+    Total      24      24
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @ROHF iter   1:   -38.31961105999222   -3.83196e+01   6.01092e-02 
-   @ROHF iter   2:   -38.82874290582877   -5.09132e-01   2.11216e-02 DIIS
-   @ROHF iter   3:   -38.90737235503750   -7.86294e-02   3.83058e-03 DIIS
-   @ROHF iter   4:   -38.91282145810774   -5.44910e-03   1.30337e-03 DIIS
-   @ROHF iter   5:   -38.91341190038020   -5.90442e-04   1.17868e-04 DIIS
-   @ROHF iter   6:   -38.91341655392770   -4.65355e-06   2.10991e-05 DIIS
-   @ROHF iter   7:   -38.91341670563057   -1.51703e-07   3.49397e-06 DIIS
-   @ROHF iter   8:   -38.91341670953769   -3.90711e-09   8.35775e-07 DIIS
-   @ROHF iter   9:   -38.91341670975637   -2.18684e-10   1.15587e-07 DIIS
-   @ROHF iter  10:   -38.91341670976102   -4.64695e-12   2.14269e-08 DIIS
-   @ROHF iter  11:   -38.91341670976116   -1.42109e-13   4.03396e-09 DIIS
+   @ROHF iter SAD:   -38.17324740294831   -3.81732e+01   0.00000e+00 
+   @ROHF iter   1:   -38.90234369081282   -7.29096e-01   6.50261e-03 DIIS
+   @ROHF iter   2:   -38.91242369713281   -1.00800e-02   1.83961e-03 DIIS
+   @ROHF iter   3:   -38.91339017288887   -9.66476e-04   2.69689e-04 DIIS
+   @ROHF iter   4:   -38.91341456819067   -2.43953e-05   8.81475e-05 DIIS
+   @ROHF iter   5:   -38.91341661898140   -2.05079e-06   1.51310e-05 DIIS
+   @ROHF iter   6:   -38.91341670674451   -8.77631e-08   3.07520e-06 DIIS
+   @ROHF iter   7:   -38.91341670984618   -3.10167e-09   4.33292e-07 DIIS
+   @ROHF iter   8:   -38.91341670989264   -4.64624e-11   7.04761e-08 DIIS
+   @ROHF iter   9:   -38.91341670989409   -1.44951e-12   1.28167e-08 DIIS
+   @ROHF iter  10:   -38.91341670989411   -1.42109e-14   1.60731e-09 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -1727,50 +1693,49 @@ Total time:
              A1    A2    B1    B2 
     DOCC [     2,    0,    0,    1 ]
     SOCC [     1,    0,    1,    0 ]
+    NA   [     3,    0,    1,    1 ]
+    NB   [     2,    0,    0,    1 ]
 
-  Energy converged.
-
-  @ROHF Final Energy:   -38.91341670976116
+  @ROHF Final Energy:   -38.91341670989411
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              6.0682980055682281
-    One-Electron Energy =                 -63.7113218383880806
-    Two-Electron Energy =                  18.7296071230586918
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -38.9134167097611581
+    Nuclear Repulsion Energy =              6.0682980294204629
+    One-Electron Energy =                 -63.7113218632468943
+    Two-Electron Energy =                  18.7296071239323254
+    Total Energy =                        -38.9134167098941077
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0254
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.7765
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.2490     Total:     0.2490
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.6328     Total:     0.6328
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.7764657            1.0254202            0.2489545
+ Magnitude           :                                                    0.2489545
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:34:16 2017
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:07:33 2022
 Module time:
-	user time   =       0.16 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.02 seconds =       0.02 minutes
-	system time =       0.97 seconds =       0.02 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.10 seconds =       0.04 minutes
+	system time =       2.90 seconds =       0.05 minutes
+	total time  =          8 seconds =       0.13 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -1784,19 +1749,19 @@ Total time:
       Number of basis functions:        24
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  11    2    4    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 11609 non-zero two-electron integrals.
+      Computed 11412 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:16 2017
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:07:33 2022
 
 
 	Wfn Parameters:
@@ -1821,7 +1786,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting AA/AB first half-transformation.
 	Sorting AA/AB half-transformed integrals.
 	Starting BB first half-transformation.
@@ -1881,7 +1846,7 @@ Total time:
 	Starting AB second half-transformation.
 	Starting BB second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -34.28298229710389
+	Frozen core energy     =    -34.28298230465726
 
 	Size of irrep 0 of <AB|CD> integrals:      0.002 (MW) /      0.018 (MB)
 	Size of irrep 1 of <AB|CD> integrals:      0.001 (MW) /      0.009 (MB)
@@ -1931,37 +1896,33 @@ Total time:
 	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
 	Total:                                     0.001 (MW) /      0.007 (MB)
 
-	Nuclear Rep. energy          =      6.06829800556823
-	SCF energy                   =    -38.91341670976116
-	One-electron energy          =    -17.65945483147467
-	Two-electron (AA) energy     =      2.53990125925700
-	Two-electron (BB) energy     =      0.38273034302465
-	Two-electron (AB) energy     =      4.03809081096753
-	Two-electron energy          =      6.96072241324918
-	Reference energy             =    -38.91341670976117
+	Nuclear Rep. energy          =      6.06829802942046
+	SCF energy                   =    -38.91341670989411
+	One-electron energy          =    -17.65945485973305
+	Two-electron (AA) energy     =      2.53990126237141
+	Two-electron (BB) energy     =      0.38273034439257
+	Two-electron (AB) energy     =      4.03809081831173
+	Two-electron energy          =      6.96072242507571
+	Reference energy             =    -38.91341670989414
 
-*** tstop() called on psinet at Mon May 15 15:34:16 2017
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:07:33 2022
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       0.05 seconds =       0.00 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.07 seconds =       0.02 minutes
-	system time =       1.02 seconds =       0.02 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:16 2017
-
+	user time   =       2.17 seconds =       0.04 minutes
+	system time =       3.04 seconds =       0.05 minutes
+	total time  =          8 seconds =       0.13 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    6.068298005568228
-    SCF energy          (wfn)     =  -38.913416709761158
-    Reference energy    (file100) =  -38.913416709761165
+    Nuclear Rep. energy (wfn)     =    6.068298029420463
+    SCF energy          (wfn)     =  -38.913416709894108
+    Reference energy    (file100) =  -38.913416709894136
 
     Input parameters:
     -----------------
@@ -1992,117 +1953,109 @@ Total time:
 
     Using old T1 amplitudes.
     Using old T2 amplitudes.
-MP2 correlation energy -0.0969789292869689
+MP2 correlation energy -0.0969789289246027
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.008462642317468    0.000e+00    0.000014    0.000000    0.000000    0.000000
-     1        -0.099144531027715    2.328e-01    0.015481    0.000000    0.000000    0.000000
-     2        -0.116878362609251    5.653e-02    0.021621    0.000000    0.000000    0.000000
-     3        -0.117163271069254    1.108e-02    0.023656    0.000000    0.000000    0.000000
-     4        -0.117420004237993    3.037e-03    0.024501    0.000000    0.000000    0.000000
-     5        -0.117405421457884    8.534e-04    0.024683    0.000000    0.000000    0.000000
-     6        -0.117413884546207    2.696e-04    0.024708    0.000000    0.000000    0.000000
-     7        -0.117416384298296    8.961e-05    0.024699    0.000000    0.000000    0.000000
-     8        -0.117416180556547    3.270e-05    0.024690    0.000000    0.000000    0.000000
-     9        -0.117416945447934    1.065e-05    0.024688    0.000000    0.000000    0.000000
-    10        -0.117416987615788    3.147e-06    0.024687    0.000000    0.000000    0.000000
-    11        -0.117416941449630    9.901e-07    0.024687    0.000000    0.000000    0.000000
-    12        -0.117416947798794    2.253e-07    0.024687    0.000000    0.000000    0.000000
-    13        -0.117416948464682    5.595e-08    0.024687    0.000000    0.000000    0.000000
+     0        -0.008462641853869    0.000e+00    0.000014    0.000000    0.000000    0.000000
+     1        -0.099144530827744    2.328e-01    0.015481    0.000000    0.000000    0.000000
+     2        -0.116878361539345    5.653e-02    0.021621    0.000000    0.000000    0.000000
+     3        -0.117163269800552    1.108e-02    0.023656    0.000000    0.000000    0.000000
+     4        -0.117420002733051    3.037e-03    0.024501    0.000000    0.000000    0.000000
+     5        -0.117405419963548    8.534e-04    0.024683    0.000000    0.000000    0.000000
+     6        -0.117413883027520    2.696e-04    0.024708    0.000000    0.000000    0.000000
+     7        -0.117416382778499    8.961e-05    0.024699    0.000000    0.000000    0.000000
+     8        -0.117416179036817    3.270e-05    0.024690    0.000000    0.000000    0.000000
+     9        -0.117416943927911    1.065e-05    0.024688    0.000000    0.000000    0.000000
+    10        -0.117416986095725    3.147e-06    0.024687    0.000000    0.000000    0.000000
+    11        -0.117416939929627    9.901e-07    0.024687    0.000000    0.000000    0.000000
+    12        -0.117416946278792    2.253e-07    0.024687    0.000000    0.000000    0.000000
+    13        -0.117416946944685    5.595e-08    0.024687    0.000000    0.000000    0.000000
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              3  13        -0.0221199857
-              3  15        -0.0164564627
-              0   1         0.0138629975
-              0   2         0.0130862843
-              0   0         0.0129715245
-              0   5         0.0109891458
-              1   2         0.0101064566
-              1   0         0.0100699016
-              1   1         0.0095782131
-              3  17         0.0085297770
+              3  13        -0.0221199980
+              3  15        -0.0164564706
+              0   1         0.0138630019
+              0   2         0.0130862803
+              0   0         0.0129715274
+              0   5         0.0109891465
+              1   2         0.0101064458
+              1   0         0.0100698720
+              1   1         0.0095782162
+              3  17         0.0085297786
 
     Largest Tia Amplitudes:
-              1  15         0.0194560272
-              0   0        -0.0192881819
-              0   1        -0.0190207258
-              0   2         0.0168555717
-              0   3        -0.0093660015
-              1  17         0.0084022425
-              1  16         0.0076705362
-              0   6        -0.0059924922
-              1  18        -0.0053551462
-              1  20         0.0021204834
+              1  15         0.0194560201
+              0   0        -0.0192881317
+              0   1        -0.0190207114
+              0   2         0.0168555801
+              0   3        -0.0093659922
+              1  17         0.0084022407
+              1  16         0.0076705443
+              0   6        -0.0059924926
+              1  18        -0.0053551453
+              1  20         0.0021204844
 
     Largest TIJAB Amplitudes:
-      2   1  10   1         0.0302444917
-      3   2   8   2        -0.0232931305
-      2   1  11   4         0.0218501563
-      3   2  15  10         0.0210314179
-      3   2  13  10         0.0205859686
-      3   1  13   1        -0.0197589694
-      3   1  15   1        -0.0197028525
-      2   1  10   2        -0.0184830427
+      2   1  10   1         0.0302444915
+      3   2   8   2        -0.0232931303
+      2   1  11   4         0.0218501562
+      3   2  15  10         0.0210314183
+      3   2  13  10         0.0205859685
+      3   1  13   1        -0.0197589696
+      3   1  15   1        -0.0197028529
+      2   1  10   2        -0.0184830431
       3   1  14   4        -0.0155434318
-      3   1  14   2        -0.0155199486
+      3   1  14   2        -0.0155199481
 
     Largest Tijab Amplitudes:
-      1   0  11   9         0.0104384322
-      1   0  16   0        -0.0079096353
-      1   0  16   1        -0.0077498919
-      1   0  16   3        -0.0074326249
-      1   0  17   0        -0.0069317706
-      1   0  15   0        -0.0068875696
+      1   0  11   9         0.0104384319
+      1   0  16   0        -0.0079096347
+      1   0  16   1        -0.0077498916
+      1   0  16   3        -0.0074326255
+      1   0  17   0        -0.0069317699
+      1   0  15   0        -0.0068875681
       1   0  15   1         0.0066463911
-      1   0  17   4         0.0062829502
-      1   0  15   4         0.0061431599
-      1   0  12   9         0.0046169725
+      1   0  17   4         0.0062829503
+      1   0  15   4         0.0061431597
+      1   0  12   9         0.0046169724
 
     Largest TIjAb Amplitudes:
-      3   1  15  17        -0.0339364542
-      3   1  13  15        -0.0326377539
-      2   0   2  11        -0.0314841232
-      3   1  13  17        -0.0295820895
-      3   1  14  16        -0.0279239145
-      3   1   2   2        -0.0278318277
-      3   1  15  15        -0.0261108788
-      1   0   4   0        -0.0259405023
+      3   1  15  17        -0.0339364551
+      3   1  13  15        -0.0326377530
+      2   0   2  11        -0.0314841224
+      3   1  13  17        -0.0295820900
+      3   1  14  16        -0.0279239139
+      3   1   2   2        -0.0278318258
+      3   1  15  15        -0.0261108791
+      1   0   4   0        -0.0259404986
       2   1  10  15         0.0257600085
-      2   1  10  17         0.0256852745
+      2   1  10  17         0.0256852748
 
-    SCF energy       (wfn)                    =  -38.913416709761158
-    Reference energy (file100)                =  -38.913416709761165
+    SCF energy       (wfn)                    =  -38.913416709894108
+    Reference energy (file100)                =  -38.913416709894136
 
-    Opposite-spin MP2 correlation energy      =   -0.073908632069800
-    Same-spin MP2 correlation energy          =   -0.020848884108368
-    MP2 correlation energy                    =   -0.096978929286969
-      * MP2 total energy                      =  -39.010395639048134
+    Opposite-spin MP2 correlation energy      =   -0.073908631756357
+    Same-spin MP2 correlation energy          =   -0.020848884135216
+    Singles MP2 correlation energy            =   -0.002221413033030
+    MP2 correlation energy                    =   -0.096978928924603
+      * MP2 total energy                      =  -39.010395638818736
 
-    Opposite-spin CCSD correlation energy     =   -0.091924321833647
-    Same-spin CCSD correlation energy         =   -0.022640807042840
-    CCSD correlation energy                   =   -0.117416948464682
-      * CCSD total energy                     =  -39.030833658225845
+    Opposite-spin CCSD correlation energy     =   -0.091924320827499
+    Same-spin CCSD correlation energy         =   -0.022640807123486
+    Singles CCSD correlation energy           =   -0.002851818993700
+    CCSD correlation energy                   =   -0.117416946944685
+      * CCSD total energy                     =  -39.030833656838823
 
-    Rotating orbitals.  Maximum T1 =  0.022119985687
-
-*** tstop() called on psinet at Mon May 15 15:34:17 2017
-Module time:
-	user time   =       0.13 seconds =       0.00 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.20 seconds =       0.02 minutes
-	system time =       1.20 seconds =       0.02 minutes
-	total time  =          3 seconds =       0.05 minutes
+    Rotating orbitals.  Maximum T1 =  0.022119998004
 Brueckner convergence check: False
 
-*** tstart() called on psinet
-*** at Mon May 15 15:34:17 2017
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:07:34 2022
 
 
 	Wfn Parameters:
@@ -2127,7 +2080,7 @@ Brueckner convergence check: False
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting AA/AB first half-transformation.
 	Sorting AA/AB half-transformed integrals.
 	Starting BB first half-transformation.
@@ -2187,7 +2140,7 @@ Brueckner convergence check: False
 	Starting AB second half-transformation.
 	Starting BB second half-transformation.
 	Two-electron integral transformation complete.
-	Frozen core energy     =    -34.28298229710386
+	Frozen core energy     =    -34.28298230465726
 
 	Size of irrep 0 of <AB|CD> integrals:      0.002 (MW) /      0.018 (MB)
 	Size of irrep 1 of <AB|CD> integrals:      0.001 (MW) /      0.009 (MB)
@@ -2237,782 +2190,742 @@ Brueckner convergence check: False
 	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
 	Total:                                     0.001 (MW) /      0.007 (MB)
 
-	Nuclear Rep. energy          =      6.06829800556823
-	SCF energy                   =    -38.91341670976116
-	One-electron energy          =    -17.66296025953259
-	Two-electron (AA) energy     =      2.56206644645293
-	Two-electron (BB) energy     =      0.37571249756083
-	Two-electron (AB) energy     =      4.02341722487214
-	Two-electron energy          =      6.96119616888590
-	Reference energy             =    -38.91644838218232
+	Nuclear Rep. energy          =      6.06829802942046
+	SCF energy                   =    -38.91341670989411
+	One-electron energy          =    -17.66296066069019
+	Two-electron (AA) energy     =      2.56207324405467
+	Two-electron (BB) energy     =      0.37571025536398
+	Two-electron (AB) energy     =      4.02341292091328
+	Two-electron energy          =      6.96119642033193
+	Reference energy             =    -38.91644851559506
 
-*** tstop() called on psinet at Mon May 15 15:34:17 2017
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:07:34 2022
 Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.23 seconds =       0.02 minutes
-	system time =       1.24 seconds =       0.02 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:17 2017
-
-            **************************
-            *                        *
-            *        CCENERGY        *
-            *                        *
-            **************************
-
-    Nuclear Rep. energy (wfn)     =    6.068298005568228
-    SCF energy          (wfn)     =  -39.030833658225845
-    Reference energy    (file100) =  -38.916448382182324
-
-    Input parameters:
-    -----------------
-    Wave function   =     BCCD_T
-    Reference wfn   =     ROHF changed to UHF for Semicanonical Orbitals
-    Brueckner       =     Yes
-    Brueckner conv. =     1.0e-04
-    Memory (Mbytes) =     524.3
-    Maxiter         =     50
-    R_Convergence   =     1.0e-07
-    E_Convergence   =     1.0e-06
-    Restart         =     Yes
-    DIIS            =     Yes
-    AO Basis        =     NONE
-    ABCD            =     NEW
-    Cache Level     =     2
-    Cache Type      =     LRU
-    Print Level     =     1
-    Num. of threads =     1
-    # Amps to Print =     10
-    Print MP2 Amps? =     No
-    Analyze T2 Amps =     No
-    Print Pair Ener =     No
-    Local CC        =     No
-    SCS-MP2         =     False
-    SCSN-MP2        =     False
-    SCS-CCSD        =     False
-
-    Using old T1 amplitudes.
-    Using old T2 amplitudes.
-MP2 correlation energy -0.0953387983046238
-                Solving CC Amplitude Equations
-                ------------------------------
-  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
-  ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.114739259932229    0.000e+00    0.024687    0.000000    0.000000    0.000000
-     1        -0.114472052023240    3.908e-02    0.009880    0.000000    0.000000    0.000000
-     2        -0.114305775356560    1.102e-02    0.004626    0.000000    0.000000    0.000000
-     3        -0.114325412634253    3.705e-03    0.002318    0.000000    0.000000    0.000000
-     4        -0.114349082098916    9.300e-04    0.001794    0.000000    0.000000    0.000000
-     5        -0.114353469824939    2.469e-04    0.001740    0.000000    0.000000    0.000000
-     6        -0.114355309366140    8.750e-05    0.001737    0.000000    0.000000    0.000000
-     7        -0.114356594381197    3.045e-05    0.001738    0.000000    0.000000    0.000000
-     8        -0.114356782248716    8.462e-06    0.001739    0.000000    0.000000    0.000000
-     9        -0.114356812045164    2.637e-06    0.001739    0.000000    0.000000    0.000000
-    10        -0.114356833205353    7.598e-07    0.001739    0.000000    0.000000    0.000000
-    11        -0.114356839284201    2.089e-07    0.001739    0.000000    0.000000    0.000000
-    12        -0.114356839682702    5.687e-08    0.001739    0.000000    0.000000    0.000000
-
-    Iterations converged.
-
-
-    Largest TIA Amplitudes:
-              3  15        -0.0010193591
-              3  13        -0.0010176280
-              1   2         0.0010066851
-              1   4         0.0009497976
-              2  11        -0.0009183897
-              0   0         0.0008606851
-              0   2         0.0008188015
-              1   0         0.0006916877
-              1   1         0.0004994470
-              0   3         0.0004736337
-
-    Largest Tia Amplitudes:
-              1  17         0.0018585860
-              1  15         0.0014732648
-              0   1        -0.0010614527
-              0   3        -0.0009342910
-              1  16         0.0008676165
-              0   2         0.0008516507
-              0   4        -0.0007894601
-              0   0         0.0005324239
-              1  20        -0.0004365268
-              0   8        -0.0003777426
-
-    Largest TIJAB Amplitudes:
-      2   1  10   1         0.0303668863
-      3   2   8   2        -0.0233684236
-      2   1  11   4         0.0218826055
-      3   2  15  10         0.0209321933
-      3   2  13  10         0.0206022140
-      3   1  13   1        -0.0197565738
-      3   1  15   1        -0.0196490251
-      2   1  10   2        -0.0182234245
-      3   1  14   2        -0.0155397061
-      3   1  14   4        -0.0154513461
-
-    Largest Tijab Amplitudes:
-      1   0  11   9         0.0103717929
-      1   0  16   1        -0.0078251654
-      1   0  16   0        -0.0077041369
-      1   0  16   3        -0.0073355230
-      1   0  15   0        -0.0069227360
-      1   0  17   0        -0.0068300125
-      1   0  15   1         0.0065060271
-      1   0  17   4         0.0062532314
-      1   0  15   4         0.0060781953
-      1   0  12   9         0.0046184587
-
-    Largest TIjAb Amplitudes:
-      3   1  15  17        -0.0338602455
-      3   1  13  15        -0.0325319339
-      2   0   2  11        -0.0314482062
-      3   1  13  17        -0.0296552393
-      3   1   2   2        -0.0288104819
-      3   1  14  16        -0.0279381883
-      3   1  15  15        -0.0258495633
-      2   1  10  17         0.0257297187
-      1   0   4   0        -0.0256705554
-      2   1  10  15         0.0256120936
-
-    SCF energy       (wfn)                    =  -39.030833658225845
-    Reference energy (file100)                =  -38.916448382182324
-
-    Opposite-spin MP2 correlation energy      =   -0.073604473754887
-    Same-spin MP2 correlation energy          =   -0.021179663094156
-    MP2 correlation energy                    =   -0.095338798304624
-      * MP2 total energy                      =  -39.011787180486948
-
-    Opposite-spin CCSD correlation energy     =   -0.091502213410614
-    Same-spin CCSD correlation energy         =   -0.022808926737607
-    CCSD correlation energy                   =   -0.114356839682702
-      * CCSD total energy                     =  -39.030805221865023
-
-    Rotating orbitals.  Maximum T1 =  0.001858585968
-
-*** tstop() called on psinet at Mon May 15 15:34:17 2017
-Module time:
-	user time   =       0.12 seconds =       0.00 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.35 seconds =       0.02 minutes
-	system time =       1.41 seconds =       0.02 minutes
-	total time  =          3 seconds =       0.05 minutes
-Brueckner convergence check: False
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:17 2017
-
-
-	Wfn Parameters:
-	--------------------
-	Wavefunction         = BCCD_T
-	Number of irreps     = 4
-	Number of MOs        = 24
-	Number of active MOs = 23
-	AO-Basis             = NONE
-	Semicanonical        = true
-	Reference            = ROHF changed to UHF for semicanonical orbitals
-	Print Level          = 1
-
-	IRREP	# MOs	# FZDC	# DOCC	# SOCC	# VIRT	# FZVR
-	-----	-----	------	------	------	------	------
-	 A1	   11	    1	    1	    1	    8	    0
-	 A2	   2	    0	    0	    0	    2	    0
-	 B1	   4	    0	    0	    1	    3	    0
-	 B2	   7	    0	    1	    0	    6	    0
-	Transforming integrals...
-	IWL integrals will be retained.
-	(OO|OO)...
-	Presorting SO-basis two-electron integrals.
-	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
-	Starting AA/AB first half-transformation.
-	Sorting AA/AB half-transformed integrals.
-	Starting BB first half-transformation.
-	Sorting BB half-transformed integrals.
-	First half integral transformation complete.
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OO|OV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OO|VV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OV|OO)...
-	Starting AA/AB first half-transformation.
-	Sorting AA/AB half-transformed integrals.
-	Starting BB first half-transformation.
-	Sorting BB half-transformed integrals.
-	First half integral transformation complete.
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OV|OV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OV|VV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(VV|OO)...
-	Starting AA/AB first half-transformation.
-	Sorting AA/AB half-transformed integrals.
-	Starting BB first half-transformation.
-	Sorting BB half-transformed integrals.
-	First half integral transformation complete.
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(VV|OV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(VV|VV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	Frozen core energy     =    -34.28298229710389
-
-	Size of irrep 0 of <AB|CD> integrals:      0.002 (MW) /      0.018 (MB)
-	Size of irrep 1 of <AB|CD> integrals:      0.001 (MW) /      0.009 (MB)
-	Size of irrep 2 of <AB|CD> integrals:      0.001 (MW) /      0.010 (MB)
-	Size of irrep 3 of <AB|CD> integrals:      0.003 (MW) /      0.023 (MB)
-	Total:                                     0.008 (MW) /      0.061 (MB)
-
-	Size of irrep 0 of <ab|cd> integrals:      0.003 (MW) /      0.027 (MB)
-	Size of irrep 1 of <ab|cd> integrals:      0.002 (MW) /      0.014 (MB)
-	Size of irrep 2 of <ab|cd> integrals:      0.002 (MW) /      0.018 (MB)
-	Size of irrep 3 of <ab|cd> integrals:      0.004 (MW) /      0.031 (MB)
-	Total:                                     0.011 (MW) /      0.090 (MB)
-
-	Size of irrep 0 of <Ab|Cd> integrals:      0.015 (MW) /      0.123 (MB)
-	Size of irrep 1 of <Ab|Cd> integrals:      0.006 (MW) /      0.046 (MB)
-	Size of irrep 2 of <Ab|Cd> integrals:      0.007 (MW) /      0.055 (MB)
-	Size of irrep 3 of <Ab|Cd> integrals:      0.013 (MW) /      0.108 (MB)
-	Total:                                     0.041 (MW) /      0.332 (MB)
-
-	Size of irrep 0 of <IA|BC> integrals:      0.003 (MW) /      0.023 (MB)
-	Size of irrep 1 of <IA|BC> integrals:      0.001 (MW) /      0.007 (MB)
-	Size of irrep 2 of <IA|BC> integrals:      0.001 (MW) /      0.009 (MB)
-	Size of irrep 3 of <IA|BC> integrals:      0.002 (MW) /      0.019 (MB)
-	Total:                                     0.007 (MW) /      0.058 (MB)
-
-	Size of irrep 0 of <ia|bc> integrals:      0.002 (MW) /      0.016 (MB)
-	Size of irrep 1 of <ia|bc> integrals:      0.001 (MW) /      0.004 (MB)
-	Size of irrep 2 of <ia|bc> integrals:      0.001 (MW) /      0.005 (MB)
-	Size of irrep 3 of <ia|bc> integrals:      0.002 (MW) /      0.015 (MB)
-	Total:                                     0.005 (MW) /      0.040 (MB)
-
-	Size of irrep 0 of <Ia|Bc> integrals:      0.003 (MW) /      0.028 (MB)
-	Size of irrep 1 of <Ia|Bc> integrals:      0.001 (MW) /      0.009 (MB)
-	Size of irrep 2 of <Ia|Bc> integrals:      0.002 (MW) /      0.013 (MB)
-	Size of irrep 3 of <Ia|Bc> integrals:      0.003 (MW) /      0.021 (MB)
-	Total:                                     0.009 (MW) /      0.070 (MB)
-
-	Size of irrep 0 of <iA|bC> integrals:      0.002 (MW) /      0.014 (MB)
-	Size of irrep 1 of <iA|bC> integrals:      0.000 (MW) /      0.003 (MB)
-	Size of irrep 2 of <iA|bC> integrals:      0.000 (MW) /      0.003 (MB)
-	Size of irrep 3 of <iA|bC> integrals:      0.002 (MW) /      0.013 (MB)
-	Total:                                     0.004 (MW) /      0.033 (MB)
-
-	Size of irrep 0 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
-	Size of irrep 1 of tIjAb amplitudes:       0.000 (MW) /      0.001 (MB)
-	Size of irrep 2 of tIjAb amplitudes:       0.000 (MW) /      0.001 (MB)
-	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
-	Total:                                     0.001 (MW) /      0.007 (MB)
-
-	Nuclear Rep. energy          =      6.06829800556823
-	SCF energy                   =    -39.03083365822584
-	One-electron energy          =    -17.66216403348233
-	Two-electron (AA) energy     =      2.56371141805566
-	Two-electron (BB) energy     =      0.37506540496966
-	Two-electron (AB) energy     =      4.02154323566908
-	Two-electron energy          =      6.96032005869440
-	Reference energy             =    -38.91652826632359
-
-*** tstop() called on psinet at Mon May 15 15:34:17 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.37 seconds =       0.02 minutes
-	system time =       1.45 seconds =       0.02 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:17 2017
-
-            **************************
-            *                        *
-            *        CCENERGY        *
-            *                        *
-            **************************
-
-    Nuclear Rep. energy (wfn)     =    6.068298005568228
-    SCF energy          (wfn)     =  -39.030805221865023
-    Reference energy    (file100) =  -38.916528266323589
-
-    Input parameters:
-    -----------------
-    Wave function   =     BCCD_T
-    Reference wfn   =     ROHF changed to UHF for Semicanonical Orbitals
-    Brueckner       =     Yes
-    Brueckner conv. =     1.0e-04
-    Memory (Mbytes) =     524.3
-    Maxiter         =     50
-    R_Convergence   =     1.0e-07
-    E_Convergence   =     1.0e-06
-    Restart         =     Yes
-    DIIS            =     Yes
-    AO Basis        =     NONE
-    ABCD            =     NEW
-    Cache Level     =     2
-    Cache Type      =     LRU
-    Print Level     =     1
-    Num. of threads =     1
-    # Amps to Print =     10
-    Print MP2 Amps? =     No
-    Analyze T2 Amps =     No
-    Print Pair Ener =     No
-    Local CC        =     No
-    SCS-MP2         =     False
-    SCSN-MP2        =     False
-    SCS-CCSD        =     False
-
-    Using old T1 amplitudes.
-    Using old T2 amplitudes.
-MP2 correlation energy -0.0952502596465473
-                Solving CC Amplitude Equations
-                ------------------------------
-  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
-  ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.114312838095805    0.000e+00    0.001739    0.000000    0.000000    0.000000
-     1        -0.114272258411503    2.473e-03    0.000865    0.000000    0.000000    0.000000
-     2        -0.114272610264133    8.660e-04    0.000422    0.000000    0.000000    0.000000
-     3        -0.114275717297774    3.016e-04    0.000213    0.000000    0.000000    0.000000
-     4        -0.114278245516063    6.560e-05    0.000178    0.000000    0.000000    0.000000
-     5        -0.114279057922609    1.618e-05    0.000176    0.000000    0.000000    0.000000
-     6        -0.114279225443069    5.294e-06    0.000176    0.000000    0.000000    0.000000
-     7        -0.114279310031228    1.989e-06    0.000176    0.000000    0.000000    0.000000
-     8        -0.114279336850365    6.246e-07    0.000176    0.000000    0.000000    0.000000
-     9        -0.114279342344202    2.006e-07    0.000176    0.000000    0.000000    0.000000
-    10        -0.114279341236471    6.015e-08    0.000176    0.000000    0.000000    0.000000
-
-    Iterations converged.
-
-
-    Largest TIA Amplitudes:
-              3  15        -0.0001952766
-              3  13        -0.0001924050
-              1   2         0.0001272621
-              3  14        -0.0001121857
-              1   0         0.0000874726
-              0   3         0.0000817276
-              0   0         0.0000814276
-              2  10         0.0000770491
-              0   2         0.0000683896
-              1   3         0.0000461282
-
-    Largest Tia Amplitudes:
-              0   3        -0.0000933182
-              0   1        -0.0000930967
-              1  17         0.0000926330
-              1  15         0.0000734757
-              0   4        -0.0000478659
-              0   0        -0.0000431237
-              0   2         0.0000388178
-              1  18        -0.0000271988
-              1  19         0.0000268886
-              0   6         0.0000256729
-
-    Largest TIJAB Amplitudes:
-      2   1  10   1         0.0304496106
-      3   2   8   2        -0.0234149571
-      2   1  11   4         0.0218942399
-      3   2  15  10         0.0209196606
-      3   2  13  10         0.0206094034
-      3   1  13   1        -0.0197539245
-      3   1  15   1        -0.0196498353
-      2   1  10   2        -0.0180883777
-      3   1  14   2        -0.0155341770
-      3   1  14   4        -0.0154419672
-
-    Largest Tijab Amplitudes:
-      1   0  11   9         0.0103683873
-      1   0  16   1        -0.0078204907
-      1   0  16   0        -0.0077031962
-      1   0  16   3        -0.0073309194
-      1   0  15   0        -0.0069222147
-      1   0  17   0        -0.0068218753
-      1   0  15   1         0.0065046647
-      1   0  17   4         0.0062522973
-      1   0  15   4         0.0060767845
-      1   0  12   9         0.0046143715
-
-    Largest TIjAb Amplitudes:
-      3   1  15  17        -0.0338638844
-      3   1  13  15        -0.0325344677
-      2   0   2  11        -0.0315098943
-      3   1  13  17        -0.0296730196
-      3   1   2   2        -0.0288462872
-      3   1  14  16        -0.0279340907
-      3   1  15  15        -0.0258312497
-      2   1  10  17         0.0257336783
-      1   0   4   0        -0.0256846402
-      2   1  10  15         0.0255969755
-
-    SCF energy       (wfn)                    =  -39.030805221865023
-    Reference energy (file100)                =  -38.916528266323589
-
-    Opposite-spin MP2 correlation energy      =   -0.073538908890249
-    Same-spin MP2 correlation energy          =   -0.021198298867092
-    MP2 correlation energy                    =   -0.095250259646547
-      * MP2 total energy                      =  -39.011778525970136
-
-    Opposite-spin CCSD correlation energy     =   -0.091455594426690
-    Same-spin CCSD correlation energy         =   -0.022822654943584
-    CCSD correlation energy                   =   -0.114279341236471
-      * CCSD total energy                     =  -39.030807607560057
-
-    Rotating orbitals.  Maximum T1 =  0.000195276602
-
-*** tstop() called on psinet at Mon May 15 15:34:17 2017
-Module time:
-	user time   =       0.09 seconds =       0.00 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.46 seconds =       0.02 minutes
-	system time =       1.62 seconds =       0.03 minutes
-	total time  =          3 seconds =       0.05 minutes
-Brueckner convergence check: False
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:17 2017
-
-
-	Wfn Parameters:
-	--------------------
-	Wavefunction         = BCCD_T
-	Number of irreps     = 4
-	Number of MOs        = 24
-	Number of active MOs = 23
-	AO-Basis             = NONE
-	Semicanonical        = true
-	Reference            = ROHF changed to UHF for semicanonical orbitals
-	Print Level          = 1
-
-	IRREP	# MOs	# FZDC	# DOCC	# SOCC	# VIRT	# FZVR
-	-----	-----	------	------	------	------	------
-	 A1	   11	    1	    1	    1	    8	    0
-	 A2	   2	    0	    0	    0	    2	    0
-	 B1	   4	    0	    0	    1	    3	    0
-	 B2	   7	    0	    1	    0	    6	    0
-	Transforming integrals...
-	IWL integrals will be retained.
-	(OO|OO)...
-	Presorting SO-basis two-electron integrals.
-	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
-	Starting AA/AB first half-transformation.
-	Sorting AA/AB half-transformed integrals.
-	Starting BB first half-transformation.
-	Sorting BB half-transformed integrals.
-	First half integral transformation complete.
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OO|OV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OO|VV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OV|OO)...
-	Starting AA/AB first half-transformation.
-	Sorting AA/AB half-transformed integrals.
-	Starting BB first half-transformation.
-	Sorting BB half-transformed integrals.
-	First half integral transformation complete.
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OV|OV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(OV|VV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(VV|OO)...
-	Starting AA/AB first half-transformation.
-	Sorting AA/AB half-transformed integrals.
-	Starting BB first half-transformation.
-	Sorting BB half-transformed integrals.
-	First half integral transformation complete.
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(VV|OV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	(VV|VV)...
-	Starting AA second half-transformation.
-	Starting AB second half-transformation.
-	Starting BB second half-transformation.
-	Two-electron integral transformation complete.
-	Frozen core energy     =    -34.28298229710386
-
-	Size of irrep 0 of <AB|CD> integrals:      0.002 (MW) /      0.018 (MB)
-	Size of irrep 1 of <AB|CD> integrals:      0.001 (MW) /      0.009 (MB)
-	Size of irrep 2 of <AB|CD> integrals:      0.001 (MW) /      0.010 (MB)
-	Size of irrep 3 of <AB|CD> integrals:      0.003 (MW) /      0.023 (MB)
-	Total:                                     0.008 (MW) /      0.061 (MB)
-
-	Size of irrep 0 of <ab|cd> integrals:      0.003 (MW) /      0.027 (MB)
-	Size of irrep 1 of <ab|cd> integrals:      0.002 (MW) /      0.014 (MB)
-	Size of irrep 2 of <ab|cd> integrals:      0.002 (MW) /      0.018 (MB)
-	Size of irrep 3 of <ab|cd> integrals:      0.004 (MW) /      0.031 (MB)
-	Total:                                     0.011 (MW) /      0.090 (MB)
-
-	Size of irrep 0 of <Ab|Cd> integrals:      0.015 (MW) /      0.123 (MB)
-	Size of irrep 1 of <Ab|Cd> integrals:      0.006 (MW) /      0.046 (MB)
-	Size of irrep 2 of <Ab|Cd> integrals:      0.007 (MW) /      0.055 (MB)
-	Size of irrep 3 of <Ab|Cd> integrals:      0.013 (MW) /      0.108 (MB)
-	Total:                                     0.041 (MW) /      0.332 (MB)
-
-	Size of irrep 0 of <IA|BC> integrals:      0.003 (MW) /      0.023 (MB)
-	Size of irrep 1 of <IA|BC> integrals:      0.001 (MW) /      0.007 (MB)
-	Size of irrep 2 of <IA|BC> integrals:      0.001 (MW) /      0.009 (MB)
-	Size of irrep 3 of <IA|BC> integrals:      0.002 (MW) /      0.019 (MB)
-	Total:                                     0.007 (MW) /      0.058 (MB)
-
-	Size of irrep 0 of <ia|bc> integrals:      0.002 (MW) /      0.016 (MB)
-	Size of irrep 1 of <ia|bc> integrals:      0.001 (MW) /      0.004 (MB)
-	Size of irrep 2 of <ia|bc> integrals:      0.001 (MW) /      0.005 (MB)
-	Size of irrep 3 of <ia|bc> integrals:      0.002 (MW) /      0.015 (MB)
-	Total:                                     0.005 (MW) /      0.040 (MB)
-
-	Size of irrep 0 of <Ia|Bc> integrals:      0.003 (MW) /      0.028 (MB)
-	Size of irrep 1 of <Ia|Bc> integrals:      0.001 (MW) /      0.009 (MB)
-	Size of irrep 2 of <Ia|Bc> integrals:      0.002 (MW) /      0.013 (MB)
-	Size of irrep 3 of <Ia|Bc> integrals:      0.003 (MW) /      0.021 (MB)
-	Total:                                     0.009 (MW) /      0.070 (MB)
-
-	Size of irrep 0 of <iA|bC> integrals:      0.002 (MW) /      0.014 (MB)
-	Size of irrep 1 of <iA|bC> integrals:      0.000 (MW) /      0.003 (MB)
-	Size of irrep 2 of <iA|bC> integrals:      0.000 (MW) /      0.003 (MB)
-	Size of irrep 3 of <iA|bC> integrals:      0.002 (MW) /      0.013 (MB)
-	Total:                                     0.004 (MW) /      0.033 (MB)
-
-	Size of irrep 0 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
-	Size of irrep 1 of tIjAb amplitudes:       0.000 (MW) /      0.001 (MB)
-	Size of irrep 2 of tIjAb amplitudes:       0.000 (MW) /      0.001 (MB)
-	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
-	Total:                                     0.001 (MW) /      0.007 (MB)
-
-	Nuclear Rep. energy          =      6.06829800556823
-	SCF energy                   =    -39.03080522186502
-	One-electron energy          =    -17.66239300892615
-	Two-electron (AA) energy     =      2.56403711600157
-	Two-electron (BB) energy     =      0.37501913565706
-	Two-electron (AB) energy     =      4.02149071802367
-	Two-electron energy          =      6.96054696968231
-	Reference energy             =    -38.91653033077947
-
-*** tstop() called on psinet at Mon May 15 15:34:18 2017
-Module time:
-	user time   =       0.04 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       1.50 seconds =       0.03 minutes
-	system time =       1.66 seconds =       0.03 minutes
-	total time  =          4 seconds =       0.07 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:18 2017
-
-            **************************
-            *                        *
-            *        CCENERGY        *
-            *                        *
-            **************************
-
-    Nuclear Rep. energy (wfn)     =    6.068298005568228
-    SCF energy          (wfn)     =  -39.030807607560057
-    Reference energy    (file100) =  -38.916530330779473
-
-    Input parameters:
-    -----------------
-    Wave function   =     BCCD_T
-    Reference wfn   =     ROHF changed to UHF for Semicanonical Orbitals
-    Brueckner       =     Yes
-    Brueckner conv. =     1.0e-04
-    Memory (Mbytes) =     524.3
-    Maxiter         =     50
-    R_Convergence   =     1.0e-07
-    E_Convergence   =     1.0e-06
-    Restart         =     Yes
-    DIIS            =     Yes
-    AO Basis        =     NONE
-    ABCD            =     NEW
-    Cache Level     =     2
-    Cache Type      =     LRU
-    Print Level     =     1
-    Num. of threads =     1
-    # Amps to Print =     10
-    Print MP2 Amps? =     No
-    Analyze T2 Amps =     No
-    Print Pair Ener =     No
-    Local CC        =     No
-    SCS-MP2         =     False
-    SCSN-MP2        =     False
-    SCS-CCSD        =     False
-
-    Using old T1 amplitudes.
-    Using old T2 amplitudes.
-MP2 correlation energy -0.0952503887557973
-                Solving CC Amplitude Equations
-                ------------------------------
-  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
-  ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.114277253290648    0.000e+00    0.000176    0.000000    0.000000    0.000000
-     1        -0.114277152214053    2.730e-04    0.000084    0.000000    0.000000    0.000000
-     2        -0.114276037428707    8.503e-05    0.000045    0.000000    0.000000    0.000000
-     3        -0.114276358066316    3.265e-05    0.000024    0.000000    0.000000    0.000000
-     4        -0.114276653140057    6.554e-06    0.000020    0.000000    0.000000    0.000000
-     5        -0.114276692669602    1.510e-06    0.000020    0.000000    0.000000    0.000000
-     6        -0.114276707551434    4.789e-07    0.000020    0.000000    0.000000    0.000000
-     7        -0.114276715178331    1.765e-07    0.000020    0.000000    0.000000    0.000000
-     8        -0.114276716204600    5.850e-08    0.000020    0.000000    0.000000    0.000000
-
-    Iterations converged.
-
-
-    Largest TIA Amplitudes:
-              1   4         0.0000086093
-              2  11        -0.0000081114
-              1   1         0.0000080900
-              2  10        -0.0000062661
-              1   2         0.0000062310
-              0   2         0.0000050163
-              1   0         0.0000041272
-              3  15        -0.0000034274
-              3  14        -0.0000034249
-              0   1        -0.0000030512
-
-    Largest Tia Amplitudes:
-              1  17         0.0000251698
-              1  15         0.0000218719
-              0   0         0.0000162206
-              0   4        -0.0000138600
-              0   1        -0.0000127722
-              0   2         0.0000088926
-              1  16         0.0000083247
-              0   3        -0.0000073076
-              1  20        -0.0000049719
-              0   8        -0.0000048821
-
-    Largest TIJAB Amplitudes:
-      2   1  10   1         0.0304491133
-      3   2   8   2        -0.0234144934
-      2   1  11   4         0.0218944172
-      3   2  15  10         0.0209197121
-      3   2  13  10         0.0206098162
-      3   1  13   1        -0.0197542021
-      3   1  15   1        -0.0196502207
-      2   1  10   2        -0.0180892266
-      3   1  14   2        -0.0155349280
-      3   1  14   4        -0.0154413251
-
-    Largest Tijab Amplitudes:
-      1   0  11   9         0.0103673544
-      1   0  16   1        -0.0078211485
-      1   0  16   0        -0.0077015003
-      1   0  16   3        -0.0073299185
-      1   0  15   0        -0.0069227363
-      1   0  17   0        -0.0068210001
-      1   0  15   1         0.0065032711
-      1   0  17   4         0.0062525053
-      1   0  15   4         0.0060761424
-      1   0  12   9         0.0046146359
-
-    Largest TIjAb Amplitudes:
-      3   1  15  17        -0.0338642456
-      3   1  13  15        -0.0325321035
-      2   0   2  11        -0.0315079047
-      3   1  13  17        -0.0296733007
-      3   1   2   2        -0.0288606529
-      3   1  14  16        -0.0279355723
-      3   1  15  15        -0.0258285508
-      2   1  10  17         0.0257355838
-      1   0   4   0        -0.0256811340
-      2   1  10  15         0.0255948139
-
-    SCF energy       (wfn)                    =  -39.030807607560057
-    Reference energy (file100)                =  -38.916530330779473
-
-    Opposite-spin MP2 correlation energy      =   -0.073534725583638
-    Same-spin MP2 correlation energy          =   -0.021200763261251
-    MP2 correlation energy                    =   -0.095250388755797
-      * MP2 total energy                      =  -39.011780719535267
-
-    Opposite-spin CCSD correlation energy     =   -0.091452152029767
-    Same-spin CCSD correlation energy         =   -0.022824069207869
-    CCSD correlation energy                   =   -0.114276716204600
-      * CCSD total energy                     =  -39.030807046984073
-
-    Brueckner orbitals converged.  Maximum T1 =  0.000025169777
-
-*** tstop() called on psinet at Mon May 15 15:34:18 2017
-Module time:
-	user time   =       0.08 seconds =       0.00 minutes
+	user time   =       0.05 seconds =       0.00 minutes
 	system time =       0.12 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.58 seconds =       0.03 minutes
-	system time =       1.78 seconds =       0.03 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       2.43 seconds =       0.04 minutes
+	system time =       3.72 seconds =       0.06 minutes
+	total time  =          9 seconds =       0.15 minutes
+            **************************
+            *                        *
+            *        CCENERGY        *
+            *                        *
+            **************************
+
+    Nuclear Rep. energy (wfn)     =    6.068298029420463
+    SCF energy          (wfn)     =  -39.030833656838823
+    Reference energy    (file100) =  -38.916448515595057
+
+    Input parameters:
+    -----------------
+    Wave function   =     BCCD_T
+    Reference wfn   =     ROHF changed to UHF for Semicanonical Orbitals
+    Brueckner       =     Yes
+    Brueckner conv. =     1.0e-04
+    Memory (Mbytes) =     524.3
+    Maxiter         =     50
+    R_Convergence   =     1.0e-07
+    E_Convergence   =     1.0e-06
+    Restart         =     Yes
+    DIIS            =     Yes
+    AO Basis        =     NONE
+    ABCD            =     NEW
+    Cache Level     =     2
+    Cache Type      =     LRU
+    Print Level     =     1
+    Num. of threads =     1
+    # Amps to Print =     10
+    Print MP2 Amps? =     No
+    Analyze T2 Amps =     No
+    Print Pair Ener =     No
+    Local CC        =     No
+    SCS-MP2         =     False
+    SCSN-MP2        =     False
+    SCS-CCSD        =     False
+
+    Using old T1 amplitudes.
+    Using old T2 amplitudes.
+MP2 correlation energy -0.0953387421906526
+                Solving CC Amplitude Equations
+                ------------------------------
+  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
+  ----     ---------------------    ---------   ----------  ----------  ----------   --------
+     0        -0.114738304606941    0.000e+00    0.024687    0.000000    0.000000    0.000000
+     1        -0.114471654546950    3.909e-02    0.009875    0.000000    0.000000    0.000000
+     2        -0.114305540471256    1.102e-02    0.004622    0.000000    0.000000    0.000000
+     3        -0.114325254615309    3.707e-03    0.002314    0.000000    0.000000    0.000000
+     4        -0.114348936622072    9.303e-04    0.001790    0.000000    0.000000    0.000000
+     5        -0.114353324737303    2.470e-04    0.001736    0.000000    0.000000    0.000000
+     6        -0.114355164795315    8.753e-05    0.001732    0.000000    0.000000    0.000000
+     7        -0.114356450200135    3.046e-05    0.001734    0.000000    0.000000    0.000000
+     8        -0.114356638147949    8.465e-06    0.001735    0.000000    0.000000    0.000000
+     9        -0.114356667959380    2.638e-06    0.001735    0.000000    0.000000    0.000000
+    10        -0.114356689130729    7.600e-07    0.001735    0.000000    0.000000    0.000000
+    11        -0.114356695210801    2.090e-07    0.001735    0.000000    0.000000    0.000000
+    12        -0.114356695609427    5.689e-08    0.001735    0.000000    0.000000    0.000000
+
+    Iterations converged.
+
+
+    Largest TIA Amplitudes:
+              3  15        -0.0010147587
+              3  13        -0.0010113219
+              1   2         0.0010035498
+              1   4         0.0009488568
+              2  11        -0.0009187411
+              0   0         0.0008562622
+              0   2         0.0008143210
+              1   0         0.0006885557
+              1   1         0.0004962440
+              0   3         0.0004724217
+
+    Largest Tia Amplitudes:
+              1  17         0.0018576585
+              1  15         0.0014702116
+              0   1        -0.0010544053
+              0   3        -0.0009312347
+              1  16         0.0008665354
+              0   2         0.0008453430
+              0   4        -0.0007895137
+              0   0         0.0005398186
+              1  20        -0.0004370475
+              0   8        -0.0003786260
+
+    Largest TIJAB Amplitudes:
+      2   1  10   1         0.0303668572
+      3   2   8   2        -0.0233684148
+      2   1  11   4         0.0218826122
+      3   2  15  10         0.0209321772
+      3   2  13  10         0.0206022267
+      3   1  13   1        -0.0197565917
+      3   1  15   1        -0.0196490157
+      2   1  10   2        -0.0182234581
+      3   1  14   2        -0.0155397298
+      3   1  14   4        -0.0154513222
+
+    Largest Tijab Amplitudes:
+      1   0  11   9         0.0103717752
+      1   0  16   1        -0.0078251919
+      1   0  16   0        -0.0077040771
+      1   0  16   3        -0.0073354908
+      1   0  15   0        -0.0069227536
+      1   0  17   0        -0.0068299846
+      1   0  15   1         0.0065059807
+      1   0  17   4         0.0062532244
+      1   0  15   4         0.0060781784
+      1   0  12   9         0.0046184639
+
+    Largest TIjAb Amplitudes:
+      3   1  15  17        -0.0338602249
+      3   1  13  15        -0.0325319054
+      2   0   2  11        -0.0314481405
+      3   1  13  17        -0.0296552530
+      3   1   2   2        -0.0288108031
+      3   1  14  16        -0.0279382067
+      3   1  15  15        -0.0258495013
+      2   1  10  17         0.0257297411
+      1   0   4   0        -0.0256704577
+      2   1  10  15         0.0256120595
+
+    SCF energy       (wfn)                    =  -39.030833656838823
+    Reference energy (file100)                =  -38.916448515595057
+
+    Opposite-spin MP2 correlation energy      =   -0.073604333421656
+    Same-spin MP2 correlation energy          =   -0.021179751880320
+    Singles MP2 correlation energy            =   -0.000554656888677
+    MP2 correlation energy                    =   -0.095338742190653
+      * MP2 total energy                      =  -39.011787257785713
+
+    Opposite-spin CCSD correlation energy     =   -0.091502091000538
+    Same-spin CCSD correlation energy         =   -0.022808973590917
+    Singles CCSD correlation energy           =   -0.000045631017972
+    CCSD correlation energy                   =   -0.114356695609427
+      * CCSD total energy                     =  -39.030805211204488
+
+    Rotating orbitals.  Maximum T1 =  0.001857658514
+Brueckner convergence check: False
+
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:07:35 2022
+
+
+	Wfn Parameters:
+	--------------------
+	Wavefunction         = BCCD_T
+	Number of irreps     = 4
+	Number of MOs        = 24
+	Number of active MOs = 23
+	AO-Basis             = NONE
+	Semicanonical        = true
+	Reference            = ROHF changed to UHF for semicanonical orbitals
+	Print Level          = 1
+
+	IRREP	# MOs	# FZDC	# DOCC	# SOCC	# VIRT	# FZVR
+	-----	-----	------	------	------	------	------
+	 A1	   11	    1	    1	    1	    8	    0
+	 A2	   2	    0	    0	    0	    2	    0
+	 B1	   4	    0	    0	    1	    3	    0
+	 B2	   7	    0	    1	    0	    6	    0
+	Transforming integrals...
+	IWL integrals will be retained.
+	(OO|OO)...
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Constructing frozen core operators
+	Starting AA/AB first half-transformation.
+	Sorting AA/AB half-transformed integrals.
+	Starting BB first half-transformation.
+	Sorting BB half-transformed integrals.
+	First half integral transformation complete.
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|OV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|VV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OO)...
+	Starting AA/AB first half-transformation.
+	Sorting AA/AB half-transformed integrals.
+	Starting BB first half-transformation.
+	Sorting BB half-transformed integrals.
+	First half integral transformation complete.
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|VV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OO)...
+	Starting AA/AB first half-transformation.
+	Sorting AA/AB half-transformed integrals.
+	Starting BB first half-transformation.
+	Sorting BB half-transformed integrals.
+	First half integral transformation complete.
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|VV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	Frozen core energy     =    -34.28298230465726
+
+	Size of irrep 0 of <AB|CD> integrals:      0.002 (MW) /      0.018 (MB)
+	Size of irrep 1 of <AB|CD> integrals:      0.001 (MW) /      0.009 (MB)
+	Size of irrep 2 of <AB|CD> integrals:      0.001 (MW) /      0.010 (MB)
+	Size of irrep 3 of <AB|CD> integrals:      0.003 (MW) /      0.023 (MB)
+	Total:                                     0.008 (MW) /      0.061 (MB)
+
+	Size of irrep 0 of <ab|cd> integrals:      0.003 (MW) /      0.027 (MB)
+	Size of irrep 1 of <ab|cd> integrals:      0.002 (MW) /      0.014 (MB)
+	Size of irrep 2 of <ab|cd> integrals:      0.002 (MW) /      0.018 (MB)
+	Size of irrep 3 of <ab|cd> integrals:      0.004 (MW) /      0.031 (MB)
+	Total:                                     0.011 (MW) /      0.090 (MB)
+
+	Size of irrep 0 of <Ab|Cd> integrals:      0.015 (MW) /      0.123 (MB)
+	Size of irrep 1 of <Ab|Cd> integrals:      0.006 (MW) /      0.046 (MB)
+	Size of irrep 2 of <Ab|Cd> integrals:      0.007 (MW) /      0.055 (MB)
+	Size of irrep 3 of <Ab|Cd> integrals:      0.013 (MW) /      0.108 (MB)
+	Total:                                     0.041 (MW) /      0.332 (MB)
+
+	Size of irrep 0 of <IA|BC> integrals:      0.003 (MW) /      0.023 (MB)
+	Size of irrep 1 of <IA|BC> integrals:      0.001 (MW) /      0.007 (MB)
+	Size of irrep 2 of <IA|BC> integrals:      0.001 (MW) /      0.009 (MB)
+	Size of irrep 3 of <IA|BC> integrals:      0.002 (MW) /      0.019 (MB)
+	Total:                                     0.007 (MW) /      0.058 (MB)
+
+	Size of irrep 0 of <ia|bc> integrals:      0.002 (MW) /      0.016 (MB)
+	Size of irrep 1 of <ia|bc> integrals:      0.001 (MW) /      0.004 (MB)
+	Size of irrep 2 of <ia|bc> integrals:      0.001 (MW) /      0.005 (MB)
+	Size of irrep 3 of <ia|bc> integrals:      0.002 (MW) /      0.015 (MB)
+	Total:                                     0.005 (MW) /      0.040 (MB)
+
+	Size of irrep 0 of <Ia|Bc> integrals:      0.003 (MW) /      0.028 (MB)
+	Size of irrep 1 of <Ia|Bc> integrals:      0.001 (MW) /      0.009 (MB)
+	Size of irrep 2 of <Ia|Bc> integrals:      0.002 (MW) /      0.013 (MB)
+	Size of irrep 3 of <Ia|Bc> integrals:      0.003 (MW) /      0.021 (MB)
+	Total:                                     0.009 (MW) /      0.070 (MB)
+
+	Size of irrep 0 of <iA|bC> integrals:      0.002 (MW) /      0.014 (MB)
+	Size of irrep 1 of <iA|bC> integrals:      0.000 (MW) /      0.003 (MB)
+	Size of irrep 2 of <iA|bC> integrals:      0.000 (MW) /      0.003 (MB)
+	Size of irrep 3 of <iA|bC> integrals:      0.002 (MW) /      0.013 (MB)
+	Total:                                     0.004 (MW) /      0.033 (MB)
+
+	Size of irrep 0 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
+	Size of irrep 1 of tIjAb amplitudes:       0.000 (MW) /      0.001 (MB)
+	Size of irrep 2 of tIjAb amplitudes:       0.000 (MW) /      0.001 (MB)
+	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
+	Total:                                     0.001 (MW) /      0.007 (MB)
+
+	Nuclear Rep. energy          =      6.06829802942046
+	SCF energy                   =    -39.03083365683882
+	One-electron energy          =    -17.66216356910555
+	Two-electron (AA) energy     =      2.56371175692443
+	Two-electron (BB) energy     =      0.37506520114495
+	Two-electron (AB) energy     =      4.02154259605859
+	Two-electron energy          =      6.96031955412797
+	Reference energy             =    -38.91652829021437
+
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:07:35 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.69 seconds =       0.04 minutes
+	system time =       4.41 seconds =       0.07 minutes
+	total time  =         10 seconds =       0.17 minutes
+            **************************
+            *                        *
+            *        CCENERGY        *
+            *                        *
+            **************************
+
+    Nuclear Rep. energy (wfn)     =    6.068298029420463
+    SCF energy          (wfn)     =  -39.030805211204488
+    Reference energy    (file100) =  -38.916528290214373
+
+    Input parameters:
+    -----------------
+    Wave function   =     BCCD_T
+    Reference wfn   =     ROHF changed to UHF for Semicanonical Orbitals
+    Brueckner       =     Yes
+    Brueckner conv. =     1.0e-04
+    Memory (Mbytes) =     524.3
+    Maxiter         =     50
+    R_Convergence   =     1.0e-07
+    E_Convergence   =     1.0e-06
+    Restart         =     Yes
+    DIIS            =     Yes
+    AO Basis        =     NONE
+    ABCD            =     NEW
+    Cache Level     =     2
+    Cache Type      =     LRU
+    Print Level     =     1
+    Num. of threads =     1
+    # Amps to Print =     10
+    Print MP2 Amps? =     No
+    Analyze T2 Amps =     No
+    Print Pair Ener =     No
+    Local CC        =     No
+    SCS-MP2         =     False
+    SCSN-MP2        =     False
+    SCS-CCSD        =     False
+
+    Using old T1 amplitudes.
+    Using old T2 amplitudes.
+MP2 correlation energy -0.0952502283005812
+                Solving CC Amplitude Equations
+                ------------------------------
+  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
+  ----     ---------------------    ---------   ----------  ----------  ----------   --------
+     0        -0.114312765160729    0.000e+00    0.001735    0.000000    0.000000    0.000000
+     1        -0.114272225239964    2.471e-03    0.000862    0.000000    0.000000    0.000000
+     2        -0.114272609675737    8.637e-04    0.000422    0.000000    0.000000    0.000000
+     3        -0.114275699573449    3.014e-04    0.000213    0.000000    0.000000    0.000000
+     4        -0.114278222382228    6.553e-05    0.000177    0.000000    0.000000    0.000000
+     5        -0.114279035948106    1.615e-05    0.000176    0.000000    0.000000    0.000000
+     6        -0.114279203248031    5.280e-06    0.000176    0.000000    0.000000    0.000000
+     7        -0.114279287448048    1.983e-06    0.000176    0.000000    0.000000    0.000000
+     8        -0.114279314285810    6.235e-07    0.000175    0.000000    0.000000    0.000000
+     9        -0.114279319806386    2.004e-07    0.000175    0.000000    0.000000    0.000000
+    10        -0.114279318698136    6.011e-08    0.000175    0.000000    0.000000    0.000000
+
+    Iterations converged.
+
+
+    Largest TIA Amplitudes:
+              3  15        -0.0001951538
+              3  13        -0.0001923087
+              1   2         0.0001270506
+              3  14        -0.0001122139
+              1   0         0.0000873196
+              0   3         0.0000816411
+              0   0         0.0000811897
+              2  10         0.0000771134
+              0   2         0.0000681335
+              1   3         0.0000461311
+
+    Largest Tia Amplitudes:
+              0   3        -0.0000930508
+              0   1        -0.0000927812
+              1  17         0.0000920470
+              1  15         0.0000730206
+              0   4        -0.0000476039
+              0   0        -0.0000433906
+              0   2         0.0000385373
+              1  18        -0.0000271223
+              1  19         0.0000269203
+              0   6         0.0000256411
+
+    Largest TIJAB Amplitudes:
+      2   1  10   1         0.0304496422
+      3   2   8   2        -0.0234149751
+      2   1  11   4         0.0218942442
+      3   2  15  10         0.0209196558
+      3   2  13  10         0.0206094054
+      3   1  13   1        -0.0197539230
+      3   1  15   1        -0.0196498353
+      2   1  10   2        -0.0180883258
+      3   1  14   2        -0.0155341743
+      3   1  14   4        -0.0154419641
+
+    Largest Tijab Amplitudes:
+      1   0  11   9         0.0103683869
+      1   0  16   1        -0.0078204883
+      1   0  16   0        -0.0077031974
+      1   0  16   3        -0.0073309186
+      1   0  15   0        -0.0069222142
+      1   0  17   0        -0.0068218732
+      1   0  15   1         0.0065046652
+      1   0  17   4         0.0062522967
+      1   0  15   4         0.0060767847
+      1   0  12   9         0.0046143699
+
+    Largest TIjAb Amplitudes:
+      3   1  15  17        -0.0338638856
+      3   1  13  15        -0.0325344705
+      2   0   2  11        -0.0315099189
+      3   1  13  17        -0.0296730254
+      3   1   2   2        -0.0288462874
+      3   1  14  16        -0.0279340877
+      3   1  15  15        -0.0258312457
+      2   1  10  17         0.0257336779
+      1   0   4   0        -0.0256846488
+      2   1  10  15         0.0255969716
+
+    SCF energy       (wfn)                    =  -39.030805211204488
+    Reference energy (file100)                =  -38.916528290214373
+
+    Opposite-spin MP2 correlation energy      =   -0.073538887601008
+    Same-spin MP2 correlation energy          =   -0.021198303401918
+    Singles MP2 correlation energy            =   -0.000513037297655
+    MP2 correlation energy                    =   -0.095250228300581
+      * MP2 total energy                      =  -39.011778518514951
+
+    Opposite-spin CCSD correlation energy     =   -0.091455580120828
+    Same-spin CCSD correlation energy         =   -0.022822658646298
+    Singles CCSD correlation energy           =   -0.000001079931010
+    CCSD correlation energy                   =   -0.114279318698136
+      * CCSD total energy                     =  -39.030807608912511
+
+    Rotating orbitals.  Maximum T1 =  0.000195153782
+Brueckner convergence check: False
+
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Sep 12 15:07:36 2022
+
+
+	Wfn Parameters:
+	--------------------
+	Wavefunction         = BCCD_T
+	Number of irreps     = 4
+	Number of MOs        = 24
+	Number of active MOs = 23
+	AO-Basis             = NONE
+	Semicanonical        = true
+	Reference            = ROHF changed to UHF for semicanonical orbitals
+	Print Level          = 1
+
+	IRREP	# MOs	# FZDC	# DOCC	# SOCC	# VIRT	# FZVR
+	-----	-----	------	------	------	------	------
+	 A1	   11	    1	    1	    1	    8	    0
+	 A2	   2	    0	    0	    0	    2	    0
+	 B1	   4	    0	    0	    1	    3	    0
+	 B2	   7	    0	    1	    0	    6	    0
+	Transforming integrals...
+	IWL integrals will be retained.
+	(OO|OO)...
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Constructing frozen core operators
+	Starting AA/AB first half-transformation.
+	Sorting AA/AB half-transformed integrals.
+	Starting BB first half-transformation.
+	Sorting BB half-transformed integrals.
+	First half integral transformation complete.
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|OV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|VV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OO)...
+	Starting AA/AB first half-transformation.
+	Sorting AA/AB half-transformed integrals.
+	Starting BB first half-transformation.
+	Sorting BB half-transformed integrals.
+	First half integral transformation complete.
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|VV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OO)...
+	Starting AA/AB first half-transformation.
+	Sorting AA/AB half-transformed integrals.
+	Starting BB first half-transformation.
+	Sorting BB half-transformed integrals.
+	First half integral transformation complete.
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|VV)...
+	Starting AA second half-transformation.
+	Starting AB second half-transformation.
+	Starting BB second half-transformation.
+	Two-electron integral transformation complete.
+	Frozen core energy     =    -34.28298230465726
+
+	Size of irrep 0 of <AB|CD> integrals:      0.002 (MW) /      0.018 (MB)
+	Size of irrep 1 of <AB|CD> integrals:      0.001 (MW) /      0.009 (MB)
+	Size of irrep 2 of <AB|CD> integrals:      0.001 (MW) /      0.010 (MB)
+	Size of irrep 3 of <AB|CD> integrals:      0.003 (MW) /      0.023 (MB)
+	Total:                                     0.008 (MW) /      0.061 (MB)
+
+	Size of irrep 0 of <ab|cd> integrals:      0.003 (MW) /      0.027 (MB)
+	Size of irrep 1 of <ab|cd> integrals:      0.002 (MW) /      0.014 (MB)
+	Size of irrep 2 of <ab|cd> integrals:      0.002 (MW) /      0.018 (MB)
+	Size of irrep 3 of <ab|cd> integrals:      0.004 (MW) /      0.031 (MB)
+	Total:                                     0.011 (MW) /      0.090 (MB)
+
+	Size of irrep 0 of <Ab|Cd> integrals:      0.015 (MW) /      0.123 (MB)
+	Size of irrep 1 of <Ab|Cd> integrals:      0.006 (MW) /      0.046 (MB)
+	Size of irrep 2 of <Ab|Cd> integrals:      0.007 (MW) /      0.055 (MB)
+	Size of irrep 3 of <Ab|Cd> integrals:      0.013 (MW) /      0.108 (MB)
+	Total:                                     0.041 (MW) /      0.332 (MB)
+
+	Size of irrep 0 of <IA|BC> integrals:      0.003 (MW) /      0.023 (MB)
+	Size of irrep 1 of <IA|BC> integrals:      0.001 (MW) /      0.007 (MB)
+	Size of irrep 2 of <IA|BC> integrals:      0.001 (MW) /      0.009 (MB)
+	Size of irrep 3 of <IA|BC> integrals:      0.002 (MW) /      0.019 (MB)
+	Total:                                     0.007 (MW) /      0.058 (MB)
+
+	Size of irrep 0 of <ia|bc> integrals:      0.002 (MW) /      0.016 (MB)
+	Size of irrep 1 of <ia|bc> integrals:      0.001 (MW) /      0.004 (MB)
+	Size of irrep 2 of <ia|bc> integrals:      0.001 (MW) /      0.005 (MB)
+	Size of irrep 3 of <ia|bc> integrals:      0.002 (MW) /      0.015 (MB)
+	Total:                                     0.005 (MW) /      0.040 (MB)
+
+	Size of irrep 0 of <Ia|Bc> integrals:      0.003 (MW) /      0.028 (MB)
+	Size of irrep 1 of <Ia|Bc> integrals:      0.001 (MW) /      0.009 (MB)
+	Size of irrep 2 of <Ia|Bc> integrals:      0.002 (MW) /      0.013 (MB)
+	Size of irrep 3 of <Ia|Bc> integrals:      0.003 (MW) /      0.021 (MB)
+	Total:                                     0.009 (MW) /      0.070 (MB)
+
+	Size of irrep 0 of <iA|bC> integrals:      0.002 (MW) /      0.014 (MB)
+	Size of irrep 1 of <iA|bC> integrals:      0.000 (MW) /      0.003 (MB)
+	Size of irrep 2 of <iA|bC> integrals:      0.000 (MW) /      0.003 (MB)
+	Size of irrep 3 of <iA|bC> integrals:      0.002 (MW) /      0.013 (MB)
+	Total:                                     0.004 (MW) /      0.033 (MB)
+
+	Size of irrep 0 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
+	Size of irrep 1 of tIjAb amplitudes:       0.000 (MW) /      0.001 (MB)
+	Size of irrep 2 of tIjAb amplitudes:       0.000 (MW) /      0.001 (MB)
+	Size of irrep 3 of tIjAb amplitudes:       0.000 (MW) /      0.003 (MB)
+	Total:                                     0.001 (MW) /      0.007 (MB)
+
+	Nuclear Rep. energy          =      6.06829802942046
+	SCF energy                   =    -39.03080521120449
+	One-electron energy          =    -17.66239316477819
+	Two-electron (AA) energy     =      2.56403724098732
+	Two-electron (BB) energy     =      0.37501912608731
+	Two-electron (AB) energy     =      4.02149074215949
+	Two-electron energy          =      6.96054710923412
+	Reference energy             =    -38.91653033078087
+
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Sep 12 15:07:36 2022
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.96 seconds =       0.05 minutes
+	system time =       5.15 seconds =       0.09 minutes
+	total time  =         11 seconds =       0.18 minutes
+            **************************
+            *                        *
+            *        CCENERGY        *
+            *                        *
+            **************************
+
+    Nuclear Rep. energy (wfn)     =    6.068298029420463
+    SCF energy          (wfn)     =  -39.030807608912511
+    Reference energy    (file100) =  -38.916530330780873
+
+    Input parameters:
+    -----------------
+    Wave function   =     BCCD_T
+    Reference wfn   =     ROHF changed to UHF for Semicanonical Orbitals
+    Brueckner       =     Yes
+    Brueckner conv. =     1.0e-04
+    Memory (Mbytes) =     524.3
+    Maxiter         =     50
+    R_Convergence   =     1.0e-07
+    E_Convergence   =     1.0e-06
+    Restart         =     Yes
+    DIIS            =     Yes
+    AO Basis        =     NONE
+    ABCD            =     NEW
+    Cache Level     =     2
+    Cache Type      =     LRU
+    Print Level     =     1
+    Num. of threads =     1
+    # Amps to Print =     10
+    Print MP2 Amps? =     No
+    Analyze T2 Amps =     No
+    Print Pair Ener =     No
+    Local CC        =     No
+    SCS-MP2         =     False
+    SCSN-MP2        =     False
+    SCS-CCSD        =     False
+
+    Using old T1 amplitudes.
+    Using old T2 amplitudes.
+MP2 correlation energy -0.0952503898506685
+                Solving CC Amplitude Equations
+                ------------------------------
+  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
+  ----     ---------------------    ---------   ----------  ----------  ----------   --------
+     0        -0.114277241124318    0.000e+00    0.000175    0.000000    0.000000    0.000000
+     1        -0.114277155392226    2.733e-04    0.000084    0.000000    0.000000    0.000000
+     2        -0.114276040274040    8.484e-05    0.000044    0.000000    0.000000    0.000000
+     3        -0.114276358540861    3.263e-05    0.000024    0.000000    0.000000    0.000000
+     4        -0.114276652881708    6.549e-06    0.000020    0.000000    0.000000    0.000000
+     5        -0.114276692414845    1.509e-06    0.000020    0.000000    0.000000    0.000000
+     6        -0.114276707267292    4.782e-07    0.000020    0.000000    0.000000    0.000000
+     7        -0.114276714877035    1.763e-07    0.000020    0.000000    0.000000    0.000000
+     8        -0.114276715901858    5.841e-08    0.000020    0.000000    0.000000    0.000000
+
+    Iterations converged.
+
+
+    Largest TIA Amplitudes:
+              1   4         0.0000086330
+              2  11        -0.0000081331
+              1   1         0.0000081129
+              2  10        -0.0000063054
+              1   2         0.0000061900
+              0   2         0.0000049955
+              1   0         0.0000040979
+              3  14        -0.0000033856
+              3  15        -0.0000033570
+              0   1        -0.0000030627
+
+    Largest Tia Amplitudes:
+              1  17         0.0000251680
+              1  15         0.0000218738
+              0   0         0.0000162607
+              0   4        -0.0000138594
+              0   1        -0.0000127517
+              0   2         0.0000088889
+              1  16         0.0000083287
+              0   3        -0.0000072794
+              1  20        -0.0000049693
+              0   8        -0.0000048814
+
+    Largest TIJAB Amplitudes:
+      2   1  10   1         0.0304491120
+      3   2   8   2        -0.0234144927
+      2   1  11   4         0.0218944171
+      3   2  15  10         0.0209197122
+      3   2  13  10         0.0206098161
+      3   1  13   1        -0.0197542021
+      3   1  15   1        -0.0196502209
+      2   1  10   2        -0.0180892287
+      3   1  14   2        -0.0155349284
+      3   1  14   4        -0.0154413249
+
+    Largest Tijab Amplitudes:
+      1   0  11   9         0.0103673540
+      1   0  16   1        -0.0078211488
+      1   0  16   0        -0.0077014996
+      1   0  16   3        -0.0073299182
+      1   0  15   0        -0.0069227364
+      1   0  17   0        -0.0068209998
+      1   0  15   1         0.0065032705
+      1   0  17   4         0.0062525054
+      1   0  15   4         0.0060761422
+      1   0  12   9         0.0046146361
+
+    Largest TIjAb Amplitudes:
+      3   1  15  17        -0.0338642459
+      3   1  13  15        -0.0325321020
+      2   0   2  11        -0.0315079030
+      3   1  13  17        -0.0296733003
+      3   1   2   2        -0.0288606581
+      3   1  14  16        -0.0279355729
+      3   1  15  15        -0.0258285498
+      2   1  10  17         0.0257355845
+      1   0   4   0        -0.0256811323
+      2   1  10  15         0.0255948131
+
+    SCF energy       (wfn)                    =  -39.030807608912511
+    Reference energy (file100)                =  -38.916530330780873
+
+    Opposite-spin MP2 correlation energy      =   -0.073534724594968
+    Same-spin MP2 correlation energy          =   -0.021200764068939
+    Singles MP2 correlation energy            =   -0.000514901186761
+    MP2 correlation energy                    =   -0.095250389850668
+      * MP2 total energy                      =  -39.011780720631542
+
+    Opposite-spin CCSD correlation energy     =   -0.091452151035258
+    Same-spin CCSD correlation energy         =   -0.022824069632849
+    Singles CCSD correlation energy           =   -0.000000495233751
+    CCSD correlation energy                   =   -0.114276715901858
+      * CCSD total energy                     =  -39.030807046682732
+
+    Brueckner orbitals converged.  Maximum T1 =  0.000025167959
 Brueckner convergence check: True
-
-*** tstart() called on psinet
-*** at Mon May 15 15:34:18 2017
-
             **************************
             *                        *
             *        CCTRIPLES       *
@@ -3023,36 +2936,29 @@ Brueckner convergence check: True
     Wave function   =    BCCD_T
     Reference wfn   =    ROHF changed to UHF for Semicanonical Orbitals
 
-    Nuclear Rep. energy (wfn)                =    6.068298005568228
-    SCF energy          (wfn)                =  -39.030807607560057
-    Reference energy    (file100)            =  -38.916530330779473
-    CCSD energy         (file100)            =   -0.114276716204600
-    Total CCSD energy   (file100)            =  -39.030807046984073
+    Nuclear Rep. energy (wfn)                =    6.068298029420463
+    SCF energy          (wfn)                =  -39.030807608912511
+    Reference energy    (file100)            =  -38.916530330780873
+    CCSD energy         (file100)            =   -0.114276715901858
+    Total CCSD energy   (file100)            =  -39.030807046682732
 
     Number of ijk index combinations:
     Spin Case AAA:                                   4
     Spin Case BBB:                                   0
     Spin Case AAB:                                  12
     Spin Case ABB:                                   4
-    AAA (T) energy                             =   -0.000061266135730
+    AAA (T) energy                             =   -0.000061266138941
     BBB (T) energy                             =    0.000000000000000
-    AAB (T) energy                             =   -0.001407532706914
-    ABB (T) energy                             =   -0.000389317637725
-    (T) energy                                   =   -0.001858116480369
-      * CCSD(T) total energy                     =  -39.032665163464443
+    AAB (T) energy                             =   -0.001407532864492
+    ABB (T) energy                             =   -0.000389317653950
+    (T) energy                                   =   -0.001858116657383
+      * CCSD(T) total energy                     =  -39.032665163340113
 
+    SCF energy............................................................................PASSED
+    B-CCD energy..........................................................................PASSED
+    B-CCD(T) energy.......................................................................PASSED
 
-*** tstop() called on psinet at Mon May 15 15:34:18 2017
-Module time:
-	user time   =       0.00 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.58 seconds =       0.03 minutes
-	system time =       1.80 seconds =       0.03 minutes
-	total time  =          4 seconds =       0.07 minutes
-	SCF energy........................................................PASSED
-	B-CCD energy......................................................PASSED
-	B-CCD(T) energy...................................................PASSED
+    Psi4 stopped on: Monday, 12 September 2022 03:07PM
+    Psi4 wall time for execution: 0:00:11.78
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
Cleanup `ccenergy/rotate.cc`. There's more cleanup to do, but this is a sufficiently large algorithm change that I'm breaking up the PR here.

## Todos
<!-- Notable points (developer or user-interest) that this PR has or will accomplish. -->
- [x] `ccenergy/rotate` return type changed to `bool`
- [x] Orbital rotation uses newer `libmints` tech for greatly reduced LoC
- [x] Gets rid of the last bit of code in `ccenergy` that needs to map between QT and Pitzer ordering. I'll leave it to a future PR to eject that from `ccenergy` permanently
- [x] Replaces yet more `MOInfo` variable access with wavefunction variable access

## Checklist
- [x] `cc15` and `cc16` pass

## Status
- [x] Ready for review
- [x] Ready for merge
