### PR TITLE
Standardize `Matrix::back_transform`

### DIFF
--- a/tests/pytests/test_matrix.py
+++ b/tests/pytests/test_matrix.py
@@ -247,6 +247,26 @@ def test_transform():
     assert compare_arrays((transformer.nph[0]).T @ original.nph[0] @ transformer.nph[1], transformed.nph[0]) 
     assert compare_arrays((transformer.nph[1]).T @ original.nph[1] @ transformer.nph[0], transformed.nph[1])
 
+def test_back_transform():
+    # transformed = transformer @ original @ transformer.T
+    rdim = Dimension([3, 2])
+    cdim = Dimension([4, 5])
+    original = build_random_mat(cdim, cdim, 1)
+
+    # Test case that transformed resize needed.
+    transformer = build_random_mat(rdim, cdim)
+    transformed = original.clone()
+    transformed.back_transform(transformer)
+    assert compare_arrays(transformer.nph[0] @ original.nph[0] @ (transformer.nph[1]).T, transformed.nph[0]) 
+    assert compare_arrays(transformer.nph[1] @ original.nph[1] @ (transformer.nph[0]).T, transformed.nph[1])
+
+    # Test case that transformed resize not needed.
+    transformer = build_random_mat(cdim, cdim)
+    transformed = original.clone()
+    transformed.back_transform(transformer)
+    assert compare_arrays(transformer.nph[0] @ original.nph[0] @ (transformer.nph[1]).T, transformed.nph[0]) 
+    assert compare_arrays(transformer.nph[1] @ original.nph[1] @ (transformer.nph[0]).T, transformed.nph[1])
+
 def test_set_matrix():
     # Use set_matrix to zero a block of a non-totally symmetric matrix.
     dim = Dimension([3, 2])


### PR DESCRIPTION
## Description
Make `back_transform` consistent across the various signatures and better behaved for more "exotic" cases.


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is detined for the release notes. May be empty. -->
- [x] Improved `Matrix::back_transform`'s ability to handle edge cases

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] All `back_transform` signatures now trickle down to a single function
- [x] All `back_transform` signatures resize the target matrix if necessary (only one did this previously, DGEMM error otherwise)
- [x] All `back_transform` signatures handle symmetry correctly (at least some would error previously)

## Checklist
- [x] `back_transform` passing tests

## Status
- [x] Ready for review
- [x] Ready for merge
