### PR TITLE
Transpose with symmetry_

### DIFF
--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -1060,21 +1060,18 @@ SharedMatrix Matrix::transpose() const {
     if (symmetry_) {
         for (int rowsym = 0; rowsym < nirrep_; ++rowsym) {
             int colsym = rowsym ^ symmetry_;
-            if (rowsym < colsym) continue;
             int rows = rowspi_[rowsym];
             int cols = colspi_[colsym];
             for (int row = 0; row < rows; row++) {
                 for (int col = 0; col < cols; col++) {
                     temp->matrix_[colsym][col][row] = matrix_[rowsym][row][col];
-                    temp->matrix_[rowsym][row][col] = matrix_[colsym][col][row];
                 }
             }
         }
     } else {
-        int h, i, j;
-        for (h = 0; h < nirrep_; ++h) {
-            for (i = 0; i < rowspi_[h]; ++i) {
-                for (j = 0; j < colspi_[h]; ++j) {
+        for (int h = 0; h < nirrep_; ++h) {
+            for (int i = 0; i < rowspi_[h]; ++i) {
+                for (int j = 0; j < colspi_[h]; ++j) {
                     temp->matrix_[h][j][i] = matrix_[h][i][j];
                 }
             }
@@ -1091,6 +1088,9 @@ void Matrix::transpose_this() {
             if (rowsym < colsym) continue;
             int rows = rowspi_[rowsym];
             int cols = colspi_[colsym];
+            if (rows != cols) {
+                throw NOT_IMPLEMENTED_EXCEPTION();
+            }
             for (int row = 0; row < rows; row++) {
                 for (int col = 0; col < cols; col++) {
                     std::swap(matrix_[colsym][col][row], matrix_[rowsym][row][col]);
@@ -1098,17 +1098,15 @@ void Matrix::transpose_this() {
             }
         }
     } else {
-        int h, i, j;
-        if (rowspi_ == colspi_) {
-            for (h = 0; h < nirrep_; ++h) {
-                for (i = 0; i < rowspi_[h]; ++i) {
-                    for (j = 0; j < i; ++j) {
-                        std::swap(matrix_[h][i][j], matrix_[h][j][i]);
-                    }
+        if (rowspi_ != colspi_) {
+            throw NOT_IMPLEMENTED_EXCEPTION();
+        }
+        for (int h = 0; h < nirrep_; ++h) {
+            for (int i = 0; i < rowspi_[h]; ++i) {
+                for (int j = 0; j < i; ++j) {
+                    std::swap(matrix_[h][i][j], matrix_[h][j][i]);
                 }
             }
-        } else {
-            throw NOT_IMPLEMENTED_EXCEPTION();
         }
     }
 }

--- a/tests/pytests/test_matrix.py
+++ b/tests/pytests/test_matrix.py
@@ -246,3 +246,28 @@ def test_set_matrix():
     new_mat = Matrix("Name", new_dim, new_dim, 1)
     mat.set_block(new_slice, new_slice, new_mat)
     assert psi4.compare_matrices(mat, control_mat)
+
+def test_transpose_this():
+    dim1 = Dimension([3, 2])
+    dim2 = Dimension([5, 7])
+    mat = Matrix("Name", dim1, dim2, 1)
+    with pytest.raises(RuntimeError):
+        mat.transpose_this()
+
+def test_transpose():
+    dim1 = Dimension([2, 3])
+    dim2 = Dimension([4, 1])
+    mat = Matrix("Matrix", dim1, dim2, 1)
+    transposed_mat = Matrix("Transposed Matrix", dim2, dim1, 1)
+    i = 0
+    for j in range(2):
+        for k in range(1):
+            mat.set(0, j, k, i)
+            transposed_mat.set(1, k, j, i)
+            i += 1
+    for j in range(3):
+        for k in range(4):
+            mat.set(1, j, k, i)
+            transposed_mat.set(0, k, j, i)
+            i += 1
+    assert psi4.compare_matrices(mat.transpose(), transposed_mat)


### PR DESCRIPTION
## User API & Changelog headlines
- [x] A segfault in `Matrix::transpose` for matrices that are not totally symmetric now performs the transpose.
- [x] A segfault in `Matrix::transpose_this` for matrices that are not totally symmetric now raises an error message. 

## Dev notes & details
- [x] All the above, plus...
- [x] Tests that the above works!
- [x] Removing variable declarations before initialization.
- [x] Reorganized logic in symmetric case for clarity. 

## Checklist
- [x] Tests added for any new features

## Status
- [x] Ready for review
- [x] Ready for merge
