### PR TITLE
Move LTD/RTD and Integrals to `Matrix`

### DIFF
--- a/psi4/src/psi4/cc/ccdensity/MOInfo.h
+++ b/psi4/src/psi4/cc/ccdensity/MOInfo.h
@@ -41,6 +41,8 @@
 namespace psi {
 namespace ccdensity {
 
+SharedMatrix block_to_matrix(double **);
+
 struct MOInfo {
     int nirreps;                     /* no. of irreducible representations */
     int nmo;                         /* no. of molecular orbitals */
@@ -100,19 +102,18 @@ struct MOInfo {
     double **I;                      /* Lagrangian matrix in the full space */
     double **I_a;                    /* Alpha Lagrangian matrix in the full space */
     double **I_b;                    /* Beta Lagrangian matrix in the full space */
-    double **ltd;                    /* <0|O|n> Left transition density */
-    double **ltd_a;                  /* <0|O|n> Left transition alpha density */
-    double **ltd_b;                  /* <0|O|n> Left transition beta density */
-    double **rtd;                    /* <n|O|0> Right transition density */
-    double **rtd_a;                  /* <n|O|0> Right transition alpha density */
-    double **rtd_b;                  /* <n|O|0> Right transition beta density */
+    Matrix ltd_mat;                  /* <0|O|n> Left transition density */
+    Matrix ltd_a_mat;                /* <0|O|n> Left transition alpha density */
+    Matrix ltd_b_mat;                /* <0|O|n> Left transition beta density */
+    Matrix rtd_mat;                  /* <n|O|0> Right transition density */
+    Matrix rtd_a_mat;                /* <n|O|0> Right transition alpha density */
+    Matrix rtd_b_mat;                /* <n|O|0> Right transition beta density */
     std::vector<int> pitzer2qt;      /* Pitzer to QT re-ordering array */
     std::vector<int> qt2pitzer;      /* QT to Pitzer re-ordering array */
-    double **scf_qt;                 /* SCF orbitals (QT ordering of MOs) */
     SharedMatrix Ca;                 /* SCF orbitals (standard ordering) */
-    double ***L;
-    double ***nabla;
-    double ***dip;
+    std::vector<SharedMatrix> L;
+    std::vector<SharedMatrix> nabla;
+    std::vector<SharedMatrix> dip;
 };
 
 }  // namespace ccdensity

--- a/psi4/src/psi4/cc/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.cc
@@ -123,7 +123,6 @@ void tdensity(const struct TD_Params& S);
 void td_print();
 void oscillator_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S);
 void rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S);
-void cleanup();
 void td_cleanup();
 void x_oe_intermediates_rhf(const struct RHO_Params& rho_params);
 void x_te_intermediates_rhf();
@@ -137,7 +136,6 @@ void ex_oscillator_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Param
                             struct XTD_Params *xtd_data);
 void ex_rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S, struct TD_Params *U, struct XTD_Params *xtd_data);
 void ex_td_print(std::vector<struct XTD_Params>);
-SharedMatrix block_to_matrix(double **);
 
 PsiReturnType ccdensity(std::shared_ptr<ccenergy::CCEnergyWavefunction> ref_wfn, Options &options) {
     int i;
@@ -214,7 +212,6 @@ PsiReturnType ccdensity(std::shared_ptr<ccenergy::CCEnergyWavefunction> ref_wfn,
             else
                 cachedone_rhf(cachelist);
             free(cachefiles);
-            cleanup();
             psio_close(PSIF_EOM_TMP_XI, 0); /* delete EOM_TMP_XI */
             psio_open(PSIF_EOM_TMP_XI, PSIO_OPEN_NEW);
             exit_io();
@@ -551,7 +548,6 @@ PsiReturnType ccdensity(std::shared_ptr<ccenergy::CCEnergyWavefunction> ref_wfn,
         cachedone_rhf(cachelist);
     free(cachefiles);
 
-    cleanup();
     exit_io();
     return Success;
 }

--- a/psi4/src/psi4/cc/ccdensity/ex_rotational_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_rotational_strength.cc
@@ -60,8 +60,6 @@ void transL(const MintsHelper &mints, double sign);
 void ex_rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S, struct TD_Params *U, struct XTD_Params *xtd_data) {
     int i, j, k;
     int no, nv, nt;
-    double lt_x, lt_y, lt_z;
-    double rt_x, rt_y, rt_z;
     double rs_lx, rs_ly, rs_lz;
     double rs_rx, rs_ry, rs_rz;
     double rs_x, rs_y, rs_z;
@@ -77,27 +75,19 @@ void ex_rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Param
                     moinfo.labels[S->irrep].c_str(), U->root + 1, moinfo.labels[U->irrep].c_str());
     outfile->Printf("\t                              X    \t       Y    \t       Z\n");
 
-    lt_x = lt_y = lt_z = 0.0;
-    rt_x = rt_y = rt_z = 0.0;
     rs_lx = rs_ly = rs_lz = 0.0;
     rs_rx = rs_ry = rs_rz = 0.0;
     rs_x = rs_y = rs_z = 0.0;
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            lt_x += moinfo.ltd[i][j] * moinfo.dip[0][i][j];
-            lt_y += moinfo.ltd[i][j] * moinfo.dip[1][i][j];
-            lt_z += moinfo.ltd[i][j] * moinfo.dip[2][i][j];
-        }
+    auto lt_x = moinfo.ltd_mat.vector_dot(moinfo.dip[0]);
+    auto lt_y = moinfo.ltd_mat.vector_dot(moinfo.dip[1]);
+    auto lt_z = moinfo.ltd_mat.vector_dot(moinfo.dip[2]);
 
     transL(mints, +1.0);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            rt_x += moinfo.rtd[i][j] * moinfo.L[0][i][j];
-            rt_y += moinfo.rtd[i][j] * moinfo.L[1][i][j];
-            rt_z += moinfo.rtd[i][j] * moinfo.L[2][i][j];
-        }
+    auto rt_x = moinfo.rtd_mat.vector_dot(moinfo.L[0]);
+    auto rt_y = moinfo.rtd_mat.vector_dot(moinfo.L[1]);
+    auto rt_z = moinfo.rtd_mat.vector_dot(moinfo.L[2]);
 
     rs_lx = lt_x * rt_x;
     rs_ly = lt_y * rt_y;
@@ -107,29 +97,15 @@ void ex_rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Param
     outfile->Printf("\t<q|mu_m|p>              %11.8lf \t %11.8lf \t %11.8lf\n", rt_x, rt_y, rt_z);
 
     // Complex Conjugate
-
-    lt_x = lt_y = lt_z = 0.0;
-    rt_x = rt_y = rt_z = 0.0;
-
-    for (i = 0; i < 3; i++)
-        for (j = 0; j < nmo; j++)
-            for (k = 0; k < nmo; k++) moinfo.L[i][j][k] = 0.0;
-
     transL(mints, -1.0);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            lt_x += moinfo.ltd[i][j] * moinfo.L[0][i][j];
-            lt_y += moinfo.ltd[i][j] * moinfo.L[1][i][j];
-            lt_z += moinfo.ltd[i][j] * moinfo.L[2][i][j];
-        }
+    lt_x = moinfo.ltd_mat.vector_dot(moinfo.L[0]);
+    lt_y = moinfo.ltd_mat.vector_dot(moinfo.L[1]);
+    lt_z = moinfo.ltd_mat.vector_dot(moinfo.L[2]);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            rt_x += moinfo.rtd[i][j] * moinfo.dip[0][i][j];
-            rt_y += moinfo.rtd[i][j] * moinfo.dip[1][i][j];
-            rt_z += moinfo.rtd[i][j] * moinfo.dip[2][i][j];
-        }
+    rt_x = moinfo.rtd_mat.vector_dot(moinfo.dip[0]);
+    rt_y = moinfo.rtd_mat.vector_dot(moinfo.dip[1]);
+    rt_z = moinfo.rtd_mat.vector_dot(moinfo.dip[2]);
 
     rs_rx = lt_x * rt_x;
     rs_ry = lt_y * rt_y;
@@ -163,29 +139,21 @@ void ex_rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Param
                     U->root + 1, moinfo.labels[U->irrep].c_str());
     outfile->Printf("\t                              X    \t       Y    \t       Z\n");
 
-    lt_x = lt_y = lt_z = 0.0;
-    rt_x = rt_y = rt_z = 0.0;
     rs_lx = rs_ly = rs_lz = 0.0;
     rs_rx = rs_ry = rs_rz = 0.0;
     rs_x = rs_y = rs_z = 0.0;
 
     transp(mints, +1.0);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            lt_x += moinfo.ltd[i][j] * moinfo.nabla[0][i][j];
-            lt_y += moinfo.ltd[i][j] * moinfo.nabla[1][i][j];
-            lt_z += moinfo.ltd[i][j] * moinfo.nabla[2][i][j];
-        }
+    lt_x = moinfo.ltd_mat.vector_dot(moinfo.nabla[0]);
+    lt_y = moinfo.ltd_mat.vector_dot(moinfo.nabla[1]);
+    lt_z = moinfo.ltd_mat.vector_dot(moinfo.nabla[2]);
 
     transL(mints, +1.0);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            rt_x += moinfo.rtd[i][j] * moinfo.L[0][i][j];
