### PR TITLE
Remove qt/pitzer from ccresponse

### DIFF
--- a/psi4/src/psi4/cc/ccresponse/MOInfo.h
+++ b/psi4/src/psi4/cc/ccresponse/MOInfo.h
@@ -81,22 +81,7 @@ struct MOInfo {
     int *vir_off;                    /* virtual orbital offsets within each irrep */
     int *avir_off;                   /* virtual alpha orbital offsets within each irrep */
     int *bvir_off;                   /* virtual beta orbital offsets within each irrep */
-    int *qt_occ;                     /* CC->QT active occupied reordering array */
-    int *qt_aocc;                    /* CC->QT alpha active occupied reordering array */
-    int *qt_bocc;                    /* CC->QT beta active occupied reordering array */
-    int *qt_vir;                     /* CC->QT active virtiual reordering array */
-    int *qt_avir;                    /* CC->QT alpha active virtiual reordering array */
-    int *qt_bvir;                    /* CC->QT beta active virtiual reordering array */
-    int *cc_occ;                     /* QT->CC active occupied reordering array */
-    int *cc_aocc;                    /* QT->CC active occupied reordering array */
-    int *cc_bocc;                    /* QT->CC active occupied reordering array */
-    int *cc_vir;                     /* QT->CC active virtual reordering array */
-    int *cc_avir;                    /* QT->CC active virtual reordering array */
-    int *cc_bvir;                    /* QT->CC active virtual reordering array */
-    double **scf;                    /* SCF eigenvectors (RHF/ROHF) (active only) */
     std::shared_ptr<Matrix> Ca;
-    double **scf_alpha;              /* Alpha SCF eigenvectors (UHF) (active only) */
-    double **scf_beta;               /* Beta SCF eigenvectors (UHF) (active only) */
     int *mu_irreps;                  /* irreps of x,y,z dipole components */
     int *l_irreps;                   /* irreps of x,y,z angular momentum components */
     int natom;                       /* number of atoms */

--- a/psi4/src/psi4/cc/ccresponse/MOInfo.h
+++ b/psi4/src/psi4/cc/ccresponse/MOInfo.h
@@ -36,6 +36,7 @@
 
 #include <string>
 #include <vector>
+#include "psi4/libmints/matrix.h"
 
 namespace psi {
 namespace ccresponse {
@@ -59,10 +60,10 @@ struct MOInfo {
     int *fruocc;                     /* no. of frozen unoccupied orbitals per irrep */
     int nvirt;                       /* total no. of (active) virtual orbitals */
     int *actpi;                      /* no. of active orbitals per irrep */
+    Dimension act_pi;                /* Dimension form of actpi */
     std::vector<std::string> labels; /* irrep labels */
-    int *pitzer2qt;                  /* Pitzer -> QT reordering array */
-    int *qt2pitzer;                  /* QT -> Pitzer reordering array */
     int *occpi;                      /* no. of occupied orbs. (incl. open) per irrep */
+    Dimension act_occpi;             /* Dimension form of occpi */
     int *aoccpi;                     /* no. of alpha occupied orbs. (incl. open) per irrep */
     int *boccpi;                     /* no. of beta occupied orbs. (incl. open) per irrep */
     int *virtpi;                     /* no. of virtual orbs. (incl. open) per irrep */
@@ -93,16 +94,11 @@ struct MOInfo {
     int *cc_avir;                    /* QT->CC active virtual reordering array */
     int *cc_bvir;                    /* QT->CC active virtual reordering array */
     double **scf;                    /* SCF eigenvectors (RHF/ROHF) (active only) */
+    std::shared_ptr<Matrix> Ca;
     double **scf_alpha;              /* Alpha SCF eigenvectors (UHF) (active only) */
     double **scf_beta;               /* Beta SCF eigenvectors (UHF) (active only) */
-    double ***MU;                    /* MO-basis dipole integrals (Pitzer order) */
     int *mu_irreps;                  /* irreps of x,y,z dipole components */
-    double ***L;                     /* MO-basis angular momentum ints (Pitzer order) */
-    double ***Lcc;                   /* Complex-conjugate of MO-basis angular momentum ints (Pitzer order) */
     int *l_irreps;                   /* irreps of x,y,z angular momentum components */
-    double ***P;                     /* MO-basis linear momentum ints (Pitzer order) */
-    double ***Pcc;                   /* Complex-conjugate of MO-basis linear momentum ints (Pitzer order) */
-    double ****Q;                    /* MO-basis traceless quadrupole ints (Pitzer order) */
     int natom;                       /* number of atoms */
     double *zvals;                   /* atomic zvals */
     double ***C;                     /* Virtual orbital transformation matrix */

--- a/psi4/src/psi4/cc/ccresponse/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccresponse/get_moinfo.cc
@@ -210,10 +210,6 @@ void cleanup() {
         free(moinfo.bocc_off);
         free(moinfo.avir_off);
         free(moinfo.bvir_off);
-        free(moinfo.qt_aocc);
-        free(moinfo.qt_bocc);
-        free(moinfo.qt_avir);
-        free(moinfo.qt_bvir);
     } else {
         for (i = 0; i < moinfo.nirreps; i++)
             if (moinfo.sopi[i] && moinfo.virtpi[i]) free_block(moinfo.C[i]);
@@ -224,8 +220,6 @@ void cleanup() {
         free(moinfo.vir_sym);
         free(moinfo.occ_off);
         free(moinfo.vir_off);
-        free(moinfo.qt_occ);
-        free(moinfo.qt_vir);
     }
 
     free(moinfo.sopi);

--- a/psi4/src/psi4/cc/ccresponse/sort_pert.cc
+++ b/psi4/src/psi4/cc/ccresponse/sort_pert.cc
@@ -54,63 +54,28 @@ namespace ccresponse {
 ** TDC, 10/05
 */
 
-void sort_pert(const char *pert, double **pertints, int irrep) {
-    int p, q, Gp, Gq, P, Q, i;
+void write_blocks(const Matrix& mat) {
+    Slice occ_slice(Dimension(moinfo.nirreps), moinfo.act_occpi);
+    Slice vir_slice(moinfo.act_occpi, moinfo.act_pi);
+
     dpdfile2 f;
-    char prefix[32], lbl[32];
 
-    sprintf(lbl, "%s_IJ", pert);
-    global_dpd_->file2_init(&f, PSIF_CC_OEI, irrep, 0, 0, lbl);
-    global_dpd_->file2_mat_init(&f);
-    for (Gp = 0; Gp < moinfo.nirreps; Gp++) { /* irrep of left-hand MO */
-        Gq = irrep ^ Gp;
-
-        for (p = 0; p < moinfo.occpi[Gp]; p++) {
-            P = moinfo.qt2pitzer[moinfo.qt_occ[p + moinfo.occ_off[Gp]]];
-            for (q = 0; q < moinfo.occpi[Gq]; q++) {
-                Q = moinfo.qt2pitzer[moinfo.qt_occ[q + moinfo.occ_off[Gq]]];
-                f.matrix[Gp][p][q] = pertints[P][Q];
-            }
-        }
-    }
-    global_dpd_->file2_mat_wrt(&f);
-    global_dpd_->file2_mat_close(&f);
+    auto block = mat.get_block(occ_slice);
+    auto lbl = mat.name() + "_IJ";
+    global_dpd_->file2_init(&f, PSIF_CC_OEI, mat.symmetry(), 0, 0, lbl);
+    block->write_to_dpdfile2(&f);
     global_dpd_->file2_close(&f);
 
-    sprintf(lbl, "%s_AB", pert);
-    global_dpd_->file2_init(&f, PSIF_CC_OEI, irrep, 1, 1, lbl);
-    global_dpd_->file2_mat_init(&f);
-    for (Gp = 0; Gp < moinfo.nirreps; Gp++) { /* irrep of left-hand MO */
-        Gq = irrep ^ Gp;
-
-        for (p = 0; p < moinfo.virtpi[Gp]; p++) {
-            P = moinfo.qt2pitzer[moinfo.qt_vir[p + moinfo.vir_off[Gp]]];
-            for (q = 0; q < moinfo.virtpi[Gq]; q++) {
-                Q = moinfo.qt2pitzer[moinfo.qt_vir[q + moinfo.vir_off[Gq]]];
-                f.matrix[Gp][p][q] = pertints[P][Q];
-            }
-        }
-    }
-    global_dpd_->file2_mat_wrt(&f);
-    global_dpd_->file2_mat_close(&f);
+    block = mat.get_block(vir_slice);
+    lbl = mat.name() + "_AB";
+    global_dpd_->file2_init(&f, PSIF_CC_OEI, mat.symmetry(), 1, 1, lbl);
+    block->write_to_dpdfile2(&f);
     global_dpd_->file2_close(&f);
 
-    sprintf(lbl, "%s_IA", pert);
-    global_dpd_->file2_init(&f, PSIF_CC_OEI, irrep, 0, 1, lbl);
-    global_dpd_->file2_mat_init(&f);
-    for (Gp = 0; Gp < moinfo.nirreps; Gp++) { /* irrep of left-hand MO */
-        Gq = irrep ^ Gp;
-
-        for (p = 0; p < moinfo.occpi[Gp]; p++) {
-            P = moinfo.qt2pitzer[moinfo.qt_occ[p + moinfo.occ_off[Gp]]];
-            for (q = 0; q < moinfo.virtpi[Gq]; q++) {
-                Q = moinfo.qt2pitzer[moinfo.qt_vir[q + moinfo.vir_off[Gq]]];
-                f.matrix[Gp][p][q] = pertints[P][Q];
-            }
-        }
-    }
-    global_dpd_->file2_mat_wrt(&f);
-    global_dpd_->file2_mat_close(&f);
+    block = mat.get_block(occ_slice, vir_slice);
+    lbl = mat.name() + "_IA";
+    global_dpd_->file2_init(&f, PSIF_CC_OEI, mat.symmetry(), 0, 1, lbl);
+    block->write_to_dpdfile2(&f);
     global_dpd_->file2_close(&f);
 }
 


### PR DESCRIPTION
## Description
Eliminate index management from `ccresponse`.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Eliminates QT-Pitzer interconversion from `ccresponse`
- [x] Eliminates memory leaks from `ccresponse`
- [x] Cleaned up integral writing to disk

## Checklist
- [x] cc tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
