### PR TITLE
Initialize lebedev_mapping_ and make use thread-safe -- and do ONLY THAT

### DIFF
--- a/psi4/src/psi4/libfock/cubature.cc
+++ b/psi4/src/psi4/libfock/cubature.cc
@@ -5062,7 +5062,13 @@ std::shared_ptr<RadialGrid> RadialGrid::build_treutler(int npoints, double alpha
 }
 
 /// Grid npoints to order map
-std::map<int, int> SphericalGrid::lebedev_mapping_;
+std::map<int, int> SphericalGrid::lebedev_mapping_ = {
+    {6,1}, {14,2}, {26,3}, {38,4}, {50,5}, {74,6}, {86,7}, {110,8}, {146,9},
+    {170,10}, {194,11}, {230,12}, {266,13}, {302,14}, {350,15}, {434,17},
+    {590,20}, {770,23}, {974,26}, {1202,29}, {1454,32}, {1730,35}, {2030,38},
+    {2354,41}, {2702,44}, {3074,47}, {3470,50}, {3890,53}, {4334,56},
+    {4802,59}, {5294,62}, {5810,65}
+};
 
 SphericalGrid::SphericalGrid() : npoints_(0) {}
 SphericalGrid::~SphericalGrid() {
@@ -5103,7 +5109,7 @@ void SphericalGrid::build_angles() {
 std::shared_ptr<SphericalGrid> SphericalGrid::build(const std::string &scheme, int npoints, const MassPoint *points) {
     auto *s = new SphericalGrid();
     s->scheme_ = scheme;
-    s->order_ = lebedev_mapping_[npoints];
+    s->order_ = lebedev_mapping_.at(npoints);
     s->npoints_ = npoints;
 
     s->x_ = new double[npoints];
@@ -5120,43 +5126,6 @@ std::shared_ptr<SphericalGrid> SphericalGrid::build(const std::string &scheme, i
 
     s->build_angles();
     return std::shared_ptr<SphericalGrid>(s);
-}
-
-void SphericalGrid::initialize_lebedev() {
-    lebedev_mapping_.clear();
-
-    lebedev_mapping_[6] = 1;
-    lebedev_mapping_[14] = 2;
-    lebedev_mapping_[26] = 3;
-    lebedev_mapping_[38] = 4;
-    lebedev_mapping_[50] = 5;
-    lebedev_mapping_[74] = 6;
-    lebedev_mapping_[86] = 7;
-    lebedev_mapping_[110] = 8;
-    lebedev_mapping_[146] = 9;
-    lebedev_mapping_[170] = 10;
-    lebedev_mapping_[194] = 11;
-    lebedev_mapping_[230] = 12;
-    lebedev_mapping_[266] = 13;
-    lebedev_mapping_[302] = 14;
-    lebedev_mapping_[350] = 15;
-    lebedev_mapping_[434] = 17;
-    lebedev_mapping_[590] = 20;
-    lebedev_mapping_[770] = 23;
-    lebedev_mapping_[974] = 26;
-    lebedev_mapping_[1202] = 29;
-    lebedev_mapping_[1454] = 32;
-    lebedev_mapping_[1730] = 35;
-    lebedev_mapping_[2030] = 38;
-    lebedev_mapping_[2354] = 41;
-    lebedev_mapping_[2702] = 44;
-    lebedev_mapping_[3074] = 47;
-    lebedev_mapping_[3470] = 50;
-    lebedev_mapping_[3890] = 53;
-    lebedev_mapping_[4334] = 56;
-    lebedev_mapping_[4802] = 59;
-    lebedev_mapping_[5294] = 62;
-    lebedev_mapping_[5810] = 65;
 }
 
 void SphericalGrid::lebedev_error() {

--- a/psi4/src/psi4/libfock/cubature.h
+++ b/psi4/src/psi4/libfock/cubature.h
@@ -316,8 +316,7 @@ class SphericalGrid {
 
     /// Grid npoints to order map
     static std::map<int, int> lebedev_mapping_;
-    /// Initialize the above arrays with the unique Lebedev grids
-    static void initialize_lebedev();
+
     /// Print valid Lebedev grids and error out (throws)
     static void lebedev_error();
 


### PR DESCRIPTION
`initialize_lebedev` wasn't ever actually called. Since we're using c++11 elsewhere, we can just use an initializer_list to build `lebedev_mapping_` and skip all this `initialize_lebedev` nonsense. Also changes the technically-thread-unsafe `[]` to a `.at()` so this can't be re-broken later.

Now, it turns out that there's a lot more ado about `SpherialGrid` and `RadialGrid` and cubature.cc in general, but, we're discussing that over in #2736 .

This PR's purpose is JUST to fix the nasty bug that could cause parallel code to hang (if multiple threads tried to touch `lebedev_mapping_` at once, and write a value because `[]` access fills-when-missing, one or more thread could get stuck forever in a tree-that-has-become-a-loop).

See #2736 for more details on who/what/where/when/why.