-            rt_y += moinfo.rtd[i][j] * moinfo.L[1][i][j];
-            rt_z += moinfo.rtd[i][j] * moinfo.L[2][i][j];
-        }
+    rt_x = moinfo.rtd_mat.vector_dot(moinfo.L[0]);
+    rt_y = moinfo.rtd_mat.vector_dot(moinfo.L[1]);
+    rt_z = moinfo.rtd_mat.vector_dot(moinfo.L[2]);
 
     rs_lx = lt_x * rt_x;
     rs_ly = lt_y * rt_y;
@@ -195,34 +163,17 @@ void ex_rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Param
     outfile->Printf("\t<q|mu_m|p>              %11.8lf \t %11.8lf \t %11.8lf\n", rt_x, rt_y, rt_z);
 
     // Complex Conjugate
-
-    lt_x = lt_y = lt_z = 0.0;
-    rt_x = rt_y = rt_z = 0.0;
-
-    for (i = 0; i < 3; i++)
-        for (j = 0; j < nmo; j++)
-            for (k = 0; k < nmo; k++) {
-                moinfo.nabla[i][j][k] = 0.0;
-                moinfo.L[i][j][k] = 0.0;
-            }
-
     transL(mints, -1.0);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            lt_x += moinfo.ltd[i][j] * moinfo.L[0][i][j];
-            lt_y += moinfo.ltd[i][j] * moinfo.L[1][i][j];
-            lt_z += moinfo.ltd[i][j] * moinfo.L[2][i][j];
-        }
+    lt_x = moinfo.ltd_mat.vector_dot(moinfo.L[0]);
+    lt_y = moinfo.ltd_mat.vector_dot(moinfo.L[1]);
+    lt_z = moinfo.ltd_mat.vector_dot(moinfo.L[2]);
 
     transp(mints, -1.0);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            rt_x += moinfo.rtd[i][j] * moinfo.nabla[0][i][j];
-            rt_y += moinfo.rtd[i][j] * moinfo.nabla[1][i][j];
-            rt_z += moinfo.rtd[i][j] * moinfo.nabla[2][i][j];
-        }
+    rt_x = moinfo.rtd_mat.vector_dot(moinfo.nabla[0]);
+    rt_y = moinfo.rtd_mat.vector_dot(moinfo.nabla[1]);
+    rt_z = moinfo.rtd_mat.vector_dot(moinfo.nabla[2]);
 
     rs_rx = lt_x * rt_x;
     rs_ry = lt_y * rt_y;

