### PR TITLE
Allow non-symmetric matrix <-> dpdfile2

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1708,4 +1708,6 @@ void export_mints(py::module& m) {
     py::class_<ERISieve, std::shared_ptr<ERISieve>>(m, "ERISieve", "docstring")
         .def(py::init<std::shared_ptr<BasisSet>, double, bool>())
         .def("shell_significant", &ERISieve::shell_significant);
+
+    m.def("test_matrix_dpd_interface", &psi::test_matrix_dpd_interface);
 }

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -2818,7 +2818,7 @@ void Matrix::write_to_dpdfile2(dpdfile2 *outFile) {
 
     if (outFile->my_irrep != symmetry_) {
         std::stringstream msg;
-        msg << "Symmetry mismatch. Matrix has symmetry " << outFile->my_irrep << " where dpdfile has "
+        msg << "Symmetry mismatch. Matrix has symmetry " << outFile->my_irrep << " whereas dpdfile has "
             << symmetry_ << " symmetry.";
         throw SanityCheckError(msg.str().c_str(), __FILE__, __LINE__);
     }

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -2816,9 +2816,11 @@ void Matrix::write_to_dpdfile2(dpdfile2 *outFile) {
         throw SanityCheckError(msg.str().c_str(), __FILE__, __LINE__);
     }
 
-    if (outFile->my_irrep != 0) {
-        throw FeatureNotImplemented("libmints Matrix class", "Matrices whose irrep is not the symmetric one", __FILE__,
-                                    __LINE__);
+    if (outFile->my_irrep != symmetry_) {
+        std::stringstream msg;
+        msg << "Symmetry mismatch. Matrix has symmetry " << outFile->my_irrep << " where dpdfile has "
+            << symmetry_ << " symmetry.";
+        throw SanityCheckError(msg.str().c_str(), __FILE__, __LINE__);
     }
 
     for (int h = 0; h < nirrep_; ++h) {
@@ -2835,7 +2837,6 @@ void Matrix::write_to_dpdfile2(dpdfile2 *outFile) {
             throw SanityCheckError(msg.str().c_str(), __FILE__, __LINE__);
         }
 
-        // TODO: optimize this with memcopys
         size_t size = rowspi_[h] * (size_t)colspi_[h ^ symmetry_] * sizeof(double);
         if (size) memcpy(&(outFile->matrix[h][0][0]), &(matrix_[h][0][0]), size);
     }
@@ -3587,4 +3588,34 @@ void free(double **Block) {
 }
 }  // namespace detail
 }  // namespace linalg
+
+bool test_matrix_dpd_interface() {
+    _default_psio_lib_->open(PSIF_OEI, PSIO_OPEN_OLD);
+    // Matrix values are insignificant.
+    // For those who like trivia, X dipole from STO-6G water (specified via ZMAT)
+    Dimension dimpi({4, 0, 1, 2});
+    Matrix mat(dimpi, dimpi, 2);
+    mat.set(0, 0, 0, -0.05373657897553);
+    mat.set(0, 1, 0, -0.64149916027709);
+    mat.set(0, 3, 0, -0.40632695574458);
+    mat.set(2, 0, 0, +0.05373657897553);
+    mat.set(2, 0, 1, +0.64149916027709);
+    mat.set(2, 0, 3, +0.40632695574458);
+
+    dpdfile2 io;
+    std::vector<int> cachefiles(PSIO_MAXUNIT);
+    auto cachelist = init_int_matrix(5, 5);
+
+    std::vector<int *> spaces;
+    spaces.push_back(dimpi);
+    std::vector<int> sym_vec {0, 0, 3, 0, 2, 0, 3};
+    spaces.push_back(sym_vec.data());
+    dpd_init(0, 4, 500e6, 0, cachefiles.data(), cachelist, nullptr, 1, spaces);
+    dpd_list[0]->file2_init(&io, PSIF_OEI, 2, 0, 0, "Test Matrix");
+    mat.write_to_dpdfile2(&io);
+    Matrix mat2(&io);
+    free_int_matrix(cachelist);
+    _default_psio_lib_->close(PSIF_OEI, 1);
+    return mat.equal(mat2);
+}
 }  // namespace psi

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -1146,49 +1146,8 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * @param theta - the angle (in radians) about which to rotate
      */
     void rotate_columns(int h, int i, int j, double theta);
