### PR TITLE
Implement interface with pyddx

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -204,6 +204,7 @@ jobs:
             # pip
           - pip
           - pip:
+             - pyddx
              - git+https://github.com/i-pi/i-pi.git@master-py3
         EOF
         cat > aux.yaml <<EOF

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -204,7 +204,6 @@ jobs:
             # pip
           - pip
           - pip:
-             - pyddx
              - git+https://github.com/i-pi/i-pi.git@master-py3
         EOF
         cat > aux.yaml <<EOF
@@ -222,6 +221,7 @@ jobs:
           - geometric
           - openfermion>=1.0
           - openfermionpsi4
+          - pyddx
           - pymdi
           - qcengine=0.25.0
 
@@ -273,6 +273,7 @@ jobs:
           - geometric
           #- psi4/label/dev::mp2d
           #- openfermionpsi4
+          #- pyddx
           - pymdi
           - psi4/label/dev::resp
           - psi4/label/dev::snsmp2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ option(ENABLE_ambit "Enables the ambit tensor library" OFF)
 option(ENABLE_CheMPS2 "Enables CheMPS2 for DMRG (requires HDF5)" OFF)
 option(ENABLE_cppe "Enables CPPE for Polarizable Embedding" OFF)
 option(ENABLE_adcc "Enables adcc for algebraic-diagrammatic construction methods (requires libtensorlight; can also be added at runtime)" OFF)
+option(ENABLE_ddx "Enables ddx for domain-decomposition contiuum solvation models (requires Fortran; can also be added at runtime)" OFF)
 option(ENABLE_dkh "Enables DKH integrals (requires Fortran)" OFF)
 option(ENABLE_ecpint "Enables libecpint for effective core potentials (ECP)" OFF)
 option(ENABLE_libefp "Enables LIBEFP and PylibEFP for fragments" OFF)