--- a/psi4/src/psi4/cc/ccdensity/ex_sort_td_rohf.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_sort_td_rohf.cc
@@ -44,166 +44,69 @@ namespace psi {
 namespace ccdensity {
 
 void ex_sort_td_rohf(char hand, int Tirrep) {
-    int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
-    int row, col, i, j, I, J, a, b, A, B, p, q;
-    double chksum, value;
-    psio_address next;
     dpdfile2 D;
 
-    nmo = moinfo.nmo;
-    nfzc = moinfo.nfzc;
-    nfzv = moinfo.nfzv;
-    nclsd = moinfo.nclsd;
-    nopen = moinfo.nopen;
-    nirreps = moinfo.nirreps;
-    const auto& occpi = moinfo.occpi;
-    const auto& virtpi = moinfo.virtpi;
-    const auto& occ_off = moinfo.occ_off;
-    const auto& vir_off = moinfo.vir_off;
-    const auto& occ_sym = moinfo.occ_sym;
-    const auto& vir_sym = moinfo.vir_sym;
-    const auto& openpi = moinfo.openpi;
-    const auto& qt_occ = moinfo.qt_occ;
-    const auto& qt_vir = moinfo.qt_vir;
+    Matrix a_mat(moinfo.orbspi, moinfo.orbspi, Tirrep);
+    Matrix b_mat(moinfo.orbspi, moinfo.orbspi, Tirrep);
 
-    // moinfo.ltd = block_matrix(nmo, nmo);
-    double **gtd = block_matrix(nmo, nmo);
+    Slice aocc_slice(moinfo.frdocc, moinfo.frdocc + moinfo.occpi);
+    Slice avir_slice(moinfo.frdocc + moinfo.occpi, moinfo.orbspi - moinfo.fruocc);
+    Slice bocc_slice(moinfo.frdocc, moinfo.frdocc + moinfo.occpi - moinfo.openpi);
+    Slice bvir_slice(moinfo.frdocc + moinfo.occpi - moinfo.openpi, moinfo.orbspi - moinfo.fruocc);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, Tirrep, 0, 0, "LTDIJ");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < occpi[h]; i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (j = 0; j < occpi[h ^ Tirrep]; j++) {
-                J = qt_occ[occ_off[h ^ Tirrep] + j];
-                gtd[I][J] += D.matrix[h][i][j];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    Matrix temp_mat(&D);
+    a_mat.set_block(aocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, Tirrep, 1, 1, "LTDAB");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (a = 0; a < (virtpi[h] - openpi[h]); a++) {
-            A = qt_vir[vir_off[h] + a];
-            for (b = 0; b < (virtpi[h ^ Tirrep] - openpi[h ^ Tirrep]); b++) {
-                B = qt_vir[vir_off[h ^ Tirrep] + b];
-                gtd[A][B] += D.matrix[h][a][b];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    a_mat.set_block(avir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     /* Note that this component of the density is stored occ-vir */
     global_dpd_->file2_init(&D, PSIF_CC_TMP, Tirrep, 0, 1, "LTDAI");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < occpi[h]; i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (a = 0; a < (virtpi[h ^ Tirrep] - openpi[h ^ Tirrep]); a++) {
-                A = qt_vir[vir_off[h ^ Tirrep] + a];
-                gtd[A][I] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    temp_mat = *temp_mat.transpose();
+    a_mat.set_block(avir_slice, aocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, Tirrep, 0, 1, "LTDIA");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < occpi[h]; i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (a = 0; a < (virtpi[h ^ Tirrep] - openpi[h ^ Tirrep]); a++) {
-                A = qt_vir[vir_off[h ^ Tirrep] + a];
-                gtd[I][A] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    a_mat.set_block(aocc_slice, avir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, Tirrep, 0, 0, "LTDij");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < (occpi[h] - openpi[h]); i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (j = 0; j < (occpi[h ^ Tirrep] - openpi[h ^ Tirrep]); j++) {
-                J = qt_occ[occ_off[h ^ Tirrep] + j];
-                gtd[I][J] += D.matrix[h][i][j];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    b_mat.set_block(bocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, Tirrep, 1, 1, "LTDab");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (a = 0; a < virtpi[h]; a++) {
-            A = qt_vir[vir_off[h] + a];
-            for (b = 0; b < virtpi[h ^ Tirrep]; b++) {
-                B = qt_vir[vir_off[h ^ Tirrep] + b];
-                gtd[A][B] += D.matrix[h][a][b];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    b_mat.set_block(bvir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     /* Note that this component of the density is stored occ-vir */
     global_dpd_->file2_init(&D, PSIF_CC_TMP, Tirrep, 0, 1, "LTDai");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < (occpi[h] - openpi[h]); i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (a = 0; a < virtpi[h ^ Tirrep]; a++) {
-                A = qt_vir[vir_off[h ^ Tirrep] + a];
-                gtd[A][I] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    temp_mat = *temp_mat.transpose();
+    b_mat.set_block(bvir_slice, bocc_slice, temp_mat);
+
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, Tirrep, 0, 1, "LTDia");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < (occpi[h] - openpi[h]); i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (a = 0; a < virtpi[h ^ Tirrep]; a++) {
-                A = qt_vir[vir_off[h ^ Tirrep] + a];
-                gtd[I][A] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    b_mat.set_block(bocc_slice, bvir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
+    a_mat.add(b_mat);
+
     if (hand == 'l') {
-        moinfo.ltd = block_matrix(nmo, nmo);
-        for (i = 0; i < nmo; ++i)
-            for (j = 0; j < nmo; ++j) moinfo.ltd[i][j] = gtd[i][j];
-        // print_mat(moinfo.ltd,nmo,nmo,outfile);
+        moinfo.ltd_mat = std::move(a_mat);
     } else if (hand == 'r') {
-        moinfo.rtd = block_matrix(nmo, nmo);
-        for (i = 0; i < nmo; ++i)
-            for (j = 0; j < nmo; ++j) moinfo.rtd[i][j] = gtd[i][j];
-        // print_mat(moinfo.rtd,nmo,nmo,outfile);
+        moinfo.rtd_mat = std::move(a_mat);
     } else
         throw PsiException("ccdensity: error", __FILE__, __LINE__);
-    free_block(gtd);
 
     return;
 }

--- a/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
@@ -61,7 +61,6 @@ namespace ccdensity {
 void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     int i, j, h, errcod;
     int nactive;
-    double **scf_pitzer;
 
     moinfo.nirreps = wfn->nirrep();
     moinfo.nmo = wfn->nmo();
@@ -78,7 +77,6 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     moinfo.openpi = wfn->soccpi();
 
     moinfo.Ca = wfn->Ca();
-    scf_pitzer = wfn->Ca()->to_block_matrix();
 
     moinfo.sym = 0;
     for (i = 0; i < moinfo.nirreps; ++i)
@@ -184,15 +182,6 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
         psio_read_entry(PSIF_CC_INFO, "CC->QT Active Virt Order", (char *)moinfo.qt_vir.data(), sizeof(int) * nactive);
         psio_read_entry(PSIF_CC_INFO, "QT->CC Active Occ Order", (char *)moinfo.cc_occ.data(), sizeof(int) * nactive);
         psio_read_entry(PSIF_CC_INFO, "QT->CC Active Virt Order", (char *)moinfo.cc_vir.data(), sizeof(int) * nactive);
-
-        /* Sort SCF MOs to QT order */
-        moinfo.scf_qt = block_matrix(moinfo.nmo, moinfo.nmo);
-        int I;
-        for (i = 0; i < moinfo.nmo; i++) {
-            I = moinfo.pitzer2qt[i]; /* Pitzer --> QT */
-            for (j = 0; j < moinfo.nmo; j++) moinfo.scf_qt[j][I] = scf_pitzer[j][i];
-        }
-        free_block(scf_pitzer);
     } else if (params.ref == 2) { /** UHF **/
 
         /* Get CC->QT and QT->CC active occupied and virtual reordering arrays */
@@ -239,13 +228,6 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
         psio_read_entry(PSIF_CC_INFO, "CC3 Energy", (char *)&(moinfo.ecc), sizeof(double));
         outfile->Printf("\tCC3 energy          (CC_INFO) = %20.15f\n", moinfo.ecc);
         outfile->Printf("\tTotal CC3 energy    (CC_INFO) = %20.15f\n", moinfo.eref + moinfo.ecc);
-    }
-}
-
-/* Frees memory allocated in get_moinfo(). */
-void cleanup() {
-    if (params.ref == 0 || params.ref == 1) { /** RHF or ROHF **/
-        free_block(moinfo.scf_qt);
     }
 }
 

--- a/psi4/src/psi4/cc/ccdensity/oscillator_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/oscillator_strength.cc
@@ -53,30 +53,11 @@ namespace ccdensity {
 
 // TODO: Do TD_Params
 void oscillator_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S) {
-    int nmo, nso, i, I, h, j;
-    int *order, *order_A, *order_B, *doccpi;
-    double **scf_pitzer, **scf_pitzer_A, **scf_pitzer_B;
-    double **scf_qt, **scf_qt_A, **scf_qt_B, **X;
-    double *mu_x_ints, *mu_y_ints, *mu_z_ints;
-    double **MUX_MO, **MUY_MO, **MUZ_MO;
-    double **MUX_SO, **MUY_SO, **MUZ_SO;
-    double **MUX_MO_A, **MUY_MO_A, **MUZ_MO_A;
-    double **MUX_MO_B, **MUY_MO_B, **MUZ_MO_B;
     double lt_x, lt_y, lt_z;
     double rt_x, rt_y, rt_z;
     double ds_x, ds_y, ds_z;
     double f_x, f_y, f_z;
     double f;
-
-    if ((params.ref == 0) || (params.ref == 1))
-        scf_pitzer = wfn.Ca()->to_block_matrix();
-    else if (params.ref == 2) {
-        scf_pitzer_A = wfn.Ca()->to_block_matrix();
-        scf_pitzer_B = wfn.Cb()->to_block_matrix();
-    }
-
-    nso = wfn.nso();
-    nmo = wfn.nmo();
 
     lt_x = lt_y = lt_z = 0.0;
     rt_x = rt_y = rt_z = 0.0;
@@ -84,153 +65,48 @@ void oscillator_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *
     f_x = f_y = f_z = 0.0;
     f = 0;
 
-    doccpi = init_int_array(moinfo.nirreps);
-    for (h = 0; h < moinfo.nirreps; h++) doccpi[h] = moinfo.frdocc[h] + moinfo.clsdpi[h];
-
-    if ((params.ref == 0) || (params.ref == 1)) {
-        order = init_int_array(nmo);
-
-        reorder_qt(doccpi, moinfo.openpi, moinfo.frdocc, moinfo.fruocc, order, moinfo.orbspi, moinfo.nirreps);
-
-        scf_qt = block_matrix(nmo, nmo);
-        for (i = 0; i < nmo; i++) {
-            I = order[i]; /* Pitzer --> QT */
-            for (j = 0; j < nmo; j++) scf_qt[j][I] = scf_pitzer[j][i];
-        }
-
-        free(order);
-        free_block(scf_pitzer);
-    } else if (params.ref == 2) {
-        order_A = init_int_array(nmo);
-        order_B = init_int_array(nmo);
-
-        reorder_qt_uhf(doccpi, moinfo.openpi, moinfo.frdocc, moinfo.fruocc, order_A, order_B, moinfo.orbspi,
-                       moinfo.nirreps);
-
-        scf_qt_A = block_matrix(nmo, nmo);
-        for (i = 0; i < nmo; i++) {
-            I = order_A[i]; /* Pitzer --> QT */
-            for (j = 0; j < nmo; j++) scf_qt_A[j][I] = scf_pitzer_A[j][i];
-        }
-
-        scf_qt_B = block_matrix(nmo, nmo);
-        for (i = 0; i < nmo; i++) {
-            I = order_B[i]; /* Pitzer --> QT */
-            for (j = 0; j < nmo; j++) scf_qt_B[j][I] = scf_pitzer_B[j][i];
-        }
-
-        free(order_A);
-        free(order_B);
-        free_block(scf_pitzer_A);
-        free_block(scf_pitzer_B);
-    }
-    free(doccpi);
-
     /*** Transform the SO dipole integrals to the MO basis ***/
 
     MintsHelper mints(wfn.basisset(), Process::environment.options, 0);
-    std::vector<SharedMatrix> dipole = mints.so_dipole();
-    MUX_SO = dipole[0]->to_block_matrix();
-    MUY_SO = dipole[1]->to_block_matrix();
-    MUZ_SO = dipole[2]->to_block_matrix();
+    auto dipole = mints.so_dipole();
 
-    X = block_matrix(nmo, nso); /* just a temporary matrix */
-
+    Matrix MUX_MO, MUY_MO, MUZ_MO, MUX_MO_A, MUY_MO_A, MUZ_MO_A, MUX_MO_B, MUY_MO_B, MUZ_MO_B;
     if ((params.ref == 0) || (params.ref == 1)) {
-        MUX_MO = block_matrix(nmo, nmo);
-        MUY_MO = block_matrix(nmo, nmo);
-        MUZ_MO = block_matrix(nmo, nmo);
-
-        C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt[0][0]), nmo, &(MUX_SO[0][0]), nso, 0, &(X[0][0]), nso);
-        C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt[0][0]), nmo, 0, &(MUX_MO[0][0]), nmo);
-
-        C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt[0][0]), nmo, &(MUY_SO[0][0]), nso, 0, &(X[0][0]), nso);
-        C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt[0][0]), nmo, 0, &(MUY_MO[0][0]), nmo);
-
-        C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt[0][0]), nmo, &(MUZ_SO[0][0]), nso, 0, &(X[0][0]), nso);
-        C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt[0][0]), nmo, 0, &(MUZ_MO[0][0]), nmo);
-
-        free_block(scf_qt);
+        MUX_MO = linalg::triplet(*wfn.Ca(), *dipole[0], *wfn.Ca(), true, false, false);
+        MUY_MO = linalg::triplet(*wfn.Ca(), *dipole[1], *wfn.Ca(), true, false, false);
+        MUZ_MO = linalg::triplet(*wfn.Ca(), *dipole[2], *wfn.Ca(), true, false, false);
     } else if (params.ref == 2) {
-        MUX_MO_A = block_matrix(nmo, nmo);
-        MUY_MO_A = block_matrix(nmo, nmo);
-        MUZ_MO_A = block_matrix(nmo, nmo);
-        MUX_MO_B = block_matrix(nmo, nmo);
-        MUY_MO_B = block_matrix(nmo, nmo);
-        MUZ_MO_B = block_matrix(nmo, nmo);
-
-        C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt_A[0][0]), nmo, &(MUX_SO[0][0]), nso, 0, &(X[0][0]), nso);
-        C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt_A[0][0]), nmo, 0, &(MUX_MO_A[0][0]), nmo);
-
-        C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt_B[0][0]), nmo, &(MUX_SO[0][0]), nso, 0, &(X[0][0]), nso);
-        C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt_B[0][0]), nmo, 0, &(MUX_MO_B[0][0]), nmo);
-
-        C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt_A[0][0]), nmo, &(MUY_SO[0][0]), nso, 0, &(X[0][0]), nso);
-        C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt_A[0][0]), nmo, 0, &(MUY_MO_A[0][0]), nmo);
-
-        C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt_B[0][0]), nmo, &(MUY_SO[0][0]), nso, 0, &(X[0][0]), nso);
-        C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt_B[0][0]), nmo, 0, &(MUY_MO_B[0][0]), nmo);
-
-        C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt_A[0][0]), nmo, &(MUZ_SO[0][0]), nso, 0, &(X[0][0]), nso);
-        C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt_A[0][0]), nmo, 0, &(MUZ_MO_A[0][0]), nmo);
-
-        C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt_B[0][0]), nmo, &(MUZ_SO[0][0]), nso, 0, &(X[0][0]), nso);
-        C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt_B[0][0]), nmo, 0, &(MUZ_MO_B[0][0]), nmo);
-
-        free_block(scf_qt_A);
-        free_block(scf_qt_B);
+        MUX_MO_A = linalg::triplet(*wfn.Ca(), *dipole[0], *wfn.Ca(), true, false, false);
+        MUY_MO_A = linalg::triplet(*wfn.Ca(), *dipole[1], *wfn.Ca(), true, false, false);
+        MUZ_MO_A = linalg::triplet(*wfn.Ca(), *dipole[2], *wfn.Ca(), true, false, false);
+        MUX_MO_B = linalg::triplet(*wfn.Cb(), *dipole[0], *wfn.Cb(), true, false, false);
+        MUY_MO_B = linalg::triplet(*wfn.Cb(), *dipole[1], *wfn.Cb(), true, false, false);
+        MUZ_MO_B = linalg::triplet(*wfn.Cb(), *dipole[2], *wfn.Cb(), true, false, false);
     }