-
-    PSI_DEPRECATED(
-        "Using `Matrix::matrix` instead of `linalg::detail::matrix` is deprecated, and as soon as 1.4 it will "
-        "stop working")
-    static double** matrix(int nrow, int ncol) { return linalg::detail::matrix(nrow, ncol); }
-
-    PSI_DEPRECATED(
-        "Using `Matrix::free` instead of `linalg::detail::free` is deprecated, and as soon as 1.4 it will "
-        "stop working")
-    static void free(double** Block) { linalg::detail::free(Block); }
-
-    PSI_DEPRECATED(
-        "Using `Matrix::create` instead of `auto my_mat = std::make_shared<Matrix>(name, rows, cols);` "
-        "is deprecated, and as soon as 1.4 it will "
-        "stop working")
-    static SharedMatrix create(const std::string& name, const Dimension& rows, const Dimension& cols) {
-        return std::make_shared<Matrix>(name, rows, cols);
-    }
-
-    PSI_DEPRECATED(
-        "Using `Matrix::horzcat` instead of `linalg::horzcat` is deprecated, and as soon as 1.4 it will "
-        "stop working")
-    static SharedMatrix horzcat(const std::vector<SharedMatrix>& mats) { return linalg::horzcat(mats); }
-
-    PSI_DEPRECATED(
-        "Using `Matrix::vertcat` instead of `linalg::vertcat` is deprecated, and as soon as 1.4 it will "
-        "stop working")
-    static SharedMatrix vertcat(const std::vector<SharedMatrix>& mats) { return linalg::vertcat(mats); }
-
-    PSI_DEPRECATED(
-        "Using `Matrix::doublet` instead of `doublet` is deprecated, and as soon as 1.4 it will "
-        "stop working")
-    static SharedMatrix doublet(const SharedMatrix& A, const SharedMatrix& B, bool transA = false,
-                                bool transB = false) {
-        return linalg::doublet(A, B, transA, transB);
-    }
-
-    PSI_DEPRECATED(
-        "Using `Matrix::triplet` instead of `triplet` is deprecated, and as soon as 1.4 it will "
-        "stop working")
-    static SharedMatrix triplet(const SharedMatrix& A, const SharedMatrix& B, const SharedMatrix& C,
-                                bool transA = false, bool transB = false, bool transC = false) {
-        return linalg::triplet(A, B, C, transA, transB, transC);
-    }
 };
+
+bool test_matrix_dpd_interface();
+
 }  // namespace psi

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,7 +62,8 @@ foreach(test_name adc1 adc2 aediis-1
                   fd-freq-energy fd-freq-energy-large fd-freq-gradient
                   fd-freq-gradient-large fd-gradient freq-isotope1 freq-isotope2 fnocc1 fnocc2
                   fnocc3 fnocc4 fnocc5 fnocc6 fnocc7 frac frac-ip-fitting frac-sym frac-traverse ghosts gibbs
-                  lccd-grad1 lccd-grad2 matrix1 mbis-1 mbis-2 mbis-3 mbis-4 mbis-5 mbis-6 mcscf1 mcscf2 mcscf3
+                  lccd-grad1 lccd-grad2 matrix1 matrix2
+                  mbis-1 mbis-2 mbis-3 mbis-4 mbis-5 mbis-6 mcscf1 mcscf2 mcscf3
                   mints1 mints2 mints3 mints4 mints5 mints6 mints8 mints-benchmark mints-helper
                   mints9 mints10 mints15 molden1 molden2 mom mom-h2o-3 mom-h2o-4
                   mp2-1  mp2-def2 mp2-grad1 mp2-grad2 mp2-h mp2p5-grad1 mp2p5-grad2 mp3-grad1 mp3-grad2

--- a/tests/matrix2/CMakeLists.txt
+++ b/tests/matrix2/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(matrix2 "psi;quicktests;misc")

--- a/tests/matrix2/input.dat
+++ b/tests/matrix2/input.dat
@@ -1,0 +1,3 @@
+#! An example of using BLAS and LAPACK calls directly from the Psi input file, demonstrating
+#
+assert psi4.core.test_matrix_dpd_interface()

--- a/tests/matrix2/test_input.py
+++ b/tests/matrix2/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("quick;misc")
+def test_matrix1():
+    ctest_runner(__file__)
+

--- a/tests/matrix2/test_input.py
+++ b/tests/matrix2/test_input.py
@@ -1,6 +1,6 @@
 from addons import *
 
 @ctest_labeler("quick;misc")
-def test_matrix1():
+def test_matrix2():
     ctest_runner(__file__)
 


### PR DESCRIPTION
## Description
Allow non-symmetric matrix <-> dpdfile2.

The hard part of this PR was figuring out how to initialize a dpd object successfully.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `Matrix::write_to_dpdfile2` now works on non-totally symmetric matrices
- [x] Several long-deprecated Matrix methods have been removed. They now live in the `linalg` namespace. 

## Checklist
- [x] New test passes

## Status
- [x] Ready for review
- [x] Ready for merge
