### PR TITLE
Modify Instability Following Step

### DIFF
--- a/psi4/src/psi4/libscf_solver/stability.h
+++ b/psi4/src/psi4/libscf_solver/stability.h
@@ -116,6 +116,7 @@ class UStab {
     virtual double compute_energy();
     SharedMatrix analyze();
     void rotate_orbs(double scale);
+    void rotate_orb(double scale, const Matrix& X, Matrix& C);
 };
 
 }  // namespace scf


### PR DESCRIPTION
## Description
The old instability following procedure Trotterized a matrix exponential. Now we compute it (more or less) exactly.

Obligatory @susilehtola ping.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Modified the orbital instability following procedure. This should be a minor change for most applications: contact developers if you notice a problem.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Change the algorithm we use to approximate a matrix exponential when instability following from a Trotter approximation to that of the build-in `expm` function.
- [x] Added documentation for the rationale for the orbital rotation step.

## Questions
- [ ] **Warning!** None of our tests cover instability following. I've run a check that the old and new codes mostly agree for the particular instability I'm trying to track. Is this an issue?

## Status
- [x] Ready for review
- [ ] Ready for merge after discussion