@@ -230,6 +231,7 @@ ExternalProject_Add(psi4-core
            libint_external
            libint2_external
            pcmsolver_external
+           ddx_external
            pybind11_external
            pylibefp_external
            qcelemental_external
@@ -273,6 +275,7 @@ ExternalProject_Add(psi4-core
               -DENABLE_simint=${ENABLE_simint}
               -DENABLE_gdma=${ENABLE_gdma}
               -DENABLE_PCMSolver=${ENABLE_PCMSolver}
+              -DENABLE_ddx=${ENABLE_ddx}
               -DENABLE_mdi=${ENABLE_mdi}
               -DENABLE_BrianQC=${ENABLE_BrianQC}
               -DENABLE_OPENMP=${ENABLE_OPENMP}
@@ -291,6 +294,7 @@ ExternalProject_Add(psi4-core
               -DLibint2_DIR=${Libint2_DIR}
               -Dlibint2_DIR=${Libint2_DIR}
               -DPCMSolver_DIR=${PCMSolver_DIR}
+              -Dddx_DIR=${ddx_DIR}
               -Dmdi_DIR=${mdi_DIR}
               -Dpybind11_DIR=${pybind11_DIR}
               -Dpylibefp_DIR=${pylibefp_DIR}

--- a/doc/sphinxman/CMakeLists.txt
+++ b/doc/sphinxman/CMakeLists.txt
@@ -47,7 +47,7 @@ if(PERL_FOUND AND SPHINX_FOUND AND SPHINX_STUFF_FOUND)
 
     # Static-doc reST files
     set(STATICDOC abbr_accents.rst adc.rst adcc.rst appendices.rst basissets.rst
-    basissets_byelement.rst bibliography.rst cbs.rst cbs_eqn.rst
+    basissets_byelement.rst bibliography.rst cbs.rst cbs_eqn.rst ddx.rst
     nbody.rst customizing.rst db.rst detci.rst dfmp2.rst dlpnomp2.rst
     diatomic.rst documentation.rst energy.rst external.rst fchk.rst
     freq.rst gdma.rst glossary_psivariables.rst index.rst intercalls.rst

--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -385,9 +385,9 @@ Bibliography
    R. Cammi,
    *J. Chem. Phys.* **131**, 164104 (2009).
 
-.. [Barone:1998:1995]
-   V. Barone and M. Cossi,
-   *J. Phys. Chem. A* **102**, 1995 (1998).
+.. [Klamt:1993:799]
+   A. Klamt, and G. Schüürmann
+   *J. Chem. Soc., Perkin Trans. 2* **5**, 799 (1993).
 
 .. [Tomasi:2005:2999]
    J. Tomasi, B. Mennucci, and R. Cammi
@@ -404,6 +404,14 @@ Bibliography
 .. [Stamm:2016:054101]
    B. Stamm, E. Cancès, F. Lipparini, Y. Maday
    *J. Chem. Phys.* **144**, 054101 (2016).
+
+.. [Lipparini:2014:184108]
+   F. Lipparini, G. Scalmani, L. Lagardère, B. Stamm, E. Cancès, Y. Maday, J.-P. Piquemal, M. Frisch, B. Mennucci
+   *J. Chem. Phys.* **141**, 184108 (2014).
+
+.. [Nottoli:2019:6061]
+   M. Nottoli, B. Stamm, G. Scalmani, F. Lipparini
+   *J. Chem. Theory Comput.* **15**, 6061 (2019).
 
 .. [Bondi:1964:441]
    A. Bondi

--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -405,6 +405,14 @@ Bibliography
    B. Stamm, E. Cancès, F. Lipparini, Y. Maday
    *J. Chem. Phys.* **144**, 054101 (2016).
 
+.. [Bondi:1964:441]
+   A. Bondi
+   *J. Phys. Chem.* **68**, 441 (1964).
+
+.. [Rappe:1992:114]
+   A. K. Rappe, C. J. Casewit, K. S. Colwell, W. A. Goddard III, W. M. Skiff
+   *J. Am. Chem. Soc.*, **25**, 114 (1992).
+
 .. [McGibbon:2017:161725]
    R. T. McGibbon, A. G. Taube, A. G. Donchev, K. Siva, F. Hern\ |a_acute|\ andez, C. Hargus, K. H. Law, J. L. Klepeis, D. E. Shaw
    *J. Chem. Phys.* **147**, 161725 (2017).

--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -394,11 +394,11 @@ Bibliography
    *Chem. Rev.* **105**, 2999 (2005).
 
 .. [Cances:1998:309]
-   E. Cances, B. Mennucci
+   E. Canc\ |e_grave|\ s, B. Mennucci
    *J. Math. Chem.* **23**, 309 (1998).
 
 .. [Cances:2013:054111]
-   E. Cances, Y. Maday, B. Stamm
+   E. Canc\ |e_grave|\ s, Y. Maday, B. Stamm
    *J. Chem. Phys.* **139**, 054111 (2013).
 
 .. [Stamm:2016:054101]

--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -385,9 +385,25 @@ Bibliography
    R. Cammi,
    *J. Chem. Phys.* **131**, 164104 (2009).
 
+.. [Barone:1998:1995]
+   V. Barone and M. Cossi,
+   *J. Phys. Chem. A* **102**, 1995 (1998).
+
 .. [Tomasi:2005:2999]
    J. Tomasi, B. Mennucci, and R. Cammi
    *Chem. Rev.* **105**, 2999 (2005).
+
+.. [Cances:1998:309]
+   E. Cances, B. Mennucci
+   *J. Math. Chem.* **23**, 309 (1998).
+
+.. [Cances:2013:054111]
+   E. Cances, Y. Maday, B. Stamm
+   *J. Chem. Phys.* **139**, 054111 (2013).
+
+.. [Stamm:2016:054101]
+   B. Stamm, E. Cancès, F. Lipparini, Y. Maday
+   *J. Chem. Phys.* **144**, 054101 (2016).
 
 .. [McGibbon:2017:161725]
    R. T. McGibbon, A. G. Taube, A. G. Donchev, K. Siva, F. Hern\ |a_acute|\ andez, C. Hargus, K. H. Law, J. L. Klepeis, D. E. Shaw

--- a/doc/sphinxman/source/build_planning.rst
+++ b/doc/sphinxman/source/build_planning.rst
@@ -344,6 +344,8 @@ Additionally, there are runtime-loaded capabilities:
 
 * MDI |w---w| https://github.com/MolSSI-MDI/MDI_Library
 
+* :ref:`ddx <sec:ddx>` |w---w| https://github.com/ddsolvation/ddx
+
 
 .. _`faq:condapsi4dev`:
 

--- a/doc/sphinxman/source/conda.rst
+++ b/doc/sphinxman/source/conda.rst
@@ -179,7 +179,7 @@ Activate environment and make the adjustments to :envvar:`PATH` and
 
 * The ``psi4-rt`` package can be added to the package list to get the
   QC runtime add-ons; could say any combination of ``v2rdm_casscf snsmp2
-  openfermion-psi4 adcc cppe`` etc. instead of ``psi4-rt``.
+  openfermion-psi4 adcc cppe ddx`` etc. instead of ``psi4-rt``.
 
 * Grab a Miniconda through one of the below, selecting OS.
 

--- a/doc/sphinxman/source/ddx.rst
+++ b/doc/sphinxman/source/ddx.rst
@@ -54,8 +54,8 @@ Interface to ddx by A. Mikhalev, A. Jha, M. Nottoli and M. F. Herbst
 by A. Mikhalev *et. al.*. The library provides a linear-scaling implementation
 of standard continuum solvation models using a domain-decomposition ansatz
 [Cances:2013:054111]_ [Stamm:2016:054101]_.
-Currently the conductor-like screening model (COSMO) [Barone:1998:1995]_
-and the polarisable continuum model (PCM) [Tomasi:2005:2999]_
+Currently the conductor-like screening model (COSMO) [Klamt:1993:799]_ [Lipparini:2014:184108]_
+and the polarisable continuum model (PCM) [Tomasi:2005:2999]_ [Nottoli:2019:6061]_
 are supported.
 No additional licence or configuration is required to use ddx with Psi4.
 
@@ -98,8 +98,9 @@ PCMSolver is based on a boundary-element discretisation [Cances:1998:309]_,
 while ddx is based on a domain decomposition approach
 [Cances:2013:054111]_ making it linear scaling.
 For more details about PCMSolver see the :ref:`section on PCMsolver <sec:pcmsolver>`.
-For a concise introduction to the `theory behind ddx <https://ddsolvation.github.io/ddX/md_docs_theory.html>`
-or further `literature references <https://ddsolvation.github.io/ddX/label_references.html>`
+For a concise introduction to the
+`theory behind ddx <https://ddsolvation.github.io/ddX/md_docs_theory.html>`_
+or further `literature references <https://ddsolvation.github.io/ddX/label_references.html>`_
 see the ddx documentation.
 
 The usage of ddx-based solvation models is enabled
@@ -194,12 +195,12 @@ of the implict description of the solvation.
 
 |ddx__dft_radial_points| and |ddx__dft_spherical_points| influence
 the accuracy of the numerical grid used to obtain the representation
-of the electric field of the solute density
-(for which a standard DFT integration grid is used).
-Unlike the case for DFT grids a finer grid than the employed default is
-rarely needed. In fact often even a coarser grid than the default
-can be used without trading too much accuracy
-(e.g. 50 radial and 230 spherical points).
+of the electric potential / field of the solute density,
+since a standard DFT integration grid is used to obtain these quantities.
+In contrast to the integration of DFT quantities much lower accuracy
+is required, such that for this step considerably smaller grids are employed.
+If extremly high accuracy reference solutions are required, the DDX
+DFT integration parameters might need to be increased, but this is rarely needed.
 
 |ddx__lmax| and |ddx__n_lebedev| determine the accuracy of the discretisation
 on the boundary of the spheres around each atom. The defaults are usually good.

--- a/doc/sphinxman/source/ddx.rst
+++ b/doc/sphinxman/source/ddx.rst
@@ -98,6 +98,9 @@ PCMSolver is based on a boundary-element discretisation [Cances:1998:309]_,
 while ddx is based on a domain decomposition approach
 [Cances:2013:054111]_ making it linear scaling.
 For more details about PCMSolver see the :ref:`section on PCMsolver <sec:pcmsolver>`.
+For a concise introduction to the `theory behind ddx <https://ddsolvation.github.io/ddX/md_docs_theory.html>`
+or further `literature references <https://ddsolvation.github.io/ddX/label_references.html>`
+see the ddx documentation.
 
 The usage of ddx-based solvation models is enabled
 by specifying |globals__ddx| ``true`` in your input file.

--- a/doc/sphinxman/source/ddx.rst
+++ b/doc/sphinxman/source/ddx.rst
@@ -169,8 +169,8 @@ The full list understood by ddx can be obtained using ::
 The **cavity** in ddx is defined as a union of spheres around each atom.
 Usually the spehere radii for each atom are determined using a standard
 set of tabulated radii per atomic species, determined by the |ddx__radii_set| parameter.
-Currently ``bondi`` and ``uff`` are supported for |ddx__radii_set|
-with ``uff`` selected by default.
+Currently ``bondi`` [Bondi:1964:441]_ and ``uff`` [Rappe:1992:114]_
+are supported for |ddx__radii_set| with ``uff`` selected by default.
 These radius values are conventionally scaled by an additional factor before use,
 conventionally 1.1 for ``uff`` and 1.2 for ``bondi``. Customisation of the scaling
 is possible using the |ddx__radii_scaling| parameter.

--- a/doc/sphinxman/source/ddx.rst
+++ b/doc/sphinxman/source/ddx.rst
@@ -1,0 +1,228 @@
+.. #
+.. # @BEGIN LICENSE
+.. #
+.. # Psi4: an open-source quantum chemistry software package
+.. #
+.. # Copyright (c) 2007-2022 The Psi4 Developers.
+.. #
+.. # The copyrights for code used from other parties are included in
+.. # the corresponding files.
+.. #
+.. # This file is part of Psi4.
+.. #
+.. # Psi4 is free software; you can redistribute it and/or modify
+.. # it under the terms of the GNU Lesser General Public License as published by
+.. # the Free Software Foundation, version 3.
+.. #
+.. # Psi4 is distributed in the hope that it will be useful,
+.. # but WITHOUT ANY WARRANTY; without even the implied warranty of
+.. # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.. # GNU Lesser General Public License for more details.
+.. #
+.. # You should have received a copy of the GNU Lesser General Public License along
+.. # with Psi4; if not, write to the Free Software Foundation, Inc.,
+.. # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+.. #
+.. # @END LICENSE
+.. #
+
+.. include:: autodoc_abbr_options_c.rst
+
+.. index:: ddx, COSMO, PCM, continuum solvation
+
+.. _`sec:ddx`:
+
+Interface to ddx by A. Mikhalev, A. Jha, M. Nottoli and M. F. Herbst
+====================================================================
+
+.. codeauthor:: Michael F. Herbst
+.. sectionauthor:: Michael F. Herbst
+
+*Module:* :ref:`Keywords <apdx:ddx>`, :ref:`PSI Variables <apdx:ddx_psivar>`
+
+.. image:: https://img.shields.io/badge/home-ddx-informational.svg
+   :target: https://github.com/ddsolvation/ddX
+
+.. raw:: html
+
+   <br>
+
+.. image:: https://img.shields.io/badge/docs-latest-5077AB.svg
+   :target: https://ddsolvation.github.io/ddX/
+
+|PSIfour| contains code to interface to the ddx FORTRAN library developed
+by A. Mikhalev *et. al.*. The library provides a linear-scaling implementation
+of standard continuum solvation models using a domain-decomposition ansatz
+[Cances:2013:054111]_ [Stamm:2016:054101]_.
+Currently the conductor-like screening model (COSMO) [Barone:1998:1995]_
+and the polarisable continuum model (PCM) [Tomasi:2005:2999]_
+are supported.
+No additional licence or configuration is required to use ddx with Psi4.
+
+
+Installation
+~~~~~~~~~~~~
+
+**Binary**
+
+* .. image:: https://anaconda.org/conda-forge/pyddx/badges/version.svg
+     :target: https://anaconda.org/conda-forge/pyddx
+
+* .. image:: https://img.shields.io/pypi/v/pyddx
+     :target: https://pypi.org/project/pyddx
+
+* ddx is available for Linux and macOS in form of the ``pyddx`` package
+  on conda-forge and on pypi.
+
+* To install from conda run ``conda install pyddx -c conda-forge``.
+
+* To remove a conda installation, ``conda remove pyddx``.
+
+**Source**
+
+* .. image:: https://img.shields.io/github/tag-date/ddsolvation/ddx.svg?maxAge=2592000
+     :target: https://github.com/ddsolvation/ddx
+
+* If using |PSIfour| built from source and you want ddx installed as well,
+  enable it as a feature with :makevar:`ENABLE_ddx`,
+  and let the build system fetch and install it.
+
+.. _`sec:usingDDX`:
+
+Using dd-based continum solvation models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In |PSIfour| two option to enable continuum solvation models
+are currently implemented using either the PCMSolver or ddx package.
+PCMSolver is based on a boundary-element discretisation [Cances:1998:309]_,
+while ddx is based on a domain decomposition approach
+[Cances:2013:054111]_ making it linear scaling.
+For more details about PCMSolver see the :ref:`section on PCMsolver <sec:pcmsolver>`.
+
+The usage of ddx-based solvation models is enabled
+by specifying |globals__ddx| ``true`` in your input file.
+The solvation model itself is selected using the |ddx__model| parameter.
+
+|Psifour| understands a number of other options to configure
+numerical details in the library (discretisation, iterative solver, cavity setup),
+see the next section.
+
+.. note:: At present dd-based solvation models
+          can only be used for energy calculations with SCF
+          wavefunctions. All ERI algorithms (``PK``, ``OUT_OF_CORE``, ``DIRECT``, ``DF``,
+          ``CD``) are supported.
+
+.. warning:: Currently the ddx interface **cannot** exploit molecular point group symmetry.
+
+.. warning:: Analytic gradients and Hessians are currently **not available**
+             with dd-based solvation models.
+
+A minimal input for a Hartree--Fock calculation with dd-based PCM would look like
+the following: ::
+
+    import psi4
+    nh3 = psi4.geometry("""
+        N     -0.0000000001    -0.1040380466      0.0000000000
+        H     -0.9015844116     0.4818470201     -1.5615900098
+        H     -0.9015844116     0.4818470201      1.5615900098
+        H      1.8031688251     0.4818470204      0.0000000000
+        symmetry c1
+        no_reorient
+        no_com
+        units bohr
+        """)
+
+    psi4.set_options({
+        "basis": "sto-3g",
+        "scf_type": "pk",
+        "ddx": True,
+    })
+
+    psi4.set_module_options("ddx", {
+        "model":     "pcm",
+        "solvent":   "water",
+        "radii_set": "uff",
+    })
+
+    scf_e = psi4.energy('SCF')
+
+
+Cavity and solvent setup
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+.. include:: autodir_options_c/globals__ddx.rst
+.. include:: autodir_options_c/ddx__model.rst
+.. include:: autodir_options_c/ddx__radii.rst
+.. include:: autodir_options_c/ddx__radii_scaling.rst
+.. include:: autodir_options_c/ddx__radii_set.rst
+.. include:: autodir_options_c/ddx__solvent_epsilon.rst
+.. include:: autodir_options_c/ddx__solvent.rst
+
+Numerical integration and discretisation parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+.. include:: autodir_options_c/ddx__dft_radial_points.rst
+.. include:: autodir_options_c/ddx__dft_spherical_points.rst
+.. include:: autodir_options_c/ddx__lmax.rst
+.. include:: autodir_options_c/ddx__n_lebedev.rst
+
+Iterative solver parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These parameters determine how the forward and adjoint linear systems
+of the solvation model are solved. Usually these parameters do not need
+to be changed. Occasionally |ddx__solvation_convergence| might need to be adapted,
+e.g. if only a very crude or a highly accurate SCF solution is targeted.
+
+.. include:: autodir_options_c/ddx__diis_max_vecs.rst
+.. include:: autodir_options_c/ddx__maxiter.rst
+.. include:: autodir_options_c/ddx__solvation_convergence.rst
+
+Further keywords for ddx
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: autodir_options_c/ddx__eta.rst
+.. include:: autodir_options_c/ddx__fmm_local_lmax.rst
+.. include:: autodir_options_c/ddx__fmm_multipole_lmax.rst
+.. include:: autodir_options_c/ddx__fmm.rst
+.. include:: autodir_options_c/ddx__incore.rst
+.. include:: autodir_options_c/ddx__logfile.rst
+.. include:: autodir_options_c/ddx__shift.rst
+
+
+.. _`cmake:ddx`:
+
+How to configure ddx for building Psi4
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Role and Dependencies**
+
+* Role |w---w| In |PSIfour|, ddx is a library for providing fast continuum
+  solvation models.
+
+* Downstream Dependencies |w---w| |PSIfour| (\ |dr| optional) ddx
+
+* Upstream Dependencies |w---w| ddx |dr| Fortran
+
+**CMake Variables**
+
+* :makevar:`ENABLE_ddx` |w---w| CMake variable toggling whether Psi4 automatically installs ddx
+
+**Examples**
+
+A. Build and install ddx if needed
+
+  .. code-block:: bash
+
+    >>> cmake -DENABLE_ddx=ON
+
+B. Build *without* ddx
+
+  .. code-block:: bash
+
+    >>> cmake
+

--- a/doc/sphinxman/source/ddx.rst
+++ b/doc/sphinxman/source/ddx.rst
@@ -105,7 +105,7 @@ see the ddx documentation.
 
 The usage of ddx-based solvation models is enabled
 by specifying |globals__ddx| ``true`` in your input file.
-The solvation model itself is selected using the |ddx__model| parameter.
+The solvation model itself is selected using the |ddx__ddx_model| parameter.
 Additionally the definition of the solvent and solute cavity is required
 and further parameters allow to influence details of discretisation,
 numerical integration and iterative solvers,
@@ -140,9 +140,9 @@ the following: ::
         "basis": "sto-3g",
         "scf_type": "pk",
         "ddx": True,
-        "ddx__model":     "pcm",
-        "ddx__solvent":   "water",
-        "ddx__radii_set": "uff",
+        "ddx_model":     "pcm",
+        "ddx_solvent":   "water",
+        "ddx_radii_set": "uff",
     })
 
     scf_e = psi4.energy('SCF')
@@ -151,14 +151,14 @@ Solvent model and solvent cavity definition
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Beyond setting |globals__ddx| to ``true`` and selecting
-a solvent model using |ddx__model|,
+a solvent model using |ddx__ddx_model|,
 the definition of the solvent is mandatory.
 Regularly one might want to influence the setup of the solvent
 cavity as well.
 
 The **solvent** can be defined either by directly providing a dielectric
-constant using |ddx__solvent_epsilon| or by looking up the dielectric
-constant in from a solvent trivial name provided by |ddx__solvent|
+constant using |ddx__ddx_solvent_epsilon| or by looking up the dielectric
+constant in from a solvent trivial name provided by |ddx__ddx_solvent|
 (e.g. ``water``, ``ethanol``, ``cis-1,2-dimethylcyclohexane``).
 By convention solvent names are all lowercase and use dashes (``-``) to separate
 quantifiers like ``o``, ``n`` etc.
@@ -169,23 +169,23 @@ The full list understood by ddx can be obtained using ::
 
 The **cavity** in ddx is defined as a union of spheres around each atom.
 Usually the spehere radii for each atom are determined using a standard
-set of tabulated radii per atomic species, determined by the |ddx__radii_set| parameter.
+set of tabulated radii per atomic species, determined by the |ddx__ddx_radii_set| parameter.
 Currently ``bondi`` [Bondi:1964:441]_ and ``uff`` [Rappe:1992:114]_
-are supported for |ddx__radii_set| with ``uff`` selected by default.
+are supported for |ddx__ddx_radii_set| with ``uff`` selected by default.
 These radius values are conventionally scaled by an additional factor before use,
 conventionally 1.1 for ``uff`` and 1.2 for ``bondi``. Customisation of the scaling
-is possible using the |ddx__radii_scaling| parameter.
+is possible using the |ddx__ddx_radii_scaling| parameter.
 A more fine-grained control over the sphere radii is available by explicitly providing
 a list of radii (one per atom, exactly in the order of the input geometry)
-using the |ddx__radii| parameter.
+using the |ddx__ddx_radii| parameter.
 
 .. include:: autodir_options_c/globals__ddx.rst
-.. include:: autodir_options_c/ddx__model.rst
-.. include:: autodir_options_c/ddx__radii.rst
-.. include:: autodir_options_c/ddx__radii_scaling.rst
-.. include:: autodir_options_c/ddx__radii_set.rst
-.. include:: autodir_options_c/ddx__solvent_epsilon.rst
-.. include:: autodir_options_c/ddx__solvent.rst
+.. include:: autodir_options_c/ddx__ddx_model.rst
+.. include:: autodir_options_c/ddx__ddx_radii.rst
+.. include:: autodir_options_c/ddx__ddx_radii_scaling.rst
+.. include:: autodir_options_c/ddx__ddx_radii_set.rst
+.. include:: autodir_options_c/ddx__ddx_solvent_epsilon.rst
+.. include:: autodir_options_c/ddx__ddx_solvent.rst
 
 Numerical integration and discretisation parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -193,49 +193,54 @@ Numerical integration and discretisation parameters
 These parameters can be altered to balance the cost and accuracy
 of the implict description of the solvation.
 
-|ddx__dft_radial_points| and |ddx__dft_spherical_points| influence
+|ddx__ddx_solute_radial_points| and |ddx__ddx_solute_spherical_points| influence
 the accuracy of the numerical grid used to obtain the representation
 of the electric potential / field of the solute density,
 since a standard DFT integration grid is used to obtain these quantities.
 In contrast to the integration of DFT quantities much lower accuracy
 is required, such that for this step considerably smaller grids are employed.
-If extremly high accuracy reference solutions are required, the DDX
+If extremely high accuracy reference solutions are required, the DDX
 DFT integration parameters might need to be increased, but this is rarely needed.
 
-|ddx__lmax| and |ddx__n_lebedev| determine the accuracy of the discretisation
-on the boundary of the spheres around each atom. The defaults are usually good.
+|ddx__ddx_lmax| and |ddx__ddx_n_lebedev| determine the accuracy of the computations
+on the boundary of the spheres around each atom performed by DDX. |ddx__ddx_lmax|
+determines the largest angular momentum of the spherical harmonics basis used
+to discretise quantities on the atomic spheres and |ddx__ddx_n_lebedev| determines the
+number of points of the Lebedev angular grid used for integration on the spheres.
+|ddx__ddx_n_lebedev| should be chosen higher than |ddx__ddx_solute_spherical_points|
+and the defaults are usually good.
 
-.. include:: autodir_options_c/ddx__dft_radial_points.rst
-.. include:: autodir_options_c/ddx__dft_spherical_points.rst
-.. include:: autodir_options_c/ddx__lmax.rst
-.. include:: autodir_options_c/ddx__n_lebedev.rst
+.. include:: autodir_options_c/ddx__ddx_solute_radial_points.rst
+.. include:: autodir_options_c/ddx__ddx_solute_spherical_points.rst
+.. include:: autodir_options_c/ddx__ddx_lmax.rst
+.. include:: autodir_options_c/ddx__ddx_n_lebedev.rst
 
 Iterative solver parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These parameters determine how the forward and adjoint linear systems
 of the solvation model are solved. Usually these parameters do not need
-to be changed. Occasionally |ddx__solvation_convergence| might need to be adapted,
+to be changed. Occasionally |ddx__ddx_solvation_convergence| might need to be adapted,
 e.g. if only a very crude or a highly accurate SCF solution is targeted.
 
-.. include:: autodir_options_c/ddx__diis_max_vecs.rst
-.. include:: autodir_options_c/ddx__maxiter.rst
-.. include:: autodir_options_c/ddx__solvation_convergence.rst
+.. include:: autodir_options_c/ddx__ddx_diis_max_vecs.rst
+.. include:: autodir_options_c/ddx__ddx_maxiter.rst
+.. include:: autodir_options_c/ddx__ddx_solvation_convergence.rst
 
 Further keywords for ddx
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 These parameter should rarely require changes.
-In particular |ddx__eta|, |ddx__shift| and |ddx__logfile|
+In particular |ddx__ddx_eta|, |ddx__ddx_shift| and |ddx__ddx_logfile|
 are expert parameters and should not be altered beyond debugging.
 
-.. include:: autodir_options_c/ddx__eta.rst
-.. include:: autodir_options_c/ddx__fmm_local_lmax.rst
-.. include:: autodir_options_c/ddx__fmm_multipole_lmax.rst
-.. include:: autodir_options_c/ddx__fmm.rst
-.. include:: autodir_options_c/ddx__incore.rst
-.. include:: autodir_options_c/ddx__logfile.rst
-.. include:: autodir_options_c/ddx__shift.rst
+.. include:: autodir_options_c/ddx__ddx_eta.rst
+.. include:: autodir_options_c/ddx__ddx_fmm_local_lmax.rst
+.. include:: autodir_options_c/ddx__ddx_fmm_multipole_lmax.rst
+.. include:: autodir_options_c/ddx__ddx_fmm.rst
+.. include:: autodir_options_c/ddx__ddx_incore.rst
+.. include:: autodir_options_c/ddx__ddx_logfile.rst
+.. include:: autodir_options_c/ddx__ddx_shift.rst
 
 
 .. _`cmake:ddx`:

--- a/doc/sphinxman/source/glossary_psivariables.rst
+++ b/doc/sphinxman/source/glossary_psivariables.rst
@@ -1380,6 +1380,11 @@ PSI Variables by Alpha
 
    The energy contribution [E_h] from the polarizable continuum model for solvation.
 
+.. psivar:: DD SOLVATION ENERGY
+
+   The energy contribution [Eh] from continuum solvation models based on a
+   domain-decomposition ansatz.
+
 .. psivar:: PE ENERGY
 
    The energy contribution [E_h] from the polarizable embedding model for solvation.

--- a/doc/sphinxman/source/interfacing.rst
+++ b/doc/sphinxman/source/interfacing.rst
@@ -48,6 +48,7 @@ platform capabilities, *etc*.
    cfour
    chemps2
    cppe
+   ddx
    dftd3
    dkh
    ecpint

--- a/doc/sphinxman/source/pcmsolver.rst
+++ b/doc/sphinxman/source/pcmsolver.rst
@@ -28,7 +28,7 @@
 
 .. include:: autodoc_abbr_options_c.rst
 
-.. index:: PCMSolver, PCM
+.. index:: PCMSolver, PCM, continuum solvation
 
 .. _`sec:pcmsolver`:
 
@@ -98,7 +98,13 @@ Using the polarizable continuum model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The inclusion of a PCM description of the solvent into your calculation
-is achieved by setting |globals__pcm| ``true`` in your input file.
+can be achieved in two ways in |PSIfour|, using either the PCMSolver or ddx package.
+PCMSolver is based on a boundary-element discretisation [Cances:1998:309]_,
+while ddx is based on a domain decomposition approach
+[Cances:2013:054111]_ making it linear scaling.
+For more details about ddx see the :ref:`section on ddx <sec:ddx>`.
+
+Using PCMsolver is achieved instead by setting |globals__pcm| ``true`` in your input file.
 |Psifour| understands the additional option |pcm__pcm_scf_type| with possible values ``total``
 (the default) or ``separate``.
 The latter forces the separate handling of nuclear and electronic electrostatic potentials and

--- a/external/upstream/CMakeLists.txt
+++ b/external/upstream/CMakeLists.txt
@@ -20,6 +20,7 @@ foreach(dir
   simint
   libxc
   brianqc
+  ddx
   )
   add_subdirectory(${dir})
 endforeach()

--- a/external/upstream/ddx/CMakeLists.txt
+++ b/external/upstream/ddx/CMakeLists.txt
@@ -1,0 +1,37 @@
+if(${ENABLE_ddx})
+    if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_ddx}))
+        include(FindPythonModule)
+        find_python_module(pyddx ATLEAST 0.0.0 QUIET)
+    endif()
+
+    if(${pyddx_FOUND})
+        message(STATUS "${Cyan}Found ddx${ColourReset}: ${PY_pyddx} (found version ${pyddx_VERSION})")
+        add_library(ddx_external INTERFACE)  # dummy
+
+    else()
+        if(${CMAKE_INSIST_FIND_PACKAGE_ddx})
+            message(FATAL_ERROR "Suitable ddx could not be externally located as user insists")
+        endif()
+
+        include(ExternalProject)
+        message(STATUS "Suitable ddx could not be located, ${Magenta}Building ddx${ColourReset} instead.")
+
+	    file(TO_NATIVE_PATH "${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}" _install_lib)
+	    file(TO_NATIVE_PATH "${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}" _install_bin)
+
+        ExternalProject_Add(ddx_external
+            BUILD_ALWAYS 1
+            URL https://github.com/ACoM-Computational-Mathematics/ddX/archive/v0.2.0.tar.gz
+            CONFIGURE_COMMAND ""
+            UPDATE_COMMAND ""
+            BUILD_COMMAND ${Python_EXECUTABLE} setup.py build
+            BUILD_IN_SOURCE 1
+            INSTALL_COMMAND ${Python_EXECUTABLE} setup.py install
+                                                          --record=record.txt
+                                                          --single-version-externally-managed
+                                                          --install-scripts=${_install_bin}
+                                                          --install-lib=${_install_lib})
+    endif()
+else()
+    add_library(ddx_external INTERFACE)  # dummy
+endif()

