### PR TITLE
PK Bugfix 

### DIFF
--- a/conda/win/meta.yaml
+++ b/conda/win/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - numpy
     - pytest>=7.0.1
     - python={{ PY_VER }}
-    - qcelemental=0.25.0
+    - qcelemental=0.25.1
     - qcengine=0.24.1
     - msgpack-python
     - gau2grid

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -1472,6 +1472,7 @@ void PKMgrInCore::allocate_buffers() {
 
     // TODO We probably need more buffer for more tasks for better load balancing
     size_t buffer_size = pk_size() / nthreads();
+    if (buffer_size == 0) buffer_size = 1;
     size_t lastbuf = pk_size() % nthreads();
 
     for (size_t i = 0; i < nthreads(); ++i) {

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -176,6 +176,11 @@ PKManager::PKManager(std::shared_ptr<BasisSet> primary, size_t memory, Options& 
     nthreads_ = 1;
 #ifdef _OPENMP
     nthreads_ = Process::environment.get_n_threads();
+    if (nthreads_ > pk_size_) {
+	outfile->Printf("  WARNING! More threads than unique shell quartets to compute!\n");
+	outfile->Printf("  Decreasing thread count to %d.\n", pk_size_);	
+	nthreads_ = pk_size_;
+    }
 #endif
 }
 
@@ -1472,7 +1477,6 @@ void PKMgrInCore::allocate_buffers() {
 
     // TODO We probably need more buffer for more tasks for better load balancing
     size_t buffer_size = pk_size() / nthreads();
-    if (buffer_size == 0) buffer_size = 1;
     size_t lastbuf = pk_size() % nthreads();
 
     for (size_t i = 0; i < nthreads(); ++i) {


### PR DESCRIPTION
## Description
This PR fixes the bug in the PK code brought up in https://github.com/psi4/psi4/issues/2760. It was observed that, for sufficiently small systems and small basis sets run in parallel, the calculation would converge to random energies. After some investigation, it was found that the buffer size assigned per thread in the PK algorithm could potentially be set to zero:

```    
    size_t buffer_size = pk_size() / nthreads(); // DP: can be set to 0 in edge cases
    size_t lastbuf = pk_size() % nthreads();

    for (size_t i = 0; i < nthreads(); ++i) {
        // DEBUG        outfile->Printf("start is %lu\n",start);
        SharedPKWrkr buf = std::make_shared<PKWrkrInCore>(primary(), sieve(), buffer_size, lastbuf, J_ints_.get(),
                                                          K_ints_.get(), wK_ints_.get(), nthreads());
        fill_buffer(buf);
        set_ntasks(nthreads());
    }
```

This leads to very unusual behavior occurring within the PK algorithm and is the root cause of the issue brought up regarding the PKJK algorithm. To address this issue, the buffer size per thread is always set to have at least a value of 1. When a minimum buffer size is enforced, the issue presented in https://github.com/psi4/psi4/issues/2760 disappears. Additionally, with these changes, the PK option produces the same answer as the DIRECT algorithm for the system in question (the H atom):

```
(p4dev) dpoole34@ds6:~$ cat minimal_example.py 
import psi4
import argparse

parser = argparse.ArgumentParser()
parser.add_argument('--num_threads', type=int, default=1)
parser.add_argument('--scf_type', type=str, default='DF')
parser.add_argument('--element', type=int, default=1)
parser.add_argument('--multiplicity', type=int, default=2)
args = parser.parse_args()

psi4.core.be_quiet()  # Silence output for clarity.
psi4.set_num_threads(args.num_threads, quiet=True)
psi4.set_options({
  'REFERENCE': 'UHF',
  'SCF_TYPE': args.scf_type,
})

for i in range(10):
  energy = psi4.energy(
    'pbe0/sto-3g',
    molecule=psi4.core.Molecule.from_arrays(
        geom=[0, 0, 0],
        elez=[args.element],
        molecular_charge=0,
        molecular_multiplicity=args.multiplicity))
  print(energy)
(p4dev) dpoole34@ds6:~$ python3 minimal_example.py --num_threads 6 --scf_type PK --element 1 --multiplicity 2
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
(p4dev) dpoole34@ds6:~$ python3 minimal_example.py --num_threads 6 --scf_type DIRECT --element 1 --multiplicity 2
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
-0.466509139020904
```
## User API & Changelog headlines

## Dev notes & details
- [x] Fix bug present within PK calculations executed on small systems with small basis sets, wherein random energies would result from the calculation.

## Questions

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
