### PR TITLE
Fix crash on CBS finite-difference with zero dipole moment

### DIFF
--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -1702,24 +1702,24 @@ class CompositeComputer(BaseComputer):
             qcvars[f"CBS {self.cbsrec[dc]['d_stage'].upper()} TOTAL ENERGY"] = self.cbsrec[dc]["d_energy"] - self.cbsrec[dc + 1]["d_energy"]
 
         G0 = assembled_results["gradient"]
-        if np.count_nonzero(G0):
+        if G0 is not None:
             qcvars["CURRENT GRADIENT"] = G0
             qcvars["CBS TOTAL GRADIENT"] = G0
             properties["return_gradient"] = G0
 
         H0 = assembled_results["hessian"]
-        if np.count_nonzero(H0):
+        if H0 is not None:
             qcvars["CURRENT HESSIAN"] = H0
             qcvars["CBS TOTAL HESSIAN"] = H0
             properties["return_hessian"] = H0
 
         D0 = assembled_results["dipole"]
-        if np.count_nonzero(D0):
+        if D0 is not None:
             qcvars["CURRENT DIPOLE"] = D0
             qcvars["CBS DIPOLE"] = D0
 
         DD0 = assembled_results["dipole gradient"]
-        if np.count_nonzero(DD0):
+        if DD0 is not None:
             qcvars["CURRENT DIPOLE GRADIENT"] = DD0
             qcvars["CBS DIPOLE GRADIENT"] = DD0
 

--- a/psi4/driver/driver_findif.py
+++ b/psi4/driver/driver_findif.py
@@ -1359,8 +1359,9 @@ class FiniteDifferenceComputer(BaseComputer):
             self.findifrec["reference"][self.driver.name] = G0
 
         elif self.metameta['mode'] == '2_1':
-            DD0 = assemble_dipder_from_dipoles(self.findifrec, self.metameta['irrep'])
-            self.findifrec["reference"]["dipole derivative"] = DD0
+            if dipole_available:
+                DD0 = assemble_dipder_from_dipoles(self.findifrec, self.metameta['irrep'])
+                self.findifrec["reference"]["dipole derivative"] = DD0
 
             H0 = assemble_hessian_from_gradients(self.findifrec, self.metameta['irrep'])
             self.findifrec["reference"][self.driver.name] = H0


### PR DESCRIPTION
## Description
I recently discovered a bug where CBS finite-difference Hessians will crash on systems with zero dipole moment. This is due to `CompositeComputer` not loading a dipole with entries all exactly zero into qcvars. This fix checks that CBS results are not None rather than have any non-zero entries before loading into qcvars. I have verified that this fixes the crash and that e.g. non-existing Hessians are stiil not loaded into result qcvars.



## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Fixed a bug causing CBS extrapolated finite-difference Hessians to crash on systems with zero dipole moment.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `CompositeComputer` loads variables with zero'd entries in qcvars.
- [x] `FiniteDifferenceComputer` checks for dipoles when doing finite-difference by gradients.

## Checklist
- [x] cbs tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
