### PR TITLE
Ensure that initialize_lebedev is called --> Clean up spaghetti in cubature

### DIFF
--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -3730,13 +3730,6 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
 
     // RMP: Like, I want to keep this info, yo?
     orientation_ = std_orientation.orientation();
-    radial_grids_.clear();
-    spherical_grids_.clear();
-
-    if (opt.namedGrid == -1) {
-        radial_grids_.resize(molecule_->natom());
-        spherical_grids_.resize(molecule_->natom());
-    }
 
 #ifdef USING_BrianQC
     std::vector<std::vector<double>> atomRotations(molecule_->natom());
@@ -3772,11 +3765,6 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
             RadialGridMgr::makeRadialGrid(opt.nradpts, RadialGridMgr::MuraKnowlesHack(opt.radscheme, Z), r.data(),
                                           wr.data(), alpha);
 
-            // RMP: Want this stuff too
-            radial_grids_[A] = RadialGrid::build("Unknown", opt.nradpts, r.data(), wr.data(), alpha, Z);
-            std::vector<std::shared_ptr<SphericalGrid>> spheres;
-            spherical_grids_[A] = spheres;
-
             int currentBlockIndex = -1;
             for (int i = 0; i < opt.nradpts; i++) {
                 int numAngPts = 0;
@@ -3809,8 +3797,6 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
                 }
 #endif
 
-                // RMP: And this stuff! This whole thing is completely and utterly FUBAR.
-                spherical_grids_[A].push_back(SphericalGrid::build("Unknown", numAngPts, anggrid));
                 for (int j = 0; j < numAngPts; j++) {
                     MassPoint mp = {r[i] * anggrid[j].x, r[i] * anggrid[j].y, r[i] * anggrid[j].z,
                                     wr[i] * anggrid[j].w};
@@ -3943,11 +3929,6 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt, const 
 
     // RMP: Like, I want to keep this info, yo?
     orientation_ = std_orientation.orientation();
-    radial_grids_.clear();
-    spherical_grids_.clear();
-
-    radial_grids_.resize(molecule_->natom());
-    spherical_grids_.resize(molecule_->natom());
 
 // Iterate over atoms
 #pragma omp parallel for schedule(static)
@@ -3964,17 +3945,9 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt, const 
             wr[i] = ws[A][i];
         }
 