-
-    free_block(X);
-    free_block(MUX_SO);
-    free_block(MUY_SO);
-    free_block(MUZ_SO);
 
     outfile->Printf("\n\tOscillator Strength for %d%3s\n", S->root + 1, moinfo.labels[S->irrep].c_str());
     outfile->Printf("\t                              X    \t       Y    \t       Z\n");
 
     if ((params.ref == 0) || (params.ref == 1)) {
-        for (i = 0; i < nmo; i++)
-            for (j = 0; j < nmo; j++) {
-                lt_x += MUX_MO[i][j] * moinfo.ltd[i][j];
-                lt_y += MUY_MO[i][j] * moinfo.ltd[i][j];
-                lt_z += MUZ_MO[i][j] * moinfo.ltd[i][j];
-            }
-
-        for (i = 0; i < nmo; i++)
-            for (j = 0; j < nmo; j++) {
-                rt_x += MUX_MO[i][j] * moinfo.rtd[i][j];
-                rt_y += MUY_MO[i][j] * moinfo.rtd[i][j];
-                rt_z += MUZ_MO[i][j] * moinfo.rtd[i][j];
-            }
+        lt_x = MUX_MO.vector_dot(moinfo.ltd_mat);
+        lt_y = MUY_MO.vector_dot(moinfo.ltd_mat);
+        lt_z = MUZ_MO.vector_dot(moinfo.ltd_mat);
+        rt_x = MUX_MO.vector_dot(moinfo.rtd_mat);
+        rt_y = MUY_MO.vector_dot(moinfo.rtd_mat);
+        rt_z = MUZ_MO.vector_dot(moinfo.rtd_mat);
     } else if (params.ref == 2) {
-        for (i = 0; i < nmo; i++)
-            for (j = 0; j < nmo; j++) {
-                lt_x += MUX_MO_A[i][j] * moinfo.ltd_a[i][j];
-                lt_y += MUY_MO_A[i][j] * moinfo.ltd_a[i][j];
-                lt_z += MUZ_MO_A[i][j] * moinfo.ltd_a[i][j];
-            }
-
-        for (i = 0; i < nmo; i++)
-            for (j = 0; j < nmo; j++) {
-                rt_x += MUX_MO_A[i][j] * moinfo.rtd_a[i][j];
-                rt_y += MUY_MO_A[i][j] * moinfo.rtd_a[i][j];
-                rt_z += MUZ_MO_A[i][j] * moinfo.rtd_a[i][j];
-            }
-
-        for (i = 0; i < nmo; i++)
-            for (j = 0; j < nmo; j++) {
-                lt_x += MUX_MO_B[i][j] * moinfo.ltd_b[i][j];
-                lt_y += MUY_MO_B[i][j] * moinfo.ltd_b[i][j];
-                lt_z += MUZ_MO_B[i][j] * moinfo.ltd_b[i][j];
-            }
-
-        for (i = 0; i < nmo; i++)
-            for (j = 0; j < nmo; j++) {
-                rt_x += MUX_MO_B[i][j] * moinfo.rtd_b[i][j];
-                rt_y += MUY_MO_B[i][j] * moinfo.rtd_b[i][j];
-                rt_z += MUZ_MO_B[i][j] * moinfo.rtd_b[i][j];
-            }
+        lt_x = MUX_MO_A.vector_dot(moinfo.ltd_a_mat);
+        lt_y = MUY_MO_A.vector_dot(moinfo.ltd_a_mat);
+        lt_z = MUZ_MO_A.vector_dot(moinfo.ltd_a_mat);
+        rt_x = MUX_MO_A.vector_dot(moinfo.rtd_a_mat);
+        rt_y = MUY_MO_A.vector_dot(moinfo.rtd_a_mat);
+        rt_z = MUZ_MO_A.vector_dot(moinfo.rtd_a_mat);
+        lt_x += MUX_MO_B.vector_dot(moinfo.ltd_b_mat);
+        lt_y += MUY_MO_B.vector_dot(moinfo.ltd_b_mat);
+        lt_z += MUZ_MO_B.vector_dot(moinfo.ltd_b_mat);
+        rt_x += MUX_MO_B.vector_dot(moinfo.rtd_b_mat);
+        rt_y += MUY_MO_B.vector_dot(moinfo.rtd_b_mat);
+        rt_z += MUZ_MO_B.vector_dot(moinfo.rtd_b_mat);
     }
 
     ds_x = lt_x * rt_x;
@@ -271,19 +147,6 @@ void oscillator_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *
     scalar_saver_ground(wfn, S, "OSCILLATOR STRENGTH (LEN)", f_x + f_y + f_z);
     scalar_saver_ground(wfn, S, "EINSTEIN A (LEN)", einstein_a);
     scalar_saver_ground(wfn, S, "EINSTEIN B (LEN)", einstein_b);
-
-    if ((params.ref == 0) || (params.ref == 1)) {
-        free_block(MUX_MO);
-        free_block(MUY_MO);
-        free_block(MUZ_MO);
-    } else if (params.ref == 2) {
-        free_block(MUX_MO_A);
-        free_block(MUY_MO_A);
-        free_block(MUZ_MO_A);
-        free_block(MUX_MO_B);
-        free_block(MUY_MO_B);
-        free_block(MUZ_MO_B);
-    }
 
     return;
 }

--- a/psi4/src/psi4/cc/ccdensity/rotational_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/rotational_strength.cc
@@ -61,8 +61,6 @@ void transL(const MintsHelper &mints, double sign);
 void rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *S) {
     int i, j, k;
     int no, nv, nt;
-    double lt_x, lt_y, lt_z;
-    double rt_x, rt_y, rt_z;
     double rs_lx, rs_ly, rs_lz;
     double rs_rx, rs_ry, rs_rz;
     double rs_x, rs_y, rs_z;
@@ -76,27 +74,19 @@ void rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *
     outfile->Printf("\n\tLength-Gauge Rotational Strength for %d%3s\n", S->root + 1, moinfo.labels[S->irrep].c_str());
     outfile->Printf("\t                              X    \t       Y    \t       Z\n");
 
-    lt_x = lt_y = lt_z = 0.0;
-    rt_x = rt_y = rt_z = 0.0;
     rs_lx = rs_ly = rs_lz = 0.0;
     rs_rx = rs_ry = rs_rz = 0.0;
     rs_x = rs_y = rs_z = 0.0;
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            lt_x += moinfo.ltd[i][j] * moinfo.dip[0][i][j];
-            lt_y += moinfo.ltd[i][j] * moinfo.dip[1][i][j];
-            lt_z += moinfo.ltd[i][j] * moinfo.dip[2][i][j];
-        }
+    auto lt_x = moinfo.ltd_mat.vector_dot(moinfo.dip[0]);
+    auto lt_y = moinfo.ltd_mat.vector_dot(moinfo.dip[1]);
+    auto lt_z = moinfo.ltd_mat.vector_dot(moinfo.dip[2]);
 
     transL(mints, +1.0);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            rt_x += moinfo.rtd[i][j] * moinfo.L[0][i][j];
-            rt_y += moinfo.rtd[i][j] * moinfo.L[1][i][j];
-            rt_z += moinfo.rtd[i][j] * moinfo.L[2][i][j];
-        }
+    auto rt_x = moinfo.rtd_mat.vector_dot(moinfo.L[0]);
+    auto rt_y = moinfo.rtd_mat.vector_dot(moinfo.L[1]);
+    auto rt_z = moinfo.rtd_mat.vector_dot(moinfo.L[2]);
 
     rs_lx = lt_x * rt_x;
     rs_ly = lt_y * rt_y;
@@ -107,28 +97,15 @@ void rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *
 
     // Complex Conjugate
 
-    lt_x = lt_y = lt_z = 0.0;
-    rt_x = rt_y = rt_z = 0.0;
-
-    for (i = 0; i < 3; i++)
-        for (j = 0; j < nmo; j++)
-            for (k = 0; k < nmo; k++) moinfo.L[i][j][k] = 0.0;
-
     transL(mints, -1.0);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            lt_x += moinfo.ltd[i][j] * moinfo.L[0][i][j];
-            lt_y += moinfo.ltd[i][j] * moinfo.L[1][i][j];
-            lt_z += moinfo.ltd[i][j] * moinfo.L[2][i][j];
-        }
+    lt_x = moinfo.ltd_mat.vector_dot(moinfo.L[0]);
+    lt_y = moinfo.ltd_mat.vector_dot(moinfo.L[1]);
+    lt_z = moinfo.ltd_mat.vector_dot(moinfo.L[2]);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            rt_x += moinfo.rtd[i][j] * moinfo.dip[0][i][j];
-            rt_y += moinfo.rtd[i][j] * moinfo.dip[1][i][j];
-            rt_z += moinfo.rtd[i][j] * moinfo.dip[2][i][j];
-        }
+    rt_x = moinfo.rtd_mat.vector_dot(moinfo.dip[0]);
+    rt_y = moinfo.rtd_mat.vector_dot(moinfo.dip[1]);
+    rt_z = moinfo.rtd_mat.vector_dot(moinfo.dip[2]);
 
     rs_rx = lt_x * rt_x;
     rs_ry = lt_y * rt_y;
