### PR TITLE
Update qcengine keywords

### DIFF
--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -213,7 +213,7 @@ class EmpiricalDispersion():
                 resi,
                 self.engine,
                 raise_error=True,
-                local_options={"scratch_directory": core.IOManager.shared_object().get_default_path(), "ncores": core.get_num_threads()})
+                task_config={"scratch_directory": core.IOManager.shared_object().get_default_path(), "ncores": core.get_num_threads()})
 
             dashd_part = float(jobrec.extras['qcvars']['DISPERSION CORRECTION ENERGY'])
             if wfn is not None:
@@ -231,7 +231,7 @@ class EmpiricalDispersion():
                     resi,
                     "gcp",
                     raise_error=True,
-                    local_options={"scratch_directory": core.IOManager.shared_object().get_default_path(), "ncores": core.get_num_threads()})
+                    task_config={"scratch_directory": core.IOManager.shared_object().get_default_path(), "ncores": core.get_num_threads()})
                 gcp_part = jobrec.return_result
                 dashd_part += gcp_part
 
@@ -283,7 +283,7 @@ class EmpiricalDispersion():
                 resi,
                 self.engine,
                 raise_error=True,
-                local_options={"scratch_directory": core.IOManager.shared_object().get_default_path(), "ncores": core.get_num_threads()})
+                task_config={"scratch_directory": core.IOManager.shared_object().get_default_path(), "ncores": core.get_num_threads()})
 
             dashd_part = core.Matrix.from_array(jobrec.extras['qcvars']['DISPERSION CORRECTION GRADIENT'])
             if wfn is not None:
@@ -296,7 +296,7 @@ class EmpiricalDispersion():
                     resi,
                     "gcp",
                     raise_error=True,
-                    local_options={"scratch_directory": core.IOManager.shared_object().get_default_path(), "ncores": core.get_num_threads()})
+                    task_config={"scratch_directory": core.IOManager.shared_object().get_default_path(), "ncores": core.get_num_threads()})
                 gcp_part = core.Matrix.from_array(jobrec.return_result)
                 dashd_part.add(gcp_part)
 


### PR DESCRIPTION
## Description
As of qcengine 0.24, the keyword `local_options` is deprecated in favor of `task_config`. This PR updates the keywords in any remaining qcng calls (looks like main call in `task_base.py` was caught in a previous PR).


## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Deprecated qcng keywords updated.

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
