### PR TITLE
Improve PSIO error messages for READ, WRITE and LSEEK

### DIFF
--- a/psi4/src/psi4/libpsio/CMakeLists.txt
+++ b/psi4/src/psi4/libpsio/CMakeLists.txt
@@ -2,6 +2,7 @@ list(APPEND sources
   aio_handler.cc
   change_namespace.cc
   close.cc
+  compose_err_msg.cc
   done.cc
   decode_errno.cc
   error.cc

--- a/psi4/src/psi4/libpsio/compose_err_msg.cc
+++ b/psi4/src/psi4/libpsio/compose_err_msg.cc
@@ -1,0 +1,54 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2022 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+/*!
+ ** \file
+ ** \ingroup PSIO
+ */
+#include <cstring>
+#include <optional>
+#include "psi4/libpsio/psio.h"
+
+namespace psi {
+/// @brief Composes an error message explaining that an IO system call has failed, with the error message from the OS
+/// (based on errno), some context from the caller of this function and the unit number. Callers should save the
+/// value of errno into a local variable **immediately** after the IO call returns, as there are a lot of things in C++
+/// that can potentially fail and overwrite the global errno with a new error code.
+/// @param beginning : Beginning of the error message. Should not end with a newline.
+/// @param context : Some information about the context of the IO call that has failed. Should not end with a newline.
+/// @param unit : Unit number that the IO failed on
+/// @param errno_in : The value of errno after the failed IO call
+/// @return String explaining the error. Ends with a newline.
+std::string psio_compose_err_msg(const std::string& beginning, const std::string& context, const size_t unit,
+                                 const std::optional<int> errno_in /* = std::nullopt*/) {
+    std::string errmsg = beginning;
+    if (errno_in.has_value()) errmsg += " Error description from the OS: " + decode_errno(errno_in.value());
+    errmsg += '\n' + context + ", unit " + std::to_string(unit) + ".\n";
+    return errmsg;
+}
+}  // namespace psi

--- a/psi4/src/psi4/libpsio/compose_err_msg.cc
+++ b/psi4/src/psi4/libpsio/compose_err_msg.cc
@@ -47,7 +47,7 @@ namespace psi {
 std::string psio_compose_err_msg(const std::string& beginning, const std::string& context, const size_t unit,
                                  const std::optional<int> errno_in /* = std::nullopt*/) {
     std::string errmsg = beginning;
-    if (errno_in.has_value()) errmsg += " Error description from the OS: " + decode_errno(errno_in.value());
+    if (errno_in.has_value()) errmsg += " Error description from the OS: " + decode_errno(*errno_in);
     errmsg += '\n' + context + ", unit " + std::to_string(unit) + ".\n";
     return errmsg;
 }

--- a/psi4/src/psi4/libpsio/psio.h
+++ b/psi4/src/psi4/libpsio/psio.h
@@ -72,7 +72,7 @@ std::string psio_getpid();
 
 PSI_API psio_address psio_get_address(psio_address start, size_t shift);
 psio_address psio_get_global_address(psio_address entry_start, psio_address rel_address);
-int psio_volseek(psio_vol *vol, size_t page, size_t offset, size_t numvols);
+void psio_volseek(const psio_vol *vol, size_t page, const size_t offset, const size_t numvols, const size_t unit);
 
 int psio_tocwrite(size_t unit);
 void psio_tocprint(size_t unit);  // debug printing

--- a/psi4/src/psi4/libpsio/psio.h
+++ b/psi4/src/psi4/libpsio/psio.h
@@ -30,6 +30,7 @@
 #define PSIO_H
 
 #include <cstdio>
+#include <optional>
 #include "psi4/libpsio/config.h"
 #include <string>
 
@@ -60,6 +61,9 @@
 namespace psi {
 
 std::string decode_errno(const int errno_in);
+std::string psio_compose_err_msg(const std::string &beginning, const std::string &context, const size_t unit,
+                                 const std::optional<int> errno_in = std::nullopt);
+
 int psio_init();
 void psio_error(size_t unit, size_t errval, std::string prev_msg = "");
 int psio_open(size_t unit, int status);

--- a/psi4/src/psi4/libpsio/rw.cc
+++ b/psi4/src/psi4/libpsio/rw.cc
@@ -50,7 +50,6 @@ namespace psi {
  ** \ingroup PSIO
  */
 void PSIO::rw(size_t unit, char *buffer, psio_address address, size_t size, int wrt) {
-    int errcod;
     size_t i;
     size_t errcod_uli;
     size_t page, offset;
@@ -67,12 +66,10 @@ void PSIO::rw(size_t unit, char *buffer, psio_address address, size_t size, int 
 
     /* Seek all volumes to correct starting positions */
     first_vol = page % numvols;
-    errcod = psio_volseek(&(this_unit->vol[first_vol]), page, offset, numvols);
-    if (errcod == -1) psio_error(unit, PSIO_ERROR_LSEEK);
+    psio_volseek(&(this_unit->vol[first_vol]), page, offset, numvols, unit);
     for (i = 1, this_page = page + 1; i < numvols; i++, this_page++) {
         this_vol = this_page % numvols;
-        errcod = psio_volseek(&(this_unit->vol[this_vol]), this_page, (size_t)0, numvols);
-        if (errcod == -1) psio_error(unit, PSIO_ERROR_LSEEK);
+        psio_volseek(&(this_unit->vol[this_vol]), this_page, (size_t)0, numvols, unit);
     }
 
     /* Number of bytes left on the first page */

--- a/psi4/src/psi4/libpsio/rw.cc
+++ b/psi4/src/psi4/libpsio/rw.cc
@@ -83,10 +83,26 @@ void PSIO::rw(size_t unit, char *buffer, psio_address address, size_t size, int 
     buf_offset = 0;
     if (wrt) {
         errcod_uli = SYSTEM_WRITE(this_unit->vol[first_vol].stream, &(buffer[buf_offset]), this_page_total);
-        if (errcod_uli != this_page_total) psio_error(unit, PSIO_ERROR_WRITE);
+        const int saved_errno = errno;
+        if (errcod_uli != this_page_total) {
+            const std::string beginning =
+                (errcod_uli == -1) ? "WRITE failed." : "WRITE failed. Only some of the bytes were written!";
+            const std::string context = "Error writing the first partial page";
+            const std::string errmsg = (errcod_uli == -1) ? psio_compose_err_msg(beginning, context, unit, saved_errno)
+                                                          : psio_compose_err_msg(beginning, context, unit);
+            psio_error(unit, PSIO_ERROR_WRITE, errmsg);
+        }
     } else {
         errcod_uli = SYSTEM_READ(this_unit->vol[first_vol].stream, &(buffer[buf_offset]), this_page_total);
-        if (errcod_uli != this_page_total) psio_error(unit, PSIO_ERROR_READ);
+        const int saved_errno = errno;
+        if (errcod_uli != this_page_total) {
+            const std::string beginning =
+                (errcod_uli == -1) ? "READ failed." : "READ failed. Only some of the bytes were read!";
+            const std::string context = "Error reading the first partial page";
+            const std::string errmsg = (errcod_uli == -1) ? psio_compose_err_msg(beginning, context, unit, saved_errno)
+                                                          : psio_compose_err_msg(beginning, context, unit);
+            psio_error(unit, PSIO_ERROR_READ, errmsg);
+        }
     }
 
     /* Total number of bytes remaining to be read/written */
@@ -100,10 +116,28 @@ void PSIO::rw(size_t unit, char *buffer, psio_address address, size_t size, int 
         this_page_total = PSIO_PAGELEN;
         if (wrt) {
             errcod_uli = SYSTEM_WRITE(this_unit->vol[this_vol].stream, &(buffer[buf_offset]), this_page_total);
-            if (errcod_uli != this_page_total) psio_error(unit, PSIO_ERROR_WRITE);
+            const int saved_errno = errno;
+            if (errcod_uli != this_page_total) {
+                const std::string beginning =
+                    (errcod_uli == -1) ? "WRITE failed." : "WRITE failed. Only some of the bytes were written!";
+                const std::string context = "Error writing a full page";
+                const std::string errmsg = (errcod_uli == -1)
+                                               ? psio_compose_err_msg(beginning, context, unit, saved_errno)
+                                               : psio_compose_err_msg(beginning, context, unit);
+                psio_error(unit, PSIO_ERROR_WRITE, errmsg);
+            }
         } else {
             errcod_uli = SYSTEM_READ(this_unit->vol[this_vol].stream, &(buffer[buf_offset]), this_page_total);
-            if (errcod_uli != this_page_total) psio_error(unit, PSIO_ERROR_READ);
+            const int saved_errno = errno;
+            if (errcod_uli != this_page_total) {
+                const std::string beginning =
+                    (errcod_uli == -1) ? "READ failed." : "READ failed. Only some of the bytes were read!";
+                const std::string context = "Error reading a full page";
+                const std::string errmsg = (errcod_uli == -1)
+                                               ? psio_compose_err_msg(beginning, context, unit, saved_errno)
+                                               : psio_compose_err_msg(beginning, context, unit);
+                psio_error(unit, PSIO_ERROR_READ, errmsg);
+            }
         }
         buf_offset += this_page_total;
     }
@@ -114,10 +148,28 @@ void PSIO::rw(size_t unit, char *buffer, psio_address address, size_t size, int 
     if (bytes_left) {
         if (wrt) {
             errcod_uli = SYSTEM_WRITE(this_unit->vol[this_vol].stream, &(buffer[buf_offset]), bytes_left);
-            if (errcod_uli != bytes_left) psio_error(unit, PSIO_ERROR_WRITE);
+            const int saved_errno = errno;
+            if (errcod_uli != bytes_left) {
+                const std::string beginning =
+                    (errcod_uli == -1) ? "WRITE failed." : "WRITE failed. Only some of the bytes were written!";
+                const std::string context = "Error writing the last partial page";
+                const std::string errmsg = (errcod_uli == -1)
+                                               ? psio_compose_err_msg(beginning, context, unit, saved_errno)
+                                               : psio_compose_err_msg(beginning, context, unit);
+                psio_error(unit, PSIO_ERROR_WRITE, errmsg);
+            }
         } else {
             errcod_uli = SYSTEM_READ(this_unit->vol[this_vol].stream, &(buffer[buf_offset]), bytes_left);
-            if (errcod_uli != bytes_left) psio_error(unit, PSIO_ERROR_READ);
+            const int saved_errno = errno;
+            if (errcod_uli != bytes_left) {
+                const std::string beginning =
+                    (errcod_uli == -1) ? "READ failed." : "READ failed. Only some of the bytes were read!";
+                const std::string context = "Error reading the last partial page";
+                const std::string errmsg = (errcod_uli == -1)
+                                               ? psio_compose_err_msg(beginning, context, unit, saved_errno)
+                                               : psio_compose_err_msg(beginning, context, unit);
+                psio_error(unit, PSIO_ERROR_READ, errmsg);
+            }
         }
     }
 }

--- a/psi4/src/psi4/libpsio/toclen.cc
+++ b/psi4/src/psi4/libpsio/toclen.cc
@@ -60,7 +60,7 @@ void PSIO::rewind_toclen(const size_t unit) {
     if (!open_check(unit)) psio_error(unit, PSIO_ERROR_UNOPENED);
     const auto stream = psio_unit[unit].vol[0].stream;
     const auto errcod = SYSTEM_LSEEK(stream, 0L, SEEK_SET);
-    const auto saved_errno = errno;
+    const int saved_errno = errno;
     if (errcod == -1) {
         const std::string errmsg =
             psio_compose_err_msg("LSEEK failed.", "Cannot seek vol[0] to its beginning", unit, saved_errno);
@@ -82,7 +82,7 @@ size_t PSIO::rd_toclen(const size_t unit) {
     size_t len;
     const auto stream = psio_unit[unit].vol[0].stream;
     const auto errcod = SYSTEM_READ(stream, (char *)&len, sizeof(size_t));
-    const auto saved_errno = errno;
+    const int saved_errno = errno;
     if (errcod != sizeof(size_t)) {
         if (errcod == -1) {
             const std::string errmsg = psio_compose_err_msg(
@@ -104,7 +104,7 @@ void PSIO::wt_toclen(const size_t unit, const size_t len) {
     // Write the value
     const auto stream = psio_unit[unit].vol[0].stream;
     const auto errcod = SYSTEM_WRITE(stream, (char *)&len, sizeof(size_t));
-    const auto saved_errno = errno;
+    const int saved_errno = errno;
     if (errcod != sizeof(size_t)) {
         const std::string errmsg = psio_compose_err_msg(
             "WRITE failed.", "Error in PSIO::wt_toclen()! Cannot write TOC length", unit, saved_errno);

--- a/psi4/src/psi4/libpsio/toclen.cc
+++ b/psi4/src/psi4/libpsio/toclen.cc
@@ -62,9 +62,8 @@ void PSIO::rewind_toclen(const size_t unit) {
     const auto errcod = SYSTEM_LSEEK(stream, 0L, SEEK_SET);
     const auto saved_errno = errno;
     if (errcod == -1) {
-        std::string errmsg = "LSEEK failed. Error description from the OS: " + decode_errno(saved_errno);
-        errmsg += "\nCannot seek vol[0] to its beginning, unit ";
-        errmsg += std::to_string(unit) + ".\n";
+        const std::string errmsg =
+            psio_compose_err_msg("LSEEK failed.", "Cannot seek vol[0] to its beginning", unit, saved_errno);
         psio_error(unit, PSIO_ERROR_LSEEK, errmsg);
     }
 }
@@ -86,9 +85,8 @@ size_t PSIO::rd_toclen(const size_t unit) {
     const auto saved_errno = errno;
     if (errcod != sizeof(size_t)) {
         if (errcod == -1) {
-            std::string errmsg = "READ failed. Error description from the OS: " + decode_errno(saved_errno);
-            errmsg += "\nError in PSIO::rd_toclen()! Cannot read TOC length, unit ";
-            errmsg += std::to_string(unit) + ".\n";
+            const std::string errmsg = psio_compose_err_msg(
+                "READ failed.", "Error in PSIO::rd_toclen()! Cannot read TOC length", unit, saved_errno);
             psio_error(unit, PSIO_ERROR_READ, errmsg);
         }
         return (0);  // assume that all is well (see comments above)
@@ -108,9 +106,8 @@ void PSIO::wt_toclen(const size_t unit, const size_t len) {
     const auto errcod = SYSTEM_WRITE(stream, (char *)&len, sizeof(size_t));
     const auto saved_errno = errno;
     if (errcod != sizeof(size_t)) {
-        std::string errmsg = "WRITE failed. Error description from the OS: " + decode_errno(saved_errno);
-        errmsg += "\nError in PSIO::wt_toclen()! Cannot write TOC length, unit ";
-        errmsg += std::to_string(unit) + ".\n";
+        const std::string errmsg = psio_compose_err_msg(
+            "WRITE failed.", "Error in PSIO::wt_toclen()! Cannot write TOC length", unit, saved_errno);
         psio_error(unit, PSIO_ERROR_WRITE, errmsg);
     }
 }

--- a/psi4/src/psi4/libpsio/toclen.cc
+++ b/psi4/src/psi4/libpsio/toclen.cc
@@ -60,9 +60,9 @@ void PSIO::rewind_toclen(const size_t unit) {
     if(!open_check(unit)) psio_error(unit, PSIO_ERROR_UNOPENED);
     const auto stream = psio_unit[unit].vol[0].stream;
     const auto errcod = SYSTEM_LSEEK(stream, 0L, SEEK_SET);
-    const auto sys_errno = errno;
+    const auto saved_errno = errno;
     if (errcod == -1) {
-        std::string errmsg = "LSEEK failed. Error description from the OS: " + decode_errno(sys_errno);
+        std::string errmsg = "LSEEK failed. Error description from the OS: " + decode_errno(saved_errno);
         errmsg += "\nCannot seek vol[0] to its beginning, unit ";
         errmsg += std::to_string(unit) + ".\n";
         psio_error(unit, PSIO_ERROR_LSEEK, errmsg);
@@ -83,10 +83,10 @@ size_t PSIO::rd_toclen(const size_t unit) {
     size_t len;
     const auto stream = psio_unit[unit].vol[0].stream;
     const auto errcod = SYSTEM_READ(stream, (char *)&len, sizeof(size_t));
-    const auto sys_errno = errno;
+    const auto saved_errno = errno;
     if (errcod != sizeof(size_t)) {
         if (errcod == -1) {
-            std::string errmsg = "READ failed. Error description from the OS: " + decode_errno(sys_errno);
+            std::string errmsg = "READ failed. Error description from the OS: " + decode_errno(saved_errno);
             errmsg += "\nError in PSIO::rd_toclen()! Cannot read TOC length, unit ";
             errmsg += std::to_string(unit) + ".\n";
             psio_error(unit, PSIO_ERROR_READ, errmsg);
@@ -106,9 +106,9 @@ void PSIO::wt_toclen(const size_t unit, const size_t len) {
     // Write the value
     const auto stream = psio_unit[unit].vol[0].stream;
     const auto errcod = SYSTEM_WRITE(stream, (char *)&len, sizeof(size_t));
-    const auto sys_errno = errno;
+    const auto saved_errno = errno;
     if (errcod != sizeof(size_t)) {
-        std::string errmsg = "WRITE failed. Error description from the OS: " + decode_errno(sys_errno);
+        std::string errmsg = "WRITE failed. Error description from the OS: " + decode_errno(saved_errno);
         errmsg += "\nError in PSIO::wt_toclen()! Cannot write TOC length, unit ";
         errmsg += std::to_string(unit) + ".\n";
         psio_error(unit, PSIO_ERROR_WRITE, errmsg);

--- a/psi4/src/psi4/libpsio/toclen.cc
+++ b/psi4/src/psi4/libpsio/toclen.cc
@@ -57,7 +57,7 @@ size_t PSIO::toclen(const size_t unit) {
 /// @brief Seek the stream of the vol[0] of a unit to its beginning
 /// @param unit : file unit number to rewind
 void PSIO::rewind_toclen(const size_t unit) {
-    if(!open_check(unit)) psio_error(unit, PSIO_ERROR_UNOPENED);
+    if (!open_check(unit)) psio_error(unit, PSIO_ERROR_UNOPENED);
     const auto stream = psio_unit[unit].vol[0].stream;
     const auto errcod = SYSTEM_LSEEK(stream, 0L, SEEK_SET);
     const auto saved_errno = errno;
@@ -76,7 +76,7 @@ void PSIO::rewind_toclen(const size_t unit) {
 /// @param unit : file unit number to read TOC length from
 /// @return length of the TOC for a given unit
 size_t PSIO::rd_toclen(const size_t unit) {
-    if(!open_check(unit)) psio_error(unit, PSIO_ERROR_UNOPENED);
+    if (!open_check(unit)) psio_error(unit, PSIO_ERROR_UNOPENED);
     // Seek to the beginning
     rewind_toclen(unit);
     // Read the value
@@ -100,7 +100,7 @@ size_t PSIO::rd_toclen(const size_t unit) {
 /// @param unit : file unit number to write TOC length to
 /// @param len  : length value to write
 void PSIO::wt_toclen(const size_t unit, const size_t len) {
-    if(!open_check(unit)) psio_error(unit, PSIO_ERROR_UNOPENED);
+    if (!open_check(unit)) psio_error(unit, PSIO_ERROR_UNOPENED);
     // Seek to the beginning
     rewind_toclen(unit);
     // Write the value

--- a/psi4/src/psi4/libpsio/volseek.cc
+++ b/psi4/src/psi4/libpsio/volseek.cc
@@ -33,7 +33,7 @@
 
 #include "psi4/libpsio/psio.h"
 #include "psi4/psi4-dec.h"
-/* This is strictly used to avoid overflow errors on lseek() calls */
+// This is strictly used to avoid overflow errors on lseek() calls
 #define PSIO_BIGNUM 10000
 
 namespace psi {
@@ -45,23 +45,21 @@ namespace psi {
 int psio_volseek(psio_vol *vol, size_t page, size_t offset, size_t numvols) {
     const int stream = vol->stream;
 
-
-    /* Set file pointer to beginning of file */
+    // Set file pointer to beginning of file
     if (SYSTEM_LSEEK(stream, 0, SEEK_SET) == -1)
         return -1;
 
-    /* lseek() through large chunks of the file to avoid offset overflows */
+    // lseek() through large chunks of the file to avoid offset overflows
     size_t bignum = PSIO_BIGNUM * numvols;
     for (; page > bignum; page -= bignum)
         if (SYSTEM_LSEEK(stream, PSIO_BIGNUM * PSIO_PAGELEN, SEEK_CUR) == -1)
             return -1;
 
-    /* Now compute the final offset including the page-relative term */
+    // Now compute the final offset including the page-relative term
     size_t final_offset = (page / numvols) * PSIO_PAGELEN + offset;
     if (SYSTEM_LSEEK(stream, final_offset, SEEK_CUR) == -1)
         return -1;
 
     return 0;
 }
-
 }  // namespace psi

--- a/psi4/src/psi4/libpsio/volseek.cc
+++ b/psi4/src/psi4/libpsio/volseek.cc
@@ -50,13 +50,13 @@ int psio_volseek(psio_vol *vol, size_t page, size_t offset, size_t numvols) {
         return -1;
 
     // lseek() through large chunks of the file to avoid offset overflows
-    size_t bignum = PSIO_BIGNUM * numvols;
+    const size_t bignum = PSIO_BIGNUM * numvols;
     for (; page > bignum; page -= bignum)
         if (SYSTEM_LSEEK(stream, PSIO_BIGNUM * PSIO_PAGELEN, SEEK_CUR) == -1)
             return -1;
 
     // Now compute the final offset including the page-relative term
-    size_t final_offset = (page / numvols) * PSIO_PAGELEN + offset;
+    const size_t final_offset = (page / numvols) * PSIO_PAGELEN + offset;
     if (SYSTEM_LSEEK(stream, final_offset, SEEK_CUR) == -1)
         return -1;
 

--- a/psi4/src/psi4/libpsio/volseek.cc
+++ b/psi4/src/psi4/libpsio/volseek.cc
@@ -43,8 +43,8 @@ namespace psi {
  ** \ingroup PSIO
  */
 int psio_volseek(psio_vol *vol, size_t page, size_t offset, size_t numvols) {
+    const int stream = vol->stream;
 
-    int stream = vol->stream;
 
     /* Set file pointer to beginning of file */
     if (SYSTEM_LSEEK(stream, 0, SEEK_SET) == -1)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR builds upon the functions added in #2711 and #2700 to provide more informative error messages if a `SYSTEM_READ`, `SYSTEM_WRITE` or `SYSTEM_LSEEK` fails, including the OS-provided error message, which may have clues for the cause of the error (disk is full, no permission, etc).

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is detined for the release notes. May be empty. -->
- [x] Error messages related to some IO errors are now more specific and detailed.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] New function: `psio_compose_err_msg`. This helps composing PSIO error messages without too much code duplication. It can optionally take an errno value and tack on the error message provided by the OS.
- [x] `psio_volseek` has been reworked to handle any errors internally by calling `psio_error`, instead of returning -1 on error. Appropriate error message generation and some `const` qualifiers were added.
- [x] `PSIO::rw` has been adapted to the changes to `psio_volseek` and error message generation was added after each read/write/seek.
- [x] Functions in `toclen.cc` are now also using `psio_compose_err_msg` to generate messages.

## Checklist
- [x] Tests run by the CI are passing.

## Status
- [x] Ready for review
- [x] Ready for merge
