### PR TITLE
Remove QT ordering from ccenergy

### DIFF
--- a/psi4/src/psi4/cc/ccenergy/MOInfo.h
+++ b/psi4/src/psi4/cc/ccenergy/MOInfo.h
@@ -75,26 +75,6 @@ struct MOInfo {
     int *vir_off;  /* virtual orbital offsets within each irrep */
     int *avir_off; /* alpha virtual orbital offsets within each irrep */
     int *bvir_off; /* beta virtual orbital offsets within each irrep */
-    int *cc_occ;   /* QT->CC active occupied reordering array */
-    int *cc_aocc;  /* QT->CC alpha active occupied reordering array */
-    int *cc_bocc;  /* QT->CC beta active occupied reordering array */
-    int *cc_vir;   /* QT->CC active virtiual reordering array */
-    int *cc_avir;  /* QT->CC alpha active virtiual reordering array */
-    int *cc_bvir;  /* QT->CC beta active virtiual reordering array */
-    int *qt_occ;   /* CC->QT active occupied reordering array */
-    int *qt_aocc;  /* CC->QT alpha active occupied reordering array */
-    int *qt_bocc;  /* CC->QT beta active occupied reordering array */
-    int *qt_vir;   /* CC->QT active virtiual reordering array */
-    int *qt_avir;  /* CC->QT alpha active virtiual reordering array */
-    int *qt_bvir;  /* CC->QT beta active virtiual reordering array */
-
-    int *pitzer2qt; /* Pitzer -> QT translation array */
-    int *qt2pitzer; /* QT -> Pitzer translation array */
-
-    int *pitzer2qt_a; /* Pitzer -> QT translation array for alpha orbitals */
-    int *qt2pitzer_a; /* QT -> Pitzer translation array for alpha orbitals */
-    int *pitzer2qt_b; /* Pitzer -> QT translation array for beta orbitals */
-    int *qt2pitzer_b; /* QT -> Pitzer translation array for beta orbitals */
 
     int iter;          /* Current CCSD iteration */
     double conv;       /* Current convergence level */

--- a/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
@@ -38,7 +38,6 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libmints/dimension.h"
@@ -134,25 +133,6 @@ void CCEnergyWavefunction::get_moinfo() {
         psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orb Offsets", (char *)moinfo_.bvir_off,
                         sizeof(int) * moinfo_.nirreps);
 
-        /* Get CC->QT and QT->CC active occupied and virtual reordering arrays */
-        moinfo_.qt_aocc = init_int_array(nactive);
-        moinfo_.qt_bocc = init_int_array(nactive);
-        moinfo_.qt_avir = init_int_array(nactive);
-        moinfo_.qt_bvir = init_int_array(nactive);
-        moinfo_.cc_aocc = init_int_array(nactive);
-        moinfo_.cc_bocc = init_int_array(nactive);
-        moinfo_.cc_avir = init_int_array(nactive);
-        moinfo_.cc_bvir = init_int_array(nactive);
-
-        psio_read_entry(PSIF_CC_INFO, "CC->QT Alpha Active Occ Order", (char *)moinfo_.qt_aocc, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "CC->QT Beta Active Occ Order", (char *)moinfo_.qt_bocc, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "CC->QT Alpha Active Virt Order", (char *)moinfo_.qt_avir, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "CC->QT Beta Active Virt Order", (char *)moinfo_.qt_bvir, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "QT->CC Alpha Active Occ Order", (char *)moinfo_.cc_aocc, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "QT->CC Beta Active Occ Order", (char *)moinfo_.cc_bocc, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "QT->CC Alpha Active Virt Order", (char *)moinfo_.cc_avir, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "QT->CC Beta Active Virt Order", (char *)moinfo_.cc_bvir, sizeof(int) * nactive);
-
     } else { /** RHF or ROHF **/
 
         moinfo_.occpi = init_int_array(nirreps);
@@ -172,15 +152,6 @@ void CCEnergyWavefunction::get_moinfo() {
         psio_read_entry(PSIF_CC_INFO, "Active Virt Orb Offsets", (char *)moinfo_.vir_off,
                         sizeof(int) * moinfo_.nirreps);
 
-        /* Get CC->QT and QT->CC active occupied and virtual reordering arrays */
-        moinfo_.qt_occ = init_int_array(nactive);
-        moinfo_.qt_vir = init_int_array(nactive);
-        moinfo_.cc_occ = init_int_array(nactive);
-        moinfo_.cc_vir = init_int_array(nactive);
-        psio_read_entry(PSIF_CC_INFO, "CC->QT Active Occ Order", (char *)moinfo_.qt_occ, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "CC->QT Active Virt Order", (char *)moinfo_.qt_vir, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "QT->CC Active Occ Order", (char *)moinfo_.cc_occ, sizeof(int) * nactive);
-        psio_read_entry(PSIF_CC_INFO, "QT->CC Active Virt Order", (char *)moinfo_.cc_vir, sizeof(int) * nactive);
     }
 
     /* Build sosym array (for AO-basis BT2) */
@@ -235,31 +206,6 @@ void CCEnergyWavefunction::get_moinfo() {
             }
         }
         moinfo_.Cbv = Cb;
