### PR TITLE
Deprecate some overloads of Matrix::diagonalize

### DIFF
--- a/psi4/src/psi4/dlpno/mp2.cc
+++ b/psi4/src/psi4/dlpno/mp2.cc
@@ -850,7 +850,7 @@ void DLPNOMP2::pno_transform() {
         // Diagonalization of pair density gives PNOs (in basis of the LMO's virtual domain) and PNO occ numbers
         auto X_pno_ij = std::make_shared<Matrix>("eigenvectors", nvir_ij, nvir_ij);
         Vector pno_occ("eigenvalues", nvir_ij);
-        D_ij->diagonalize(X_pno_ij, pno_occ, descending);
+        D_ij->diagonalize(*X_pno_ij, pno_occ, descending);
 
         int nvir_ij_final = 0;
         for (size_t a = 0; a < nvir_ij; ++a) {

--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -3211,7 +3211,7 @@ void OrientationMgr::diagonalize(LMatrix const &M, LMatrix *Q_out, LVector *D_ou
     Ip[2][1] = Ip[1][2] = (std::fabs(M.yz) < EPSILON ? 0.0 : M.yz);
     Matrix VV("Eigenvectors", 3, 3);
     Vector DD("Eigenvalues", 3);
-    I.diagonalize(&VV, &DD);  // Note: This line ONLY works for symmetric matrices!
+    I.diagonalize(VV, DD);  // Note: This line ONLY works for symmetric matrices!
     double *evals = DD.pointer();
     D_out->x = evals[0];
     D_out->y = evals[1];

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -2805,14 +2805,6 @@ void Matrix::back_transform(const Matrix &transformer) {
 
 double Matrix::vector_dot(const Matrix &rhs) { return vector_dot(&rhs); }
 
-void Matrix::diagonalize(Matrix &eigvectors, Vector &eigvalues, int nMatz) {
-    for (int h = 0; h < nirrep_; ++h) {
-        if (rowspi_[h]) {
-            sq_rsp(rowspi_[h], colspi_[h], matrix_[h], eigvalues.pointer(h), nMatz, eigvectors.matrix_[h], 1.0e-14);
-        }
-    }
-}
-
 void Matrix::write_to_dpdfile2(dpdfile2 *outFile) {
     global_dpd_->file2_mat_init(outFile);
 

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -1729,6 +1729,10 @@ void Matrix::diagonalize(Matrix *eigvectors, Vector *eigvalues, diagonalize_orde
     }
 }
 
+void Matrix::diagonalize(Matrix &eigvectors, Vector &eigvalues, diagonalize_order nMatz/* = ascending*/) {
+    diagonalize(&eigvectors, &eigvalues, nMatz);
+}
+
 void Matrix::diagonalize(SharedMatrix &eigvectors, std::shared_ptr<Vector> &eigvalues, diagonalize_order nMatz) {
     diagonalize(eigvectors.get(), eigvalues.get(), nMatz);
 }

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -1717,28 +1717,29 @@ double Matrix::vector_dot(const Matrix *const rhs) {
 
 double Matrix::vector_dot(const SharedMatrix &rhs) { return vector_dot(rhs.get()); }
 
-void Matrix::diagonalize(Matrix *eigvectors, Vector *eigvalues, diagonalize_order nMatz) {
+void Matrix::diagonalize(Matrix *eigvectors, Vector *eigvalues, diagonalize_order nMatz /* = ascending*/) {
+    diagonalize(*eigvectors, *eigvalues, nMatz);
+}
+
+void Matrix::diagonalize(Matrix &eigvectors, Vector &eigvalues, diagonalize_order nMatz /* = ascending*/) {
     if (symmetry_) {
         throw PSIEXCEPTION("Matrix::diagonalize: Matrix is non-totally symmetric.");
     }
     for (int h = 0; h < nirrep_; ++h) {
         if (rowspi_[h]) {
-            sq_rsp(rowspi_[h], colspi_[h], matrix_[h], eigvalues->pointer(h), static_cast<int>(nMatz),
-                   eigvectors->matrix_[h], 1.0e-14);
+            sq_rsp(rowspi_[h], colspi_[h], matrix_[h], eigvalues.pointer(h), static_cast<int>(nMatz),
+                   eigvectors.matrix_[h], 1.0e-14);
         }
     }
 }
 
-void Matrix::diagonalize(Matrix &eigvectors, Vector &eigvalues, diagonalize_order nMatz/* = ascending*/) {
-    diagonalize(&eigvectors, &eigvalues, nMatz);
+void Matrix::diagonalize(SharedMatrix &eigvectors, std::shared_ptr<Vector> &eigvalues,
+                         diagonalize_order nMatz /* = ascending*/) {
+    diagonalize(*eigvectors, *eigvalues, nMatz);
 }
 
-void Matrix::diagonalize(SharedMatrix &eigvectors, std::shared_ptr<Vector> &eigvalues, diagonalize_order nMatz) {
-    diagonalize(eigvectors.get(), eigvalues.get(), nMatz);
-}
-
-void Matrix::diagonalize(SharedMatrix &eigvectors, Vector &eigvalues, diagonalize_order nMatz) {
-    diagonalize(eigvectors.get(), &eigvalues, nMatz);
+void Matrix::diagonalize(SharedMatrix &eigvectors, Vector &eigvalues, diagonalize_order nMatz /* = ascending*/) {
+    diagonalize(*eigvectors, eigvalues, nMatz);
 }
 
 void Matrix::diagonalize(SharedMatrix &metric, SharedMatrix & /*eigvectors*/, std::shared_ptr<Vector> &eigvalues,

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -863,14 +863,20 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
 
     /// @{
     /// Diagonalizes this, eigvectors and eigvalues must be created by caller.  Only for symmetric matrices.
+    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and will be removed in 1.7.")
     void diagonalize(Matrix* eigvectors, Vector* eigvalues, diagonalize_order nMatz = ascending);
+    
+    void diagonalize(Matrix& eigvectors, Vector& eigvalues, diagonalize_order nMatz = ascending);
     void diagonalize(SharedMatrix& eigvectors, std::shared_ptr<Vector>& eigvalues, diagonalize_order nMatz = ascending);
+
+    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and will be removed in 1.7.")
     void diagonalize(SharedMatrix& eigvectors, Vector& eigvalues, diagonalize_order nMatz = ascending);
     /// @}
 
     /// @{
     /// Diagonalizes this, applying supplied metric, eigvectors and eigvalues must be created by caller.  Only for
     /// symmetric matrices.
+    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and will be removed in 1.7.")
     void diagonalize(SharedMatrix& metric, SharedMatrix& eigvectors, std::shared_ptr<Vector>& eigvalues,
                      diagonalize_order nMatz = ascending);
     /// @}
@@ -1097,6 +1103,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     /// General matrix multiply, saves result to this
     void gemm(bool transa, bool transb, double alpha, const Matrix& a, const Matrix& b, double beta);
     /// Diagonalize a symmetric matrix. Eigvectors and eigvalues must be created by caller.
+    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and will be removed in 1.7.")
     void diagonalize(Matrix& eigvectors, Vector& eigvalues, int nMatz = 1);
 
     /// @{

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -1102,9 +1102,6 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
 
     /// General matrix multiply, saves result to this
     void gemm(bool transa, bool transb, double alpha, const Matrix& a, const Matrix& b, double beta);
-    /// Diagonalize a symmetric matrix. Eigvectors and eigvalues must be created by caller.
-    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and will be removed in 1.7.")
-    void diagonalize(Matrix& eigvectors, Vector& eigvalues, int nMatz = 1);
 
     /// @{
     /// Retrieves the i'th irrep

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -863,20 +863,20 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
 
     /// @{
     /// Diagonalizes this, eigvectors and eigvalues must be created by caller.  Only for symmetric matrices.
-    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and will be removed in 1.7.")
+    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and 1.7 will be the last release to have it.")
     void diagonalize(Matrix* eigvectors, Vector* eigvalues, diagonalize_order nMatz = ascending);
     
     void diagonalize(Matrix& eigvectors, Vector& eigvalues, diagonalize_order nMatz = ascending);
     void diagonalize(SharedMatrix& eigvectors, std::shared_ptr<Vector>& eigvalues, diagonalize_order nMatz = ascending);
 
-    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and will be removed in 1.7.")
+    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and 1.7 will be the last release to have it.")
     void diagonalize(SharedMatrix& eigvectors, Vector& eigvalues, diagonalize_order nMatz = ascending);
     /// @}
 
     /// @{
     /// Diagonalizes this, applying supplied metric, eigvectors and eigvalues must be created by caller.  Only for
     /// symmetric matrices.
-    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and will be removed in 1.7.")
+    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and 1.7 will be the last release to have it.")
     void diagonalize(SharedMatrix& metric, SharedMatrix& eigvectors, std::shared_ptr<Vector>& eigvalues,
                      diagonalize_order nMatz = ascending);
     /// @}

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -1354,7 +1354,7 @@ Vector Molecule::rotational_constants(double zero_tol) const {
     SharedMatrix pI(inertia_tensor());
     Vector evals(3);
     auto eigenvectors = std::make_shared<Matrix>(3, 3);
-    pI->diagonalize(eigenvectors, evals, ascending);
+    pI->diagonalize(*eigenvectors, evals, ascending);
 
     // Conversion factor from moments to rotational constants.
     double im2rotconst = pc_h / (8 * pc_pi * pc_pi * pc_c);
@@ -2566,7 +2566,7 @@ void Molecule::set_full_point_group(double zero_tol) {
         SharedMatrix It(inertia_tensor());
         Vector I_evals(3);
         auto I_evects = std::make_shared<Matrix>(3, 3);
-        It->diagonalize(I_evects, I_evals, ascending);
+        It->diagonalize(*I_evects, I_evals, ascending);
         // I_evects->print_out();
         // outfile->Printf("I_evals %15.10lf %15.10lf %15.10lf\n", I_evals[0], I_evals[1], I_evals[2]);
 

--- a/psi4/src/psi4/occ/ekt_ea.cc
+++ b/psi4/src/psi4/occ/ekt_ea.cc
@@ -143,9 +143,9 @@ void OCCWave::ekt_ea() {
     UvecA->zero();
     Diag_g1A.zero();
     if (reference_ == "RESTRICTED")
-        G1tilde->diagonalize(UvecA, Diag_g1A);
+        G1tilde->diagonalize(*UvecA, Diag_g1A);
     else if (reference_ == "UNRESTRICTED")
-        G1tildeA->diagonalize(UvecA, Diag_g1A);
+        G1tildeA->diagonalize(*UvecA, Diag_g1A);
 
     // Make sure all eigenvalues are positive
     for (int h = 0; h < nirrep_; ++h) {
@@ -183,7 +183,7 @@ void OCCWave::ekt_ea() {
     // Diagonalize GFock to get orbital energies
     eorbA.zero();
     Uvec_primeA->zero();
-    GFock_primeA->diagonalize(Uvec_primeA, eorbA);
+    GFock_primeA->diagonalize(*Uvec_primeA, eorbA);
     UvecA->gemm(false, false, 1.0, g1HalfA, Uvec_primeA, 0.0);
 
     // Pole strength
@@ -329,7 +329,7 @@ void OCCWave::ekt_ea() {
         // Diagonalize OPDM
         UvecB->zero();
         Diag_g1B.zero();
-        G1tildeB->diagonalize(UvecB, Diag_g1B);
+        G1tildeB->diagonalize(*UvecB, Diag_g1B);
 
         // Make sure all eigenvalues are positive
         for (int h = 0; h < nirrep_; ++h) {

--- a/psi4/src/psi4/occ/ekt_ip.cc
+++ b/psi4/src/psi4/occ/ekt_ip.cc
@@ -87,9 +87,9 @@ void OCCWave::ekt_ip() {
     UvecA->zero();
     Diag_g1A.zero();
     if (reference_ == "RESTRICTED")
-        g1symm->diagonalize(UvecA, Diag_g1A);
+        g1symm->diagonalize(*UvecA, Diag_g1A);
     else if (reference_ == "UNRESTRICTED")
-        g1symmA->diagonalize(UvecA, Diag_g1A);
+        g1symmA->diagonalize(*UvecA, Diag_g1A);
 
     // Make sure all eigenvalues are positive
     for (int h = 0; h < nirrep_; ++h) {
@@ -308,7 +308,7 @@ void OCCWave::ekt_ip() {
         // Diagonalize OPDM
         UvecB->zero();
         Diag_g1B.zero();
-        g1symmB->diagonalize(UvecB, Diag_g1B);
+        g1symmB->diagonalize(*UvecB, Diag_g1B);
 
         // Make sure all eigenvalues are positive
         for (int h = 0; h < nirrep_; ++h) {

--- a/psi4/src/psi4/occ/semi_canonic.cc
+++ b/psi4/src/psi4/occ/semi_canonic.cc
@@ -89,8 +89,8 @@ void OCCWave::semi_canonic() {
     }
 
     // Diagonalize Fock
-    FockooA->diagonalize(UooA, eigooA);
-    FockvvA->diagonalize(UvvA, eigvvA);
+    FockooA->diagonalize(*UooA, eigooA);
+    FockvvA->diagonalize(*UvvA, eigvvA);
 
     // Print orbital energies
     if (occ_orb_energy == "TRUE" && mo_optimized == 1) {
@@ -222,8 +222,8 @@ void OCCWave::semi_canonic() {
         }
 
         // Diagonalize Fock
-        FockooB->diagonalize(UooB, eigooB);
-        FockvvB->diagonalize(UvvB, eigvvB);
+        FockooB->diagonalize(*UooB, eigooB);
+        FockvvB->diagonalize(*UvvB, eigvvB);
 
         // print orbital energies
         if (occ_orb_energy == "TRUE" && mo_optimized == 1 && reference_ == "UNRESTRICTED") {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Some overloads of `Matrix::diagonalize` in `libmints` are never called anywhere within Psi4, and some more are currently taking pointer arguments. They should be removed, but as discussed in #2693 the entire `Matrix` class is `PSI_API` and Forte is for sure using these diagonalization functions.

To keep the promise of not randomly breaking API without fair warning, this PR deprecates said functions but keeps them usable. Call sites within Psi4 are however converted to use non-deprecated overloads, so after 1.7 is out, completing the removal should just be a simple deletion of the deprecated overloads.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is detined for the release notes. May be empty. -->
- [x] `PSI_API` member function `Matrix::diagonalize(Matrix* eigvectors, Vector* eigvalues, diagonalize_order nMatz = ascending)` is deprecated and 1.7 will be the last release with it present.
- [x] `PSI_API` member function `Matrix::diagonalize(SharedMatrix& eigvectors, Vector& eigvalues, diagonalize_order nMatz = ascending)` is deprecated and 1.7 will be the last release with it present.
- [x] `PSI_API` member function `Matrix::diagonalize(SharedMatrix& metric, SharedMatrix& eigvectors, std::shared_ptr<Vector>& eigvalues, diagonalize_order nMatz = ascending)` is deprecated and 1.7 will be the last release with it present.
- [x] `PSI_API` member function `Matrix::diagonalize(Matrix& eigvectors, Vector& eigvalues, int nMatz = 1)` is now using the `diagonalize_order` enum, like the other overloads: `Matrix::diagonalize(Matrix& eigvectors, Vector& eigvalues, diagonalize_order nMatz = ascending)`. But since `ascending = 1`, this should not cause disruptions.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `PSI_DEPRECATED` has been added to the three functions mentioned _vide supra_.
- [x] Both `Matrix::diagonalize(Matrix&, Vector&, int)` and `Matrix::diagonalize(Matrix*, Vector*, diagonalize_order)` used to call `sq_rsp`, now only `Matrix::diagonalize(Matrix&, Vector&, diagonalize_order)` calls it.
- [x] All other overloads are now calling `Matrix::diagonalize(Matrix&, Vector&, diagonalize_order)`, except the deprecated `Matrix::diagonalize(SharedMatrix& metric, ....` function.
- [x] Code where one of the now-deprecated functions was called from has been modified to call a non-deprecated one.

## Checklist
- [X] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