-        // RMP: Want this stuff too
-        radial_grids_[A] = RadialGrid::build("Unknown", rs[A].size(), r.data(), wr.data(), alpha, Z);
-        std::vector<std::shared_ptr<SphericalGrid>> spheres;
-        spherical_grids_[A] = spheres;
-
         for (size_t i = 0; i < rs[A].size(); i++) {
             int numAngPts = LebedevGridMgr::findNPointsByOrder(Ls[A][i]);
             const MassPoint *anggrid = LebedevGridMgr::findGridByNPoints(numAngPts);
-
-            // RMP: And this stuff! This whole thing is completely and utterly FUBAR.
-            spherical_grids_[A].push_back(SphericalGrid::build("Unknown", numAngPts, anggrid));
 
             for (int j = 0; j < numAngPts; j++) {
                 MassPoint mp = {r[i] * anggrid[j].x, r[i] * anggrid[j].y, r[i] * anggrid[j].z, wr[i] * anggrid[j].w};
@@ -4560,23 +4533,6 @@ void MolecularGrid::print(std::string out, int /*print*/) const {
     Process::environment.globals["XC GRID SPHERICAL POINTS"] = options_.nangpts;
     Process::environment.globals["XC GRID RADIAL POINTS"] = options_.nradpts;
 }
-void MolecularGrid::print_details(std::string out, int /*print*/) const {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    printer->Printf("   > Grid Details <\n\n");
-    for (size_t A = 0; A < radial_grids_.size(); A++) {
-        printer->Printf("    Atom: %4zu, Nrad = %6d, Alpha = %11.3E:\n", A, radial_grids_[A]->npoints(),
-                        radial_grids_[A]->alpha());
-        for (size_t R = 0; R < spherical_grids_[A].size(); R++) {
-            double Rval = radial_grids_[A]->r()[R];
-            double Wval = radial_grids_[A]->w()[R];
-            int Nsphere = spherical_grids_[A][R]->npoints();
-            int Lsphere = spherical_grids_[A][R]->order();
-            printer->Printf("    Node: %4zu, R = %11.3E, WR = %11.3E, Nsphere = %6d, Lsphere = %6d\n", R, Rval, Wval,
-                            Nsphere, Lsphere);
-        }
-    }
-    printer->Printf("\n");
-}
 
 GridBlocker::GridBlocker(const int npoints_ref, double const *x_ref, double const *y_ref, double const *z_ref,
                          double const *w_ref, const int max_points, const int min_points, const double max_radius,
@@ -4952,252 +4908,4 @@ void OctreeGridBlocker::block() {
     }
 }
 
-RadialGrid::RadialGrid() : npoints_(0) {}
-RadialGrid::~RadialGrid() {
-    if (npoints_) {
-        delete[] r_;
-        delete[] w_;
-    }
-}
-void RadialGrid::print(std::string out, int level) const {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    if (level > 0) {
-        printer->Printf("   => RadialGrid: %s Scheme <=\n\n", scheme_.c_str());
-        printer->Printf("      Points: %d\n", npoints_);
-        printer->Printf("      Alpha:  %24.16E\n\n", alpha_);
-        printer->Printf("   %4s %24s %24s\n", "N", "R", "W");
-        if (level > 1) {
-            for (int i = 0; i < npoints_; i++) {
-                printer->Printf("   %4d %24.16E %24.16E\n", i + 1, r_[i], w_[i]);
-            }
-        }
-        printer->Printf("\n");
-    }
-}
-std::shared_ptr<RadialGrid> RadialGrid::build(const std::string &scheme, int npoints, double alpha, int Z) {
-    if (scheme == "BECKE") {
-        return RadialGrid::build_becke(npoints, alpha, Z);
-    } else if (scheme == "TREUTLER") {
-        return RadialGrid::build_treutler(npoints, alpha, Z);
-    } else {
-        throw PSIEXCEPTION("RadialGrid::build: Unrecognized radial grid.");
-    }
-}
-std::shared_ptr<RadialGrid> RadialGrid::build(const std::string &scheme, int npoints, double *r, double *wr,
-                                              double alpha, int Z) {
-    RadialGrid *grid = new RadialGrid();
-
-    grid->scheme_ = scheme;
-    grid->npoints_ = npoints;
-    grid->alpha_ = alpha;
-    grid->r_ = new double[npoints];
-    grid->w_ = new double[npoints];
-
-    ::memcpy(grid->r_, r, sizeof(double) * npoints);
-    ::memcpy(grid->w_, wr, sizeof(double) * npoints);
-
-    return std::shared_ptr<RadialGrid>(grid);
-}
-std::shared_ptr<RadialGrid> RadialGrid::build_becke(int npoints, double alpha, int Z) {
-    RadialGrid *grid = new RadialGrid();
-
-    grid->scheme_ = "BECKE";
-    grid->npoints_ = npoints;
-    grid->alpha_ = alpha;
-    grid->r_ = new double[npoints];
-    grid->w_ = new double[npoints];
-
-    for (int tau = 1; tau <= npoints; tau++) {
-        double x = cos(tau / (npoints + 1.0) * M_PI);
-        double r = alpha * (1.0 - x) / (1.0 + x);
-        double temp = sin(tau / (npoints + 1.0) * M_PI);
-        double w =
-            M_PI / (npoints + 1.0) * temp * temp * alpha * 2.0 / ((1.0 + x) * (1.0 + x) * sqrt(1.0 - x * x)) * r * r;
-        grid->r_[tau - 1] = r;
-        grid->w_[tau - 1] = w;
-    }
-
-    return std::shared_ptr<RadialGrid>(grid);
-}
-std::shared_ptr<RadialGrid> RadialGrid::build_treutler(int npoints, double alpha, int Z) {
-    RadialGrid *grid = new RadialGrid();
-
-    // Treutler/Ahlrichs 1995 mapping parameters
-    // clang-format off
-    static const std::vector<double> TreutlerEta =  { 1.0,
-      0.800, 0.900,
-      1.800, 1.400,                                                                       1.300, 1.100, 0.900, 0.900, 0.900, 0.900,
-      1.400, 1.300,                                                                       1.300, 1.200, 1.100, 1.000, 1.000, 1.000,
-      1.500, 1.400, 1.300, 1.200, 1.200, 1.200, 1.200, 1.200, 1.200, 1.100, 1.100, 1.100, 1.100, 1.000, 0.900, 0.900, 0.900, 0.900,
-      2.000, 1.700, 1.500, 1.500, 1.350, 1.350, 1.250, 1.200, 1.250, 1.300, 1.500, 1.500, 1.300, 1.200, 1.200, 1.150, 1.150, 1.150,
-      2.500, 2.200,
-             2.500, 1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,
-             1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500,
-      2.500, 2.100,
-             3.685,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,
-    };
-
-    // clang-format on
-    grid->scheme_ = "TREUTLER";
-    grid->npoints_ = npoints;
-    grid->alpha_ = alpha;
-    grid->r_ = new double[npoints];
-    grid->w_ = new double[npoints];
-
-    double INVLN2 = TreutlerEta.data()[Z] / log(2.0);
-
-    for (int tau = 1; tau <= npoints; tau++) {
-        double x = cos(tau / (npoints + 1.0) * M_PI);
-        double r = alpha * INVLN2 * pow(1.0 + x, 0.6) * log(2.0 / (1.0 - x));
-        double temp = sin(tau / (npoints + 1.0) * M_PI);
-        double w = M_PI / (npoints + 1.0) * temp * temp;
-        w *= alpha * INVLN2 * (0.6 * pow(1.0 + x, 0.6 - 1.0) * log(2.0 / (1.0 - x)) + pow(1.0 + x, 0.6) / (1.0 - x));
-        w *= 1.0 / sqrt(1.0 - x * x);
-        w *= r * r;
-        grid->r_[tau - 1] = r;
-        grid->w_[tau - 1] = w;
-    }
-
-    return std::shared_ptr<RadialGrid>(grid);
-}
-
-/// Grid npoints to order map
-std::map<int, int> SphericalGrid::lebedev_mapping_;
-std::once_flag SphericalGrid::lebedev_mapping_initd_;
-
-SphericalGrid::SphericalGrid() : npoints_(0) {}
-SphericalGrid::~SphericalGrid() {
-    if (npoints_) {
-        delete[] x_;
-        delete[] y_;
-        delete[] z_;
-        delete[] w_;
-        delete[] phi_;
-        delete[] theta_;
-    }
-}
-void SphericalGrid::print(std::string out, int level) const {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    if (level > 0) {
-        printer->Printf("   => SphericalGrid: %s Scheme <=\n\n", scheme_.c_str());
-        printer->Printf("      Points: %d\n", npoints_);
-        printer->Printf("   %4s %24s %24s %24s %24s\n", "N", "X", "Y", "Z", "W");
-        if (level > 1) {
-            for (int i = 0; i < npoints_; i++) {
-                printer->Printf("   %4d %24.16E %24.16E %24.16E %24.16E\n", i + 1, x_[i], y_[i], z_[i], w_[i]);
-            }
-        }
-        printer->Printf("\n");
-    }
-}
-void SphericalGrid::build_angles() {
-    phi_ = new double[npoints_];
-    theta_ = new double[npoints_];
-    for (int i = 0; i < npoints_; i++) {
-        double xv = x_[i];
-        double yv = y_[i];
-        double zv = z_[i];
-        phi_[i] = atan2(yv, xv);
-        theta_[i] = acos(zv / sqrt(xv * xv + yv * yv + zv * zv));
-    }
-}
-std::shared_ptr<SphericalGrid> SphericalGrid::build(const std::string &scheme, int npoints, const MassPoint *points) {
-    std::call_once(lebedev_mapping_initd_, initialize_lebedev);
-    auto *s = new SphericalGrid();
-    s->scheme_ = scheme;
-    s->order_ = lebedev_mapping_[npoints];
-    s->npoints_ = npoints;
-
-    s->x_ = new double[npoints];
-    s->y_ = new double[npoints];
-    s->z_ = new double[npoints];
-    s->w_ = new double[npoints];
-
-    for (int i = 0; i < npoints; i++) {
-        s->x_[i] = points[i].x;
-        s->y_[i] = points[i].y;
-        s->z_[i] = points[i].z;
-        s->w_[i] = points[i].w;
-    }
-
-    s->build_angles();
-    return std::shared_ptr<SphericalGrid>(s);
-}
-
-void SphericalGrid::initialize_lebedev() {
-    lebedev_mapping_.clear();
-
-    lebedev_mapping_[6] = 1;
-    lebedev_mapping_[14] = 2;
-    lebedev_mapping_[26] = 3;
-    lebedev_mapping_[38] = 4;
-    lebedev_mapping_[50] = 5;
-    lebedev_mapping_[74] = 6;
-    lebedev_mapping_[86] = 7;
-    lebedev_mapping_[110] = 8;
-    lebedev_mapping_[146] = 9;
-    lebedev_mapping_[170] = 10;
-    lebedev_mapping_[194] = 11;
-    lebedev_mapping_[230] = 12;
-    lebedev_mapping_[266] = 13;
-    lebedev_mapping_[302] = 14;
-    lebedev_mapping_[350] = 15;
-    lebedev_mapping_[434] = 17;
-    lebedev_mapping_[590] = 20;
-    lebedev_mapping_[770] = 23;
-    lebedev_mapping_[974] = 26;
-    lebedev_mapping_[1202] = 29;
-    lebedev_mapping_[1454] = 32;
-    lebedev_mapping_[1730] = 35;
-    lebedev_mapping_[2030] = 38;
-    lebedev_mapping_[2354] = 41;
-    lebedev_mapping_[2702] = 44;
-    lebedev_mapping_[3074] = 47;
-    lebedev_mapping_[3470] = 50;
-    lebedev_mapping_[3890] = 53;
-    lebedev_mapping_[4334] = 56;
-    lebedev_mapping_[4802] = 59;
-    lebedev_mapping_[5294] = 62;
-    lebedev_mapping_[5810] = 65;
-}
-
-void SphericalGrid::lebedev_error() {
-    outfile->Printf("  ==> Valid Lebedev Grids <==\n\n");
-    outfile->Printf("    L     2L+1   N   \n");
-    outfile->Printf("    1     3      6   \n");
-    outfile->Printf("    2     5      14  \n");
-    outfile->Printf("    3     7      26  \n");
-    outfile->Printf("    4     9      38  \n");
-    outfile->Printf("    5     11     50  \n");
-    outfile->Printf("    6     13     74  \n");
-    outfile->Printf("    7     15     86  \n");
-    outfile->Printf("    8     17     110 \n");
-    outfile->Printf("    9     19     146 \n");
-    outfile->Printf("    10    21     170 \n");
-    outfile->Printf("    11    23     194 \n");
-    outfile->Printf("    12    25     230 \n");
-    outfile->Printf("    13    27     266 \n");
-    outfile->Printf("    14    29     302 \n");
-    outfile->Printf("    15    31     350 \n");
-    outfile->Printf("    17    35     434 \n");
-    outfile->Printf("    20    41     590 \n");
-    outfile->Printf("    23    47     770 \n");
-    outfile->Printf("    26    53     974 \n");
-    outfile->Printf("    29    59     1202\n");
-    outfile->Printf("    32    65     1454\n");
-    outfile->Printf("    35    71     1730\n");
-    outfile->Printf("    38    77     2030\n");
-    outfile->Printf("    41    83     2354\n");
-    outfile->Printf("    44    89     2702\n");
-    outfile->Printf("    47    95     3074\n");
-    outfile->Printf("    50    101    3470\n");
-    outfile->Printf("    53    107    3890\n");
-    outfile->Printf("    56    113    4334\n");
-    outfile->Printf("    59    119    4802\n");
-    outfile->Printf("    62    125    5294\n");
-    outfile->Printf("    65    131    5810\n");
-    outfile->Printf("\n");
-    outfile->Printf("    In Soviet Russia, grid build you!\n\n");
-    throw PSIEXCEPTION("SphericalGrid: Bad Lebedev number requested, see outfile for details.");
-}
 }  // namespace psi

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -3808,7 +3808,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
 #endif
 
                 // This is JUST so we can do some printing later...
-                radial_grids_[A].spheres.push_back({numAngPts, LebedevGridMgr::findOrderByNPoints(numAngPts)});
+                radial_grids_[A].spheres_.push_back({numAngPts, LebedevGridMgr::findOrderByNPoints(numAngPts)});
                 for (int j = 0; j < numAngPts; j++) {
                     MassPoint mp = {r[i] * anggrid[j].x, r[i] * anggrid[j].y, r[i] * anggrid[j].z,
                                     wr[i] * anggrid[j].w};
@@ -3969,7 +3969,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt, const 
             const MassPoint *anggrid = LebedevGridMgr::findGridByNPoints(numAngPts);
 
             // This is JUST so we can do some printing later...
-            radial_grids_[A].spheres.push_back({numAngPts, Ls[A][i]});
+            radial_grids_[A].spheres_.push_back({numAngPts, Ls[A][i]});
 
             for (int j = 0; j < numAngPts; j++) {
                 MassPoint mp = {r[i] * anggrid[j].x, r[i] * anggrid[j].y, r[i] * anggrid[j].z, wr[i] * anggrid[j].w};
@@ -4561,15 +4561,15 @@ void MolecularGrid::print_details(std::string out, int /*print*/) const {
     for (size_t A = 0; A < radial_grids_.size(); A++) {
         printer->Printf("    Atom: %4zu, Nrad = %6d, Alpha = %11.3E:\n", A,
                         radial_grids_[A].npoints_, radial_grids_[A].alpha_);
-        for (size_t R = 0; R < radial_grids_[A].spheres.size(); R++) {
+        for (size_t R = 0; R < radial_grids_[A].spheres_.size(); R++) {
             double Rval = radial_grids_[A].r[R];
             double Wval = radial_grids_[A].w[R];
-            int Nsphere = radial_grids_[A].spheres[R].npoints_;
-            int Lsphere = radial_grids_[A].spheres[R].order_;
+            int Nsphere = radial_grids_[A].spheres_[R].npoints_;
+            int Lsphere = radial_grids_[A].spheres_[R].order_;
             printer->Printf("    Node: %4zu, R = %11.3E, WR = %11.3E, Nsphere = %6d, Lsphere = %6d\n",
                             R, radial_grids_[A].r[R], radial_grids_[A].w[R],
-                            radial_grids_[A].spheres[R].npoints_,
-                            radial_grids_[A].spheres[R].order_);
+                            radial_grids_[A].spheres_[R].npoints_,
+                            radial_grids_[A].spheres_[R].order_);
         }
     }
     printer->Printf("\n");

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -3731,11 +3731,9 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
     // RMP: Like, I want to keep this info, yo?
     orientation_ = std_orientation.orientation();
     radial_grids_.clear();
-    spherical_grids_.clear();
 
     if (opt.namedGrid == -1) {
         radial_grids_.resize(molecule_->natom());
-        spherical_grids_.resize(molecule_->natom());
     }
 
 #ifdef USING_BrianQC
@@ -3944,10 +3942,8 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt, const 
     // RMP: Like, I want to keep this info, yo?
     orientation_ = std_orientation.orientation();
     radial_grids_.clear();
-    spherical_grids_.clear();
 
     radial_grids_.resize(molecule_->natom());
-    spherical_grids_.resize(molecule_->natom());
 
 // Iterate over atoms
 #pragma omp parallel for schedule(static)

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -3793,7 +3793,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt) {
             // RMP: Want this stuff too
             // This is JUST so we can do some printing later...
             std::vector<SphericalGrid> spheres;
-            radial_grids_[A] = {opt.nradpts, alpha, r.data(), wr.data(), spheres};
+            radial_grids_[A] = {opt.nradpts, alpha, r, wr, spheres};
 
             int currentBlockIndex = -1;
             for (int i = 0; i < opt.nradpts; i++) {
@@ -3983,7 +3983,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt, const 
         // RMP: Want this stuff too
         // This is JUST so we can do some printing later...
         std::vector<SphericalGrid> spheres;
-        radial_grids_[A] = {static_cast<int>(rs[A].size()), alpha, r.data(), wr.data(), spheres};
+        radial_grids_[A] = {static_cast<int>(rs[A].size()), alpha, r, wr, spheres};
         for (size_t i = 0; i < rs[A].size(); i++) {
             int numAngPts = LebedevGridMgr::findNPointsByOrder(Ls[A][i]);
             const MassPoint *anggrid = LebedevGridMgr::findGridByNPoints(numAngPts);

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -5063,6 +5063,7 @@ std::shared_ptr<RadialGrid> RadialGrid::build_treutler(int npoints, double alpha
 
 /// Grid npoints to order map
 std::map<int, int> SphericalGrid::lebedev_mapping_;
+std::once_flag SphericalGrid::lebedev_mapping_initd_;
 
 SphericalGrid::SphericalGrid() : npoints_(0) {}
 SphericalGrid::~SphericalGrid() {
@@ -5101,6 +5102,7 @@ void SphericalGrid::build_angles() {
     }
 }
 std::shared_ptr<SphericalGrid> SphericalGrid::build(const std::string &scheme, int npoints, const MassPoint *points) {
+    std::call_once(lebedev_mapping_initd_, initialize_lebedev);
     auto *s = new SphericalGrid();
     s->scheme_ = scheme;
     s->order_ = lebedev_mapping_[npoints];

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -4562,12 +4562,12 @@ void MolecularGrid::print_details(std::string out, int /*print*/) const {
         printer->Printf("    Atom: %4zu, Nrad = %6d, Alpha = %11.3E:\n", A,
                         radial_grids_[A].npoints_, radial_grids_[A].alpha_);
         for (size_t R = 0; R < radial_grids_[A].spheres_.size(); R++) {
-            double Rval = radial_grids_[A].r[R];
-            double Wval = radial_grids_[A].w[R];
+            double Rval = radial_grids_[A].r_[R];
+            double Wval = radial_grids_[A].w_[R];
             int Nsphere = radial_grids_[A].spheres_[R].npoints_;
             int Lsphere = radial_grids_[A].spheres_[R].order_;
             printer->Printf("    Node: %4zu, R = %11.3E, WR = %11.3E, Nsphere = %6d, Lsphere = %6d\n",
-                            R, radial_grids_[A].r[R], radial_grids_[A].w[R],
+                            R, radial_grids_[A].r_[R], radial_grids_[A].w_[R],
                             radial_grids_[A].spheres_[R].npoints_,
                             radial_grids_[A].spheres_[R].order_);
         }

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -3963,7 +3963,7 @@ void MolecularGrid::buildGridFromOptions(MolecularGridOptions const &opt, const 
         // RMP: Want this stuff too
         // This is JUST so we can do some printing later...
         std::vector<SphericalGrid> spheres;
-        radial_grids_[A] = {rs[A].size(), alpha, r.data(), wr.data(), spheres};
+        radial_grids_[A] = {static_cast<int>(rs[A].size()), alpha, r.data(), wr.data(), spheres};
         for (size_t i = 0; i < rs[A].size(); i++) {
             int numAngPts = LebedevGridMgr::findNPointsByOrder(Ls[A][i]);
             const MassPoint *anggrid = LebedevGridMgr::findGridByNPoints(numAngPts);

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -2042,6 +2042,26 @@ class RadialGridMgr {
     }
 
 // See O. Treutler and R. Ahlrichs, J. Chem. Phys. 102 (1995) 346
+
+// TODO: The eta  mapping is missing in actual Treutler usage, as the
+// below table only was used in RadialGrid::build_treutler, which was
+// never used and has since been excised. At some point these proper
+// eta mapping values should be brought back into the code.
+//
+// // Treutler/Ahlrichs 1995 mapping parameters
+// static const std::vector<double> TreutlerEta =  { 1.0,
+//   0.800, 0.900,
+//  1.800, 1.400,                                                                       1.300, 1.100, 0.900, 0.900, 0.900, 0.900,
+//  1.400, 1.300,                                                                       1.300, 1.200, 1.100, 1.000, 1.000, 1.000,
+//  1.500, 1.400, 1.300, 1.200, 1.200, 1.200, 1.200, 1.200, 1.200, 1.100, 1.100, 1.100, 1.100, 1.000, 0.900, 0.900, 0.900, 0.900,
+//  2.000, 1.700, 1.500, 1.500, 1.350, 1.350, 1.250, 1.200, 1.250, 1.300, 1.500, 1.500, 1.300, 1.200, 1.200, 1.150, 1.150, 1.150,
+//  2.500, 2.200,
+//         2.500, 1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,
+//         1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500, 1.500,
+//  2.500, 2.100,
+//         3.685,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,1.500,
+// };
+
 #define INVLN2 1.4426950408889634074  // = 1/log(2)
     static double ahlrichs_r(double x) {
         double alpha = 0.6;

--- a/psi4/src/psi4/libfock/cubature.h
+++ b/psi4/src/psi4/libfock/cubature.h
@@ -37,7 +37,6 @@
 #include "psi4/libpsi4util/exception.h"
 
 #include <map>
-#include <mutex>
 #include <vector>
 
 namespace psi {
@@ -55,9 +54,29 @@ class Options;
 //
 // RMP: You got that right. Calling nuclear weights one point at a time is another
 // great way to get a 1000x slowdown. What an incredible smell you've discovered!
-//
+
+
 struct MassPoint {
     double x, y, z, w;
+};
+
+struct SphericalGrid {
+    /// Number of points in radial grid
+    int npoints_;
+    /// Order of spherical harmonics in spherical grid (integrates products up to L_tot = 2 * order_ + 1)
+    int order_;
+};
+
+struct RadialGrid {
+    int npoints_;
+    /// Alpha scale (for user reference)
+    double alpha_;
+    /// Nodes (including alpha)
+    double* r_;
+    /// Weights (including alpha and r^2)
+    double* w_;
+    /// Spherical points
+    std::vector<SphericalGrid> spherical_grids_;
 };
 
 class MolecularGrid {
@@ -90,6 +109,8 @@ class MolecularGrid {
 
     /// Orientation matrix
     std::shared_ptr<Matrix> orientation_;
+    /// Radial grids, per atom
+    std::vector<RadialGrid> spherical_grids_;
     /// Grid points, per atom. Available for any grid blocking scheme unlike atomic_blocks_.
     std::vector<std::vector<MassPoint>> atomic_grids_;
 
@@ -149,6 +170,7 @@ class MolecularGrid {
 
     /// Print information about the grid
     void print(std::string out_fname = "outfile", int print = 2) const;
+    // void print_details(std::string out_fname = "outfile", int print = 2) const;
 
     /// Orientation matrix
     std::shared_ptr<Matrix> orientation() const { return orientation_; }

--- a/psi4/src/psi4/libfock/cubature.h
+++ b/psi4/src/psi4/libfock/cubature.h
@@ -37,6 +37,7 @@
 #include "psi4/libpsi4util/exception.h"
 
 #include <map>
+#include <mutex>
 #include <vector>
 
 namespace psi {
@@ -316,6 +317,8 @@ class SphericalGrid {
 
     /// Grid npoints to order map
     static std::map<int, int> lebedev_mapping_;
+    /// Checks that the mapping has been init'd
+    static std::once_flag lebedev_mapping_initd_;
     /// Initialize the above arrays with the unique Lebedev grids
     static void initialize_lebedev();
     /// Print valid Lebedev grids and error out (throws)

--- a/psi4/src/psi4/libfock/cubature.h
+++ b/psi4/src/psi4/libfock/cubature.h
@@ -76,7 +76,7 @@ struct RadialGrid {
     /// Weights (including alpha and r^2)
     double* w_;
     /// Spherical points
-    std::vector<SphericalGrid> spherical_grids_;
+    std::vector<SphericalGrid> spheres_;
 };
 
 class MolecularGrid {

--- a/psi4/src/psi4/libfock/cubature.h
+++ b/psi4/src/psi4/libfock/cubature.h
@@ -47,8 +47,6 @@ class Matrix;
 class Vector;
 class BasisExtents;
 class BlockOPoints;
-class RadialGrid;
-class SphericalGrid;
 class Options;
 
 // This is an auxiliary structure used internally by the grid-builder class.
@@ -92,10 +90,6 @@ class MolecularGrid {
 
     /// Orientation matrix
     std::shared_ptr<Matrix> orientation_;
-    /// Radial grids, per atom
-    std::vector<std::shared_ptr<RadialGrid>> radial_grids_;
-    /// Spherical grids, per atom and radial point
-    std::vector<std::vector<std::shared_ptr<SphericalGrid>>> spherical_grids_;
     /// Grid points, per atom. Available for any grid blocking scheme unlike atomic_blocks_.
     std::vector<std::vector<MassPoint>> atomic_grids_;
 
@@ -155,14 +149,9 @@ class MolecularGrid {
 
     /// Print information about the grid
     void print(std::string out_fname = "outfile", int print = 2) const;
-    void print_details(std::string out_fname = "outfile", int print = 2) const;
 
     /// Orientation matrix
     std::shared_ptr<Matrix> orientation() const { return orientation_; }
-    /// Radial grids, per atom
-    const std::vector<std::shared_ptr<RadialGrid>>& radial_grids() const { return radial_grids_; }
-    /// Spherical grids, per atom and radial point
-    const std::vector<std::vector<std::shared_ptr<SphericalGrid>>>& spherical_grids() const { return spherical_grids_; }
 
     /// Number of grid points
     int npoints() const { return npoints_; }
@@ -236,135 +225,6 @@ class DFTGrid : public MolecularGrid {
             std::map<std::string, int> int_opts_map, std::map<std::string, std::string> str_opts_map, 
             std::map<std::string, double> float_opts_map, Options& options);
     ~DFTGrid() override;
-};
-
-class RadialGrid {
-   protected:
-    /// Scheme
-    std::string scheme_;
-    /// Number of points in radial grid
-    int npoints_;
-    /// Alpha scale (for user reference)
-    double alpha_;
-    /// Nodes (including alpha)
-    double* r_;
-    /// Weights (including alpha and r^2)
-    double* w_;
-
-    // ==> Standard Radial Grids <== //
-
-    /// Build the Becke 1988 radial grid
-    static std::shared_ptr<RadialGrid> build_becke(int npoints, double alpha, int Z);
-    /// Build the Treutler-Ahlrichs 1995 radial grid (scale power = 0.6)
-    static std::shared_ptr<RadialGrid> build_treutler(int npoints, double alpha, int Z);
-    // TODO: Add more grids
-
-    /// Protected constructor
-    RadialGrid();
-
-   public:
-    // ==> Initializers <== //
-
-    /// Destructor
-    virtual ~RadialGrid();
-
-    /// Master build routine
-    static std::shared_ptr<RadialGrid> build(const std::string& scheme, int npoints, double alpha, int Z);
-    /// Hack build routine (TODO: Remove ASAP)
-    static std::shared_ptr<RadialGrid> build(const std::string& scheme, int npoints, double* r, double* wr,
-                                             double alpha, int Z);
-
-    // ==> Accessors <== //
-
-    /// Scheme of this radial grid
-    std::string scheme() const { return scheme_; }
-    /// Number of points in radial grid
-    int npoints() const { return npoints_; }
-    /// Alpha scale (for user reference)
-    double alpha() const { return alpha_; }
-    /// Radial nodes (including alpha scale). You do not own this.
-    double* r() const { return r_; }
-    /// Radial weights (including alpha scale and r^2). You do not own this.
-    double* w() const { return w_; }
-
-    /// Reflection
-    void print(std::string out_fname = "outfile", int level = 1) const;
-};
-
-class SphericalGrid {
-   protected:
-    /// Scheme
-    std::string scheme_;
-    /// Number of points in radial grid
-    int npoints_;
-    /// Order of spherical harmonics in spherical grid (integrates products up to L_tot = 2 * order_ + 1)
-    int order_;
-    /// Spherical nodes, on the unit sphere
-    double* x_;
-    /// Spherical nodes, on the unit sphere
-    double* y_;
-    /// Spherical nodes, on the unit sphere
-    double* z_;
-    /// Spherical weights, normalized to 4pi
-    double* w_;
-
-    /// Spherical nodes, in spherical coordinates (azimuth)
-    double* phi_;
-    /// Spherical nodes, in spherical coordinates (inclination)
-    double* theta_;
-
-    // ==> Unique Lebedev Grids (statically stored) <== //
-
-    /// Grid npoints to order map
-    static std::map<int, int> lebedev_mapping_;
-    /// Checks that the mapping has been init'd
-    static std::once_flag lebedev_mapping_initd_;
-    /// Initialize the above arrays with the unique Lebedev grids
-    static void initialize_lebedev();
-    /// Print valid Lebedev grids and error out (throws)
-    static void lebedev_error();
-
-    // ==> Utility Routines <== //
-
-    /// Build the spherical angles from <x,y,z>, for reference
-    void build_angles();
-
-    /// Protected constructor
-    SphericalGrid();
-
-   public:
-    // ==> Initializers <== //
-
-    /// Destructor
-    virtual ~SphericalGrid();
-
-    /// Master build routines
-    static std::shared_ptr<SphericalGrid> build(const std::string& scheme, int npoints, const MassPoint* points);
-
-    // ==> Accessors <== //
-
-    /// Scheme of this radial grid
-    std::string scheme() const { return scheme_; }
-    /// Number of points in radial grid
-    int npoints() const { return npoints_; }
-    /// Order of spherical harmonics in spherical grid (integrates products up to L_tot = 2 * order_ + 1)
-    int order() const { return order_; }
-    /// Spherical nodes, on the unit sphere
-    double* x() const { return x_; }
-    /// Spherical nodes, on the unit sphere
-    double* y() const { return y_; }
-    /// Spherical nodes, on the unit sphere
-    double* z() const { return z_; }
-    /// Spherical weights, normalized to 4pi
-    double* w() const { return w_; }
-
-    /// Spherical nodes, in spherical coordinates (azimuth)
-    double* phi() const { return phi_; }
-    /// Spherical nodes, in spherical coordinates (inclination)
-    double* theta() const { return theta_; }
-
-    /// Reflection
-    void print(std::string out_fname = "outfile", int level = 1) const;
 };
 
 class BlockOPoints {

--- a/psi4/src/psi4/libfock/cubature.h
+++ b/psi4/src/psi4/libfock/cubature.h
@@ -72,9 +72,9 @@ struct RadialGrid {
     /// Alpha scale (for user reference)
     double alpha_;
     /// Nodes (including alpha)
-    double* r_;
+    std::vector<double> r_;
     /// Weights (including alpha and r^2)
-    double* w_;
+    std::vector<double> w_;
     /// Spherical points
     std::vector<SphericalGrid> spheres_;
 };

--- a/psi4/src/psi4/libfock/cubature.h
+++ b/psi4/src/psi4/libfock/cubature.h
@@ -110,7 +110,9 @@ class MolecularGrid {
     /// Orientation matrix
     std::shared_ptr<Matrix> orientation_;
     /// Radial grids, per atom
-    std::vector<RadialGrid> spherical_grids_;
+    /// Spherical grids, per atom and radial point are hidden inside of
+    ///radial_grids_[A].spheres
+    std::vector<RadialGrid> radial_grids_;
     /// Grid points, per atom. Available for any grid blocking scheme unlike atomic_blocks_.
     std::vector<std::vector<MassPoint>> atomic_grids_;
 

--- a/psi4/src/psi4/libfock/cubature.h
+++ b/psi4/src/psi4/libfock/cubature.h
@@ -170,7 +170,7 @@ class MolecularGrid {
 
     /// Print information about the grid
     void print(std::string out_fname = "outfile", int print = 2) const;
-    // void print_details(std::string out_fname = "outfile", int print = 2) const;
+    void print_details(std::string out_fname = "outfile", int print = 2) const;
 
     /// Orientation matrix
     std::shared_ptr<Matrix> orientation() const { return orientation_; }

--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -725,7 +725,6 @@ void VBase::print_header() const {
     outfile->Printf("  ==> DFT Potential <==\n\n");
     functional_->print("outfile", print_);
     grid_->print("outfile", print_);
-    if (print_ > 2) grid_->print_details("outfile", print_);
 }
 std::shared_ptr<BlockOPoints> VBase::get_block(int block) { return grid_->blocks()[block]; }
 size_t VBase::nblocks() { return grid_->blocks().size(); }
@@ -1114,7 +1113,6 @@ void SAP::finalize() { VBase::finalize(); }
 void SAP::print_header() const {
     outfile->Printf("  ==> SAP guess <==\n\n");
     grid_->print("outfile", print_);
-    if (print_ > 2) grid_->print_details("outfile", print_);
 }
 void SAP::compute_V(std::vector<SharedMatrix> ret) {
     timer_on("SAP: Form V");

--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -725,6 +725,7 @@ void VBase::print_header() const {
     outfile->Printf("  ==> DFT Potential <==\n\n");
     functional_->print("outfile", print_);
     grid_->print("outfile", print_);
+    if (print_ > 2) grid_->print_details("outfile", print_);
 }
 std::shared_ptr<BlockOPoints> VBase::get_block(int block) { return grid_->blocks()[block]; }
 size_t VBase::nblocks() { return grid_->blocks().size(); }
@@ -1113,6 +1114,7 @@ void SAP::finalize() { VBase::finalize(); }
 void SAP::print_header() const {
     outfile->Printf("  ==> SAP guess <==\n\n");
     grid_->print("outfile", print_);
+    if (print_ > 2) grid_->print_details("outfile", print_);
 }
 void SAP::compute_V(std::vector<SharedMatrix> ret) {
     timer_on("SAP: Form V");


### PR DESCRIPTION
Closes #2735 

Previously, `initialize_lebedev` was never called, and in fact was getting optimized out of the module completely upon compilation. When `lebedev_mappping_[]` is then accessed across multiple OpenMP threads, the std::map is empty, and a deadlock can happen where two threads try to access-write (since [key] fills if key is not found), and the slightly slower thread ends up in a Bad State where it thinks there is a value but ends up infinitely looping on the lookup (the program will hang on `[]`).

This only happens once every several thousand runs, and only when running with a high degree of parallelism in a system with many atoms. I cannot induce it in captivity, but I have observed it in the wild.

Anyway, `[]` accesses on std::map aren't thread-safe if you aren't super-duper sure the map is fully filled for all keys you'd ever look up, which *should* be the case if `initialize_lebedev` was ever called anywhere. But it wasn't, and that was Bad.

Now it's called exactly once (thanks, c++11's `call_once`! I do see that this isn't used anywhere else in the code, but I do see mutex is imported in several files, so I don't think I'm adding any new deps here).

The hangs should be gone, though I'll have to churn through another several thousand runs to likely be sure (as, again, it is a very rare kind of hang). This will take me a few days to confirm, but given all debugging efforts point to this being the problem, I'm like 99% confident this will do the trick.

That said, as far as I can tell, besides one print function the resulting order_ that's assigned to is never *used*. Maybe a candidate to be axed in the future?

## Description
Actually invokes initialize_lebedev before accessing lebedev_mapping_ to ensure the mapping has values, and prevents a deadlock when running in parallel

## User API & Changelog headlines
Prevents a nasty, rare hang

## Dev notes & details
See the main PR body

## Questions
- [x] What does `order_` actually do in SphericalGrid? It never appears to be used anywhere except one print function that also appears unused.

## Checklist
- [x] No tests needed -- no observable changes and it's hard to write a test for a very rare race condition :)

## Status
- [x] Ready for review
- [x] Ready for merge