-    }
-
-    /* Compute spatial-orbital reordering arrays */
-    if (params_.ref == 0 || params_.ref == 1) {
-        moinfo_.pitzer2qt = init_int_array(moinfo_.nmo);
-        moinfo_.qt2pitzer = init_int_array(moinfo_.nmo);
-        reorder_qt(moinfo_.clsdpi, moinfo_.openpi, moinfo_.frdocc, moinfo_.fruocc, moinfo_.pitzer2qt, moinfo_.orbspi,
-                   moinfo_.nirreps);
-        for (int i = 0; i < moinfo_.nmo; i++) {
-            j = moinfo_.pitzer2qt[i];
-            moinfo_.qt2pitzer[j] = i;
-        }
-    } else if (params_.ref == 2) {
-        moinfo_.pitzer2qt_a = init_int_array(moinfo_.nmo);
-        moinfo_.qt2pitzer_a = init_int_array(moinfo_.nmo);
-        moinfo_.pitzer2qt_b = init_int_array(moinfo_.nmo);
-        moinfo_.qt2pitzer_b = init_int_array(moinfo_.nmo);
-        reorder_qt_uhf(moinfo_.clsdpi, moinfo_.openpi, moinfo_.frdocc, moinfo_.fruocc, moinfo_.pitzer2qt_a,
-                       moinfo_.pitzer2qt_b, moinfo_.orbspi, moinfo_.nirreps);
-        for (int i = 0; i < moinfo_.nmo; i++) {
-            j = moinfo_.pitzer2qt_a[i];
-            moinfo_.qt2pitzer_a[j] = i;
-            j = moinfo_.pitzer2qt_b[i];
-            moinfo_.qt2pitzer_b[j] = i;
-        }
     }
 
     /* Adjust clsdpi array for frozen orbitals */
@@ -328,14 +274,6 @@ void CCEnergyWavefunction::cleanup() {
         free(moinfo_.bocc_off);
         free(moinfo_.avir_off);
         free(moinfo_.bvir_off);
-        free(moinfo_.qt_aocc);
-        free(moinfo_.qt_bocc);
-        free(moinfo_.qt_avir);
-        free(moinfo_.qt_bvir);
-        free(moinfo_.cc_aocc);
-        free(moinfo_.cc_bocc);
-        free(moinfo_.cc_avir);
-        free(moinfo_.cc_bvir);
     } else {
         free(moinfo_.occpi);
         free(moinfo_.virtpi);
@@ -343,10 +281,6 @@ void CCEnergyWavefunction::cleanup() {
         free(moinfo_.vir_sym);
         free(moinfo_.occ_off);
         free(moinfo_.vir_off);
-        free(moinfo_.qt_occ);
-        free(moinfo_.qt_vir);
-        free(moinfo_.cc_occ);
-        free(moinfo_.cc_vir);
     }
 }
 


### PR DESCRIPTION
## Description
When the `cc` mega-module was first created, the `Matrix` class did not exist, and manual reordering arrays were used to keep track of orbital indexing between the symmetry-blocked and non-symmetry-blocked convention. Thanks to #2719, the last of these in `ccenergy` has been replaced with `Matrix` technology, so there is no need to keep this reordering around. This PR thus removes them.

My next CC cleanup PR will Matrix-ify the remaining QT-using parts of `ccresponse`.

## Dev notes & details
- [x] Removes QT reordering arrays from `ccenergy` for lack of use

## Checklist
- [x] `cc` tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