--- a/external/upstream/ddx/CMakeLists.txt
+++ b/external/upstream/ddx/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(${ENABLE_ddx})
     if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_ddx}))
         include(FindPythonModule)
-        find_python_module(pyddx ATLEAST 0.0.4 QUIET)
+        find_python_module(pyddx ATLEAST 0.1.1 QUIET)
     endif()
 
     if(${pyddx_FOUND})
@@ -21,7 +21,7 @@ if(${ENABLE_ddx})
 
         ExternalProject_Add(ddx_external
             BUILD_ALWAYS 1
-            URL https://github.com/ddsolvation/ddX/archive/v0.0.4.tar.gz
+            URL https://github.com/ddsolvation/ddX/archive/v0.1.1.tar.gz
             CONFIGURE_COMMAND ""
             UPDATE_COMMAND ""
             BUILD_COMMAND ${Python_EXECUTABLE} setup.py build

--- a/external/upstream/ddx/CMakeLists.txt
+++ b/external/upstream/ddx/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(${ENABLE_ddx})
     if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_ddx}))
         include(FindPythonModule)
-        find_python_module(pyddx ATLEAST 0.1.1 QUIET)
+        find_python_module(pyddx ATLEAST 0.1.3 QUIET)
     endif()
 
     if(${pyddx_FOUND})
@@ -21,7 +21,7 @@ if(${ENABLE_ddx})
 
         ExternalProject_Add(ddx_external
             BUILD_ALWAYS 1
-            URL https://github.com/ddsolvation/ddX/archive/v0.1.1.tar.gz
+            URL https://github.com/ddsolvation/ddX/archive/v0.1.3.tar.gz
             CONFIGURE_COMMAND ""
             UPDATE_COMMAND ""
             BUILD_COMMAND ${Python_EXECUTABLE} setup.py build

--- a/external/upstream/ddx/CMakeLists.txt
+++ b/external/upstream/ddx/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(${ENABLE_ddx})
     if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_ddx}))
         include(FindPythonModule)
-        find_python_module(pyddx ATLEAST 0.0.0 QUIET)
+        find_python_module(pyddx ATLEAST 0.0.4 QUIET)
     endif()
 
     if(${pyddx_FOUND})
@@ -16,12 +16,12 @@ if(${ENABLE_ddx})
         include(ExternalProject)
         message(STATUS "Suitable ddx could not be located, ${Magenta}Building ddx${ColourReset} instead.")
 
