### PR TITLE
Coalesce PSIO system call macros

### DIFF
--- a/psi4/src/psi4/libpsio/close.cc
+++ b/psi4/src/psi4/libpsio/close.cc
@@ -32,16 +32,6 @@
  ** \file
  ** \ingroup PSIO
  */
-
-#ifdef _MSC_VER
-#include <io.h>
-#define SYSTEM_CLOSE ::_close
-#define SYSTEM_UNLINK ::_unlink
-#else
-#include <unistd.h>
-#define SYSTEM_CLOSE ::close
-#define SYSTEM_UNLINK ::unlink
-#endif
 #include <cstring>
 #include <cstdlib>
 #include "psi4/libpsio/psio.h"

--- a/psi4/src/psi4/libpsio/filemanager.cc
+++ b/psi4/src/psi4/libpsio/filemanager.cc
@@ -26,13 +26,6 @@
  * @END LICENSE
  */
 
-#ifdef _MSC_VER
-#include <io.h>
-#define SYSTEM_UNLINK ::_unlink
-#else
-#include <unistd.h>
-#define SYSTEM_UNLINK ::unlink
-#endif
 #include <cstdio>
 #include <cstdlib>
 #include <string>

--- a/psi4/src/psi4/libpsio/open.cc
+++ b/psi4/src/psi4/libpsio/open.cc
@@ -35,21 +35,6 @@
 #include <fcntl.h>
 #include <cstring>
 #include <cstdlib>
-#ifdef _MSC_VER
-#include <io.h>
-#define SYSTEM_OPEN ::_open
-#define SYSTEM_CLOSE ::_close
-#define PSIO_OPEN_OLD_FLAGS _O_BINARY | _O_CREAT | _O_RDWR
-#define PSIO_OPEN_NEW_FLAGS _O_BINARY | _O_CREAT | _O_RDWR | _O_TRUNC
-#define PERMISSION_MODE _S_IWRITE
-#else
-#include <unistd.h>
-#define SYSTEM_OPEN ::open
-#define SYSTEM_CLOSE ::close
-#define PSIO_OPEN_OLD_FLAGS O_CREAT | O_RDWR
-#define PSIO_OPEN_NEW_FLAGS O_CREAT | O_RDWR | O_TRUNC
-#define PERMISSION_MODE S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
-#endif
 #include <string>
 #include <map>
 #include <sstream>

--- a/psi4/src/psi4/libpsio/psio.h
+++ b/psi4/src/psi4/libpsio/psio.h
@@ -35,9 +35,11 @@
 
 #ifdef _MSC_VER
 #include <io.h>
+#define SYSTEM_READ ::_read
 #define SYSTEM_LSEEK ::_lseeki64
 #else
 #include <unistd.h>
+#define SYSTEM_READ ::read
 #define SYSTEM_LSEEK ::lseek
 #endif
 

--- a/psi4/src/psi4/libpsio/psio.h
+++ b/psi4/src/psi4/libpsio/psio.h
@@ -35,10 +35,12 @@
 
 #ifdef _MSC_VER
 #include <io.h>
+#define SYSTEM_WRITE ::_write
 #define SYSTEM_READ ::_read
 #define SYSTEM_LSEEK ::_lseeki64
 #else
 #include <unistd.h>
+#define SYSTEM_WRITE ::write
 #define SYSTEM_READ ::read
 #define SYSTEM_LSEEK ::lseek
 #endif

--- a/psi4/src/psi4/libpsio/psio.h
+++ b/psi4/src/psi4/libpsio/psio.h
@@ -33,6 +33,14 @@
 #include "psi4/libpsio/config.h"
 #include <string>
 