@@ -154,29 +131,21 @@ void rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *
     outfile->Printf("\n\tVelocity-Gauge Rotational Strength for %d%3s\n", S->root + 1, moinfo.labels[S->irrep].c_str());
     outfile->Printf("\t                              X    \t       Y    \t       Z\n");
 
-    lt_x = lt_y = lt_z = 0.0;
-    rt_x = rt_y = rt_z = 0.0;
     rs_lx = rs_ly = rs_lz = 0.0;
     rs_rx = rs_ry = rs_rz = 0.0;
     rs_x = rs_y = rs_z = 0.0;
 
     transp(mints, +1.0);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            lt_x += moinfo.ltd[i][j] * moinfo.nabla[0][i][j];
-            lt_y += moinfo.ltd[i][j] * moinfo.nabla[1][i][j];
-            lt_z += moinfo.ltd[i][j] * moinfo.nabla[2][i][j];
-        }
+    lt_x = moinfo.ltd_mat.vector_dot(moinfo.nabla[0]);
+    lt_y = moinfo.ltd_mat.vector_dot(moinfo.nabla[1]);
+    lt_z = moinfo.ltd_mat.vector_dot(moinfo.nabla[2]);
 
     transL(mints, +1.0);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            rt_x += moinfo.rtd[i][j] * moinfo.L[0][i][j];
-            rt_y += moinfo.rtd[i][j] * moinfo.L[1][i][j];
-            rt_z += moinfo.rtd[i][j] * moinfo.L[2][i][j];
-        }
+    rt_x = moinfo.rtd_mat.vector_dot(moinfo.L[0]);
+    rt_y = moinfo.rtd_mat.vector_dot(moinfo.L[1]);
+    rt_z = moinfo.rtd_mat.vector_dot(moinfo.L[2]);
 
     rs_lx = lt_x * rt_x;
     rs_ly = lt_y * rt_y;
@@ -186,34 +155,17 @@ void rotational_strength(ccenergy::CCEnergyWavefunction& wfn, struct TD_Params *
     outfile->Printf("\t<n|mu_m|0>              %11.8lf \t %11.8lf \t %11.8lf\n", rt_x, rt_y, rt_z);
 
     // Complex Conjugate
-
-    lt_x = lt_y = lt_z = 0.0;
-    rt_x = rt_y = rt_z = 0.0;
-
-    for (i = 0; i < 3; i++)
-        for (j = 0; j < nmo; j++)
-            for (k = 0; k < nmo; k++) {
-                moinfo.nabla[i][j][k] = 0.0;
-                moinfo.L[i][j][k] = 0.0;
-            }
-
     transL(mints, -1.0);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            lt_x += moinfo.ltd[i][j] * moinfo.L[0][i][j];
-            lt_y += moinfo.ltd[i][j] * moinfo.L[1][i][j];
-            lt_z += moinfo.ltd[i][j] * moinfo.L[2][i][j];
-        }
+    lt_x = moinfo.ltd_mat.vector_dot(moinfo.L[0]);
+    lt_y = moinfo.ltd_mat.vector_dot(moinfo.L[1]);
+    lt_z = moinfo.ltd_mat.vector_dot(moinfo.L[2]);
 
     transp(mints, -1.0);
 
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) {
-            rt_x += moinfo.rtd[i][j] * moinfo.nabla[0][i][j];
-            rt_y += moinfo.rtd[i][j] * moinfo.nabla[1][i][j];
-            rt_z += moinfo.rtd[i][j] * moinfo.nabla[2][i][j];
-        }
+    rt_x = moinfo.rtd_mat.vector_dot(moinfo.nabla[0]);
+    rt_y = moinfo.rtd_mat.vector_dot(moinfo.nabla[1]);
+    rt_z = moinfo.rtd_mat.vector_dot(moinfo.nabla[2]);
 
     rs_rx = lt_x * rt_x;
     rs_ry = lt_y * rt_y;

