### PR TITLE
`set_block` with `symmetry_`

### DIFF
--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -673,17 +673,20 @@ void Matrix::set_block(const Slice &rows, const Slice &cols, const Matrix& block
     if (cols.end() - cols.begin() != block.colspi()) {
         throw PSIEXCEPTION("Invalid call to Matrix::set_block() column Slice doesn't match block's columns dimension.");
     }
-    const Dimension &rows_begin = rows.begin();
-    const Dimension &cols_begin = cols.begin();
-    Dimension block_rows = rows.end() - rows.begin();
-    Dimension block_cols = cols.end() - cols.begin();
+    if (symmetry_ != block.symmetry()) {
+        throw PSIEXCEPTION("Invalid call to Matrix::set_block() Target and destination matrix have different symmetry..");
+    }
+    const auto &rows_begin = rows.begin();
+    const auto &cols_begin = cols.begin();
+    auto block_rows = rows.end() - rows.begin();
+    auto block_cols = cols.end() - cols.begin();
     for (int h = 0; h < nirrep_; h++) {
         int max_p = block_rows[h];
-        int max_q = block_cols[h];
+        int max_q = block_cols[h ^ symmetry_];
         for (int p = 0; p < max_p; p++) {
             for (int q = 0; q < max_q; q++) {
                 double value = block.get(h, p, q);
-                set(h, p + rows_begin[h], q + cols_begin[h], value);
+                set(h, p + rows_begin[h], q + cols_begin[h ^ symmetry_], value);
             }
         }
     }

--- a/tests/pytests/test_matrix.py
+++ b/tests/pytests/test_matrix.py
@@ -2,7 +2,8 @@ import itertools
 
 import numpy as np
 import pytest
-from psi4.core import Dimension, Matrix, doublet
+from psi4.core import Dimension, Matrix, Slice, doublet
+import psi4
 from utils import compare_arrays
 
 pytestmark = [pytest.mark.psi, pytest.mark.api]
@@ -225,3 +226,23 @@ def test_doublets(adl, adr, Ga, bdl, bdr, Gb, at, bt):
     block_checks = []
     for blk_idx in range(res.nirrep()):
         assert compare_arrays(expected[blk_idx], res_blocks[blk_idx], 8, f"Block[{blk_idx}]")
+
+def test_set_matrix():
+    # I want blank symmetric matrix. I'll send an off-block.
+    dim = Dimension([3, 2])
+    mat = Matrix("Name", dim, dim, 1)
+    control_mat = Matrix("Name", dim, dim, 1)
+    i = 0
+    for j in range(3):
+        for k in range(2):
+            mat.set(0, j, k, i)
+            mat.set(1, k, j, 10 + i)
+            if i not in {0, 2}:
+                control_mat.set(0, j, k, i)
+                control_mat.set(1, k, j, 10 + i)
+            i += 1
+    new_dim = Dimension([2, 1])
+    new_slice = Slice(Dimension([0, 0]), new_dim)
+    new_mat = Matrix("Name", new_dim, new_dim, 1)
+    mat.set_block(new_slice, new_slice, new_mat)
+    assert psi4.compare_matrices(mat, control_mat)

--- a/tests/pytests/test_matrix.py
+++ b/tests/pytests/test_matrix.py
@@ -6,7 +6,7 @@ from psi4.core import Dimension, Matrix, Slice, doublet
 import psi4
 from utils import compare_arrays
 
-pytestmark = [pytest.mark.psi, pytest.mark.api]
+pytestmark = [pytest.mark.psi, pytest.mark.api, pytest.mark.quick]
 
 def check_dense_mat(m, exp_r, exp_c, exp_name=None):
     assert m.rows() == exp_r
@@ -228,7 +228,7 @@ def test_doublets(adl, adr, Ga, bdl, bdr, Gb, at, bt):
         assert compare_arrays(expected[blk_idx], res_blocks[blk_idx], 8, f"Block[{blk_idx}]")
 
 def test_set_matrix():
-    # I want blank symmetric matrix. I'll send an off-block.
+    # Use set_matrix to zero a block of a non-totally symmetric matrix.
     dim = Dimension([3, 2])
     mat = Matrix("Name", dim, dim, 1)
     control_mat = Matrix("Name", dim, dim, 1)


### PR DESCRIPTION
## Description
See below.

## User API & Changelog headlines
- [x] `Matrix::set_block` can be used on matrices that are not totally symmetric.

## Dev notes & details
- [x] `Matrix::set_block` can be used on matrices that are not totally symmetric.
- [x] `Matrix::set_block` now raises an explicit error when the symmetry of the target and block matrices disagree.

## Checklist
- [x]  New test working

## Status
- [x] Ready for review
- [x] Ready for merge