+#ifdef _MSC_VER
+#include <io.h>
+#define SYSTEM_LSEEK ::_lseeki64
+#else
+#include <unistd.h>
+#define SYSTEM_LSEEK ::lseek
+#endif
+
 namespace psi {
 
 std::string decode_errno(const int errno_in);

--- a/psi4/src/psi4/libpsio/psio.h
+++ b/psi4/src/psi4/libpsio/psio.h
@@ -40,6 +40,7 @@
 #define SYSTEM_LSEEK ::_lseeki64
 #define SYSTEM_OPEN ::_open
 #define SYSTEM_CLOSE ::_close
+#define SYSTEM_UNLINK ::_unlink
 #define PSIO_OPEN_OLD_FLAGS _O_BINARY | _O_CREAT | _O_RDWR
 #define PSIO_OPEN_NEW_FLAGS _O_BINARY | _O_CREAT | _O_RDWR | _O_TRUNC
 #define PERMISSION_MODE _S_IWRITE
@@ -50,6 +51,7 @@
 #define SYSTEM_LSEEK ::lseek
 #define SYSTEM_OPEN ::open
 #define SYSTEM_CLOSE ::close
+#define SYSTEM_UNLINK ::unlink
 #define PSIO_OPEN_OLD_FLAGS O_CREAT | O_RDWR
 #define PSIO_OPEN_NEW_FLAGS O_CREAT | O_RDWR | O_TRUNC
 #define PERMISSION_MODE S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH

--- a/psi4/src/psi4/libpsio/psio.h
+++ b/psi4/src/psi4/libpsio/psio.h
@@ -38,11 +38,21 @@
 #define SYSTEM_WRITE ::_write
 #define SYSTEM_READ ::_read
 #define SYSTEM_LSEEK ::_lseeki64
+#define SYSTEM_OPEN ::_open
+#define SYSTEM_CLOSE ::_close
+#define PSIO_OPEN_OLD_FLAGS _O_BINARY | _O_CREAT | _O_RDWR
+#define PSIO_OPEN_NEW_FLAGS _O_BINARY | _O_CREAT | _O_RDWR | _O_TRUNC
+#define PERMISSION_MODE _S_IWRITE
 #else
 #include <unistd.h>
 #define SYSTEM_WRITE ::write
 #define SYSTEM_READ ::read
 #define SYSTEM_LSEEK ::lseek
+#define SYSTEM_OPEN ::open
+#define SYSTEM_CLOSE ::close
+#define PSIO_OPEN_OLD_FLAGS O_CREAT | O_RDWR
+#define PSIO_OPEN_NEW_FLAGS O_CREAT | O_RDWR | O_TRUNC
+#define PERMISSION_MODE S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
 #endif
 
 namespace psi {

--- a/psi4/src/psi4/libpsio/rw.cc
+++ b/psi4/src/psi4/libpsio/rw.cc
@@ -32,13 +32,6 @@
  */
 
 #include <cstdio>
-#ifdef _MSC_VER
-#include <io.h>
-#define SYSTEM_WRITE ::_write
-#else
-#include <unistd.h>
-#define SYSTEM_WRITE ::write
-#endif
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/psi4-dec.h"

--- a/psi4/src/psi4/libpsio/rw.cc
+++ b/psi4/src/psi4/libpsio/rw.cc
@@ -34,11 +34,9 @@
 #include <cstdio>
 #ifdef _MSC_VER
 #include <io.h>
-#define SYSTEM_READ ::_read
 #define SYSTEM_WRITE ::_write
 #else
 #include <unistd.h>
-#define SYSTEM_READ ::read
 #define SYSTEM_WRITE ::write
 #endif
 #include "psi4/libpsio/psio.h"

--- a/psi4/src/psi4/libpsio/toclen.cc
+++ b/psi4/src/psi4/libpsio/toclen.cc
@@ -34,11 +34,9 @@
 #include <cstdio>
 #ifdef _MSC_VER
 #include <io.h>
-#define SYSTEM_READ ::_read
 #define SYSTEM_WRITE ::_write
 #else
 #include <unistd.h>
-#define SYSTEM_READ ::read
 #define SYSTEM_WRITE ::write
 #endif
 #include <cstdlib>

--- a/psi4/src/psi4/libpsio/toclen.cc
+++ b/psi4/src/psi4/libpsio/toclen.cc
@@ -32,13 +32,6 @@
  */
 
 #include <cstdio>
-#ifdef _MSC_VER
-#include <io.h>
-#define SYSTEM_WRITE ::_write
-#else
-#include <unistd.h>
-#define SYSTEM_WRITE ::write
-#endif
 #include <cstdlib>
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libpsio/psio.h"

--- a/psi4/src/psi4/libpsio/toclen.cc
+++ b/psi4/src/psi4/libpsio/toclen.cc
@@ -34,12 +34,10 @@
 #include <cstdio>
 #ifdef _MSC_VER
 #include <io.h>
-#define SYSTEM_LSEEK ::_lseek
 #define SYSTEM_READ ::_read
 #define SYSTEM_WRITE ::_write
 #else
 #include <unistd.h>
-#define SYSTEM_LSEEK ::lseek
 #define SYSTEM_READ ::read
 #define SYSTEM_WRITE ::write
 #endif

--- a/psi4/src/psi4/libpsio/volseek.cc
+++ b/psi4/src/psi4/libpsio/volseek.cc
@@ -33,15 +33,6 @@
 
 #include "psi4/libpsio/psio.h"
 #include "psi4/psi4-dec.h"
-
-#ifdef _MSC_VER
-#include <io.h>
-#define SYSTEM_LSEEK ::_lseeki64
-#else
-#include <unistd.h>
-#define SYSTEM_LSEEK ::lseek
-#endif
-
 /* This is strictly used to avoid overflow errors on lseek() calls */
 #define PSIO_BIGNUM 10000
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Definitions of various IO system call macros are currently replicated and/or scattered across files. These macros were added to paper over differences between Windows and Linux/Mac.
This PR coalesces all of them into `psio.h`.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is detined for the release notes. May be empty. -->
None

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `SYSTEM_WRITE`, `SYSTEM_READ`, `SYSTEM_LSEEK`, `SYSTEM_OPEN`, `SYSTEM_CLOSE`, `SYSTEM_UNLINK`, `PSIO_OPEN_OLD_FLAGS`, `PSIO_OPEN_NEW_FLAGS `and `PERMISSION_MODE `are now only defined in `psio.h`, which is already included by pretty much all PSIO-related files anyways.
- [x] Same goes for the Windows specific `io.h` include, and the non-Windows `unistd.h`.

## Checklist
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