--- a/psi4/src/psi4/cc/ccdensity/sort_ltd_rohf.cc
+++ b/psi4/src/psi4/cc/ccdensity/sort_ltd_rohf.cc
@@ -42,153 +42,63 @@ namespace psi {
 namespace ccdensity {
 
 void sort_ltd_rohf(const struct TD_Params& S) {
-    int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
-    int row, col, i, j, I, J, a, b, A, B, p, q;
-    double chksum, value;
-    psio_address next;
     dpdfile2 D;
 
-    nmo = moinfo.nmo;
-    nfzc = moinfo.nfzc;
-    nfzv = moinfo.nfzv;
-    nclsd = moinfo.nclsd;
-    nopen = moinfo.nopen;
-    nirreps = moinfo.nirreps;
-    const auto& occpi = moinfo.occpi;
-    const auto& virtpi = moinfo.virtpi;
-    const auto& occ_off = moinfo.occ_off;
-    const auto& vir_off = moinfo.vir_off;
-    const auto& occ_sym = moinfo.occ_sym;
-    const auto& vir_sym = moinfo.vir_sym;
-    const auto& openpi = moinfo.openpi;
-    const auto& qt_occ = moinfo.qt_occ;
-    const auto& qt_vir = moinfo.qt_vir;
+    moinfo.ltd_a_mat = Matrix(moinfo.orbspi, moinfo.orbspi, S.irrep);
+    moinfo.ltd_b_mat = Matrix(moinfo.orbspi, moinfo.orbspi, S.irrep);
 
-    moinfo.ltd = block_matrix(nmo, nmo);
+    Slice aocc_slice(moinfo.frdocc, moinfo.frdocc + moinfo.occpi);
+    Slice avir_slice(moinfo.frdocc + moinfo.occpi, moinfo.orbspi - moinfo.fruocc);
+    Slice bocc_slice(moinfo.frdocc, moinfo.frdocc + moinfo.occpi - moinfo.openpi);
+    Slice bvir_slice(moinfo.frdocc + moinfo.occpi - moinfo.openpi, moinfo.orbspi - moinfo.fruocc);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 0, "LTDIJ");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < occpi[h]; i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (j = 0; j < occpi[h ^ S.irrep]; j++) {
-                J = qt_occ[occ_off[h ^ S.irrep] + j];
-                moinfo.ltd[I][J] += D.matrix[h][i][j];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    Matrix temp_mat(&D);
+    moinfo.ltd_a_mat.set_block(aocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 1, 1, "LTDAB");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (a = 0; a < (virtpi[h] - openpi[h]); a++) {
-            A = qt_vir[vir_off[h] + a];
-            for (b = 0; b < (virtpi[h ^ S.irrep] - openpi[h ^ S.irrep]); b++) {
-                B = qt_vir[vir_off[h ^ S.irrep] + b];
-                moinfo.ltd[A][B] += D.matrix[h][a][b];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.ltd_a_mat.set_block(avir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     /* Note that this component of the density is stored occ-vir */
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 1, "LTDAI");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < occpi[h]; i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (a = 0; a < (virtpi[h ^ S.irrep] - openpi[h ^ S.irrep]); a++) {
-                A = qt_vir[vir_off[h ^ S.irrep] + a];
-                moinfo.ltd[A][I] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    temp_mat = *temp_mat.transpose();
+    moinfo.ltd_a_mat.set_block(avir_slice, aocc_slice, temp_mat);
+    outfile->Printf("D");
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 1, "LTDIA");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < occpi[h]; i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (a = 0; a < (virtpi[h ^ S.irrep] - openpi[h ^ S.irrep]); a++) {
-                A = qt_vir[vir_off[h ^ S.irrep] + a];
-                moinfo.ltd[I][A] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.ltd_a_mat.set_block(aocc_slice, avir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 0, "LTDij");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < (occpi[h] - openpi[h]); i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (j = 0; j < (occpi[h ^ S.irrep] - openpi[h ^ S.irrep]); j++) {
-                J = qt_occ[occ_off[h ^ S.irrep] + j];
-                moinfo.ltd[I][J] += D.matrix[h][i][j];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.ltd_b_mat.set_block(bocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 1, 1, "LTDab");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (a = 0; a < virtpi[h]; a++) {
-            A = qt_vir[vir_off[h] + a];
-            for (b = 0; b < virtpi[h ^ S.irrep]; b++) {
-                B = qt_vir[vir_off[h ^ S.irrep] + b];
-                moinfo.ltd[A][B] += D.matrix[h][a][b];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.ltd_b_mat.set_block(bvir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     /* Note that this component of the density is stored occ-vir */
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 1, "LTDai");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < (occpi[h] - openpi[h]); i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (a = 0; a < virtpi[h ^ S.irrep]; a++) {
-                A = qt_vir[vir_off[h ^ S.irrep] + a];
-                moinfo.ltd[A][I] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    temp_mat = *temp_mat.transpose();
+    moinfo.ltd_b_mat.set_block(bvir_slice, bocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 1, "LTDia");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < (occpi[h] - openpi[h]); i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (a = 0; a < virtpi[h ^ S.irrep]; a++) {
-                A = qt_vir[vir_off[h ^ S.irrep] + a];
-                moinfo.ltd[I][A] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.ltd_b_mat.set_block(bocc_slice, bvir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
-    /*mat_print(moinfo.ltd,nmo,nmo,outfile);*/
+    moinfo.ltd_mat = *moinfo.ltd_a_mat.clone();
+    moinfo.ltd_mat.add(moinfo.ltd_b_mat.clone());
 
     return;
 }

--- a/psi4/src/psi4/cc/ccdensity/sort_ltd_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/sort_ltd_uhf.cc
@@ -42,159 +42,59 @@ namespace psi {
 namespace ccdensity {
 
 void sort_ltd_uhf(const struct TD_Params& S) {
-    int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
-    int row, col, i, j, I, J, a, b, A, B, p, q;
-    double chksum, value;
     dpdfile2 D;
 
-    nmo = moinfo.nmo;
-    nfzc = moinfo.nfzc;
-    nfzv = moinfo.nfzv;
-    nclsd = moinfo.nclsd;
-    nopen = moinfo.nopen;
-    nirreps = moinfo.nirreps;
-    const auto& aoccpi = moinfo.aoccpi;
-    const auto& avirtpi = moinfo.avirtpi;
-    const auto& boccpi = moinfo.boccpi;
-    const auto& bvirtpi = moinfo.bvirtpi;
-    const auto& aocc_off = moinfo.aocc_off;
-    const auto& avir_off = moinfo.avir_off;
-    const auto& bocc_off = moinfo.bocc_off;
-    const auto& bvir_off = moinfo.bvir_off;
-    const auto& aocc_sym = moinfo.aocc_sym;
-    const auto& avir_sym = moinfo.avir_sym;
-    const auto& qt_aocc = moinfo.qt_aocc;
-    const auto& qt_avir = moinfo.qt_avir;
-    const auto& qt_bocc = moinfo.qt_bocc;
-    const auto& qt_bvir = moinfo.qt_bvir;
+    moinfo.ltd_a_mat = Matrix(moinfo.orbspi, moinfo.orbspi, S.irrep);
+    moinfo.ltd_b_mat = Matrix(moinfo.orbspi, moinfo.orbspi, S.irrep);
 
-    moinfo.ltd_a = block_matrix(nmo, nmo);
-    moinfo.ltd_b = block_matrix(nmo, nmo);
+    Slice aocc_slice(moinfo.frdocc, moinfo.frdocc + moinfo.aoccpi);
+    Slice avir_slice(moinfo.frdocc + moinfo.aoccpi, moinfo.orbspi - moinfo.fruocc);
+    Slice bocc_slice(moinfo.frdocc, moinfo.frdocc + moinfo.boccpi);
+    Slice bvir_slice(moinfo.frdocc + moinfo.boccpi, moinfo.orbspi - moinfo.fruocc);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 0, "LTDIJ");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < aoccpi[h]; i++) {
-            I = qt_aocc[aocc_off[h] + i];
-            for (j = 0; j < aoccpi[h ^ S.irrep]; j++) {
-                J = qt_aocc[aocc_off[h ^ S.irrep] + j];
-                moinfo.ltd_a[I][J] += D.matrix[h][i][j];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    Matrix temp_mat(&D);
+    moinfo.ltd_a_mat.set_block(aocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 1, 1, "LTDAB");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (a = 0; a < avirtpi[h]; a++) {
-            A = qt_avir[avir_off[h] + a];
-            for (b = 0; b < avirtpi[h ^ S.irrep]; b++) {
-                B = qt_avir[avir_off[h ^ S.irrep] + b];
-                moinfo.ltd_a[A][B] += D.matrix[h][a][b];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.ltd_a_mat.set_block(avir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     /* Note that this component of the density is stored occ-vir */
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 1, "LTDAI");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < aoccpi[h]; i++) {
-            I = qt_aocc[aocc_off[h] + i];
-            for (a = 0; a < avirtpi[h ^ S.irrep]; a++) {
-                A = qt_avir[avir_off[h ^ S.irrep] + a];
-                moinfo.ltd_a[A][I] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    temp_mat = *temp_mat.transpose();
+    moinfo.ltd_a_mat.set_block(avir_slice, aocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 1, "LTDIA");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < aoccpi[h]; i++) {
-            I = qt_aocc[aocc_off[h] + i];
-            for (a = 0; a < avirtpi[h ^ S.irrep]; a++) {
-                A = qt_avir[avir_off[h ^ S.irrep] + a];
-                moinfo.ltd_a[I][A] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.ltd_a_mat.set_block(aocc_slice, avir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 2, 2, "LTDij");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < boccpi[h]; i++) {
-            I = qt_bocc[bocc_off[h] + i];
-            for (j = 0; j < boccpi[h ^ S.irrep]; j++) {
-                J = qt_bocc[bocc_off[h ^ S.irrep] + j];
-                moinfo.ltd_b[I][J] += D.matrix[h][i][j];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.ltd_b_mat.set_block(bocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 3, 3, "LTDab");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (a = 0; a < bvirtpi[h]; a++) {
-            A = qt_bvir[bvir_off[h] + a];
-            for (b = 0; b < bvirtpi[h ^ S.irrep]; b++) {
-                B = qt_bvir[bvir_off[h ^ S.irrep] + b];
-                moinfo.ltd_b[A][B] += D.matrix[h][a][b];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.ltd_b_mat.set_block(bvir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     /* Note that this component of the density is stored occ-vir */
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 2, 3, "LTDai");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < boccpi[h]; i++) {
-            I = qt_bocc[bocc_off[h] + i];
-            for (a = 0; a < bvirtpi[h ^ S.irrep]; a++) {
-                A = qt_bvir[bvir_off[h ^ S.irrep] + a];
-                moinfo.ltd_b[A][I] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    temp_mat = *temp_mat.transpose();
+    moinfo.ltd_b_mat.set_block(bvir_slice, bocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 2, 3, "LTDia");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < boccpi[h]; i++) {
-            I = qt_bocc[bocc_off[h] + i];
-            for (a = 0; a < bvirtpi[h ^ S.irrep]; a++) {
-                A = qt_bvir[bvir_off[h ^ S.irrep] + a];
-                moinfo.ltd_b[I][A] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.ltd_b_mat.set_block(bocc_slice, bvir_slice, temp_mat);
     global_dpd_->file2_close(&D);
-
-    /*mat_print(moinfo.ltd_a,nmo,nmo,outfile);*/
-    /*mat_print(moinfo.ltd_b,nmo,nmo,outfile);*/
 
     return;
 }

--- a/psi4/src/psi4/cc/ccdensity/sort_rtd_rohf.cc
+++ b/psi4/src/psi4/cc/ccdensity/sort_rtd_rohf.cc
@@ -42,152 +42,62 @@ namespace psi {
 namespace ccdensity {
 
 void sort_rtd_rohf(const struct TD_Params& S) {
-    int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
-    int row, col, i, j, I, J, a, b, A, B, p, q;
-    double chksum, value;
     dpdfile2 D;
 
-    nmo = moinfo.nmo;
-    nfzc = moinfo.nfzc;
-    nfzv = moinfo.nfzv;
-    nclsd = moinfo.nclsd;
-    nopen = moinfo.nopen;
-    nirreps = moinfo.nirreps;
-    const auto& occpi = moinfo.occpi;
-    const auto& virtpi = moinfo.virtpi;
-    const auto& occ_off = moinfo.occ_off;
-    const auto& vir_off = moinfo.vir_off;
-    const auto& occ_sym = moinfo.occ_sym;
-    const auto& vir_sym = moinfo.vir_sym;
-    const auto& openpi = moinfo.openpi;
-    const auto& qt_occ = moinfo.qt_occ;
-    const auto& qt_vir = moinfo.qt_vir;
+    moinfo.rtd_a_mat = Matrix(moinfo.orbspi, moinfo.orbspi, S.irrep);
+    moinfo.rtd_b_mat = Matrix(moinfo.orbspi, moinfo.orbspi, S.irrep);
 
-    moinfo.rtd = block_matrix(nmo, nmo);
+    Slice aocc_slice(moinfo.frdocc, moinfo.frdocc + moinfo.occpi);
+    Slice avir_slice(moinfo.frdocc + moinfo.occpi, moinfo.orbspi - moinfo.fruocc);
+    Slice bocc_slice(moinfo.frdocc, moinfo.frdocc + moinfo.occpi - moinfo.openpi);
+    Slice bvir_slice(moinfo.frdocc + moinfo.occpi - moinfo.openpi, moinfo.orbspi - moinfo.fruocc);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 0, "RTDIJ");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < occpi[h]; i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (j = 0; j < occpi[h ^ S.irrep]; j++) {
-                J = qt_occ[occ_off[h ^ S.irrep] + j];
-                moinfo.rtd[I][J] += D.matrix[h][i][j];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    Matrix temp_mat(&D);
+    moinfo.rtd_a_mat.set_block(aocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 1, 1, "RTDAB");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (a = 0; a < (virtpi[h] - openpi[h]); a++) {
-            A = qt_vir[vir_off[h] + a];
-            for (b = 0; b < (virtpi[h ^ S.irrep] - openpi[h ^ S.irrep]); b++) {
-                B = qt_vir[vir_off[h ^ S.irrep] + b];
-                moinfo.rtd[A][B] += D.matrix[h][a][b];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.rtd_a_mat.set_block(avir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     /* Note that this component of the density is stored occ-vir */
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 1, "RTDAI");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < occpi[h]; i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (a = 0; a < (virtpi[h ^ S.irrep] - openpi[h ^ S.irrep]); a++) {
-                A = qt_vir[vir_off[h ^ S.irrep] + a];
-                moinfo.rtd[A][I] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    temp_mat = *temp_mat.transpose();
+    moinfo.rtd_a_mat.set_block(avir_slice, aocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 1, "RTDIA");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < occpi[h]; i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (a = 0; a < (virtpi[h ^ S.irrep] - openpi[h ^ S.irrep]); a++) {
-                A = qt_vir[vir_off[h ^ S.irrep] + a];
-                moinfo.rtd[I][A] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.rtd_a_mat.set_block(aocc_slice, avir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 0, "RTDij");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < (occpi[h] - openpi[h]); i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (j = 0; j < (occpi[h ^ S.irrep] - openpi[h ^ S.irrep]); j++) {
-                J = qt_occ[occ_off[h ^ S.irrep] + j];
-                moinfo.rtd[I][J] += D.matrix[h][i][j];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.rtd_b_mat.set_block(bocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 1, 1, "RTDab");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (a = 0; a < virtpi[h]; a++) {
-            A = qt_vir[vir_off[h] + a];
-            for (b = 0; b < virtpi[h ^ S.irrep]; b++) {
-                B = qt_vir[vir_off[h ^ S.irrep] + b];
-                moinfo.rtd[A][B] += D.matrix[h][a][b];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.rtd_b_mat.set_block(bvir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     /* Note that this component of the density is stored occ-vir */
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 1, "RTDai");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < (occpi[h] - openpi[h]); i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (a = 0; a < virtpi[h ^ S.irrep]; a++) {
-                A = qt_vir[vir_off[h ^ S.irrep] + a];
-                moinfo.rtd[A][I] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    temp_mat = *temp_mat.transpose();
+    moinfo.rtd_b_mat.set_block(bvir_slice, bocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 1, "RTDia");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < (occpi[h] - openpi[h]); i++) {
-            I = qt_occ[occ_off[h] + i];
-            for (a = 0; a < virtpi[h ^ S.irrep]; a++) {
-                A = qt_vir[vir_off[h ^ S.irrep] + a];
-                moinfo.rtd[I][A] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.rtd_b_mat.set_block(bocc_slice, bvir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
-    /*print_mat(moinfo.rtd,nmo,nmo,outfile);*/
+    moinfo.rtd_mat = *moinfo.rtd_a_mat.clone();
+    moinfo.rtd_mat.add(moinfo.rtd_b_mat.clone());
 
     return;
 }

--- a/psi4/src/psi4/cc/ccdensity/sort_rtd_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/sort_rtd_uhf.cc
@@ -42,162 +42,59 @@ namespace psi {
 namespace ccdensity {
 
 void sort_rtd_uhf(const struct TD_Params& S) {
-    int h, nirreps, nmo, nfzv, nfzc, nclsd, nopen;
-    int row, col, i, j, I, J, a, b, A, B, p, q;
-    double chksum, value;
     dpdfile2 D;
 
-    nmo = moinfo.nmo;
-    nfzc = moinfo.nfzc;
-    nfzv = moinfo.nfzv;
-    nclsd = moinfo.nclsd;
-    nopen = moinfo.nopen;
-    nirreps = moinfo.nirreps;
-    const auto& aoccpi = moinfo.aoccpi;
-    const auto& avirtpi = moinfo.avirtpi;
-    const auto& boccpi = moinfo.boccpi;
-    const auto& bvirtpi = moinfo.bvirtpi;
-    const auto& aocc_off = moinfo.aocc_off;
-    const auto& avir_off = moinfo.avir_off;
-    const auto& bocc_off = moinfo.bocc_off;
-    const auto& bvir_off = moinfo.bvir_off;
-    const auto& aocc_sym = moinfo.aocc_sym;
-    const auto& avir_sym = moinfo.avir_sym;
-    const auto& bocc_sym = moinfo.bocc_sym;
-    const auto& bvir_sym = moinfo.bvir_sym;
+    moinfo.rtd_a_mat = Matrix(moinfo.orbspi, moinfo.orbspi, S.irrep);
+    moinfo.rtd_b_mat = Matrix(moinfo.orbspi, moinfo.orbspi, S.irrep);
 
-    const auto& qt_aocc = moinfo.qt_aocc;
-    const auto& qt_avir = moinfo.qt_avir;
-    const auto& qt_bocc = moinfo.qt_bocc;
-    const auto& qt_bvir = moinfo.qt_bvir;
-
-    moinfo.rtd_a = block_matrix(nmo, nmo);
-    moinfo.rtd_b = block_matrix(nmo, nmo);
+    Slice aocc_slice(moinfo.frdocc, moinfo.frdocc + moinfo.aoccpi);
+    Slice avir_slice(moinfo.frdocc + moinfo.aoccpi, moinfo.orbspi - moinfo.fruocc);
+    Slice bocc_slice(moinfo.frdocc, moinfo.frdocc + moinfo.boccpi);
+    Slice bvir_slice(moinfo.frdocc + moinfo.boccpi, moinfo.orbspi - moinfo.fruocc);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 0, "RTDIJ");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < aoccpi[h]; i++) {
-            I = qt_aocc[aocc_off[h] + i];
-            for (j = 0; j < aoccpi[h ^ S.irrep]; j++) {
-                J = qt_aocc[aocc_off[h ^ S.irrep] + j];
-                moinfo.rtd_a[I][J] += D.matrix[h][i][j];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    Matrix temp_mat(&D);
+    moinfo.rtd_a_mat.set_block(aocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 1, 1, "RTDAB");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (a = 0; a < avirtpi[h]; a++) {
-            A = qt_avir[avir_off[h] + a];
-            for (b = 0; b < avirtpi[h ^ S.irrep]; b++) {
-                B = qt_avir[avir_off[h ^ S.irrep] + b];
-                moinfo.rtd_a[A][B] += D.matrix[h][a][b];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.rtd_a_mat.set_block(avir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     /* Note that this component of the density is stored occ-vir */
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 1, "RTDAI");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < aoccpi[h]; i++) {
-            I = qt_aocc[aocc_off[h] + i];
-            for (a = 0; a < avirtpi[h ^ S.irrep]; a++) {
-                A = qt_avir[avir_off[h ^ S.irrep] + a];
-                moinfo.rtd_a[A][I] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    temp_mat = *temp_mat.transpose();
+    moinfo.rtd_a_mat.set_block(avir_slice, aocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 0, 1, "RTDIA");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < aoccpi[h]; i++) {
-            I = qt_aocc[aocc_off[h] + i];
-            for (a = 0; a < avirtpi[h ^ S.irrep]; a++) {
-                A = qt_avir[avir_off[h ^ S.irrep] + a];
-                moinfo.rtd_a[I][A] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.rtd_a_mat.set_block(aocc_slice, avir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 2, 2, "RTDij");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < boccpi[h]; i++) {
-            I = qt_bocc[bocc_off[h] + i];
-            for (j = 0; j < boccpi[h ^ S.irrep]; j++) {
-                J = qt_bocc[bocc_off[h ^ S.irrep] + j];
-                moinfo.rtd_b[I][J] += D.matrix[h][i][j];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.rtd_b_mat.set_block(bocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 3, 3, "RTDab");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (a = 0; a < bvirtpi[h]; a++) {
-            A = qt_bvir[bvir_off[h] + a];
-            for (b = 0; b < bvirtpi[h ^ S.irrep]; b++) {
-                B = qt_bvir[bvir_off[h ^ S.irrep] + b];
-                moinfo.rtd_b[A][B] += D.matrix[h][a][b];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.rtd_b_mat.set_block(bvir_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     /* Note that this component of the density is stored occ-vir */
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 2, 3, "RTDai");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < boccpi[h]; i++) {
-            I = qt_bocc[bocc_off[h] + i];
-            for (a = 0; a < bvirtpi[h ^ S.irrep]; a++) {
-                A = qt_bvir[bvir_off[h ^ S.irrep] + a];
-                moinfo.rtd_b[A][I] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    temp_mat = *temp_mat.transpose();
+    moinfo.rtd_b_mat.set_block(bvir_slice, bocc_slice, temp_mat);
     global_dpd_->file2_close(&D);
 
     global_dpd_->file2_init(&D, PSIF_CC_TMP, S.irrep, 2, 3, "RTDia");
-    global_dpd_->file2_mat_init(&D);
-    global_dpd_->file2_mat_rd(&D);
-    for (h = 0; h < nirreps; h++) {
-        for (i = 0; i < boccpi[h]; i++) {
-            I = qt_bocc[bocc_off[h] + i];
-            for (a = 0; a < bvirtpi[h ^ S.irrep]; a++) {
-                A = qt_bvir[bvir_off[h ^ S.irrep] + a];
-                moinfo.rtd_b[I][A] += D.matrix[h][i][a];
-            }
-        }
-    }
-    global_dpd_->file2_mat_close(&D);
+    temp_mat = Matrix(&D);
+    moinfo.rtd_b_mat.set_block(bocc_slice, bvir_slice, temp_mat);
     global_dpd_->file2_close(&D);
-
-    /*print_mat(moinfo.rtd_a,nmo,nmo,outfile);*/
-    /*print_mat(moinfo.rtd_b,nmo,nmo,outfile);*/
 
     return;
 }

--- a/psi4/src/psi4/cc/ccdensity/td_cleanup.cc
+++ b/psi4/src/psi4/cc/ccdensity/td_cleanup.cc
@@ -59,16 +59,6 @@ void td_cleanup() {
     psio_open(PSIF_CC_GL, PSIO_OPEN_NEW);
     psio_open(PSIF_CC_GR, PSIO_OPEN_NEW);
 
-    if ((params.ref == 0) || (params.ref == 1)) {
-        free_block(moinfo.ltd);
-        free_block(moinfo.rtd);
-    } else if (params.ref == 2) {
-        free_block(moinfo.ltd_a);
-        free_block(moinfo.ltd_b);
-        free_block(moinfo.rtd_a);
-        free_block(moinfo.rtd_b);
-    }
-
     return;
 }
 

--- a/psi4/src/psi4/cc/ccdensity/transL.cc
+++ b/psi4/src/psi4/cc/ccdensity/transL.cc
@@ -49,47 +49,12 @@ namespace psi {
 namespace ccdensity {
 
 void transL(const MintsHelper &mints, double sign) {
-    int nmo, nso;
-    double **scf_qt, **X;
-    double **LX_MO, **LY_MO, **LZ_MO;
-    double **LX_SO, **LY_SO, **LZ_SO;
-
-    nso = moinfo.nso;
-    nmo = moinfo.nmo;
-    scf_qt = moinfo.scf_qt;
-
-    /*** Transform the SO nabla integrals to the MO basis ***/
-    std::vector<SharedMatrix> dipole = mints.so_angular_momentum();
-    for (int i = 0; i < 3; i++) dipole[i]->scale(-0.5 * sign);
-    LX_SO = dipole[0]->to_block_matrix();
-    LY_SO = dipole[1]->to_block_matrix();
-    LZ_SO = dipole[2]->to_block_matrix();
-
-    X = block_matrix(nmo, nso); /* just a temporary matrix */
-
-    LX_MO = block_matrix(nmo, nmo);
-    LY_MO = block_matrix(nmo, nmo);
-    LZ_MO = block_matrix(nmo, nmo);
-
-    C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt[0][0]), nmo, &(LX_SO[0][0]), nso, 0, &(X[0][0]), nso);
-    C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt[0][0]), nmo, 0, &(LX_MO[0][0]), nmo);
-
-    C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt[0][0]), nmo, &(LY_SO[0][0]), nso, 0, &(X[0][0]), nso);
-    C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt[0][0]), nmo, 0, &(LY_MO[0][0]), nmo);
-
-    C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt[0][0]), nmo, &(LZ_SO[0][0]), nso, 0, &(X[0][0]), nso);
-    C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt[0][0]), nmo, 0, &(LZ_MO[0][0]), nmo);
-
-    free_block(X);
-
-    moinfo.L = (double ***)malloc(3 * sizeof(double **));
-    moinfo.L[0] = LX_MO;
-    moinfo.L[1] = LY_MO;
-    moinfo.L[2] = LZ_MO;
-
-    free_block(LX_SO);
-    free_block(LY_SO);
-    free_block(LZ_SO);
+    /*** Transform the SO angular momentum integrals to the MO basis ***/
+    moinfo.L = mints.so_angular_momentum();
+    for (const auto& i : moinfo.L) {
+        i->scale(-0.5 * sign);
+        i->transform(moinfo.Ca);
+    }
 
     return;
 }

--- a/psi4/src/psi4/cc/ccdensity/transdip.cc
+++ b/psi4/src/psi4/cc/ccdensity/transdip.cc
@@ -49,46 +49,12 @@ namespace psi {
 namespace ccdensity {
 
 void transdip(const MintsHelper &mints) {
-    int nmo, nso;
-    double **scf_qt, **X;
-    double **MUX_MO, **MUY_MO, **MUZ_MO;
-    double **MUX_SO, **MUY_SO, **MUZ_SO;
-
-    nso = moinfo.nso;
-    nmo = moinfo.nmo;
-    scf_qt = moinfo.scf_qt;
 
     /*** Transform the SO dipole integrals to the MO basis ***/
-    std::vector<SharedMatrix> dipole = mints.so_dipole();
-    MUX_SO = dipole[0]->to_block_matrix();
-    MUY_SO = dipole[1]->to_block_matrix();
-    MUZ_SO = dipole[2]->to_block_matrix();
-
-    X = block_matrix(nmo, nso); /* just a temporary matrix */
-
-    MUX_MO = block_matrix(nmo, nmo);
-    MUY_MO = block_matrix(nmo, nmo);
-    MUZ_MO = block_matrix(nmo, nmo);
-
-    C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt[0][0]), nmo, &(MUX_SO[0][0]), nso, 0, &(X[0][0]), nso);
-    C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt[0][0]), nmo, 0, &(MUX_MO[0][0]), nmo);
-
-    C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt[0][0]), nmo, &(MUY_SO[0][0]), nso, 0, &(X[0][0]), nso);
-    C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt[0][0]), nmo, 0, &(MUY_MO[0][0]), nmo);
-
-    C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt[0][0]), nmo, &(MUZ_SO[0][0]), nso, 0, &(X[0][0]), nso);
-    C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt[0][0]), nmo, 0, &(MUZ_MO[0][0]), nmo);
-
-    free_block(X);
-
-    moinfo.dip = (double ***)malloc(3 * sizeof(double **));
-    moinfo.dip[0] = MUX_MO;
-    moinfo.dip[1] = MUY_MO;
-    moinfo.dip[2] = MUZ_MO;
-
-    free_block(MUX_SO);
-    free_block(MUY_SO);
-    free_block(MUZ_SO);
+    moinfo.dip = mints.so_dipole();
+    for (auto& i : moinfo.dip) {
+        i->transform(moinfo.Ca);
+    }
 
     return;
 }

--- a/psi4/src/psi4/cc/ccdensity/transp.cc
+++ b/psi4/src/psi4/cc/ccdensity/transp.cc
@@ -49,47 +49,12 @@ namespace psi {
 namespace ccdensity {
 
 void transp(const MintsHelper &mints, double sign) {
-    int nmo, nso;
-    double **scf_qt, **X;
-    double **NX_MO, **NY_MO, **NZ_MO;
-    double **NX_SO, **NY_SO, **NZ_SO;
-
-    nso = moinfo.nso;
-    nmo = moinfo.nmo;
-    scf_qt = moinfo.scf_qt;
-
     /*** Transform the SO nabla integrals to the MO basis ***/
-    std::vector<SharedMatrix> dipole = mints.so_nabla();
-    for (int i = 0; i < 3; i++) dipole[i]->scale(-1.0 * sign);
-    NX_SO = dipole[0]->to_block_matrix();
-    NY_SO = dipole[1]->to_block_matrix();
-    NZ_SO = dipole[2]->to_block_matrix();
-
-    X = block_matrix(nmo, nso); /* just a temporary matrix */
-
-    NX_MO = block_matrix(nmo, nmo);
-    NY_MO = block_matrix(nmo, nmo);
-    NZ_MO = block_matrix(nmo, nmo);
-
-    C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt[0][0]), nmo, &(NX_SO[0][0]), nso, 0, &(X[0][0]), nso);
-    C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt[0][0]), nmo, 0, &(NX_MO[0][0]), nmo);
-
-    C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt[0][0]), nmo, &(NY_SO[0][0]), nso, 0, &(X[0][0]), nso);
-    C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt[0][0]), nmo, 0, &(NY_MO[0][0]), nmo);
-
-    C_DGEMM('t', 'n', nmo, nso, nso, 1, &(scf_qt[0][0]), nmo, &(NZ_SO[0][0]), nso, 0, &(X[0][0]), nso);
-    C_DGEMM('n', 'n', nmo, nmo, nso, 1, &(X[0][0]), nso, &(scf_qt[0][0]), nmo, 0, &(NZ_MO[0][0]), nmo);
-
-    free_block(X);
-
-    moinfo.nabla = (double ***)malloc(3 * sizeof(double **));
-    moinfo.nabla[0] = NX_MO;
-    moinfo.nabla[1] = NY_MO;
-    moinfo.nabla[2] = NZ_MO;
-
-    free_block(NX_SO);
-    free_block(NY_SO);
-    free_block(NZ_SO);
+    moinfo.nabla = mints.so_nabla();
+    for (auto& i : moinfo.nabla) {
+        i->scale(-1.0 * sign);
+        i->transform(moinfo.Ca);
+    }
 
     return;
 }


### PR DESCRIPTION
## Description
All pieces of `ccdensity` related to transition densities have been migrated to use `Matrix` and `Slice` tech, for a net cut of nearly 1100 lines of code!

Don't let the large delta LoC fool you. It's the same tricks over and over and over...

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `L`, `nabla` and `dipole` integrals within `ccdensity` changed to `Matrix`
- [x] Left and right transition densities (alpha and beta) changed to `Matrix` 
- [x] `scf_qt` eliminated from MOInfo
- [x] _Massive_ elimination of manual BLAS and indexing and LoC 

## Checklist
- [x] Tests still pass. Three cheers for the mega test pass on `cc`

## Status
- [x] Ready for review
- [x] Ready for merge