-	    file(TO_NATIVE_PATH "${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}" _install_lib)
-	    file(TO_NATIVE_PATH "${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}" _install_bin)
+        file(TO_NATIVE_PATH "${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}" _install_lib)
+        file(TO_NATIVE_PATH "${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}" _install_bin)
 
         ExternalProject_Add(ddx_external
             BUILD_ALWAYS 1
-            URL https://github.com/ACoM-Computational-Mathematics/ddX/archive/v0.2.0.tar.gz
+            URL https://github.com/ddsolvation/ddX/archive/v0.0.4.tar.gz
             CONFIGURE_COMMAND ""
             UPDATE_COMMAND ""
             BUILD_COMMAND ${Python_EXECUTABLE} setup.py build

--- a/psi4/__init__.py
+++ b/psi4/__init__.py
@@ -96,6 +96,8 @@ if "@ENABLE_PCMSolver@".upper() in ["1", "ON", "YES", "TRUE", "Y"]:  # PCMSolver
     sys.path.insert(1, "@PCMSolver_PYMOD@")
 if "@ENABLE_cppe@".upper() in ["1", "ON", "YES", "TRUE", "Y"]:  # cppe
     sys.path.insert(1, "@cppe_PYMOD@")
+if "@ENABLE_ddx@".upper() in ["1", "ON", "YES", "TRUE", "Y"]:  # pyddx
+    sys.path.insert(1, "@pyddx_PYMOD@")
 if "@ENABLE_libefp@".upper() in ["1", "ON", "YES", "TRUE", "Y"]:  # pylibefp
     sys.path.insert(1, "@pylibefp_PYMOD@")
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1602,14 +1602,14 @@ def scf_helper(name, post_scf=True, **kwargs):
     elif _chkfile is True:
         write_checkpoint_file = True
 
-    # PCM needs to be run w/o symmetry
-    if core.get_option("SCF", "PCM"):
+    # Continuum solvation needs to be run w/o symmetry
+    if core.get_option("SCF", "PCM") or core.get_option("SCF", "DDX"):
         c1_molecule = scf_molecule.clone()
         c1_molecule.reset_point_group('c1')
         c1_molecule.update_geometry()
 
         scf_molecule = c1_molecule
-        core.print_out("""  PCM does not make use of molecular symmetry: """
+        core.print_out("""  PCM or DDX continuum solvation does not make use of molecular symmetry: """
                        """further calculations in C1 point group.\n""")
 
     # PE needs to use exactly input orientation to correspond to potfile

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1843,6 +1843,16 @@ def scf_helper(name, post_scf=True, **kwargs):
         pcm_print_level = core.get_option('SCF', "PRINT")
         scf_wfn.set_PCM(core.PCM(pcmsolver_parsed_fname, pcm_print_level, scf_wfn.basisset()))
 
+    # DDPCM preparation
+    if core.get_option('SCF', 'DDX'):
+        if not solvent._have_ddx:
+            raise ModuleNotFoundError('Python module ddx not found. Solve by installing it: `pip install pyddx`')
+        ddx_options = solvent.ddx.get_ddx_options(scf_molecule)
+        scf_wfn.ddx_state = solvent.ddx.DdxInterface(
+            molecule=scf_molecule, options=ddx_options,
+            basisset=scf_wfn.basisset()
+        )
+
     # PE preparation
     if core.get_option('SCF', 'PE'):
         if not solvent._have_pe:

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -319,8 +319,8 @@ def scf_iterate(self, e_conv=None, d_conv=None):
             uddx, Vddx = self.ddx_state.get_solvation_contributions(Dt)
             SCFE += uddx
             self.push_back_external_potential(Vddx)
-        self.set_variable("DDX ENERGY", uddx)  # P::e DDX
-        self.set_energies("DDX Energy", uddx)
+        self.set_variable("DD SOLVATION ENERGY", uddx)  # P::e DDX
+        self.set_energies("DD Solvation Energy", uddx)
 
         upe = 0.0
         if core.get_option('SCF', 'PE'):
@@ -712,13 +712,13 @@ def scf_print_energies(self):
     evv10 = self.get_energies('VV10')
     eefp = self.get_energies('EFP')
     epcm = self.get_energies('PCM Polarization')
-    eddx = self.get_energies('DDX Energy')
+    edd = self.get_energies('DD Solvation Energy')
     epe = self.get_energies('PE Energy')
     ke = self.get_energies('Kinetic')
 
     hf_energy = enuc + e1 + e2
     dft_energy = hf_energy + exc + ed + evv10
-    total_energy = dft_energy + eefp + epcm + eddx + epe
+    total_energy = dft_energy + eefp + epcm + edd + epe
     full_qm = (not core.get_option('SCF', 'PCM') and not core.get_option('SCF', 'DDX') and not core.get_option('SCF', 'PE')
                and not hasattr(self.molecule(), 'EFP'))
 
@@ -733,7 +733,7 @@ def scf_print_energies(self):
     if core.get_option('SCF', 'PCM'):
         core.print_out("    PCM Polarization Energy =         {:24.16f}\n".format(epcm))
     if core.get_option('SCF', 'DDX'):
-        core.print_out("    DDX Solvation Energy =            {:24.16f}\n".format(eddx))
+        core.print_out("    DD Solvation Energy =            {:24.16f}\n".format(edd))
     if core.get_option('SCF', 'PE'):
         core.print_out("    PE Energy =                       {:24.16f}\n".format(epe))
     if hasattr(self.molecule(), 'EFP'):

--- a/psi4/driver/procrouting/solvent/__init__.py
+++ b/psi4/driver/procrouting/solvent/__init__.py
@@ -33,6 +33,15 @@ A helper folder for solvent models
 _have_pe = False
 try:
     from . import pol_embed
+
     _have_pe = True
+except ImportError:
+    pass
+
+_have_ddx = False
+try:
+    from . import ddx
+
+    _have_ddx = True
 except ImportError:
     pass

--- a/psi4/driver/procrouting/solvent/ddx.py
+++ b/psi4/driver/procrouting/solvent/ddx.py
@@ -46,18 +46,18 @@ def get_ddx_options(molecule):
     else:
         convfac = 1.0
 
-    if core.has_option_changed("DDX", "RADII"):
-        radii = convfac * np.fromiter(core.get_option("DDX", "RADII"), float)
+    if core.has_option_changed("DDX", "DDX_RADII"):
+        radii = convfac * np.fromiter(core.get_option("DDX", "DDX_RADII"), float)
         if not radii.shape[0] == molecule.natom():
             raise ValidationError("Length of vector of custom cavity radii does "
                                   "not agree with number of atoms.")
     else:
-        radii_set = core.get_option("DDX", "RADII_SET").lower()
+        radii_set = core.get_option("DDX", "DDX_RADII_SET").lower()
         radii_lookup = getattr(pyddx.data, "radius_" + radii_set)
 
         # Use user-specified or ddx-recommended radius offset/scaling
-        if core.has_option_changed("DDX", "RADII_SCALING"):
-            radii_scaling = core.get_option("DDX", "RADII_SCALING")
+        if core.has_option_changed("DDX", "DDX_RADII_SCALING"):
+            radii_scaling = core.get_option("DDX", "DDX_RADII_SCALING")
         else:
             radii_scaling = getattr(pyddx.data, "radius_" + radii_set + "_scaling")
 
@@ -70,9 +70,9 @@ def get_ddx_options(molecule):
                                       "manually using the 'RADII' option.")
             radii[i] = radii_scaling * radii_lookup[element]
 
-    solvent = core.get_option("DDX", "SOLVENT").lower()
-    if core.has_option_changed("DDX", "SOLVENT_EPSILON"):
-        solvent_epsilon = core.get_option("DDX", "SOLVENT_EPSILON")
+    solvent = core.get_option("DDX", "DDX_SOLVENT").lower()
+    if core.has_option_changed("DDX", "DDX_SOLVENT_EPSILON"):
+        solvent_epsilon = core.get_option("DDX", "DDX_SOLVENT_EPSILON")
     elif solvent == "":
         raise ValidationError("Required option 'SOLVENT' is missing.")
     elif solvent not in pyddx.data.solvent_epsilon:
@@ -80,38 +80,38 @@ def get_ddx_options(molecule):
     else:
         solvent_epsilon = pyddx.data.solvent_epsilon[solvent]
 
-    fmm_multipole_lmax = core.get_option("DDX", "LMAX")
-    if core.has_option_changed("DDX", "FMM_MULTIPOLE_LMAX"):
-        fmm_multipole_lmax = core.get_option("DDX", "FMM_MULTIPOLE_LMAX")
+    fmm_multipole_lmax = core.get_option("DDX", "DDX_LMAX")
+    if core.has_option_changed("DDX", "DDX_FMM_MULTIPOLE_LMAX"):
+        fmm_multipole_lmax = core.get_option("DDX", "DDX_FMM_MULTIPOLE_LMAX")
 
     model_options = {
-        "model": core.get_option("DDX", "MODEL").lower(),
+        "model": core.get_option("DDX", "DDX_MODEL").lower(),
         "sphere_charges": np.array([molecule.Z(i) for i in range(molecule.natom())]),
         "sphere_centres": molecule.geometry().np.T,
         "sphere_radii": radii,
         "solvent_epsilon": solvent_epsilon,
-        "lmax": core.get_option("DDX", "LMAX"),
-        "n_lebedev": core.get_option("DDX", "N_LEBEDEV"),
-        "maxiter": core.get_option("DDX", "MAXITER"),
-        "jacobi_n_diis": core.get_option("DDX", "DIIS_MAX_VECS"),
+        "lmax": core.get_option("DDX", "DDX_LMAX"),
+        "n_lebedev": core.get_option("DDX", "DDX_N_LEBEDEV"),
+        "maxiter": core.get_option("DDX", "DDX_MAXITER"),
+        "jacobi_n_diis": core.get_option("DDX", "DDX_DIIS_MAX_VECS"),
         "n_proc": core.get_num_threads(),
-        "incore": core.get_option("DDX", "INCORE"),
-        "enable_fmm": core.get_option("DDX", "FMM"),
-        "fmm_local_lmax": core.get_option("DDX", "FMM_LOCAL_LMAX"),
+        "incore": core.get_option("DDX", "DDX_INCORE"),
+        "enable_fmm": core.get_option("DDX", "DDX_FMM"),
+        "fmm_local_lmax": core.get_option("DDX", "DDX_FMM_LOCAL_LMAX"),
         "fmm_multipole_lmax": fmm_multipole_lmax,
-        "logfile": core.get_option("DDX", "LOGFILE"),
-        "eta": core.get_option("DDX", "ETA"),
-        "shift": core.get_option("DDX", "SHIFT"),
+        "logfile": core.get_option("DDX", "DDX_LOGFILE"),
+        "eta": core.get_option("DDX", "DDX_ETA"),
+        "shift": core.get_option("DDX", "DDX_SHIFT"),
     }
     solver_options = {
-        "tol": core.get_option("DDX", "SOLVATION_CONVERGENCE"),
+        "tol": core.get_option("DDX", "DDX_SOLVATION_CONVERGENCE"),
     }
     grid_options = {
         # This overrides some DFT grid parameters just for the integrals
         # needed for DDX. The defaults are safe to avoid people from falling
         # into traps if they change their DFT grid setup.
-        "DFT_SPHERICAL_POINTS": core.get_option("DDX", "DFT_SPHERICAL_POINTS"),
-        "DFT_RADIAL_POINTS": core.get_option("DDX", "DFT_RADIAL_POINTS"),
+        "DFT_SPHERICAL_POINTS": core.get_option("DDX", "DDX_SOLUTE_SPHERICAL_POINTS"),
+        "DFT_RADIAL_POINTS": core.get_option("DDX", "DDX_SOLUTE_RADIAL_POINTS"),
         "DFT_NUCLEAR_SCHEME": "BECKE",  # Treutler and others might work here,
         "DFT_RADIAL_SCHEME": "BECKE",   # but this is so far untested with Psi4
         "DFT_PRUNING_SCHEME": "ROBUST",

--- a/psi4/driver/procrouting/solvent/ddx.py
+++ b/psi4/driver/procrouting/solvent/ddx.py
@@ -29,11 +29,11 @@ import numpy as np
 
 from qcelemental import constants
 
-from psi4 import core
-from psi4.driver.p4util.exceptions import ValidationError
-
 import pyddx
 import pyddx.data
+
+from psi4 import core
+from psi4.driver.p4util.exceptions import ValidationError
 
 
 def get_ddx_options(molecule):
@@ -200,15 +200,8 @@ class DdxInterface:
                for (block, ylm) in zip(self.dftgrid.blocks(), self.scaled_ylms)]
         V_ddx = self.numints.potential_integral(eta)
 
-        # This hack is needed because ExternalPotential() assumes the same
-        # units as the molecule.
-        convfac = 1.0
-        if self.basisset.molecule().units() == "Angstrom":
-            convfac = constants.bohr2angstroms
-
         extern = core.ExternalPotential()
         for xi_nj, pos_nj in zip(self.state.xi, self.model.cavity.T):
-            pos_nj = convfac * pos_nj
             extern.addCharge(xi_nj, pos_nj[0], pos_nj[1], pos_nj[2])
         V_ddx.add(extern.computePotentialMatrix(self.basisset))
 

--- a/psi4/driver/procrouting/solvent/ddx.py
+++ b/psi4/driver/procrouting/solvent/ddx.py
@@ -201,6 +201,8 @@ class DdxInterface:
         self.state = None
 
     def get_solvation_contributions(self, density_matrix, elec_only=False):
+        # TODO elec_only=True has not yet been tested. Will be properly integrated in a follow-up
+        #
         # Compute electronic contributions
         psi = self.numints.dd_density_integral(self.scaled_ylms, density_matrix).np.T
         dummy_charges = core.Vector.from_array(np.ones(self.model.n_cav))

--- a/psi4/driver/procrouting/solvent/ddx.py
+++ b/psi4/driver/procrouting/solvent/ddx.py
@@ -30,11 +30,11 @@ import numpy as np
 from qcelemental import constants
 from pkg_resources import parse_version
 
-import pyddx
-import pyddx.data
-
 from psi4 import core
 from psi4.driver.p4util.exceptions import ValidationError
+
+import pyddx
+import pyddx.data
 
 
 def get_ddx_options(molecule):
@@ -87,6 +87,7 @@ def get_ddx_options(molecule):
         "sphere_radii": radii,
         "solvent_epsilon": solvent_epsilon,
         "eta": core.get_option("DDX", "ETA"),
+        "shift": core.get_option("DDX", "SHIFT"),
         "lmax": core.get_option("DDX", "LMAX"),
         "n_lebedev": core.get_option("DDX", "N_LEBEDEV"),
         "maxiter": 100,       # TODO Configurable
@@ -213,7 +214,7 @@ class DdxInterface:
         self.state.solve_adjoint(**self.op_solver)
 
         # Compute solvation energy
-        f_epsilon = 1.0
+        fepsilon = 1.0
         if self.model.model == "cosmo":
             epsilon = self.model.solvent_epsilon
             fepsilon = (epsilon - 1) / epsilon

--- a/psi4/driver/procrouting/solvent/ddx.py
+++ b/psi4/driver/procrouting/solvent/ddx.py
@@ -80,6 +80,10 @@ def get_ddx_options(molecule):
     else:
         solvent_epsilon = pyddx.data.solvent_epsilon[solvent]
 
+    fmm_multipole_lmax = core.get_option("DDX", "LMAX")
+    if core.has_option_changed("DDX", "FMM_MULTIPOLE_LMAX"):
+        fmm_multipole_lmax = core.get_option("DDX", "FMM_MULTIPOLE_LMAX")
+
     model_options = {
         "model": core.get_option("DDX", "MODEL").lower(),
         "sphere_charges": np.array([molecule.Z(i) for i in range(molecule.natom())]),
@@ -94,7 +98,7 @@ def get_ddx_options(molecule):
         "incore": core.get_option("DDX", "INCORE"),
         "enable_fmm": core.get_option("DDX", "FMM"),
         "fmm_local_lmax": core.get_option("DDX", "FMM_LOCAL_LMAX"),
-        "fmm_multipole_lmax": core.get_option("DDX", "FMM_MULTIPOLE_LMAX"),
+        "fmm_multipole_lmax": fmm_multipole_lmax,
         "logfile": core.get_option("DDX", "LOGFILE"),
         "eta": core.get_option("DDX", "ETA"),
         "shift": core.get_option("DDX", "SHIFT"),

--- a/psi4/driver/procrouting/solvent/ddx.py
+++ b/psi4/driver/procrouting/solvent/ddx.py
@@ -1,0 +1,216 @@
+#
+# @BEGIN LICENSE
+#
+# Psi4: an open-source quantum chemistry software package
+#
+# Copyright (c) 2007-2021 The Psi4 Developers.
+#
+# The copyrights for code used from other parties are included in
+# the corresponding files.
+#
+# This file is part of Psi4.
+#
+# Psi4 is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# Psi4 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with Psi4; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# @END LICENSE
+#
+import numpy as np
+
+from qcelemental import constants
+
+from psi4 import core
+from psi4.driver.p4util.exceptions import ValidationError
+
+import pyddx
+import pyddx.data
+
+
+def get_ddx_options(molecule):
+    if core.get_option("SCF", "PCM"):
+        raise ValidationError("Error: DDX and PCM are exclusive.")
+
+    if molecule.units() == "Angstrom":
+        convfac = 1 / constants.bohr2angstroms
+    else:
+        convfac = 1.0
+
+    if core.has_option_changed("DDX", "RADII"):
+        radii = convfac * np.fromiter(core.get_option("DDX", "RADII"), float)
+        if not radii.shape[0] == molecule.natom():
+            raise ValidationError("Length of vector of custom cavity radii does "
+                                  "not agree with number of atoms.")
+    else:
+        radii_set = core.get_option("DDX", "RADII_SET").lower()
+        radii_lookup = getattr(pyddx.data, "radius_" + radii_set)
+
+        # Use user-specified or ddx-recommended radius offset/scaling
+        if core.has_option_changed("DDX", "RADII_SCALING"):
+            radii_scaling = core.get_option("DDX", "RADII_SCALING")
+        else:
+            radii_scaling = getattr(pyddx.data, "radius_" + radii_set + "_scaling")
+
+        radii = np.empty((molecule.natom()))
+        for i in range(molecule.natom()):
+            element = molecule.label(i).lower()
+            if element not in radii_lookup:
+                raise ValidationError(f"Element {element} not known in radii_set {radii_set}. "
+                                      "Please choose a different radii_set or provide radii "
+                                      "manually using the 'RADII' option.")
+            radii[i] = radii_scaling * radii_lookup[element]
+
+    solvent = core.get_option("DDX", "SOLVENT").lower()
+    if core.has_option_changed("DDX", "SOLVENT_EPSILON"):
+        solvent_epsilon = core.get_option("DDX", "SOLVENT_EPSILON")
+    elif solvent == "":
+        raise ValidationError("Required option 'SOLVENT' is missing.")
+    elif solvent not in pyddx.data.solvent_epsilon:
+        raise ValidationError("Unknown solvent {solvent}.")
+    else:
+        solvent_epsilon = pyddx.data.solvent_epsilon[solvent]
+
+    model_options = {
+        "model": core.get_option("DDX", "MODEL").lower(),
+        "sphere_charges": np.array([molecule.Z(i) for i in range(molecule.natom())]),
+        "sphere_centres": molecule.geometry().np.T,
+        "sphere_radii": radii,
+        "solvent_epsilon": solvent_epsilon,
+        "eta": core.get_option("DDX", "ETA"),
+        "lmax": core.get_option("DDX", "LMAX"),
+        "n_lebedev": core.get_option("DDX", "N_LEBEDEV"),
+        "maxiter": 100,       # TODO Configurable
+        "jacobi_n_diis": 20,  # TODO Configurable
+    }
+    solver_options = {
+        "tol": 1e-8,  # TODO Configurable!
+    }
+    return {"model": model_options, "solver": solver_options }
+
+
+def _print_cavity(charges, centres, radii, unit="Angstrom"):
+    if unit == "Angstrom":
+        convfac = constants.bohr2angstroms
+    elif unit == "Bohr":
+        convfac = 1.0
+    core.print_out(f"\n    Cavity sphere setup (in {unit}):\n\n")
+    core.print_out(("    {0:^6s}   {1:^10s}   {2:^10s}   {3:^10s}   {4:^10s}"
+                   "\n").format("Charge", "X", "Y", "Z", "Radius"))
+    core.print_out("    " + "-" * 6 + ("   " + "-" * 10) * 4 + "\n")
+    for i in range(len(charges)):
+        core.print_out(f"    {charges[i]:6.2f}")
+        for j in range(3):
+            core.print_out(f"   {convfac * centres[j, i]:10.6f}")
+        core.print_out(f"   {convfac * radii[i]:10.6f}\n")
+
+
+class DdxInterface:
+    def __init__(self, molecule, options, basisset):
+        self.basisset = basisset
+        self.mints = core.MintsHelper(self.basisset)
+        self.op_solver = options["solver"]
+
+        # Setup the model
+        try:
+            self.model = pyddx.Model(**options["model"])
+        except ValidationError as e:
+            raise ValidationError(str(e))
+        self.cavity = core.Matrix.from_array(self.model.cavity.T)
+
+        # Print summary of options
+        core.print_out("  ==> DDX options <==\n")
+        for k in sorted(list(self.model.input_parameters)):
+            if k not in ("sphere_charges", "sphere_centres", "sphere_radii"):
+                core.print_out(f"    {k:<15s} = {self.model.input_parameters[k]}\n")
+        for k in sorted(list(self.op_solver.keys())):
+            core.print_out(f"    {k:<15s} = {self.op_solver[k]}\n")
+        _print_cavity(self.model.sphere_charges, self.model.sphere_centres,
+                      self.model.sphere_radii, "Angstrom")
+        _print_cavity(self.model.sphere_charges, self.model.sphere_centres,
+                      self.model.sphere_radii, "Bohr")
+        core.print_out("\n")
+
+        # DFT grid for numerical integration
+        # TODO Make configurable!
+        int_opts = {
+            # "DFT_BLOCK_MAX_POINTS": 0,
+            # "DFT_BLOCK_MIN_POINTS": 0,
+            # "DFT_SPHERICAL_POINTS": 0,
+            # "DFT_RADIAL_POINTS": 0,
+            # "PRINT": 0,
+            # "DEBUG": 0,
+            # "BENCH": 0,
+        }
+        string_opts = {
+            # "DFT_RADIAL_SCHEME": "",
+            # "DFT_PRUNING_SCHEME": "",
+            # "DFT_NUCLEAR_SCHEME": "",
+            # "DFT_GRID_NAME": "",
+            "DFT_BLOCK_SCHEME": "ATOMIC",
+        }
+        self.dftgrid = core.DFTGrid.build(molecule, basisset, int_opts, string_opts)
+        self.numints = core.NumIntHelper(self.dftgrid)
+
+        # Build the scaled ylms
+        self.scaled_ylms = []
+        for block in self.dftgrid.blocks():
+            mtx = np.zeros((block.npoints(), self.model.n_basis))
+            for (i, (x, y, z)) in enumerate(zip(block.x().np, block.y().np, block.z().np)):
+                # Notice mtx[i, :] is contiguous in (row-major) memory
+                self.model.scaled_ylm([x, y, z], block.parent_atom(), out=mtx[i, :])
+            self.scaled_ylms.append(core.Matrix.from_array(mtx.T))
+
+        self.state = self.model.initial_guess()
+
+    def get_solvation_contributions(self, density_matrix, elec_only=False):
+        assert not elec_only  # Not yet implemented
+
+        # Initialise with nuclear contributions:
+        nuclear = self.model.solute_nuclear_contribution()
+        phi, psi = nuclear["phi"], nuclear["psi"]
+
+        # Add electronic contributions
+        psi += self.numints.dd_density_integral(self.scaled_ylms, density_matrix).np.T
+        dummy_charges = core.Vector.from_array(np.ones(self.model.n_cav))
+        coords = core.Matrix.from_array(self.model.cavity.T)
+        phi += self.mints.electrostatic_potential_value(dummy_charges, coords, density_matrix).np
+
+        # Solve problem and adjoint problem
+        self.state = self.model.solve(self.state, phi, **self.op_solver)
+        self.state = self.model.adjoint_solve(self.state, psi, **self.op_solver)
+
+        # Compute solvation energy
+        f_epsilon = 1.0
+        if self.model.model == "cosmo":
+            epsilon = self.model.solvent_epsilon
+            fepsilon = (epsilon - 1) / epsilon
+        E_ddx = 0.5 * fepsilon * np.sum(self.state.x * psi)
+
+        # Fock-matrix contributions
+        eta = [core.Vector.from_array(ylm.np.T @ self.state.x[:, block.parent_atom()])
+               for (block, ylm) in zip(self.dftgrid.blocks(), self.scaled_ylms)]
+        V_ddx = self.numints.potential_integral(eta)
+
+        # This hack is needed because ExternalPotential() assumes the same
+        # units as the molecule.
+        convfac = 1.0
+        if self.basisset.molecule().units() == "Angstrom":
+            convfac = constants.bohr2angstroms
+
+        extern = core.ExternalPotential()
+        for xi_nj, pos_nj in zip(self.state.xi, self.model.cavity.T):
+            pos_nj = convfac * pos_nj
+            extern.addCharge(xi_nj, pos_nj[0], pos_nj[1], pos_nj[2])
+        V_ddx.add(extern.computePotentialMatrix(self.basisset))
+
+        V_ddx.scale(-0.5 * fepsilon)  # Scale total potential
+        return E_ddx, V_ddx

--- a/psi4/driver/procrouting/solvent/ddx.py
+++ b/psi4/driver/procrouting/solvent/ddx.py
@@ -94,7 +94,7 @@ def get_ddx_options(molecule):
         "n_lebedev": core.get_option("DDX", "N_LEBEDEV"),
         "maxiter": core.get_option("DDX", "MAXITER"),
         "jacobi_n_diis": core.get_option("DDX", "DIIS_MAX_VECS"),
-        "n_proc": 1,  # TODO Multi-threading still buggy in DDX
+        "n_proc": core.get_num_threads(),
         "incore": core.get_option("DDX", "INCORE"),
         "enable_fmm": core.get_option("DDX", "FMM"),
         "fmm_local_lmax": core.get_option("DDX", "FMM_LOCAL_LMAX"),
@@ -140,7 +140,7 @@ class DdxInterface:
     def __init__(self, molecule, options, basisset):
         # verify that the minimal version is used if pyddx is provided
         # from outside the Psi4 ecosystem
-        min_version = "0.1.0"
+        min_version = "0.1.3"
         if parse_version(pyddx.__version__) < parse_version(min_version):
             raise ModuleNotFoundError("pyddx version {} is required at least. "
                                       "Version {}"

--- a/psi4/driver/procrouting/solvent/pol_embed.py
+++ b/psi4/driver/procrouting/solvent/pol_embed.py
@@ -39,8 +39,8 @@ from psi4.driver.p4util.exceptions import ValidationError
 
 
 def get_pe_options():
-    if core.get_option('SCF', 'PCM'):
-        raise ValidationError("""Error: 3-layer QM/PE/PCM not implemented.\n""")
+    if core.get_option('SCF', 'PCM') or core.get_option('SCF', 'DDX'):
+        raise ValidationError("""Error: 3-layer QM/PE/continuum solvation not implemented.\n""")
     rmin = core.get_option('PE', 'BORDER_RMIN')
     if core.get_option('PE', 'BORDER_RMIN_UNIT').upper() == "AA":
         rmin *= 1.0 / constants.bohr2angstroms

--- a/psi4/extras.py
+++ b/psi4/extras.py
@@ -145,6 +145,7 @@ _addons_ = {
     "ipi": which_import("ipi", return_bool=True),
     "pcmsolver": _CMake_to_Py_boolean("@ENABLE_PCMSolver@"),
     "cppe": which_import("cppe", return_bool=True),
+    "ddx": which_import("pyddx", return_bool=True),
     "simint": _CMake_to_Py_boolean("@ENABLE_simint@"),
     "dftd3": psi4_which("dftd3", return_bool=True),
     "cfour": psi4_which("xcfour", return_bool=True),

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -34,6 +34,7 @@
 #include "psi4/libmints/vector.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/typedefs.h"
+#include "psi4/libmints/numinthelper.h"
 #include "psi4/libdisp/dispersion.h"
 #include "psi4/libfock/v.h"
 #include "psi4/libfock/points.h"
@@ -326,4 +327,20 @@ void export_functional(py::module &m) {
              "Forms the uncoupled amplitudes and other matrices for either monomer.")
         .def("R_A", &sapt::FDDS_Dispersion::R_A, "Obtains (R^t)^-1 for monomer A.")
         .def("R_B", &sapt::FDDS_Dispersion::R_B, "Obtains (R^t)^-1 for monomer B.");
+
+     py::class_<NumIntHelper, std::shared_ptr<NumIntHelper>>(m, "NumIntHelper",
+                                                             "Computes numerical integrals using a DFT grid.")
+         .def(py::init<std::shared_ptr<DFTGrid>>())
+         .def("numint_grid", &NumIntHelper::numint_grid)
+         .def("density_integral", &NumIntHelper::density_integral,
+              "Compute an integral \\int \\rho(r) f(r) where f is a vector-valued function. f is represented for each "
+              "block of points of the integration grid as a matrix (n_data, n_points). Return has shape (n_data)",
+              "grid_data"_a, "D"_a)
+         .def("dd_density_integral", &NumIntHelper::dd_density_integral,
+              "Compute an integral \\int \\rho(r) f(r) where f is a vector-valued function. f is represented for each "
+              "block of points of the integration grid as a matrix (n_data, n_points). Return has shape (n_atoms, "
+              "n_data)", "grid_data"_a, "D"_a)
+         .def("potential_integral", &NumIntHelper::potential_integral,
+              "Compute an integral \\int \\chi_\\mu(r) \\chi_\\nu(r) f(r) where f is a scalar function represented for "
+              "each block of points of the integration grid as a vector of n_points.");
 }

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1502,6 +1502,9 @@ void export_mints(py::module& m) {
              "coordinates (needed for EFP and PE)")
         .def("electric_field_value", &MintsHelper::electric_field_value,
              "Electric field expectation value at given sites")
+        .def("electrostatic_potential_value", &MintsHelper::electrostatic_potential_value,
+             "Electrostatic potential values at given sites with associated charge, specified as an (n_sites, 4) matrix.",
+             "charges"_a, "coords"_a, "D"_a)
 
         // Two-electron AO
         .def("ao_eri", normal_eri_factory(&MintsHelper::ao_eri), "AO ERI integrals", "factory"_a = nullptr)
@@ -1589,6 +1592,7 @@ void export_mints(py::module& m) {
              "Gradient of AO basis electric dipole integrals: returns (3 * natoms) matrices", "atom"_a)
         .def("mo_elec_dip_deriv1", &MintsHelper::mo_elec_dip_deriv1,
              "Gradient of MO basis electric dipole integrals: returns (3 * natoms) matrices", "atom"_a, "C1"_a, "C2"_a);
+
 
     py::class_<OrbitalSpace>(m, "OrbitalSpace", "Contains information about the orbitals")
         .def(py::init<const std::string&, const std::string&, const SharedMatrix&, const SharedVector&,

--- a/psi4/src/psi4/libfock/cubature.h
+++ b/psi4/src/psi4/libfock/cubature.h
@@ -228,6 +228,8 @@ class DFTGrid : public MolecularGrid {
     Options& options_;
 
    public:
+    std::shared_ptr<BasisSet> primary() const { return primary_; }
+
     DFTGrid(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> primary, Options& options);
     DFTGrid(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> primary,
             std::map<std::string, int> int_opts_map, std::map<std::string, std::string> str_opts_map, Options& options);

--- a/psi4/src/psi4/libfock/dft_integrators.h
+++ b/psi4/src/psi4/libfock/dft_integrators.h
@@ -82,7 +82,7 @@ inline std::vector<double> rks_quadrature_integrate(std::shared_ptr<BlockOPoints
     return ret;
 }
 
-inline void sap_integrator(std::shared_ptr<BlockOPoints> block, const std::vector<double>& sap_potential,
+inline void sap_integrator(std::shared_ptr<BlockOPoints> block, const SharedVector& sap_potential,
                            std::shared_ptr<PointFunctions> pworker, SharedMatrix V) {
     // Block data
     const std::vector<int>& function_map = block->functions_local_to_global();
@@ -100,11 +100,12 @@ inline void sap_integrator(std::shared_ptr<BlockOPoints> block, const std::vecto
     // V2 Temporary
     int max_functions = V->ncol();
     double** V2p = V->pointer();
+    auto& potential = *sap_potential;
 
     // => LSDA contribution (symmetrized) <= //
     for (int P = 0; P < npoints; P++) {
         std::fill(Tp[P], Tp[P] + nlocal, 0.0);
-        C_DAXPY(nlocal, 0.5 * sap_potential[P] * w[P], phi[P], 1, Tp[P], 1);
+        C_DAXPY(nlocal, 0.5 * potential[P] * w[P], phi[P], 1, Tp[P], 1);
     }
     // parallel_timer_off("LSDA Phi_tmp", rank);
 

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -35,6 +35,7 @@ list(APPEND sources
   molecule.cc
   intvector.cc
   mintshelper.cc
+  numinthelper.cc
   coordentry.cc
   matrix.cc
   gshell.cc

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1758,21 +1758,21 @@ SharedVector MintsHelper::electrostatic_potential_value(SharedVector charges, Sh
     }
 
     auto potential_integrals_ = static_cast<PCMPotentialInt *>(integral_->pcm_potentialint());
-    // std::vector<std::pair<double, std::array<double, 3>>> Zxyz;
-    // for (size_t i = 0; i < coords->nrow(); ++i) {
-    //     Zxyz.push_back({charges->pointer()[i], {coords->pointer()[i][0],
-    //                                             coords->pointer()[i][1],
-    //                                             coords->pointer()[i][2]}});
-    // }
-    // potential_integrals_->set_charge_field(Zxyz);
-    SharedMatrix Zxyz =  std::make_shared<Matrix>("Zxyz", coords->nrow(), 4);
+    std::vector<std::pair<double, std::array<double, 3>>> Zxyz;
     for (size_t i = 0; i < coords->nrow(); ++i) {
-        Zxyz->pointer()[i][0] = charges->pointer()[i];
-        Zxyz->pointer()[i][1] = coords->pointer()[i][0];
-        Zxyz->pointer()[i][2] = coords->pointer()[i][1];
-        Zxyz->pointer()[i][3] = coords->pointer()[i][2];
+        Zxyz.push_back({charges->pointer()[i], {coords->pointer()[i][0],
+                                                coords->pointer()[i][1],
+                                                coords->pointer()[i][2]}});
     }
     potential_integrals_->set_charge_field(Zxyz);
+    // SharedMatrix Zxyz =  std::make_shared<Matrix>("Zxyz", coords->nrow(), 4);
+    // for (size_t i = 0; i < coords->nrow(); ++i) {
+    //     Zxyz->pointer()[i][0] = charges->pointer()[i];
+    //     Zxyz->pointer()[i][1] = coords->pointer()[i][0];
+    //     Zxyz->pointer()[i][2] = coords->pointer()[i][1];
+    //     Zxyz->pointer()[i][3] = coords->pointer()[i][2];
+    // }
+    // potential_integrals_->set_charge_field(Zxyz);
 
     PetiteList petite(basisset_, integral_, true);
     auto my_aotoso_ = petite.aotoso();

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1765,25 +1765,19 @@ SharedVector MintsHelper::electrostatic_potential_value(SharedVector charges, Sh
                                                 coords->pointer()[i][2]}});
     }
     potential_integrals_->set_charge_field(Zxyz);
-    // SharedMatrix Zxyz =  std::make_shared<Matrix>("Zxyz", coords->nrow(), 4);
-    // for (size_t i = 0; i < coords->nrow(); ++i) {
-    //     Zxyz->pointer()[i][0] = charges->pointer()[i];
-    //     Zxyz->pointer()[i][1] = coords->pointer()[i][0];
-    //     Zxyz->pointer()[i][2] = coords->pointer()[i][1];
-    //     Zxyz->pointer()[i][3] = coords->pointer()[i][2];
+
+    // TODO Is this needed or not?
+    auto D_carts = D;
+    // PetiteList petite(basisset_, integral_, true);
+    // auto my_aotoso_ = petite.aotoso();
+
+    // SharedMatrix D_carts;
+    // if (basisset_->has_puream()) {
+    //     D_carts = std::make_shared<Matrix>("D carts", basisset_->nao(), basisset_->nao());
+    //     D_carts->back_transform(D, my_aotoso_);
+    // } else {
+    //     D_carts = D;
     // }
-    // potential_integrals_->set_charge_field(Zxyz);
-
-    PetiteList petite(basisset_, integral_, true);
-    auto my_aotoso_ = petite.aotoso();
-
-    SharedMatrix D_carts;
-    if (basisset_->has_puream()) {
-        D_carts = std::make_shared<Matrix>("D carts", basisset_->nao(), basisset_->nao());
-        D_carts->back_transform(D, my_aotoso_);
-    } else {
-        D_carts = D;
-    }
 
     SharedVector potvalues = std::make_shared<Vector>("potential values", coords->nrow());
     ContractOverDensityFunctor contract_density_functor(potvalues->dim(), potvalues->pointer(), D_carts);

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1766,21 +1766,8 @@ SharedVector MintsHelper::electrostatic_potential_value(SharedVector charges, Sh
     }
     potential_integrals_->set_charge_field(Zxyz);
 
-    // TODO Is this needed or not?
-    auto D_carts = D;
-    // PetiteList petite(basisset_, integral_, true);
-    // auto my_aotoso_ = petite.aotoso();
-
-    // SharedMatrix D_carts;
-    // if (basisset_->has_puream()) {
-    //     D_carts = std::make_shared<Matrix>("D carts", basisset_->nao(), basisset_->nao());
-    //     D_carts->back_transform(D, my_aotoso_);
-    // } else {
-    //     D_carts = D;
-    // }
-
     SharedVector potvalues = std::make_shared<Vector>("potential values", coords->nrow());
-    ContractOverDensityFunctor contract_density_functor(potvalues->dim(), potvalues->pointer(), D_carts);
+    ContractOverDensityFunctor contract_density_functor(potvalues->dim(), potvalues->pointer(), D);
     potential_integrals_->compute(contract_density_functor);
     return potvalues;
 }

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1774,8 +1774,19 @@ SharedVector MintsHelper::electrostatic_potential_value(SharedVector charges, Sh
     }
     potential_integrals_->set_charge_field(Zxyz);
 
+    PetiteList petite(basisset_, integral_, true);
+    auto my_aotoso_ = petite.aotoso();
+
+    SharedMatrix D_carts;
+    if (basisset_->has_puream()) {
+        D_carts = std::make_shared<Matrix>("D carts", basisset_->nao(), basisset_->nao());
+        D_carts->back_transform(D, my_aotoso_);
+    } else {
+        D_carts = D;
+    }
+
     SharedVector potvalues = std::make_shared<Vector>("potential values", coords->nrow());
-    ContractOverDensityFunctor contract_density_functor(potvalues->dim(), potvalues->pointer(), D);
+    ContractOverDensityFunctor contract_density_functor(potvalues->dim(), potvalues->pointer(), D_carts);
     potential_integrals_->compute(contract_density_functor);
     return potvalues;
 }

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -340,6 +340,9 @@ class PSI_API MintsHelper {
     /// Vector SO Traceless Quadrupole Integrals
     std::vector<SharedMatrix> so_traceless_quadrupole();
 
+    /// Electrostatic potential values at given sites with associated charge, specified as an (n_sites, 4) matrix
+    SharedVector electrostatic_potential_value(SharedVector charges, SharedMatrix coords, SharedMatrix D);
+
     /// Returns a CdSalcList object
     std::shared_ptr<CdSalcList> cdsalcs(int needed_irreps = 0xF, bool project_out_translations = true,
                                         bool project_out_rotations = true);

--- a/psi4/src/psi4/libmints/numinthelper.cc
+++ b/psi4/src/psi4/libmints/numinthelper.cc
@@ -16,7 +16,6 @@ NumIntHelper::NumIntHelper(std::shared_ptr<DFTGrid> numint_grid) : print_(0), nt
 #ifdef _OPENMP
     nthread_ = Process::environment.get_n_threads();
 #endif
-    nthread_ = 1;  // TODO For testing
 
     Options& options_ = Process::environment.options;
     print_ = options_.get_int("PRINT");

--- a/psi4/src/psi4/libmints/numinthelper.cc
+++ b/psi4/src/psi4/libmints/numinthelper.cc
@@ -1,0 +1,187 @@
+#include "numinthelper.h"
+#include "psi4/libfock/cubature.h"
+#include "psi4/libmints/molecule.h"
+#include "psi4/libfock/points.h"
+#include "psi4/libfock/dft_integrators.h"
+#include "psi4/libfock/sap.h"
+#include "psi4/libpsi4util/process.h"
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace psi {
+
+NumIntHelper::NumIntHelper(std::shared_ptr<DFTGrid> numint_grid) : print_(0), nthread_(1), numint_grid_(numint_grid) {
+#ifdef _OPENMP
+    nthread_ = Process::environment.get_n_threads();
+#endif
+    nthread_ = 1;  // TODO For testing
+
+    Options& options_ = Process::environment.options;
+    print_ = options_.get_int("PRINT");
+}
+
+namespace {
+
+struct GridFunction {
+    int n_output;
+    const std::vector<SharedMatrix>& grid_data;
+    GridFunction(const std::vector<SharedMatrix>& grid_data)
+        : n_output(grid_data[0]->rowspi()[0]), grid_data(grid_data) {}
+
+    void process_block(size_t iblock, const std::shared_ptr<BlockOPoints>& block,
+                       const std::shared_ptr<PointFunctions>& worker, bool sum_over_atoms, SharedMatrix& output) const {
+        auto rho_block = worker->point_values()["RHO_A"];
+        double** data_block = grid_data[iblock]->pointer();
+        size_t n_data = static_cast<size_t>(n_output);
+
+        for (size_t idata = 0; idata < n_data; ++idata) {
+            for (int ig = 0; ig < block->npoints(); ++ig) {
+                const size_t icomponent = sum_over_atoms ? 0 : block->parent_atom();
+                output->pointer()[icomponent][idata] -= data_block[idata][ig] * rho_block->get(ig) * block->w()[ig];
+            }
+        }
+    }
+};
+}  // namespace
+
+template <typename Integrand>
+SharedMatrix evaluate_density_integral(const std::shared_ptr<DFTGrid>& numint_grid, int nthread, bool sum_over_atoms,
+                                       Integrand integrand, const SharedMatrix& D) {
+    const int max_points = numint_grid->max_points();
+    const int max_functions = numint_grid->max_functions();
+    const std::shared_ptr<BasisSet> basisset = numint_grid->primary();
+    const int n_atoms = basisset->molecule()->natom();
+    const int n_components = sum_over_atoms ? 1 : n_atoms;
+
+    std::vector<SharedMatrix> integral_local;
+    std::vector<std::shared_ptr<PointFunctions>> numint_point_workers;
+    for (size_t i = 0; i < nthread; i++) {
+        integral_local.push_back(std::make_shared<Matrix>("Integral Temp", n_components, integrand.n_output));
+
+        // Use RKS function to have total density at grid points available
+        auto point_tmp = std::make_shared<RKSFunctions>(basisset, max_points, max_functions);
+        point_tmp->set_ansatz(0);    // LDA is enough
+        point_tmp->set_pointers(D);  // TODO What is needed for unrestricted?
+        numint_point_workers.push_back(point_tmp);
+    }
+
+    int rank = 0;
+// Traverse the blocks of points
+#pragma omp parallel for private(rank) schedule(guided) num_threads(nthread)
+    for (size_t Q = 0; Q < numint_grid->blocks().size(); Q++) {
+#ifdef _OPENMP
+        rank = omp_get_thread_num();
+#endif
+        // Extract per-thread info
+        std::shared_ptr<BlockOPoints> block = numint_grid->blocks()[Q];
+        std::shared_ptr<PointFunctions> worker = numint_point_workers[rank];
+        // worker->set_pointers(D);   // TODO Check with parallelised version ... does not seem to be needed
+
+        // Compute Rho on grid.
+        parallel_timer_on("Density evaluation", rank);
+        worker->compute_points(block, false);
+        parallel_timer_off("Density evaluation", rank);
+
+        parallel_timer_on("Process block", rank);
+        integrand.process_block(Q, block, worker, sum_over_atoms, integral_local[rank]);
+        parallel_timer_off("Process block", rank);
+    }  // grid blocks
+
+    // Accumulate results in integral_local[0]
+    for (size_t rank = 1; rank < nthread; rank++) {
+        integral_local[0]->add(integral_local[rank]);
+    }
+    integral_local[0]->scale(0.5);  // TODO Why is this needed?
+    return integral_local[0];
+}
+
+SharedVector NumIntHelper::density_integral(const std::vector<SharedMatrix>& grid_data, const SharedMatrix& D) const {
+    if (numint_grid_->blocks().size() != grid_data.size()) {
+        throw PSIEXCEPTION("Mismatch of grid data size and DFT integration blocks.");
+    }
+    timer_on("NumIntHelper: density_integral");
+    const bool sum_over_atoms = true;
+    auto Vout = evaluate_density_integral(numint_grid_, nthread_, sum_over_atoms, GridFunction(grid_data), D);
+    timer_off("NumIntHelper: density_integral");
+    return Vout->get_row(0, 0);  // get first (and only) row
+}
+
+SharedMatrix NumIntHelper::dd_density_integral(const std::vector<SharedMatrix>& grid_data,
+                                               const SharedMatrix& D) const {
+    if (numint_grid_->blocks().size() != grid_data.size()) {
+        throw PSIEXCEPTION("Mismatch of grid data size and DFT integration blocks.");
+    }
+    timer_on("NumIntHelper: dd_density_integral");
+    const bool sum_over_atoms = false;
+    auto Vout = evaluate_density_integral(numint_grid_, nthread_, sum_over_atoms, GridFunction(grid_data), D);
+    timer_off("NumIntHelper: dd_density_integral");
+    return Vout;
+}
+
+SharedMatrix NumIntHelper::potential_integral(const std::vector<SharedVector>& grid_data) const {
+    if (numint_grid_->blocks().size() != grid_data.size()) {
+        throw PSIEXCEPTION("Mismatch of grid data size and DFT integration blocks.");
+    }
+    timer_on("NumIntHelper: potential_integral");
+    const int max_points = numint_grid_->max_points();
+    const int max_functions = numint_grid_->max_functions();
+    std::shared_ptr<BasisSet> basisset = numint_grid_->primary();
+
+    std::vector<std::shared_ptr<PointFunctions>> numint_point_workers;
+    std::vector<SharedMatrix> V_local;
+    for (size_t i = 0; i < nthread_; i++) {
+        V_local.push_back(std::make_shared<Matrix>("V Temp", max_functions, max_functions));
+        auto point_tmp = std::make_shared<SAPFunctions>(basisset, max_points, max_functions);
+        point_tmp->set_ansatz(0);
+        numint_point_workers.push_back(point_tmp);
+    }
+
+    auto V_AO = std::make_shared<Matrix>("V(PC) operator", basisset->nbf(), basisset->nbf());
+    double** Vp = V_AO->pointer();
+
+    int rank = 0;
+    // Traverse the blocks of points
+#pragma omp parallel for private(rank) schedule(guided) num_threads(nthread_)
+    for (size_t Q = 0; Q < numint_grid_->blocks().size(); Q++) {
+#ifdef _OPENMP
+        rank = omp_get_thread_num();
+#endif
+
+        // Extract per-thread info
+        std::shared_ptr<BlockOPoints> block = numint_grid_->blocks()[Q];
+        std::shared_ptr<PointFunctions> worker = numint_point_workers[rank];
+
+        // Compute data on grid points
+        parallel_timer_on("Properties", rank);
+        worker->compute_points(block, false);
+        parallel_timer_off("Properties", rank);
+
+        parallel_timer_on("finish operator", rank);
+        // PHI * potential * PHI.
+        dft_integrators::sap_integrator(block, grid_data[Q], worker, V_local[rank]);
+
+        // => Unpacking <= //
+        double** V2p = V_local[rank]->pointer();
+        const std::vector<int>& function_map = block->functions_local_to_global();
+        int nlocal = function_map.size();
+
+        for (int ml = 0; ml < nlocal; ml++) {
+            int mg = function_map[ml];
+            for (int nl = 0; nl < ml; nl++) {
+                int ng = function_map[nl];
+#pragma omp atomic update
+                Vp[mg][ng] += V2p[ml][nl];
+#pragma omp atomic update
+                Vp[ng][mg] += V2p[ml][nl];
+            }
+#pragma omp atomic update
+            Vp[mg][mg] += V2p[ml][ml];
+        }
+        parallel_timer_off("finish operator", rank);
+    }  // grid blocks
+    timer_off("NumIntHelper: potential_integral");
+    return V_AO;
+}
+}  // namespace psi

--- a/psi4/src/psi4/libmints/numinthelper.h
+++ b/psi4/src/psi4/libmints/numinthelper.h
@@ -1,0 +1,73 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2020 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+// Similar to https://github.com/psi4/psi4/pull/2076/files
+
+#ifndef NUMINT_HELPER_H
+#define NUMINT_HELPER_H
+#include "psi4/libmints/typedefs.h"
+#include "psi4/pragma.h"
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <string>
+
+namespace psi {
+class BasisSet;
+class DFTGrid;
+
+class NumIntHelper {
+   protected:
+    int print_;
+    int nthread_;
+
+    /// Local grid object
+    std::shared_ptr<DFTGrid> numint_grid_;
+
+   public:
+    std::shared_ptr<DFTGrid> numint_grid() const { return numint_grid_; }
+
+    NumIntHelper(std::shared_ptr<DFTGrid> numint_grid);
+
+    /// Compute an integral \int -\rho(r) f(r) where f is a vector-valued function.
+    /// f is represented for each block of points of the DFT integration grid as
+    /// the matrix (n_data, n_points). The output has (n_data)
+    SharedVector density_integral(const std::vector<SharedMatrix>& grid_data, const SharedMatrix& D) const;
+
+    /// Same as density_integral, but don't sum over the atoms. Output is a matrix
+    /// (n_atoms, n_data).
+    SharedMatrix dd_density_integral(const std::vector<SharedMatrix>& grid_data, const SharedMatrix& D) const;
+
+    /// Compute an integral \int \chi_\mu(r) \chi_\nu(r) f(r) where f is a scalar function.
+    /// f is represented for each block of points of the DFT integration grid as
+    /// the vector (n_points). The output has (n_bas, n_bas)
+    SharedMatrix potential_integral(const std::vector<SharedVector>& grid_data) const;
+};
+
+}  // namespace psi
+#endif

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -302,6 +302,46 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_str("PCM_CC_TYPE", "PTE", "PTE");
     }
 
+    // TODO Should be merged with real PCM
+    /*- DDX boolean for ddx module -*/
+    options.add_bool("DDX", false);
+    if (name == "DDX" || options.read_globals()) {
+        /*- MODULEDESCRIPTION Performs continuum solvation model computations using
+            the domain-decomposition paradigm. -*/
+
+        /*- The amount of information to print to the output file for the ddx
+        module. 0 is essentially quiet and 1 is recommended. -*/
+        options.add_int("PRINT", 1);
+
+        /*- Switch available solvation models -*/
+        options.add_str("MODEL", "PCM", "PCM COSMO");
+
+        /*- Radius set for cavity spheres. Ignored if RADII is set. -*/
+        options.add_str("RADII_SET", "UFF", "UFF BONDI");
+
+        /*- Scaling factor for cavity spheres. Ignored if RADII is set. The default depends on
+            the radii set chosen. -*/
+        options.add_double("RADII_SCALING", 1.1);
+
+        /*- Custom cavity radii. One per atom, uses the unit of the molecule. -*/
+        options.add("RADII", new ArrayType());
+
+        /*- Solvent to use. Not case sensitive. Ignored if SOLVENT_EPSILON is set. -*/
+        options.add_str("SOLVENT", "");
+
+        /*- Dielectric constant of the solvent to use -*/
+        options.add_double("SOLVENT_EPSILON", 0);
+
+        /*- Maximal degree of modelling spherical harmonics -*/
+        options.add_int("LMAX", 10);
+
+        /*- Number of Lebedev grid points to use -*/
+        options.add_int("N_LEBEDEV", 302);
+
+        /*- Sphere overlap regularisation parameter -*/
+        options.add_double("ETA", 0.1);
+    }
+
     if (name == "PE" || options.read_globals()) {
         /*- MODULEDESCRIPTION Performs polarizable embedding model (PE) computations. -*/
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -328,9 +328,10 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("SOLVENT_EPSILON", 0);
 
         /*- Maximal degree of modelling spherical harmonics -*/
-        options.add_int("LMAX", 7);
+        options.add_int("LMAX", 9);
 
-        /*- Number of Lebedev grid points to use -*/
+        /*- Number of Lebedev grid points to use.
+            (A :ref:`Lebedev Points <table:lebedevorder>` number) -*/
         options.add_int("N_LEBEDEV", 302);
 
         /*- Maximal number of iterations used inside DDX -*/
@@ -344,10 +345,10 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
 
         /*- Number of spherical points used to compute the integrals for DDX calculations
             (A :ref:`Lebedev Points <table:lebedevorder>` number) -*/
-        options.add_int("DFT_SPHERICAL_POINTS", 302);
+        options.add_int("DFT_SPHERICAL_POINTS", 110);
 
         /*- Number of radial points used to compute the integrals for DDX calculations -*/
-        options.add_int("DFT_RADIAL_POINTS", 75);
+        options.add_int("DFT_RADIAL_POINTS", 35);
 
         /*- Use an in-core version, which uses more memory, but is generally faster -*/
         options.add_bool("INCORE", false);
@@ -356,8 +357,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_bool("FMM", true);
 
         /*- Maximal degree of multipole spherical harmonics (far-field FMM interactions).
-	    Using the same value as |ddx__lmax| is recommended and done by default. -*/
-        options.add_int("FMM_MULTIPOLE_LMAX", 7);
+            Using the same value as |ddx__lmax| is recommended and done by default. -*/
+        options.add_int("FMM_MULTIPOLE_LMAX", 9);
 
         /*- Maximal degree of local spherical harmonics (near-field FMM interations). -*/
         options.add_int("FMM_LOCAL_LMAX", 6);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -338,8 +338,16 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- Number of Lebedev grid points to use -*/
         options.add_int("N_LEBEDEV", 302);
 
-        /*- Sphere overlap regularisation parameter -*/
+        /*- Regularization parameter for characteristic function of sphere overlap.
+            Advanced parameter, which usually does not need to be modified. Valid
+            values are within the range [0, 1]. -*/
         options.add_double("ETA", 0.1);
+
+        /*- Shift for characteristic function of sphere overlap.
+            Advanced parameter, which usually does not need to be modified. Valid values
+            are within the range [-1, 1] with -100 denoting an automatic selection of the
+            best shift. -*/
+        options.add_double("SHIFT", -100.0);
     }
 
     if (name == "PE" || options.read_globals()) {

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -290,6 +290,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     options.add_bool("PCM", false);
     /*- PE boolean for polarizable embedding module -*/
     options.add_bool("PE", false);
+    /*- DDX boolean for ddx module -*/
+    options.add_bool("DDX", false);
 
     if (name == "PCM" || options.read_globals()) {
         /*- MODULEDESCRIPTION Performs polarizable continuum model (PCM) computations. -*/
@@ -302,8 +304,6 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_str("PCM_CC_TYPE", "PTE", "PTE");
     }
 
-    /*- DDX boolean for ddx module -*/
-    options.add_bool("DDX", false);
     if (name == "DDX" || options.read_globals()) {
         /*- MODULEDESCRIPTION Performs continuum solvation model computations using
             the domain-decomposition paradigm. -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -302,16 +302,11 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_str("PCM_CC_TYPE", "PTE", "PTE");
     }
 
-    // TODO Should be merged with real PCM
     /*- DDX boolean for ddx module -*/
     options.add_bool("DDX", false);
     if (name == "DDX" || options.read_globals()) {
         /*- MODULEDESCRIPTION Performs continuum solvation model computations using
             the domain-decomposition paradigm. -*/
-
-        /*- The amount of information to print to the output file for the ddx
-        module. 0 is essentially quiet and 1 is recommended. -*/
-        options.add_int("PRINT", 1);
 
         /*- Switch available solvation models -*/
         options.add_str("MODEL", "PCM", "PCM COSMO");
@@ -338,15 +333,46 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- Number of Lebedev grid points to use -*/
         options.add_int("N_LEBEDEV", 302);
 
+        /*- Maximal number of iterations used inside DDX -*/
+        options.add_int("MAXITER", 100);
+
+        /*- Number of previous iterates to use in DIIS acceleration inside DDX -*/
+        options.add_int("DIIS_MAX_VECS", 20);
+
+        /*- Tolerance to which DDX linear systems are solved -*/
+        options.add_double("SOLVATION_CONVERGENCE", 1e-8);
+
+        /*- Number of spherical points used to compute the integrals for DDX calculations
+            (A :ref:`Lebedev Points <table:lebedevorder>` number) -*/
+        options.add_int("DFT_SPHERICAL_POINTS", 302);
+
+        /*- Number of radial points used to compute the integrals for DDX calculations -*/
+        options.add_int("DFT_RADIAL_POINTS", 75);
+
+        /*- Use an in-core version, which uses more memory, but is generally faster -*/
+        options.add_bool("INCORE", false);
+
+        /*- Use the fast multipole method to accelerate the solver -*/
+        options.add_bool("FMM", true);
+
+        /*- Maximal degree of multipole spherical harmonics (far-field FMM interactions). -*/
+        options.add_int("FMM_MULTIPOLE_LMAX", 7);
+
+        /*- Maximal degree of local spherical harmonics (near-field FMM interations). -*/
+        options.add_int("FMM_LOCAL_LMAX", 6);
+
+        /*- Logfile to dump a full trace of the DDX solver history for debugging. !expert -*/
+        options.add_str("LOGFILE", "");
+
         /*- Regularization parameter for characteristic function of sphere overlap.
             Advanced parameter, which usually does not need to be modified. Valid
-            values are within the range [0, 1]. -*/
+            values are within the range [0, 1]. !expert -*/
         options.add_double("ETA", 0.1);
 
         /*- Shift for characteristic function of sphere overlap.
             Advanced parameter, which usually does not need to be modified. Valid values
             are within the range [-1, 1] with -100 denoting an automatic selection of the
-            best shift. -*/
+            best shift. !expert -*/
         options.add_double("SHIFT", -100.0);
     }
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -309,73 +309,73 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
             the domain-decomposition paradigm. -*/
 
         /*- Switch available solvation models -*/
-        options.add_str("MODEL", "PCM", "PCM COSMO");
+        options.add_str("DDX_MODEL", "PCM", "PCM COSMO");
 
         /*- Radius set for cavity spheres. Ignored if RADII is set. -*/
-        options.add_str("RADII_SET", "UFF", "UFF BONDI");
+        options.add_str("DDX_RADII_SET", "UFF", "UFF BONDI");
 
         /*- Scaling factor for cavity spheres. Ignored if RADII is set. The default depends on
             the radii set chosen. -*/
-        options.add_double("RADII_SCALING", 1.1);
+        options.add_double("DDX_RADII_SCALING", 1.1);
 
         /*- Custom cavity radii. One per atom, uses the unit of the molecule. -*/
-        options.add("RADII", new ArrayType());
+        options.add("DDX_RADII", new ArrayType());
 
         /*- Solvent to use. Not case sensitive. Ignored if SOLVENT_EPSILON is set. -*/
-        options.add_str("SOLVENT", "");
+        options.add_str("DDX_SOLVENT", "");
 
         /*- Dielectric constant of the solvent to use -*/
-        options.add_double("SOLVENT_EPSILON", 0);
+        options.add_double("DDX_SOLVENT_EPSILON", 0);
 
         /*- Maximal degree of modelling spherical harmonics -*/
-        options.add_int("LMAX", 9);
+        options.add_int("DDX_LMAX", 9);
 
         /*- Number of Lebedev grid points to use.
             (A :ref:`Lebedev Points <table:lebedevorder>` number) -*/
-        options.add_int("N_LEBEDEV", 302);
+        options.add_int("DDX_N_LEBEDEV", 302);
 
         /*- Maximal number of iterations used inside DDX -*/
-        options.add_int("MAXITER", 100);
+        options.add_int("DDX_MAXITER", 100);
 
         /*- Number of previous iterates to use in DIIS acceleration inside DDX -*/
-        options.add_int("DIIS_MAX_VECS", 20);
+        options.add_int("DDX_DIIS_MAX_VECS", 20);
 
         /*- Tolerance to which DDX linear systems are solved -*/
-        options.add_double("SOLVATION_CONVERGENCE", 1e-8);
+        options.add_double("DDX_SOLVATION_CONVERGENCE", 1e-8);
 
-        /*- Number of spherical points used to compute the integrals for DDX calculations
-            (A :ref:`Lebedev Points <table:lebedevorder>` number) -*/
-        options.add_int("DFT_SPHERICAL_POINTS", 110);
+        /*- Number of spherical points used to compute the solute electric potential/field
+            integrals for DDX calculations (A :ref:`Lebedev Points <table:lebedevorder>` number) -*/
+        options.add_int("DDX_SOLUTE_SPHERICAL_POINTS", 110);
 
         /*- Number of radial points used to compute the integrals for DDX calculations -*/
-        options.add_int("DFT_RADIAL_POINTS", 35);
+        options.add_int("DDX_SOLUTE_RADIAL_POINTS", 35);
 
         /*- Use an in-core version, which uses more memory, but is generally faster -*/
-        options.add_bool("INCORE", false);
+        options.add_bool("DDX_INCORE", false);
 
         /*- Use the fast multipole method to accelerate the solver -*/
-        options.add_bool("FMM", true);
+        options.add_bool("DDX_FMM", true);
 
         /*- Maximal degree of multipole spherical harmonics (far-field FMM interactions).
-            Using the same value as |ddx__lmax| is recommended and done by default. -*/
-        options.add_int("FMM_MULTIPOLE_LMAX", 9);
+            Using the same value as |ddx__ddx_lmax| is recommended and done by default. -*/
+        options.add_int("DDX_FMM_MULTIPOLE_LMAX", 9);
 
         /*- Maximal degree of local spherical harmonics (near-field FMM interations). -*/
-        options.add_int("FMM_LOCAL_LMAX", 6);
+        options.add_int("DDX_FMM_LOCAL_LMAX", 6);
 
         /*- Logfile to dump a full trace of the DDX solver history for debugging. !expert -*/
-        options.add_str("LOGFILE", "");
+        options.add_str("DDX_LOGFILE", "");
 
         /*- Regularization parameter for characteristic function of sphere overlap.
             Advanced parameter, which usually does not need to be modified. Valid
             values are within the range [0, 1]. !expert -*/
-        options.add_double("ETA", 0.1);
+        options.add_double("DDX_ETA", 0.1);
 
         /*- Shift for characteristic function of sphere overlap.
             Advanced parameter, which usually does not need to be modified. Valid values
             are within the range [-1, 1] with -100 denoting an automatic selection of the
             best shift. !expert -*/
-        options.add_double("SHIFT", -100.0);
+        options.add_double("DDX_SHIFT", -100.0);
     }
 
     if (name == "PE" || options.read_globals()) {

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -328,7 +328,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("SOLVENT_EPSILON", 0);
 
         /*- Maximal degree of modelling spherical harmonics -*/
-        options.add_int("LMAX", 10);
+        options.add_int("LMAX", 7);
 
         /*- Number of Lebedev grid points to use -*/
         options.add_int("N_LEBEDEV", 302);
@@ -355,7 +355,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- Use the fast multipole method to accelerate the solver -*/
         options.add_bool("FMM", true);
 
-        /*- Maximal degree of multipole spherical harmonics (far-field FMM interactions). -*/
+        /*- Maximal degree of multipole spherical harmonics (far-field FMM interactions).
+	    Using the same value as |ddx__lmax| is recommended and done by default. -*/
         options.add_int("FMM_MULTIPOLE_LMAX", 7);
 
         /*- Maximal degree of local spherical harmonics (near-field FMM interations). -*/

--- a/pytest.ini
+++ b/pytest.ini
@@ -135,6 +135,7 @@ markers =
     cct3
     chemps2: "tests using CheMPS2 software; skip if unavailable"
     cppe: "tests using cppe software; skip if unavailable"
+    ddx: "tests using pyddx software; skip if unavailable"
     dkh: "tests using dkh software; skip if unavailable"
     ecpint: "tests using ecpint software; skip if unavailable"
     libefp: "tests using LibEFP software; skip if unavailable"

--- a/tests/pytests/addons.py
+++ b/tests/pytests/addons.py
@@ -61,6 +61,7 @@ _programs = {
     "cct3": which_import("cct3", return_bool=True),
     "chemps2": psi4.addons("chemps2"),
     "cppe": which_import("cppe", return_bool=True),  # package pycppe, import cppe
+    "ddx": which_import("pyddx", return_bool=True),
     "dkh": psi4.addons("dkh"),
     "ecpint": psi4.addons("ecpint"),
     "libefp": which_import("pylibefp", return_bool=True),

--- a/tests/pytests/test_ddx.py
+++ b/tests/pytests/test_ddx.py
@@ -1,0 +1,226 @@
+import psi4
+import pytest
+import numpy as np
+
+from psi4 import core
+from psi4.driver.procrouting.solvent import ddx
+
+from utils import compare_values
+from addons import using
+
+pytestmark = pytest.mark.quick
+
+__geoms = {
+    "benzene":
+    """
+    C -0.886454    0.338645    0.000000
+    C  0.508706    0.338645    0.000000
+    C  1.206244    1.546396    0.000000
+    C  0.508590    2.754905   -0.001199
+    C -0.886235    2.754827   -0.001678
+    C -1.583836    1.546621   -0.000682
+    H -1.436213   -0.613672    0.000450
+    H  1.058214   -0.613868    0.001315
+    H  2.305924    1.546476    0.000634
+    H  1.058790    3.707048   -0.001258
+    H -1.436357    3.707108   -0.002631
+    H -2.683440    1.546804   -0.000862
+    symmetry c1
+    units angstrom
+    """,
+    "fcm":
+    """
+    C   -0.502049    0.594262    0.000000
+    H   -0.145376    1.098660    0.873652
+    H   -1.572049    0.594275    0.000000
+    Cl   0.084628    1.423927   -1.437034
+    F   -0.052065   -0.678535    0.000000
+    symmetry c1
+    units angstrom
+    """,
+    "methane":
+    """
+    C  0.268924   -0.099602    0.000000
+    H  0.625579   -1.108412    0.000000
+    H  0.625597    0.404797    0.873652
+    H  0.625597    0.404797   -0.873652
+    H -0.801076   -0.099588    0.000000
+    symmetry c1
+    units angstrom
+    """,
+    "h2o":
+    """
+    O -0.966135 0.119522 0
+    H -0.006135 0.119522 0
+    H -1.286590 1.024458 0
+    symmetry c1
+    units angstrom
+    """,
+    "h2":
+    """
+    H 0 0 0.5
+    H 0 0 -0.5
+    symmetry c1
+    units angstrom
+    """,
+    "h":
+    """
+    H 0 0 0
+    1 1
+    symmetry c1
+    units angstrom
+    """
+}
+
+
+def _base_test_fock(fock_term, density_matrix, eps=1e-4, tol=1e-6):
+    E, V = fock_term(density_matrix)
+
+    perturbation = np.random.random(density_matrix.np.shape)
+    perturbation = perturbation + perturbation.T
+    delta = np.sum(V.np * perturbation)
+
+    Em, _ = fock_term(core.Matrix.from_array(density_matrix.np - eps * perturbation))
+    Ep, _ = fock_term(core.Matrix.from_array(density_matrix.np + eps * perturbation))
+    delta_ref = (Ep - Em) / (2 * eps)
+
+    assert abs(delta - delta_ref) < 1e-6
+
+
+@pytest.mark.parametrize("inp", [
+   pytest.param({
+       "geom": __geoms["h"],
+       "dm": core.Matrix.from_array(np.array([[0.]])),
+       "radii": [1.0],  # Angstrom
+       "ref": -0.2645886054599999,  # from Gaussian
+   }, id='h', marks=using('ddx')),
+   pytest.param({
+       "geom": __geoms["h2"],
+       "dm": core.Matrix.from_array(0.6682326961201372 * np.ones((2, 2))),
+       "radii": [1.5873, 1.5873],  # Angstrom
+       "ref": -0.0002016948,  # from Gaussian
+   }, id='h2', marks=using('ddx')),
+])
+def test_ddx_fock_build(inp):
+    """
+    Tests COSMO energy against reference from Gaussian
+    and internal consistency of Fock matrix versus the energy.
+    """
+    psi4.set_options({
+        # Note: DFT grids used for DDX numerical integration
+        "dft_spherical_points": 350,
+        "dft_nuclear_scheme": "Becke",
+        "dft_pruning_scheme": "robust",
+        "df_scf_guess": False,
+        #
+        "ddx__model": "cosmo",
+        "ddx__solvent_epsilon": 1e8,
+        "ddx__eta": 0,
+        "ddx__lmax": 3,
+        "ddx__n_lebedev": 302,
+        "ddx__radii": inp["radii"],
+    })
+
+    # build the DDX object to test
+    mol = psi4.geometry(inp["geom"])
+    basis = psi4.core.BasisSet.build(mol, "BASIS", "sto-3g")
+    ddx_options = ddx.get_ddx_options(mol)
+    ddx_state = ddx.DdxInterface(mol, ddx_options, basis)
+
+    def get_EV(density_matrix):
+        return ddx_state.get_solvation_contributions(density_matrix)
+
+    _base_test_fock(get_EV, inp["dm"])
+
+    E, _ = get_EV(inp["dm"])
+    assert compare_values(inp["ref"], E, atol=1e-16, rtol=1e-2)
+
+@pytest.mark.parametrize("inp", [
+    pytest.param({
+        "geom": __geoms["h2o"],
+        "ddx": {"model": "cosmo", "solvent_epsilon": 1e8, "eta": 0, "lmax": 3,
+                "n_lebedev": 302, "radii_set": "uff", },
+        "ref": -75.5946789010,  # from Gaussian
+        "solvation": -0.009402,
+    }, id='h2o', marks=using('ddx')),
+    #
+    pytest.param({
+        "geom": __geoms["methane"],
+        "ddx": {"model": "cosmo", "solvent_epsilon": 1e8, "eta": 0, "lmax": 3,
+                "n_lebedev": 302, "radii_set": "uff", },
+        "ref": -39.9764868732,  # from Gaussian
+        "solvation": -0.000083,
+    }, id='ch4', marks=using('ddx')),
+    #
+    pytest.param({
+        "geom": __geoms["fcm"],
+        "ddx": {"model": "cosmo", "solvent_epsilon": 1e8, "eta": 0, "lmax": 3,
+                "n_lebedev": 302, "radii_set": "uff", },
+        "ref": -594.993575419,  # from Gaussian
+        "solvation": -0.006719,
+    }, id='fcm', marks=using('ddx')),
+    #
+    pytest.param({
+        "geom": __geoms["fcm"],
+        "ddx": {"model": "cosmo", "solvent_epsilon": 2.0, "eta": 0, "lmax": 3,
+                "n_lebedev": 302, "radii_set": "uff", },
+        "ref": -594.990420855,  # from Gaussian
+        "solvation": -0.002964,
+    }, id='fcmeps', marks=using('ddx')),
+    #
+    pytest.param({
+        "geom": __geoms["fcm"],
+        "ddx": {"model": "cosmo", "solvent_epsilon": 2.0, "eta": 0.2, "lmax": 3,
+                "n_lebedev": 302, "radii_set": "uff", },
+        "ref": -594.990487330,  # from Gaussian
+        "solvation": -0.003041,
+    }, id='fcmepseta', marks=using('ddx')),
+    #
+    pytest.param({
+        "geom": __geoms["benzene"],
+        "ddx": {"model": "cosmo", "solvent_epsilon": 1e8, "eta": 0, "lmax": 3,
+                "n_lebedev": 302, "radii_set": "uff", },
+        "ref": -229.420391688,  # from Gaussian
+        "solvation": -0.005182,
+    }, id='benzene', marks=using('ddx')),
+])
+def test_ddx_rhf_reference(inp):
+    mol = psi4.geometry(inp["geom"])
+    psi4.set_options({
+        "ddx": True,
+        "basis": "3-21g",
+        "guess": "core",
+        "scf_type": "direct",
+    })
+    for key in inp["ddx"].keys():
+        psi4.set_options({"ddx__" + key: inp["ddx"][key]})
+    scf_e, wfn = psi4.energy('SCF', return_wfn=True, molecule=mol)
+    ddx_e = wfn.get_variable("ddx energy")
+
+    assert compare_values(inp["solvation"], ddx_e, 4, "DDX solvation energy versus Gaussian")
+    assert compare_values(inp["ref"], scf_e, 4, "Total SCF energy with DDX versus Gaussian")
+
+
+@pytest.mark.parametrize("inp", [
+    pytest.param({
+        "geom": __geoms["h2o"],
+        "basis": "cc-pvdz",
+        "ddx": {"model": "cosmo", "solvent": "water", "eta": 0.05,
+                "lmax": 10, "n_lebedev": 302, "radii_set": "bondi",
+                "radii_scaling": 1.2},
+        "solvent": "water",
+        "ref": -76.0346373391875,
+    }, id='h2o', marks=using('ddx')),
+])
+def test_ddx_rhf_consistency(inp):
+    mol = psi4.geometry(inp["geom"])
+    psi4.set_options({
+        "ddx": True,
+        "basis": inp["basis"],
+        "guess": "core",
+        "scf_type": "direct",
+    })
+    for key in inp["ddx"].keys():
+        psi4.set_options({"ddx__" + key: inp["ddx"][key]})
+    scf_e, wfn = psi4.energy('SCF', return_wfn=True, molecule=mol)
+    assert compare_values(inp["ref"], scf_e, 9, "Total SCF energy with DDX versus reference data")

--- a/tests/pytests/test_ddx.py
+++ b/tests/pytests/test_ddx.py
@@ -94,13 +94,13 @@ def _base_test_fock(fock_term, density_matrix, eps=1e-4, tol=1e-6):
        "dm": core.Matrix.from_array(np.array([[0.]])),
        "radii": [1.0],  # Angstrom
        "ref": -0.2645886054599999,  # from Gaussian
-   }, id='h', marks=using('ddx')),
+   }, id='h'),
    pytest.param({
        "geom": __geoms["h2"],
        "dm": core.Matrix.from_array(0.6682326961201372 * np.ones((2, 2))),
        "radii": [1.5873, 1.5873],  # Angstrom
        "ref": -0.0002016948,  # from Gaussian
-   }, id='h2', marks=using('ddx')),
+   }, id='h2'),
 ])
 def test_ddx_fock_build(inp):
     """
@@ -144,50 +144,50 @@ def test_ddx_fock_build(inp):
     pytest.param({
         "geom": __geoms["h2o"],
         "ddx": {"model": "cosmo", "solvent_epsilon": 1e8, "eta": 0, "lmax": 3,
-                "n_lebedev": 302, "radii_set": "uff", },
+                "n_lebedev": 302, "radii_set": "uff", "shift": 0.0, },
         "ref": -75.5946789010,  # from Gaussian
         "solvation": -0.009402,
-    }, id='h2o', marks=using('ddx')),
+    }, id='h2o'),
     #
     pytest.param({
         "geom": __geoms["methane"],
         "ddx": {"model": "cosmo", "solvent_epsilon": 1e8, "eta": 0, "lmax": 3,
-                "n_lebedev": 302, "radii_set": "uff", },
+                "n_lebedev": 302, "radii_set": "uff", "shift": 0.0, },
         "ref": -39.9764868732,  # from Gaussian
         "solvation": -0.000083,
-    }, id='ch4', marks=using('ddx')),
+    }, id='ch4'),
     #
     pytest.param({
         "geom": __geoms["fcm"],
         "ddx": {"model": "cosmo", "solvent_epsilon": 1e8, "eta": 0, "lmax": 3,
-                "n_lebedev": 302, "radii_set": "uff", },
+                "n_lebedev": 302, "radii_set": "uff", "shift": 0.0, },
         "ref": -594.993575419,  # from Gaussian
         "solvation": -0.006719,
-    }, id='fcm', marks=using('ddx')),
+    }, id='fcm'),
     #
     pytest.param({
         "geom": __geoms["fcm"],
         "ddx": {"model": "cosmo", "solvent_epsilon": 2.0, "eta": 0, "lmax": 3,
-                "n_lebedev": 302, "radii_set": "uff", },
+                "n_lebedev": 302, "radii_set": "uff", "shift": 0.0, },
         "ref": -594.990420855,  # from Gaussian
         "solvation": -0.002964,
-    }, id='fcmeps', marks=using('ddx')),
+    }, id='fcmeps'),
     #
     pytest.param({
         "geom": __geoms["fcm"],
         "ddx": {"model": "cosmo", "solvent_epsilon": 2.0, "eta": 0.2, "lmax": 3,
-                "n_lebedev": 302, "radii_set": "uff", },
+                "n_lebedev": 302, "radii_set": "uff", "shift": 0.0, },
         "ref": -594.990487330,  # from Gaussian
         "solvation": -0.003041,
-    }, id='fcmepseta', marks=using('ddx')),
+    }, id='fcmepseta'),
     #
     pytest.param({
         "geom": __geoms["benzene"],
         "ddx": {"model": "cosmo", "solvent_epsilon": 1e8, "eta": 0, "lmax": 3,
-                "n_lebedev": 302, "radii_set": "uff", },
+                "n_lebedev": 302, "radii_set": "uff", "shift": 0.0, },
         "ref": -229.420391688,  # from Gaussian
         "solvation": -0.005182,
-    }, id='benzene', marks=using('ddx')),
+    }, id='benzene'),
 ])
 def test_ddx_rhf_reference(inp):
     mol = psi4.geometry(inp["geom"])
@@ -216,8 +216,17 @@ def test_ddx_rhf_reference(inp):
                 "lmax": 10, "n_lebedev": 302, "radii_set": "bondi",
                 "radii_scaling": 1.2},
         "solvent": "water",
-        "ref": -76.0346373391875,
-    }, id='h2o', marks=using('ddx')),
+        "ref": -76.0346400389023,
+    }, id='h2o-cosmo'),
+    pytest.param({
+        "geom": __geoms["h2o"],
+        "basis": "cc-pvdz",
+        "ddx": {"model": "pcm", "solvent": "water", "eta": 0.1,
+                "lmax": 10, "n_lebedev": 302, "radii_set": "bondi",
+                "radii_scaling": 1.2},
+        "solvent": "water",
+        "ref": -76.03458075209939,
+    }, id='h2o-pcm'),
 ])
 def test_ddx_rhf_consistency(inp):
     mol = psi4.geometry(inp["geom"])

--- a/tests/pytests/test_ddx.py
+++ b/tests/pytests/test_ddx.py
@@ -180,7 +180,7 @@ def test_ddx_rhf_reference(inp):
     for key in inp["ddx"].keys():
         psi4.set_options({"ddx__" + key: inp["ddx"][key]})
     scf_e, wfn = psi4.energy('SCF', return_wfn=True, molecule=mol)
-    ddx_e = wfn.scalar_variable("ddx energy")
+    ddx_e = wfn.scalar_variable("dd solvation energy")
 
     assert compare_values(inp["solvation"], ddx_e, 4, "DDX solvation energy versus Gaussian")
     assert compare_values(inp["ref"], scf_e, 4, "Total SCF energy with DDX versus Gaussian")

--- a/tests/pytests/test_ddx.py
+++ b/tests/pytests/test_ddx.py
@@ -1,13 +1,11 @@
+import psi4
 import pytest
 import numpy as np
 
-import psi4
+from psi4 import core
 
 from utils import compare_values
-from addons import using
-
-from psi4 import core
-from psi4.driver.procrouting.solvent import ddx
+from addons import using, uusing
 
 pytestmark = [pytest.mark.psi, pytest.mark.api]
 

--- a/tests/pytests/test_ddx.py
+++ b/tests/pytests/test_ddx.py
@@ -1,14 +1,15 @@
-import psi4
 import pytest
 import numpy as np
 
-from psi4 import core
-from psi4.driver.procrouting.solvent import ddx
+import psi4
 
 from utils import compare_values
 from addons import using
 
-pytestmark = pytest.mark.quick
+from psi4 import core
+from psi4.driver.procrouting.solvent import ddx
+
+pytestmark = [pytest.mark.psi, pytest.mark.api]
 
 __geoms = {
     "benzene":
@@ -87,6 +88,8 @@ def _base_test_fock(fock_term, density_matrix, eps=1e-4, tol=1e-6):
     assert abs(delta - delta_ref) < 1e-6
 
 
+@pytest.mark.quick
+@uusing("ddx")
 @pytest.mark.parametrize("inp", [
    pytest.param({
        "geom": __geoms["h"],
@@ -135,6 +138,8 @@ def test_ddx_fock_build(inp):
     E, _ = get_EV(inp["dm"])
     assert compare_values(inp["ref"], E, atol=1e-16, rtol=1e-2)
 
+@pytest.mark.quick
+@uusing("ddx")
 @pytest.mark.parametrize("inp", [
     pytest.param({
         "geom": __geoms["h2o"],
@@ -201,6 +206,8 @@ def test_ddx_rhf_reference(inp):
     assert compare_values(inp["ref"], scf_e, 4, "Total SCF energy with DDX versus Gaussian")
 
 
+@pytest.mark.quick
+@uusing("ddx")
 @pytest.mark.parametrize("inp", [
     pytest.param({
         "geom": __geoms["h2o"],

--- a/tests/pytests/test_ddx.py
+++ b/tests/pytests/test_ddx.py
@@ -113,14 +113,14 @@ def test_ddx_fock_build(inp):
     psi4.set_options({
         "df_scf_guess": False,
         #
-        "ddx__model": "cosmo",
-        "ddx__solvent_epsilon": 1e8,
-        "ddx__eta": 0,
-        "ddx__lmax": 3,
-        "ddx__n_lebedev": 302,
-        "ddx__radii": inp["radii"],
-        "ddx__dft_spherical_points": 350,
-        "ddx__dft_radial_points": 99,
+        "ddx_model": "cosmo",
+        "ddx_solvent_epsilon": 1e8,
+        "ddx_eta": 0,
+        "ddx_lmax": 3,
+        "ddx_n_lebedev": 302,
+        "ddx_radii": inp["radii"],
+        "ddx_solute_spherical_points": 350,
+        "ddx_solute_radial_points": 99,
     })
 
     # build the DDX object to test
@@ -183,16 +183,16 @@ def test_ddx_rhf_reference(inp):
         "guess": "core",
         "scf_type": "direct",
         #
-        "ddx__model": "cosmo",
-        "ddx__radii_set": "uff",
-        "ddx__lmax": 3,
-        "ddx__n_lebedev": 302,
-        "ddx__dft_spherical_points": 302,
-        "ddx__dft_radial_points": 75,
-        "ddx__shift": 0.0,
+        "ddx_model": "cosmo",
+        "ddx_radii_set": "uff",
+        "ddx_lmax": 3,
+        "ddx_n_lebedev": 302,
+        "ddx_solute_spherical_points": 302,
+        "ddx_solute_radial_points": 75,
+        "ddx_shift": 0.0,
     })
     for key in inp["ddx"].keys():
-        psi4.set_options({"ddx__" + key: inp["ddx"][key]})
+        psi4.set_options({"ddx_" + key: inp["ddx"][key]})
     scf_e, wfn = psi4.energy('SCF', return_wfn=True, molecule=mol)
     ddx_e = wfn.scalar_variable("dd solvation energy")
 
@@ -222,13 +222,13 @@ def test_ddx_rhf_consistency(inp):
         "ddx": True,
         "basis": inp["basis"],
         #
-        "ddx__lmax": 10,
-        "ddx__n_lebedev": 302,
-        "ddx__dft_spherical_points": 302,
-        "ddx__dft_radial_points": 75,
+        "ddx_lmax": 10,
+        "ddx_n_lebedev": 302,
+        "ddx_solute_spherical_points": 302,
+        "ddx_solute_radial_points": 75,
     })
     for key in inp["ddx"].keys():
-        psi4.set_options({"ddx__" + key: inp["ddx"][key]})
+        psi4.set_options({"ddx_" + key: inp["ddx"][key]})
     scf_e, wfn = psi4.energy('SCF', return_wfn=True, molecule=mol)
     assert compare_values(inp["ref"], scf_e, 9, "Total SCF energy with DDX versus reference data")
 
@@ -241,9 +241,9 @@ def test_ddx_eri_algorithms(scf_type):
         "scf_type": scf_type,
         "basis": "6-31g",
         "ddx": True,
-        "ddx__model": "pcm",
-        "ddx__solvent": "water",
-        "ddx__radii_set": "uff",
+        "ddx_model": "pcm",
+        "ddx_solvent": "water",
+        "ddx_radii_set": "uff",
     })
     ref = -56.1715394
     scf_e = psi4.energy('SCF')

--- a/tests/pytests/test_ddx.py
+++ b/tests/pytests/test_ddx.py
@@ -1,9 +1,9 @@
+import psi4
 import pytest
 import numpy as np
 
-import psi4
-
 from psi4 import core
+
 from utils import *
 from addons import using, uusing
 
@@ -243,11 +243,9 @@ def test_ddx_eri_algorithms(scf_type):
         "scf_type": scf_type,
         "basis": "6-31g",
         "ddx": True,
-    })
-    psi4.set_module_options("ddx", {
-        "model":     "pcm",
-        "solvent":   "water",
-        "radii_set": "uff",
+        "ddx__model": "pcm",
+        "ddx__solvent": "water",
+        "ddx__radii_set": "uff",
     })
     ref = -56.1715394
     scf_e = psi4.energy('SCF')

--- a/tests/pytests/test_ddx.py
+++ b/tests/pytests/test_ddx.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from psi4 import core
 
-from utils import compare_values
+from utils import *
 from addons import using, uusing
 
 pytestmark = [pytest.mark.psi, pytest.mark.api]

--- a/tests/pytests/test_ddx.py
+++ b/tests/pytests/test_ddx.py
@@ -142,40 +142,35 @@ def test_ddx_fock_build(inp):
 @pytest.mark.parametrize("inp", [
     pytest.param({
         "geom": __geoms["h2o"],
-        "ddx": {"model": "cosmo", "solvent_epsilon": 1e8, "eta": 0, "lmax": 3,
-                "n_lebedev": 302, "radii_set": "uff", "shift": 0.0, },
+        "ddx": {"solvent_epsilon": 1e8, "eta": 0, },
         "ref": -75.5946789010,  # from Gaussian
         "solvation": -0.009402,
     }, id='h2o'),
     #
     pytest.param({
         "geom": __geoms["fcm"],
-        "ddx": {"model": "cosmo", "solvent_epsilon": 1e8, "eta": 0, "lmax": 3,
-                "n_lebedev": 302, "radii_set": "uff", "shift": 0.0, },
+        "ddx": {"solvent_epsilon": 1e8, "eta": 0, },
         "ref": -594.993575419,  # from Gaussian
         "solvation": -0.006719,
     }, id='fcm'),
     #
     pytest.param({
         "geom": __geoms["fcm"],
-        "ddx": {"model": "cosmo", "solvent_epsilon": 2.0, "eta": 0, "lmax": 3,
-                "n_lebedev": 302, "radii_set": "uff", "shift": 0.0, },
+        "ddx": {"solvent_epsilon": 2.0, "eta": 0, },
         "ref": -594.990420855,  # from Gaussian
         "solvation": -0.002964,
     }, id='fcmeps'),
     #
     pytest.param({
         "geom": __geoms["fcm"],
-        "ddx": {"model": "cosmo", "solvent_epsilon": 2.0, "eta": 0.2, "lmax": 3,
-                "n_lebedev": 302, "radii_set": "uff", "shift": 0.0, },
+        "ddx": {"solvent_epsilon": 2.0, "eta": 0.2, },
         "ref": -594.990487330,  # from Gaussian
         "solvation": -0.003041,
     }, id='fcmepseta'),
     #
     pytest.param({
         "geom": __geoms["benzene"],
-        "ddx": {"model": "cosmo", "solvent_epsilon": 1e8, "eta": 0, "lmax": 3,
-                "n_lebedev": 302, "radii_set": "uff", "shift": 0.0, },
+        "ddx": {"solvent_epsilon": 1e8, "eta": 0, },
         "ref": -229.420391688,  # from Gaussian
         "solvation": -0.005182,
     }, id='benzene'),
@@ -187,6 +182,14 @@ def test_ddx_rhf_reference(inp):
         "basis": "3-21g",
         "guess": "core",
         "scf_type": "direct",
+        #
+        "ddx__model": "cosmo",
+        "ddx__radii_set": "uff",
+        "ddx__lmax": 3,
+        "ddx__n_lebedev": 302,
+        "ddx__dft_spherical_points": 302,
+        "ddx__dft_radial_points": 75,
+        "ddx__shift": 0.0,
     })
     for key in inp["ddx"].keys():
         psi4.set_options({"ddx__" + key: inp["ddx"][key]})
@@ -203,31 +206,26 @@ def test_ddx_rhf_reference(inp):
     pytest.param({
         "geom": __geoms["h2o"],
         "basis": "cc-pvdz",
-        "ddx": {"model": "cosmo", "solvent": "water", "eta": 0.05,
-                "lmax": 10, "n_lebedev": 302, "radii_set": "bondi",
-                "radii_scaling": 1.2, "dft_spherical_points": 302,
-                "dft_radial_points": 75, },
-        "solvent": "water",
-        "ref": -76.03464496611537,
+        "ddx": {"model": "cosmo", "solvent": "water", "radii_set": "bondi", },
+        "ref": -76.0346355428018,
     }, id='h2o-cosmo'),
     pytest.param({
-        "geom": __geoms["h2o"],
+        "geom": __geoms["fcm"],
         "basis": "cc-pvdz",
-        "ddx": {"model": "pcm", "solvent": "water", "eta": 0.1,
-                "lmax": 10, "n_lebedev": 302, "radii_set": "bondi",
-                "radii_scaling": 1.2, "dft_spherical_points": 302,
-                "dft_radial_points": 75, },
-        "solvent": "water",
-        "ref": -76.03458316484547,
-    }, id='h2o-pcm'),
+        "ddx": {"model": "pcm", "solvent": "water", "radii_set": "uff", },
+        "ref": -597.9718942424215,
+    }, id='fcm-pcm'),
 ])
 def test_ddx_rhf_consistency(inp):
     mol = psi4.geometry(inp["geom"])
     psi4.set_options({
         "ddx": True,
         "basis": inp["basis"],
-        "guess": "core",
-        "scf_type": "direct",
+        #
+        "ddx__lmax": 10,
+        "ddx__n_lebedev": 302,
+        "ddx__dft_spherical_points": 302,
+        "ddx__dft_radial_points": 75,
     })
     for key in inp["ddx"].keys():
         psi4.set_options({"ddx__" + key: inp["ddx"][key]})

--- a/tests/pytests/test_ddx.py
+++ b/tests/pytests/test_ddx.py
@@ -107,6 +107,8 @@ def test_ddx_fock_build(inp):
     Tests COSMO energy against reference from Gaussian
     and internal consistency of Fock matrix versus the energy.
     """
