### PR TITLE
`get_block` with `symmetry_`

### DIFF
--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -623,17 +623,17 @@ SharedMatrix Matrix::get_block(const Slice &rows, const Slice &cols) const {
             throw PSIEXCEPTION(msg);
         }
     }
-    const Dimension &rows_begin = rows.begin();
-    const Dimension &cols_begin = cols.begin();
+    const auto &rows_begin = rows.begin();
+    const auto &cols_begin = cols.begin();
     Dimension block_rows = rows.end() - rows.begin();
     Dimension block_cols = cols.end() - cols.begin();
-    auto block = std::make_shared<Matrix>("Block", block_rows, block_cols);
+    auto block = std::make_shared<Matrix>("Block", block_rows, block_cols, symmetry_);
     for (int h = 0; h < nirrep_; h++) {
         int max_p = block_rows[h];
-        int max_q = block_cols[h];
+        int max_q = block_cols[h ^ symmetry_];
         for (int p = 0; p < max_p; p++) {
             for (int q = 0; q < max_q; q++) {
-                double value = get(h, p + rows_begin[h], q + cols_begin[h]);
+                double value = get(h, p + rows_begin[h], q + cols_begin[h ^ symmetry_]);
                 block->set(h, p, q, value);
             }
         }

--- a/tests/pytests/test_matrix.py
+++ b/tests/pytests/test_matrix.py
@@ -267,6 +267,28 @@ def test_back_transform():
     assert compare_arrays(transformer.nph[0] @ original.nph[0] @ (transformer.nph[1]).T, transformed.nph[0]) 
     assert compare_arrays(transformer.nph[1] @ original.nph[1] @ (transformer.nph[0]).T, transformed.nph[1])
 
+def test_get_matrix():
+    # Use get_matrix to extrct a block of a non-totally symmetric matrix.
+    dim = Dimension([3, 2])
+    mat = Matrix("Name", dim, dim, 1)
+    new_dim = Dimension([2, 1])
+    control_mat = Matrix("Name", new_dim, new_dim, 1)
+    i = 0
+    for j in range(3):
+        for k in range(2):
+            # Populate both non-zero irreps of the original matrix.
+            mat.set(0, j, k, i)
+            mat.set(1, k, j, 10 + i)
+            # Populate the parts we extract of both non-zero irreps, for the control matrix.
+            if i in {0, 2}:
+                control_mat.set(0, j, k, i)
+                control_mat.set(1, k, j, 10 + i)
+            i += 1
+    new_slice = Slice(Dimension([0, 0]), new_dim)
+    new_mat = Matrix("Name", new_dim, new_dim, 1)
+    block = mat.get_block(new_slice, new_slice)
+    assert psi4.compare_matrices(block, control_mat)
+
 def test_set_matrix():
     # Use set_matrix to zero a block of a non-totally symmetric matrix.
     dim = Dimension([3, 2])
@@ -275,8 +297,10 @@ def test_set_matrix():
     i = 0
     for j in range(3):
         for k in range(2):
+            # Populate both non-zero irreps, for the original matrix.
             mat.set(0, j, k, i)
             mat.set(1, k, j, 10 + i)
+            # Populate the parts we don't zero of both non-zero irreps, for the control matrix.
             if i not in {0, 2}:
                 control_mat.set(0, j, k, i)
                 control_mat.set(1, k, j, 10 + i)

--- a/tests/pytests/test_matrix.py
+++ b/tests/pytests/test_matrix.py
@@ -268,7 +268,7 @@ def test_back_transform():
     assert compare_arrays(transformer.nph[1] @ original.nph[1] @ (transformer.nph[0]).T, transformed.nph[1])
 
 def test_get_matrix():
-    # Use get_matrix to extrct a block of a non-totally symmetric matrix.
+    # Use get_matrix to extract a block of a non-totally symmetric matrix.
     dim = Dimension([3, 2])
     mat = Matrix("Name", dim, dim, 1)
     new_dim = Dimension([2, 1])
@@ -287,7 +287,7 @@ def test_get_matrix():
     new_slice = Slice(Dimension([0, 0]), new_dim)
     new_mat = Matrix("Name", new_dim, new_dim, 1)
     block = mat.get_block(new_slice, new_slice)
-    assert psi4.compare_matrices(block, control_mat)
+    assert psi4.compare_matrices(control_mat, block)
 
 def test_set_matrix():
     # Use set_matrix to zero a block of a non-totally symmetric matrix.


### PR DESCRIPTION
## Description
See below. Sister PR to #2734. Needed before I can cleanup `ccresponse`.

## User API & Changelog headlines
- [x] `Matrix::get_block` can be used on matrices that are not totally symmetric.

## Dev notes & details
- [x] `Matrix::get_block` can be used on matrices that are not totally symmetric.

## Checklist
- [x]  New test working

## Status
- [x] Ready for review
- [x] Ready for merge