+    from psi4.driver.procrouting.solvent import ddx
+
     psi4.set_options({
         # Note: DFT grids used for DDX numerical integration
         "dft_spherical_points": 350,


### PR DESCRIPTION
## Description
This PR strives to implement an interface of psi4 to the [ddX library](https://github.com/ACoM-Computational-Mathematics/ddX), which implements solvation models (COSMO, PCM, linearised Poisson-Boltzmann) following a domain-decomposition approach.

At its current stage I open the PR to get some feedback from devs about the suggested changes and structure and to finalise the upstream python interface of ddX. Note that this PR Is currently deliberately done on top of an outdated master, since any commit after #2388 introduces segfaults (details see below), which so far I have not yet been able to trace down. Any help on that would be much appreciated.

## User API & Changelog headlines
- Implementation of PCM and COSMO solvation models based on the ddx library.

## Dev notes & details
- Introduction of a NumIntHelper class to compute some integrals numerically using a DFT grid
- Introduction of ddx solvation model and new ddx options

## Reproducer for the mysterious segfault
As part of rebasing against the current master I encountered a really strange segfault. I managed to produce a minimal example, which has really nothing to do with ddx and only adds a python interface to a simple numerical electrostatic integral. See here for a [trimmed-down diff](https://github.com/psi4/psi4/compare/master...mfherbst:psi4:segfault). On my machine checking out this `segfault` branch with `0_configure.sh`, building and running the `mytests/runtests.sh` script gives a segfault inside the numerical integration in the `PCMPotentialInt` class. Note that the code I added *is not even called*, the call to `PCMPotentialInt` happens from the pcm code *which I have not modified*.

Now, commenting out
```c++
PrintIntegralsFunctor printer;
potential_integrals_->compute(printer);
```
the segfault disappears. I'm getting the weird feeling I'm doing something really stupid here and I just missed it.

## Questions
- [x] Thoughts on the NumIntHelper?
- [x] Is D -> D_cart needed or not ([this stuff](https://github.com/psi4/psi4/pull/2767/commits/108b6bb1a53cdc428933475dea991e08a3330d98#diff-48947c7a095c933d6843e0564043f051b0e54dff111fff222bf25cd968f6f9daR1769-R1780))
- [x] Any idea on the segfault when rebasing against master?

## Checklist
- [x] Find and fix segfaults when using psi4 master
- [x] Remove debug restriction to one thread in numerical integrals
- [x] Documentation
- [x] Bring forward more options to change numerical grid details for DDX solvation models
- [x] ~~Merge to the largest extent possible PCM and DDX solvation options~~ (I don't think this can be done easily. Leaving it for now)
- [X] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge

Tagging @hokru, @loriab and @andysim who were involved in discussions about this some point (but a long time ago ... sorry for taking so long to tackle this :smile:). 