### PR TITLE
Expand Testing of COSX and LINK SCF Types

### DIFF
--- a/samples/scf5/input.dat
+++ b/samples/scf5/input.dat
@@ -47,11 +47,11 @@ E = energy('scf')
 set scf_type mem_df
 E = energy('scf')
 
-set scf_type cosx 
+set scf_type cosx
 E = energy('scf')
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 
 set scf reference uhf
@@ -72,11 +72,11 @@ E = energy('scf')
 set scf_type mem_df
 E = energy('scf')
 
-set scf_type cosx 
+set scf_type cosx
 E = energy('scf')
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 
 set scf reference cuhf
@@ -97,11 +97,11 @@ E = energy('scf')
 set scf_type mem_df
 E = energy('scf')
 
-set scf_type cosx 
+set scf_type cosx
 E = energy('scf')
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 
 activate(triplet_o2)
@@ -130,11 +130,11 @@ E = energy('scf')
 set scf_type mem_df
 E = energy('scf')
 
-set scf_type cosx 
+set scf_type cosx
 E = energy('scf')
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 
 clean()
@@ -160,11 +160,11 @@ E = energy('scf')
 set scf_type mem_df
 E = energy('scf')
 
-set scf_type cosx 
+set scf_type cosx
 E = energy('scf')
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 
 clean()
@@ -190,9 +190,9 @@ E = energy('scf')
 set scf_type mem_df
 E = energy('scf')
 
-set scf_type cosx 
+set scf_type cosx
 E = energy('scf')
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')

--- a/samples/scf5/input.dat
+++ b/samples/scf5/input.dat
@@ -30,6 +30,7 @@ set {
 }
 
 set scf reference rhf
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -44,9 +45,17 @@ set scf_type disk_df
 E = energy('scf')
 
 set scf_type mem_df
+E = energy('scf')
+
+set scf_type cosx 
+E = energy('scf')
+
+set scf_type link
+set screening density 
 E = energy('scf')
 
 set scf reference uhf
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -61,9 +70,17 @@ set scf_type disk_df
 E = energy('scf')
 
 set scf_type mem_df
+E = energy('scf')
+
+set scf_type cosx 
+E = energy('scf')
+
+set scf_type link
+set screening density 
 E = energy('scf')
 
 set scf reference cuhf
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -78,6 +95,13 @@ set scf_type disk_df
 E = energy('scf')
 
 set scf_type mem_df
+E = energy('scf')
+
+set scf_type cosx 
+E = energy('scf')
+
+set scf_type link
+set screening density 
 E = energy('scf')
 
 activate(triplet_o2)
@@ -89,6 +113,7 @@ set {
 }
 
 set scf reference uhf
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -103,11 +128,19 @@ set scf_type disk_df
 E = energy('scf')
 
 set scf_type mem_df
+E = energy('scf')
+
+set scf_type cosx 
+E = energy('scf')
+
+set scf_type link
+set screening density 
 E = energy('scf')
 
 clean()
 
 set scf reference rohf
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -125,11 +158,19 @@ set scf_type disk_df
 E = energy('scf')
 
 set scf_type mem_df
+E = energy('scf')
+
+set scf_type cosx 
+E = energy('scf')
+
+set scf_type link
+set screening density 
 E = energy('scf')
 
 clean()
 
 set scf reference cuhf
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -147,4 +188,11 @@ set scf_type disk_df
 E = energy('scf')
 
 set scf_type mem_df
+E = energy('scf')
+
+set scf_type cosx 
+E = energy('scf')
+
+set scf_type link
+set screening density 
 E = energy('scf')

--- a/samples/scf5/test.in
+++ b/samples/scf5/test.in
@@ -102,13 +102,13 @@ E = energy('scf')
 compare_values(Eref_sing_df, E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK UHF energy') #TEST
 
 print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
-set screening csam 
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -135,7 +135,7 @@ E = energy('scf')
 compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK CUHF energy') #TEST
 
@@ -149,7 +149,7 @@ set {
 
 print('    -Triplet UHF:') #TEST
 set scf reference uhf
-set screening csam 
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -184,7 +184,7 @@ clean()
 
 print('    -Triplet ROHF:') #TEST
 set scf reference rohf
-set screening csam 
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -214,7 +214,7 @@ E = energy('scf')
 compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX ROHF energy') #TEST
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK ROHF energy') #TEST
 
@@ -222,7 +222,7 @@ clean()
 
 print('    -Triplet CUHF:') #TEST
 set scf reference cuhf
-set screening csam 
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -252,8 +252,6 @@ E = energy('scf')
 compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST
-
-

--- a/samples/scf5/test.in
+++ b/samples/scf5/test.in
@@ -5,13 +5,13 @@ print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet
 #Ensure that the checkpoint file is always nuked
 psi4_io.set_specific_retention(32,False)
 
-Eref_nuc          =   30.7884922572     #TEST
-Eref_sing_can     = -149.58723684929720 #TEST
-Eref_sing_df      = -149.58715054487624 #TEST
-Eref_uhf_can      = -149.67135517240553 #TEST
-Eref_uhf_df       = -149.67125624291961 #TEST
-Eref_rohf_can     = -149.65170765757173 #TEST
-Eref_rohf_df      = -149.65160796208073 #TEST
+Eref_nuc      =   30.7884922572     #TEST
+Eref_sing_can = -149.58723684929720 #TEST
+Eref_sing_df  = -149.58715054487624 #TEST
+Eref_uhf_can  = -149.67135517240553 #TEST
+Eref_uhf_df   = -149.67125624291961 #TEST
+Eref_rohf_can = -149.65170765757173 #TEST
+Eref_rohf_df  = -149.65160796208073 #TEST
 
 molecule singlet_o2 {
     0 1
@@ -59,6 +59,10 @@ compare_values(Eref_sing_can, E, 6, 'Singlet Disk RHF energy') #TEST
 set scf_type disk_df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF RHF energy') #TEST
+
+set scf_type mem_df
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet MemDF RHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')

--- a/samples/scf5/test.in
+++ b/samples/scf5/test.in
@@ -5,13 +5,13 @@ print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet
 #Ensure that the checkpoint file is always nuked
 psi4_io.set_specific_retention(32,False)
 
-Eref_nuc      =   30.7884922572     #TEST
-Eref_sing_can = -149.58723684929720 #TEST
-Eref_sing_df  = -149.58715054487624 #TEST
-Eref_uhf_can  = -149.67135517240553 #TEST
-Eref_uhf_df   = -149.67125624291961 #TEST
-Eref_rohf_can = -149.65170765757173 #TEST
-Eref_rohf_df  = -149.65160796208073 #TEST
+Eref_nuc          =   30.7884922572     #TEST
+Eref_sing_can     = -149.58723684929720 #TEST
+Eref_sing_df      = -149.58715054487624 #TEST
+Eref_uhf_can      = -149.67135517240553 #TEST
+Eref_uhf_df       = -149.67125624291961 #TEST
+Eref_rohf_can     = -149.65170765757173 #TEST
+Eref_rohf_df      = -149.65160796208073 #TEST
 
 molecule singlet_o2 {
     0 1
@@ -42,6 +42,7 @@ set {
 
 print('    -Singlet RHF:') #TEST
 set scf reference rhf
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -59,12 +60,18 @@ set scf_type disk_df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF RHF energy') #TEST
 
-set scf_type mem_df
+set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet MemDF RHF energy') #TEST
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX RHF energy') #TEST
+
+set scf_type link
+set screening density
+E = energy('scf')
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK RHF energy') #TEST
 
 print('    -Singlet UHF:') #TEST
 set scf reference uhf
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -86,8 +93,18 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet MemDF UHF energy') #TEST
 
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_sing_df, E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
+
+set scf_type link
+set screening density 
+E = energy('scf')
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK UHF energy') #TEST
+
 print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
+set screening csam 
 
 set scf_type pk
 E = energy('scf')
@@ -109,6 +126,15 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet MemDF CUHF energy') #TEST
 
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX CUHF energy') #TEST
+
+set scf_type link
+set screening density 
+E = energy('scf')
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK CUHF energy') #TEST
+
 activate(triplet_o2)
 set {
     basis cc-pvtz
@@ -119,6 +145,7 @@ set {
 
 print('    -Triplet UHF:') #TEST
 set scf reference uhf
+set screening csam 
 
 set scf_type pk
 E = energy('scf')
@@ -140,10 +167,20 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref_uhf_df, E, 6, 'Triplet MemDF UHF energy') #TEST
 
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_uhf_can, E, 4, 'Triplet DFJ+COSX UHF energy') #TEST
+
+set scf_type link
+set screening density
+E = energy('scf')
+compare_values(Eref_uhf_can, E, 4, 'Triplet DFJ+LinK UHF energy') #TEST
+
 clean()
 
 print('    -Triplet ROHF:') #TEST
 set scf reference rohf
+set screening csam 
 
 set scf_type pk
 E = energy('scf')
@@ -168,10 +205,20 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref_rohf_df, E, 6, 'Triplet MemDF ROHF energy') #TEST
 
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX ROHF energy') #TEST
+
+set scf_type link
+set screening density 
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK ROHF energy') #TEST
+
 clean()
 
 print('    -Triplet CUHF:') #TEST
 set scf reference cuhf
+set screening csam 
 
 set scf_type pk
 E = energy('scf')
@@ -195,3 +242,14 @@ compare_values(Eref_rohf_df, E, 6, 'Triplet DiskDF CUHF energy') #TEST
 set scf_type mem_df
 E = energy('scf')
 compare_values(Eref_rohf_df, E, 6, 'Triplet MemDF CUHF energy') #TEST
+
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX CUHF energy') #TEST
+
+set scf_type link
+set screening density 
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST
+
+

--- a/samples/scf5/test.in
+++ b/samples/scf5/test.in
@@ -99,7 +99,7 @@ compare_values(Eref_sing_df, E, 6, 'Singlet MemDF UHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_df, E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
 set screening density

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -102,13 +102,13 @@ E = energy('scf')
 compare_values(Eref_sing_df, E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK UHF energy') #TEST
 
 print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
-set screening csam 
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -135,7 +135,7 @@ E = energy('scf')
 compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK CUHF energy') #TEST
 
@@ -149,7 +149,7 @@ set {
 
 print('    -Triplet UHF:') #TEST
 set scf reference uhf
-set screening csam 
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -184,7 +184,7 @@ clean()
 
 print('    -Triplet ROHF:') #TEST
 set scf reference rohf
-set screening csam 
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -214,7 +214,7 @@ E = energy('scf')
 compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX ROHF energy') #TEST
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK ROHF energy') #TEST
 
@@ -222,7 +222,7 @@ clean()
 
 print('    -Triplet CUHF:') #TEST
 set scf reference cuhf
-set screening csam 
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -252,8 +252,6 @@ E = energy('scf')
 compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST
-
-

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -11,7 +11,7 @@ Eref = {
         "Canonical"    : -149.58723684929720, #TEST
         "DF"           : -149.58715054487624, #TEST
         "Composite": {
-          "DFJ+COSX"   : -149.58723684929720, #TEST
+          "DFJ+COSX"   : -149.58722317236171, #TEST, updated 
           "DFJ+LinK"   : -149.58723684929720  #TEST
         } 
     },
@@ -19,7 +19,7 @@ Eref = {
         "Canonical"    : -149.67135517240553, #TEST
         "DF"           : -149.67125624291961, #TEST
         "Composite": {
-          "DFJ+COSX"   : -149.67135517240553, #TEST
+          "DFJ+COSX"   : -149.67132922581225, #TEST, updated 
           "DFJ+LinK"   : -149.67135517240553  #TEST
         }
     },
@@ -27,7 +27,7 @@ Eref = {
         "Canonical"    : -149.65170765757173, #TEST
         "DF"           : -149.65160796208073, #TEST
         "Composite": {
-          "DFJ+COSX"   : -149.65170765757173, #TEST
+          "DFJ+COSX"   : -149.65168894156605, #TEST, updated 
           "DFJ+LinK"   : -149.65170765757173  #TEST
         }
     }
@@ -86,7 +86,7 @@ compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF RHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref["Singlet"]["Composite"]["DFJ+COSX"], E, 4, 'Singlet DFJ+COSX RHF energy') #TEST
+compare_values(Eref["Singlet"]["Composite"]["DFJ+COSX"], E, 6, 'Singlet DFJ+COSX RHF energy') #TEST
 
 set scf_type link
 set screening density
@@ -119,7 +119,7 @@ compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF UHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref["Singlet"]["Composite"]["DFJ+COSX"], E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
+compare_values(Eref["Singlet"]["Composite"]["DFJ+COSX"], E, 6, 'Singlet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
 set screening density
@@ -152,7 +152,7 @@ compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF CUHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref["Singlet"]["Composite"]["DFJ+COSX"], E, 4, 'Singlet DFJ+COSX CUHF energy') #TEST
+compare_values(Eref["Singlet"]["Composite"]["DFJ+COSX"], E, 6, 'Singlet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
 set screening density
@@ -193,7 +193,7 @@ compare_values(Eref["Triplet UHF"]["DF"], E, 6, 'Triplet MemDF UHF energy') #TES
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref["Triplet UHF"]["Composite"]["DFJ+COSX"], E, 4, 'Triplet DFJ+COSX UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["Composite"]["DFJ+COSX"], E, 6, 'Triplet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
 set screening density
@@ -231,7 +231,7 @@ compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF ROHF energy') #T
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref["Triplet ROHF"]["Composite"]["DFJ+COSX"], E, 4, 'Triplet DFJ+COSX ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Composite"]["DFJ+COSX"], E, 6, 'Triplet DFJ+COSX ROHF energy') #TEST
 
 set scf_type link
 set screening density
@@ -269,7 +269,7 @@ compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF CUHF energy') #T
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref["Triplet ROHF"]["Composite"]["DFJ+COSX"], E, 4, 'Triplet DFJ+COSX CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Composite"]["DFJ+COSX"], E, 6, 'Triplet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
 set screening density

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -5,13 +5,13 @@ print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet
 #Ensure that the checkpoint file is always nuked
 psi4_io.set_specific_retention(32,False)
 
-Eref_nuc      =   30.7884922572     #TEST
-Eref_sing_can = -149.58723684929720 #TEST
-Eref_sing_df  = -149.58715054487624 #TEST
-Eref_uhf_can  = -149.67135517240553 #TEST
-Eref_uhf_df   = -149.67125624291961 #TEST
-Eref_rohf_can = -149.65170765757173 #TEST
-Eref_rohf_df  = -149.65160796208073 #TEST
+Eref_nuc          =   30.7884922572     #TEST
+Eref_sing_can     = -149.58723684929720 #TEST
+Eref_sing_df      = -149.58715054487624 #TEST
+Eref_uhf_can      = -149.67135517240553 #TEST
+Eref_uhf_df       = -149.67125624291961 #TEST
+Eref_rohf_can     = -149.65170765757173 #TEST
+Eref_rohf_df      = -149.65160796208073 #TEST
 
 molecule singlet_o2 {
     0 1
@@ -42,6 +42,7 @@ set {
 
 print('    -Singlet RHF:') #TEST
 set scf reference rhf
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -61,14 +62,16 @@ compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF RHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DFJ+COSX RHF energy') #TEST
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX RHF energy') #TEST
 
 set scf_type link
+set screening density
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DFJ+LinK RHF energy') #TEST
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK RHF energy') #TEST
 
 print('    -Singlet UHF:') #TEST
 set scf reference uhf
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -92,14 +95,16 @@ compare_values(Eref_sing_df, E, 6, 'Singlet MemDF UHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DFJ+COSX UHF energy') #TEST
+compare_values(Eref_sing_df, E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
+set screening density 
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DFJ+LinK UHF energy') #TEST
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK UHF energy') #TEST
 
 print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
+set screening csam 
 
 set scf_type pk
 E = energy('scf')
@@ -123,11 +128,12 @@ compare_values(Eref_sing_df, E, 6, 'Singlet MemDF CUHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DFJ+COSX CUHF energy') #TEST
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
+set screening density 
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DFJ+LinK CUHF energy') #TEST
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK CUHF energy') #TEST
 
 activate(triplet_o2)
 set {
@@ -139,6 +145,7 @@ set {
 
 print('    -Triplet UHF:') #TEST
 set scf reference uhf
+set screening csam 
 
 set scf_type pk
 E = energy('scf')
@@ -162,16 +169,18 @@ compare_values(Eref_uhf_df, E, 6, 'Triplet MemDF UHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Triplet DFJ+COSX UHF energy') #TEST
+compare_values(Eref_uhf_can, E, 4, 'Triplet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
+set screening density
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Triplet DFJ+LinK UHF energy') #TEST
+compare_values(Eref_uhf_can, E, 4, 'Triplet DFJ+LinK UHF energy') #TEST
 
 clean()
 
 print('    -Triplet ROHF:') #TEST
 set scf reference rohf
+set screening csam 
 
 set scf_type pk
 E = energy('scf')
@@ -198,16 +207,18 @@ compare_values(Eref_rohf_df, E, 6, 'Triplet MemDF ROHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Triplet DFJ+COSX ROHF energy') #TEST
+compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX ROHF energy') #TEST
 
 set scf_type link
+set screening density 
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Triplet DFJ+LinK ROHF energy') #TEST
+compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK ROHF energy') #TEST
 
 clean()
 
 print('    -Triplet CUHF:') #TEST
 set scf reference cuhf
+set screening csam 
 
 set scf_type pk
 E = energy('scf')
@@ -234,10 +245,11 @@ compare_values(Eref_rohf_df, E, 6, 'Triplet MemDF CUHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Triplet DFJ+COSX CUHF energy') #TEST
+compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
+set screening density 
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Triplet DFJ+LinK CUHF energy') #TEST
+compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST
 
 

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -5,13 +5,13 @@ print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet
 #Ensure that the checkpoint file is always nuked
 psi4_io.set_specific_retention(32,False)
 
-Eref_nuc          =   30.7884922572     #TEST
-Eref_sing_can     = -149.58723684929720 #TEST
-Eref_sing_df      = -149.58715054487624 #TEST
-Eref_uhf_can      = -149.67135517240553 #TEST
-Eref_uhf_df       = -149.67125624291961 #TEST
-Eref_rohf_can     = -149.65170765757173 #TEST
-Eref_rohf_df      = -149.65160796208073 #TEST
+Eref_nuc      =   30.7884922572     #TEST
+Eref_sing_can = -149.58723684929720 #TEST
+Eref_sing_df  = -149.58715054487624 #TEST
+Eref_uhf_can  = -149.67135517240553 #TEST
+Eref_uhf_df   = -149.67125624291961 #TEST
+Eref_rohf_can = -149.65170765757173 #TEST
+Eref_rohf_df  = -149.65160796208073 #TEST
 
 molecule singlet_o2 {
     0 1
@@ -59,6 +59,10 @@ compare_values(Eref_sing_can, E, 6, 'Singlet Disk RHF energy') #TEST
 set scf_type disk_df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF RHF energy') #TEST
+
+set scf_type mem_df
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet MemDF RHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -5,13 +5,21 @@ print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet
 #Ensure that the checkpoint file is always nuked
 psi4_io.set_specific_retention(32,False)
 
-Eref_nuc      =   30.7884922572     #TEST
-Eref_sing_can = -149.58723684929720 #TEST
-Eref_sing_df  = -149.58715054487624 #TEST
-Eref_uhf_can  = -149.67135517240553 #TEST
-Eref_uhf_df   = -149.67125624291961 #TEST
-Eref_rohf_can = -149.65170765757173 #TEST
-Eref_rohf_df  = -149.65160796208073 #TEST
+Eref = {  
+    "Nuclear"      :   30.7884922572,     #TEST
+    "Singlet": {
+        "Canonical": -149.58723684929720, #TEST
+        "DF"       : -149.58715054487624  #TEST
+    },
+    "Triplet UHF": {
+        "Canonical": -149.67135517240553, #TEST
+        "DF"       : -149.67125624291961  #TEST
+    },
+    "Triplet ROHF": {
+        "Canonical": -149.65170765757173, #TEST
+        "DF"       : -149.65160796208073  #TEST
+    }
+}
 
 molecule singlet_o2 {
     0 1
@@ -30,8 +38,8 @@ singlet_o2.update_geometry()
 triplet_o2.update_geometry()
 
 print('   -Nuclear Repulsion:') #TEST
-compare_values(Eref_nuc, triplet_o2.nuclear_repulsion_energy(), 9, "Triplet nuclear repulsion energy")  #TEST
-compare_values(Eref_nuc, singlet_o2.nuclear_repulsion_energy(), 9, "Singlet nuclear repulsion energy")  #TEST
+compare_values(Eref["Nuclear"], triplet_o2.nuclear_repulsion_energy(), 9, "Triplet nuclear repulsion energy")  #TEST
+compare_values(Eref["Nuclear"], singlet_o2.nuclear_repulsion_energy(), 9, "Singlet nuclear repulsion energy")  #TEST
 
 activate(singlet_o2)
 set {
@@ -46,32 +54,32 @@ set screening csam
 
 set scf_type pk
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet PK RHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet PK RHF energy') #TEST
 
 set scf_type direct
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet Direct RHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet Direct RHF energy') #TEST
 
 set scf_type out_of_core
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet Disk RHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet Disk RHF energy') #TEST
 
 set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF RHF energy') #TEST
+compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet DiskDF RHF energy') #TEST
 
 set scf_type mem_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet MemDF RHF energy') #TEST
+compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF RHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX RHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 4, 'Singlet DFJ+COSX RHF energy') #TEST
 
 set scf_type link
 set screening density
 E = energy('scf')
-compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK RHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 4, 'Singlet DFJ+LinK RHF energy') #TEST
 
 print('    -Singlet UHF:') #TEST
 set scf reference uhf
@@ -79,32 +87,32 @@ set screening csam
 
 set scf_type pk
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet PK UHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet PK UHF energy') #TEST
 
 set scf_type direct
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet Direct UHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet Direct UHF energy') #TEST
 
 set scf_type out_of_core
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet Disk UHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet Disk UHF energy') #TEST
 
 set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF UHF energy') #TEST
+compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet DiskDF UHF energy') #TEST
 
 set scf_type mem_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet MemDF UHF energy') #TEST
+compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF UHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
 set screening density
 E = energy('scf')
-compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK UHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 4, 'Singlet DFJ+LinK UHF energy') #TEST
 
 print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
@@ -112,32 +120,32 @@ set screening csam
 
 set scf_type pk
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet PK CUHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet PK CUHF energy') #TEST
 
 set scf_type direct
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet Direct CUHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet Direct CUHF energy') #TEST
 
 set scf_type out_of_core
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet Disk CUHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet Disk CUHF energy') #TEST
 
 set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF CUHF energy') #TEST
+compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet DiskDF CUHF energy') #TEST
 
 set scf_type mem_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet MemDF CUHF energy') #TEST
+compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF CUHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX CUHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 4, 'Singlet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
 set screening density
 E = energy('scf')
-compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK CUHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 4, 'Singlet DFJ+LinK CUHF energy') #TEST
 
 activate(triplet_o2)
 set {
@@ -153,32 +161,32 @@ set screening csam
 
 set scf_type pk
 E = energy('scf')
-compare_values(Eref_uhf_can, E, 6, 'Triplet PK UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["Canonical"], E, 6, 'Triplet PK UHF energy') #TEST
 
 set scf_type direct
 E = energy('scf')
-compare_values(Eref_uhf_can, E, 6, 'Triplet Direct UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["Canonical"], E, 6, 'Triplet Direct UHF energy') #TEST
 
 set scf_type out_of_core
 E = energy('scf')
-compare_values(Eref_uhf_can, E, 6, 'Triplet Disk UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["Canonical"], E, 6, 'Triplet Disk UHF energy') #TEST
 
 set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_uhf_df, E, 6, 'Triplet DiskDF UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["DF"], E, 6, 'Triplet DiskDF UHF energy') #TEST
 
 set scf_type mem_df
 E = energy('scf')
-compare_values(Eref_uhf_df, E, 6, 'Triplet MemDF UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["DF"], E, 6, 'Triplet MemDF UHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_uhf_can, E, 4, 'Triplet DFJ+COSX UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["Canonical"], E, 4, 'Triplet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
 set screening density
 E = energy('scf')
-compare_values(Eref_uhf_can, E, 4, 'Triplet DFJ+LinK UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["Canonical"], E, 4, 'Triplet DFJ+LinK UHF energy') #TEST
 
 clean()
 
@@ -188,35 +196,35 @@ set screening csam
 
 set scf_type pk
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 6, 'Triplet PK ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 6, 'Triplet PK ROHF energy') #TEST
 clean()
 
 set scf_type direct
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 6, 'Triplet Direct ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 6, 'Triplet Direct ROHF energy') #TEST
 clean()
 
 set scf_type out_of_core
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 6, 'Triplet Disk ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 6, 'Triplet Disk ROHF energy') #TEST
 clean()
 
 set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_rohf_df, E, 6, 'Triplet DiskDF ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet DiskDF ROHF energy') #TEST
 
 set scf_type mem_df
 E = energy('scf')
-compare_values(Eref_rohf_df, E, 6, 'Triplet MemDF ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF ROHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 4, 'Triplet DFJ+COSX ROHF energy') #TEST
 
 set scf_type link
 set screening density
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 4, 'Triplet DFJ+LinK ROHF energy') #TEST
 
 clean()
 
@@ -226,32 +234,32 @@ set screening csam
 
 set scf_type pk
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 6, 'Triplet PK CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 6, 'Triplet PK CUHF energy') #TEST
 clean()
 
 set scf_type direct
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 6, 'Triplet Direct CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 6, 'Triplet Direct CUHF energy') #TEST
 clean()
 
 set scf_type out_of_core
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 6, 'Triplet Disk CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 6, 'Triplet Disk CUHF energy') #TEST
 clean()
 
 set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_rohf_df, E, 6, 'Triplet DiskDF CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet DiskDF CUHF energy') #TEST
 
 set scf_type mem_df
 E = energy('scf')
-compare_values(Eref_rohf_df, E, 6, 'Triplet MemDF CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF CUHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 4, 'Triplet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
 set screening density
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -12,7 +12,7 @@ Eref = {
         "DF"           : -149.58715054487624, #TEST
         "Composite": {
           "DFJ+COSX"   : -149.58722317236171, #TEST, updated 
-          "DFJ+LinK"   : -149.58723684929720  #TEST
+          "DFJ+LinK"   : -149.58726772171027  #TEST, updated 
         } 
     },
     "Triplet UHF": {
@@ -20,7 +20,7 @@ Eref = {
         "DF"           : -149.67125624291961, #TEST
         "Composite": {
           "DFJ+COSX"   : -149.67132922581225, #TEST, updated 
-          "DFJ+LinK"   : -149.67135517240553  #TEST
+          "DFJ+LinK"   : -149.67137328005577  #TEST, updated 
         }
     },
     "Triplet ROHF": {
@@ -28,7 +28,7 @@ Eref = {
         "DF"           : -149.65160796208073, #TEST
         "Composite": {
           "DFJ+COSX"   : -149.65168894156605, #TEST, updated 
-          "DFJ+LinK"   : -149.65170765757173  #TEST
+          "DFJ+LinK"   : -149.65172557470324  #TEST, updated
         }
     }
 }

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -59,9 +59,13 @@ set scf_type disk_df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF RHF energy') #TEST
 
-set scf_type mem_df
+set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet MemDF RHF energy') #TEST
+compare_values(Eref_sing_df, E, 6, 'Singlet DFJ+COSX RHF energy') #TEST
+
+set scf_type link
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet DFJ+LinK RHF energy') #TEST
 
 print('    -Singlet UHF:') #TEST
 set scf reference uhf
@@ -86,6 +90,14 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet MemDF UHF energy') #TEST
 
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet DFJ+COSX UHF energy') #TEST
+
+set scf_type link
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet DFJ+LinK UHF energy') #TEST
+
 print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
 
@@ -108,6 +120,14 @@ compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF CUHF energy') #TEST
 set scf_type mem_df
 E = energy('scf')
 compare_values(Eref_sing_df, E, 6, 'Singlet MemDF CUHF energy') #TEST
+
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet DFJ+COSX CUHF energy') #TEST
+
+set scf_type link
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet DFJ+LinK CUHF energy') #TEST
 
 activate(triplet_o2)
 set {
@@ -140,6 +160,14 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref_uhf_df, E, 6, 'Triplet MemDF UHF energy') #TEST
 
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Triplet DFJ+COSX UHF energy') #TEST
+
+set scf_type link
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Triplet DFJ+LinK UHF energy') #TEST
+
 clean()
 
 print('    -Triplet ROHF:') #TEST
@@ -168,6 +196,14 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref_rohf_df, E, 6, 'Triplet MemDF ROHF energy') #TEST
 
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Triplet DFJ+COSX ROHF energy') #TEST
+
+set scf_type link
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Triplet DFJ+LinK ROHF energy') #TEST
+
 clean()
 
 print('    -Triplet CUHF:') #TEST
@@ -195,3 +231,13 @@ compare_values(Eref_rohf_df, E, 6, 'Triplet DiskDF CUHF energy') #TEST
 set scf_type mem_df
 E = energy('scf')
 compare_values(Eref_rohf_df, E, 6, 'Triplet MemDF CUHF energy') #TEST
+
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Triplet DFJ+COSX CUHF energy') #TEST
+
+set scf_type link
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Triplet DFJ+LinK CUHF energy') #TEST
+
+

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -6,18 +6,30 @@ print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet
 psi4_io.set_specific_retention(32,False)
 
 Eref = {  
-    "Nuclear"      :   30.7884922572,     #TEST
+    "Nuclear"          :   30.7884922572,     #TEST
     "Singlet": {
-        "Canonical": -149.58723684929720, #TEST
-        "DF"       : -149.58715054487624  #TEST
+        "Canonical"    : -149.58723684929720, #TEST
+        "DF"           : -149.58715054487624, #TEST
+        "Composite": {
+          "DFJ+COSX"   : -149.58723684929720, #TEST
+          "DFJ+LinK"   : -149.58723684929720  #TEST
+        } 
     },
     "Triplet UHF": {
-        "Canonical": -149.67135517240553, #TEST
-        "DF"       : -149.67125624291961  #TEST
+        "Canonical"    : -149.67135517240553, #TEST
+        "DF"           : -149.67125624291961, #TEST
+        "Composite": {
+          "DFJ+COSX"   : -149.67135517240553, #TEST
+          "DFJ+LinK"   : -149.67135517240553  #TEST
+        }
     },
     "Triplet ROHF": {
-        "Canonical": -149.65170765757173, #TEST
-        "DF"       : -149.65160796208073  #TEST
+        "Canonical"    : -149.65170765757173, #TEST
+        "DF"           : -149.65160796208073, #TEST
+        "Composite": {
+          "DFJ+COSX"   : -149.65170765757173, #TEST
+          "DFJ+LinK"   : -149.65170765757173  #TEST
+        }
     }
 }
 
@@ -74,12 +86,12 @@ compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF RHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref["Singlet"]["Canonical"], E, 4, 'Singlet DFJ+COSX RHF energy') #TEST
+compare_values(Eref["Singlet"]["Composite"]["DFJ+COSX"], E, 4, 'Singlet DFJ+COSX RHF energy') #TEST
 
 set scf_type link
 set screening density
 E = energy('scf')
-compare_values(Eref["Singlet"]["Canonical"], E, 4, 'Singlet DFJ+LinK RHF energy') #TEST
+compare_values(Eref["Singlet"]["Composite"]["DFJ+LinK"], E, 4, 'Singlet DFJ+LinK RHF energy') #TEST
 
 print('    -Singlet UHF:') #TEST
 set scf reference uhf
@@ -107,12 +119,12 @@ compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF UHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref["Singlet"]["Canonical"], E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
+compare_values(Eref["Singlet"]["Composite"]["DFJ+COSX"], E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
 set screening density
 E = energy('scf')
-compare_values(Eref["Singlet"]["Canonical"], E, 4, 'Singlet DFJ+LinK UHF energy') #TEST
+compare_values(Eref["Singlet"]["Composite"]["DFJ+LinK"], E, 4, 'Singlet DFJ+LinK UHF energy') #TEST
 
 print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
@@ -140,12 +152,12 @@ compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF CUHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref["Singlet"]["Canonical"], E, 4, 'Singlet DFJ+COSX CUHF energy') #TEST
+compare_values(Eref["Singlet"]["Composite"]["DFJ+COSX"], E, 4, 'Singlet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
 set screening density
 E = energy('scf')
-compare_values(Eref["Singlet"]["Canonical"], E, 4, 'Singlet DFJ+LinK CUHF energy') #TEST
+compare_values(Eref["Singlet"]["Composite"]["DFJ+LinK"], E, 4, 'Singlet DFJ+LinK CUHF energy') #TEST
 
 activate(triplet_o2)
 set {
@@ -181,12 +193,12 @@ compare_values(Eref["Triplet UHF"]["DF"], E, 6, 'Triplet MemDF UHF energy') #TES
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref["Triplet UHF"]["Canonical"], E, 4, 'Triplet DFJ+COSX UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["Composite"]["DFJ+COSX"], E, 4, 'Triplet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
 set screening density
 E = energy('scf')
-compare_values(Eref["Triplet UHF"]["Canonical"], E, 4, 'Triplet DFJ+LinK UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["Composite"]["DFJ+LinK"], E, 4, 'Triplet DFJ+LinK UHF energy') #TEST
 
 clean()
 
@@ -219,12 +231,12 @@ compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF ROHF energy') #T
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref["Triplet ROHF"]["Canonical"], E, 4, 'Triplet DFJ+COSX ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Composite"]["DFJ+COSX"], E, 4, 'Triplet DFJ+COSX ROHF energy') #TEST
 
 set scf_type link
 set screening density
 E = energy('scf')
-compare_values(Eref["Triplet ROHF"]["Canonical"], E, 4, 'Triplet DFJ+LinK ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Composite"]["DFJ+LinK"], E, 4, 'Triplet DFJ+LinK ROHF energy') #TEST
 
 clean()
 
@@ -257,9 +269,9 @@ compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF CUHF energy') #T
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref["Triplet ROHF"]["Canonical"], E, 4, 'Triplet DFJ+COSX CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Composite"]["DFJ+COSX"], E, 4, 'Triplet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
 set screening density
 E = energy('scf')
-compare_values(Eref["Triplet ROHF"]["Canonical"], E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Composite"]["DFJ+LinK"], E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -99,7 +99,7 @@ compare_values(Eref_sing_df, E, 6, 'Singlet MemDF UHF energy') #TEST
 
 set scf_type cosx
 E = energy('scf')
-compare_values(Eref_sing_df, E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
 set screening density

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -85,11 +85,10 @@ E = energy('scf')
 compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF RHF energy') #TEST
 
 for method in Eref["Singlet"]["Composite"].keys():
+    set scf_type $method 
     if method == "COSX": 
-      set scf_type cosx # NOTE: if I knew how to directly assign scf_type to the value in method in Psithon here, I would
       set screening csam
-    elif method == "LinK":
-      set scf_type link 
+    else:
       set screening density
 
     E = energy('scf')
@@ -120,11 +119,10 @@ E = energy('scf')
 compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF UHF energy') #TEST
 
 for method in Eref["Singlet"]["Composite"].keys():
+    set scf_type $method 
     if method == "COSX": 
-      set scf_type cosx 
       set screening csam
-    elif method == "LinK":
-      set scf_type link 
+    else:
       set screening density
 
     E = energy('scf')
@@ -155,11 +153,10 @@ E = energy('scf')
 compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF CUHF energy') #TEST
 
 for method in Eref["Singlet"]["Composite"].keys():
+    set scf_type $method 
     if method == "COSX": 
-      set scf_type cosx 
       set screening csam
-    elif method == "LinK":
-      set scf_type link 
+    else:
       set screening density
 
     E = energy('scf')
@@ -198,11 +195,10 @@ E = energy('scf')
 compare_values(Eref["Triplet UHF"]["DF"], E, 6, 'Triplet MemDF UHF energy') #TEST
 
 for method in Eref["Triplet UHF"]["Composite"].keys():
+    set scf_type $method 
     if method == "COSX": 
-      set scf_type cosx 
       set screening csam
-    elif method == "LinK":
-      set scf_type link 
+    else:
       set screening density
 
     E = energy('scf')
@@ -238,11 +234,10 @@ E = energy('scf')
 compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF ROHF energy') #TEST
 
 for method in Eref["Triplet ROHF"]["Composite"].keys():
+    set scf_type $method 
     if method == "COSX": 
-      set scf_type cosx 
       set screening csam
-    elif method == "LinK":
-      set scf_type link 
+    else:
       set screening density
 
     E = energy('scf')
@@ -278,11 +273,10 @@ E = energy('scf')
 compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF CUHF energy') #TEST
 
 for method in Eref["Triplet ROHF"]["Composite"].keys():
+    set scf_type $method 
     if method == "COSX": 
-      set scf_type cosx 
       set screening csam
-    elif method == "LinK":
-      set scf_type link 
+    else:
       set screening density
 
     E = energy('scf')

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -6,29 +6,29 @@ print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet
 psi4_io.set_specific_retention(32,False)
 
 Eref = {  
-    "Nuclear"          :   30.7884922572,     #TEST
+    "Nuclear"       :   30.7884922572,     #TEST
     "Singlet": {
-        "Canonical"    : -149.58723684929720, #TEST
-        "DF"           : -149.58715054487624, #TEST
+        "Canonical" : -149.58723684929720, #TEST
+        "DF"        : -149.58715054487624, #TEST
         "Composite": {
-          "DFJ+COSX"   : -149.58722317236171, #TEST, updated 
-          "DFJ+LinK"   : -149.58726772171027  #TEST, updated 
+          "COSX"    : -149.58722317236171, #TEST
+          "LinK"    : -149.58726772171027  #TEST
         } 
     },
     "Triplet UHF": {
-        "Canonical"    : -149.67135517240553, #TEST
-        "DF"           : -149.67125624291961, #TEST
+        "Canonical" : -149.67135517240553, #TEST
+        "DF"        : -149.67125624291961, #TEST
         "Composite": {
-          "DFJ+COSX"   : -149.67132922581225, #TEST, updated 
-          "DFJ+LinK"   : -149.67137328005577  #TEST, updated 
+          "COSX"    : -149.67132922581225, #TEST
+          "LinK"    : -149.67137328005577  #TEST
         }
     },
     "Triplet ROHF": {
-        "Canonical"    : -149.65170765757173, #TEST
-        "DF"           : -149.65160796208073, #TEST
+        "Canonical" : -149.65170765757173, #TEST
+        "DF"        : -149.65160796208073, #TEST
         "Composite": {
-          "DFJ+COSX"   : -149.65168894156605, #TEST, updated 
-          "DFJ+LinK"   : -149.65172557470324  #TEST, updated
+          "COSX"    : -149.65168894156605, #TEST
+          "LinK"    : -149.65172557470324  #TEST
         }
     }
 }

--- a/tests/scf5/input.dat
+++ b/tests/scf5/input.dat
@@ -84,14 +84,16 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF RHF energy') #TEST
 
-set scf_type cosx
-E = energy('scf')
-compare_values(Eref["Singlet"]["Composite"]["DFJ+COSX"], E, 6, 'Singlet DFJ+COSX RHF energy') #TEST
+for method in Eref["Singlet"]["Composite"].keys():
+    if method == "COSX": 
+      set scf_type cosx # NOTE: if I knew how to directly assign scf_type to the value in method in Psithon here, I would
+      set screening csam
+    elif method == "LinK":
+      set scf_type link 
+      set screening density
 
-set scf_type link
-set screening density
-E = energy('scf')
-compare_values(Eref["Singlet"]["Composite"]["DFJ+LinK"], E, 4, 'Singlet DFJ+LinK RHF energy') #TEST
+    E = energy('scf')
+    compare_values(Eref["Singlet"]["Composite"][method], E, 6, f'Singlet {method} RHF energy') #TEST
 
 print('    -Singlet UHF:') #TEST
 set scf reference uhf
@@ -117,14 +119,16 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF UHF energy') #TEST
 
-set scf_type cosx
-E = energy('scf')
-compare_values(Eref["Singlet"]["Composite"]["DFJ+COSX"], E, 6, 'Singlet DFJ+COSX UHF energy') #TEST
+for method in Eref["Singlet"]["Composite"].keys():
+    if method == "COSX": 
+      set scf_type cosx 
+      set screening csam
+    elif method == "LinK":
+      set scf_type link 
+      set screening density
 
-set scf_type link
-set screening density
-E = energy('scf')
-compare_values(Eref["Singlet"]["Composite"]["DFJ+LinK"], E, 4, 'Singlet DFJ+LinK UHF energy') #TEST
+    E = energy('scf')
+    compare_values(Eref["Singlet"]["Composite"][method], E, 6, f'Singlet {method} UHF energy') #TEST
 
 print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
@@ -150,14 +154,16 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF CUHF energy') #TEST
 
-set scf_type cosx
-E = energy('scf')
-compare_values(Eref["Singlet"]["Composite"]["DFJ+COSX"], E, 6, 'Singlet DFJ+COSX CUHF energy') #TEST
+for method in Eref["Singlet"]["Composite"].keys():
+    if method == "COSX": 
+      set scf_type cosx 
+      set screening csam
+    elif method == "LinK":
+      set scf_type link 
+      set screening density
 
-set scf_type link
-set screening density
-E = energy('scf')
-compare_values(Eref["Singlet"]["Composite"]["DFJ+LinK"], E, 4, 'Singlet DFJ+LinK CUHF energy') #TEST
+    E = energy('scf')
+    compare_values(Eref["Singlet"]["Composite"][method], E, 6, f'Singlet {method} CUHF energy') #TEST
 
 activate(triplet_o2)
 set {
@@ -191,14 +197,16 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref["Triplet UHF"]["DF"], E, 6, 'Triplet MemDF UHF energy') #TEST
 
-set scf_type cosx
-E = energy('scf')
-compare_values(Eref["Triplet UHF"]["Composite"]["DFJ+COSX"], E, 6, 'Triplet DFJ+COSX UHF energy') #TEST
+for method in Eref["Triplet UHF"]["Composite"].keys():
+    if method == "COSX": 
+      set scf_type cosx 
+      set screening csam
+    elif method == "LinK":
+      set scf_type link 
+      set screening density
 
-set scf_type link
-set screening density
-E = energy('scf')
-compare_values(Eref["Triplet UHF"]["Composite"]["DFJ+LinK"], E, 4, 'Triplet DFJ+LinK UHF energy') #TEST
+    E = energy('scf')
+    compare_values(Eref["Triplet UHF"]["Composite"][method], E, 6, f'Triplet {method} UHF energy') #TEST
 
 clean()
 
@@ -229,14 +237,16 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF ROHF energy') #TEST
 
-set scf_type cosx
-E = energy('scf')
-compare_values(Eref["Triplet ROHF"]["Composite"]["DFJ+COSX"], E, 6, 'Triplet DFJ+COSX ROHF energy') #TEST
+for method in Eref["Triplet ROHF"]["Composite"].keys():
+    if method == "COSX": 
+      set scf_type cosx 
+      set screening csam
+    elif method == "LinK":
+      set scf_type link 
+      set screening density
 
-set scf_type link
-set screening density
-E = energy('scf')
-compare_values(Eref["Triplet ROHF"]["Composite"]["DFJ+LinK"], E, 4, 'Triplet DFJ+LinK ROHF energy') #TEST
+    E = energy('scf')
+    compare_values(Eref["Triplet ROHF"]["Composite"][method], E, 6, f'Triplet {method} ROHF energy') #TEST
 
 clean()
 
@@ -267,11 +277,13 @@ set scf_type mem_df
 E = energy('scf')
 compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF CUHF energy') #TEST
 
-set scf_type cosx
-E = energy('scf')
-compare_values(Eref["Triplet ROHF"]["Composite"]["DFJ+COSX"], E, 6, 'Triplet DFJ+COSX CUHF energy') #TEST
+for method in Eref["Triplet ROHF"]["Composite"].keys():
+    if method == "COSX": 
+      set scf_type cosx 
+      set screening csam
+    elif method == "LinK":
+      set scf_type link 
+      set screening density
 
-set scf_type link
-set screening density
-E = energy('scf')
-compare_values(Eref["Triplet ROHF"]["Composite"]["DFJ+LinK"], E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST
+    E = energy('scf')
+    compare_values(Eref["Triplet ROHF"]["Composite"][method], E, 6, f'Triplet {method} CUHF energy') #TEST

--- a/tests/scf5/output.ref
+++ b/tests/scf5/output.ref
@@ -30,9 +30,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 07 November 2022 10:56AM
+    Psi4 started on: Monday, 07 November 2022 11:04AM
 
-    Process ID: 29881
+    Process ID: 30461
     Host:       ds6
     PSIDATADIR: /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4
     Memory:     500.0 MiB
@@ -145,13 +145,13 @@ E = energy('scf')
 compare_values(Eref_sing_df, E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK UHF energy') #TEST
 
 print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
-set screening csam 
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -178,7 +178,7 @@ E = energy('scf')
 compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK CUHF energy') #TEST
 
@@ -192,7 +192,7 @@ set {
 
 print('    -Triplet UHF:') #TEST
 set scf reference uhf
-set screening csam 
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -227,7 +227,7 @@ clean()
 
 print('    -Triplet ROHF:') #TEST
 set scf reference rohf
-set screening csam 
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -257,7 +257,7 @@ E = energy('scf')
 compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX ROHF energy') #TEST
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK ROHF energy') #TEST
 
@@ -265,7 +265,7 @@ clean()
 
 print('    -Triplet CUHF:') #TEST
 set scf reference cuhf
-set screening csam 
+set screening csam
 
 set scf_type pk
 E = energy('scf')
@@ -295,11 +295,9 @@ E = energy('scf')
 compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX CUHF energy') #TEST
 
 set scf_type link
-set screening density 
+set screening density
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST
-
-
 --------------------------------------------------------------------------
     Triplet nuclear repulsion energy......................................................PASSED
     Singlet nuclear repulsion energy......................................................PASSED
@@ -307,7 +305,7 @@ compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:33 2022
+*** at Mon Nov  7 11:04:15 2022
 
    => Loading Basis Set <=
 
@@ -434,10 +432,10 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RHF iter SAD:  -149.27731917078717   -1.49277e+02   0.00000e+00 
-   @RHF iter   1:  -149.56362429559402   -2.86305e-01   1.10129e-02 ADIIS/DIIS
-   @RHF iter   2:  -149.58582140635929   -2.21971e-02   2.91434e-03 ADIIS/DIIS
-   @RHF iter   3:  -149.58712033600358   -1.29893e-03   6.40033e-04 ADIIS/DIIS
-   @RHF iter   4:  -149.58723140197705   -1.11066e-04   1.37095e-04 ADIIS/DIIS
+   @RHF iter   1:  -149.56362429559402   -2.86305e-01   1.10129e-02 DIIS/ADIIS
+   @RHF iter   2:  -149.58582140635929   -2.21971e-02   2.91434e-03 DIIS/ADIIS
+   @RHF iter   3:  -149.58712033600358   -1.29893e-03   6.40033e-04 DIIS/ADIIS
+   @RHF iter   4:  -149.58723140197705   -1.11066e-04   1.37095e-04 DIIS/ADIIS
    @RHF iter   5:  -149.58723670345904   -5.30148e-06   1.80224e-05 DIIS
    @RHF iter   6:  -149.58723684553323   -1.42074e-07   2.57334e-06 DIIS
    @RHF iter   7:  -149.58723684812222   -2.58899e-09   2.40539e-07 DIIS
@@ -513,21 +511,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:34 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:16 2022
 Module time:
-	user time   =       0.50 seconds =       0.01 minutes
-	system time =       0.07 seconds =       0.00 minutes
+	user time   =       0.52 seconds =       0.01 minutes
+	system time =       0.06 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.50 seconds =       0.01 minutes
-	system time =       0.07 seconds =       0.00 minutes
+	user time   =       0.52 seconds =       0.01 minutes
+	system time =       0.06 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
     Singlet PK RHF energy.................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:34 2022
+*** at Mon Nov  7 11:04:16 2022
 
    => Loading Basis Set <=
 
@@ -669,10 +667,10 @@ Scratch directory: /scratch/dpoole34/
                            Total Energy        Delta E     RMS |[F,P]|
 
    @DF-RHF iter SAD:  -149.27728822299315   -1.49277e+02   0.00000e+00 
-   @DF-RHF iter   1:  -149.56354408328301   -2.86256e-01   1.10101e-02 ADIIS/DIIS
-   @DF-RHF iter   2:  -149.58573446084225   -2.21904e-02   2.91563e-03 ADIIS/DIIS
-   @DF-RHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 ADIIS/DIIS
-   @DF-RHF iter   4:  -149.58714509680499   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-RHF iter   1:  -149.56354408328301   -2.86256e-01   1.10101e-02 DIIS/ADIIS
+   @DF-RHF iter   2:  -149.58573446084225   -2.21904e-02   2.91563e-03 DIIS/ADIIS
+   @DF-RHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 DIIS/ADIIS
+   @DF-RHF iter   4:  -149.58714509680499   -1.11214e-04   1.37129e-04 DIIS/ADIIS
    @DF-RHF iter   5:  -149.58715039895961   -5.30215e-06   1.80355e-05 DIIS
    @DF-RHF iter   6:  -149.58715054109817   -1.42139e-07   2.57889e-06 DIIS
    @DF-RHF iter   7:  -149.58715054369765   -2.59948e-09   2.41536e-07 DIIS
@@ -765,13 +763,13 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:35 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:17 2022
 Module time:
-	user time   =       0.78 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.79 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.30 seconds =       0.02 minutes
+	user time   =       1.33 seconds =       0.02 minutes
 	system time =       0.07 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
     Singlet Direct RHF energy.............................................................PASSED
@@ -779,7 +777,7 @@ Total time:
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:35 2022
+*** at Mon Nov  7 11:04:17 2022
 
    => Loading Basis Set <=
 
@@ -888,10 +886,10 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RHF iter SAD:  -149.27731917078719   -1.49277e+02   0.00000e+00 
-   @RHF iter   1:  -149.56362429559408   -2.86305e-01   1.10129e-02 ADIIS/DIIS
-   @RHF iter   2:  -149.58582140635937   -2.21971e-02   2.91434e-03 ADIIS/DIIS
-   @RHF iter   3:  -149.58712033600364   -1.29893e-03   6.40033e-04 ADIIS/DIIS
-   @RHF iter   4:  -149.58723140197696   -1.11066e-04   1.37095e-04 ADIIS/DIIS
+   @RHF iter   1:  -149.56362429559408   -2.86305e-01   1.10129e-02 DIIS/ADIIS
+   @RHF iter   2:  -149.58582140635937   -2.21971e-02   2.91434e-03 DIIS/ADIIS
+   @RHF iter   3:  -149.58712033600364   -1.29893e-03   6.40033e-04 DIIS/ADIIS
+   @RHF iter   4:  -149.58723140197696   -1.11066e-04   1.37095e-04 DIIS/ADIIS
    @RHF iter   5:  -149.58723670345884   -5.30148e-06   1.80224e-05 DIIS
    @RHF iter   6:  -149.58723684553328   -1.42074e-07   2.57334e-06 DIIS
    @RHF iter   7:  -149.58723684812233   -2.58905e-09   2.40539e-07 DIIS
@@ -967,21 +965,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:36 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:17 2022
 Module time:
-	user time   =       0.37 seconds =       0.01 minutes
+	user time   =       0.36 seconds =       0.01 minutes
 	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.70 seconds =       0.03 minutes
+	user time   =       1.71 seconds =       0.03 minutes
 	system time =       0.09 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	total time  =          2 seconds =       0.03 minutes
     Singlet Disk RHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:36 2022
+*** at Mon Nov  7 11:04:17 2022
 
    => Loading Basis Set <=
 
@@ -1120,10 +1118,10 @@ Scratch directory: /scratch/dpoole34/
                            Total Energy        Delta E     RMS |[F,P]|
 
    @DF-RHF iter SAD:  -149.27728822299318   -1.49277e+02   0.00000e+00 
-   @DF-RHF iter   1:  -149.56354408328303   -2.86256e-01   1.10101e-02 ADIIS/DIIS
-   @DF-RHF iter   2:  -149.58573446084227   -2.21904e-02   2.91563e-03 ADIIS/DIIS
-   @DF-RHF iter   3:  -149.58703388315291   -1.29942e-03   6.40386e-04 ADIIS/DIIS
-   @DF-RHF iter   4:  -149.58714509680490   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-RHF iter   1:  -149.56354408328303   -2.86256e-01   1.10101e-02 DIIS/ADIIS
+   @DF-RHF iter   2:  -149.58573446084227   -2.21904e-02   2.91563e-03 DIIS/ADIIS
+   @DF-RHF iter   3:  -149.58703388315291   -1.29942e-03   6.40386e-04 DIIS/ADIIS
+   @DF-RHF iter   4:  -149.58714509680490   -1.11214e-04   1.37129e-04 DIIS/ADIIS
    @DF-RHF iter   5:  -149.58715039895969   -5.30215e-06   1.80355e-05 DIIS
    @DF-RHF iter   6:  -149.58715054109820   -1.42139e-07   2.57889e-06 DIIS
    @DF-RHF iter   7:  -149.58715054369767   -2.59948e-09   2.41536e-07 DIIS
@@ -1199,21 +1197,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:36 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:18 2022
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.21 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.96 seconds =       0.03 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =       1.95 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
     Singlet DiskDF RHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:36 2022
+*** at Mon Nov  7 11:04:18 2022
 
    => Loading Basis Set <=
 
@@ -1353,10 +1351,10 @@ Scratch directory: /scratch/dpoole34/
                            Total Energy        Delta E     RMS |[F,P]|
 
    @DF-RHF iter SAD:  -149.27728822299315   -1.49277e+02   0.00000e+00 
-   @DF-RHF iter   1:  -149.56354408328301   -2.86256e-01   1.10101e-02 ADIIS/DIIS
-   @DF-RHF iter   2:  -149.58573446084225   -2.21904e-02   2.91563e-03 ADIIS/DIIS
-   @DF-RHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 ADIIS/DIIS
-   @DF-RHF iter   4:  -149.58714509680499   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-RHF iter   1:  -149.56354408328301   -2.86256e-01   1.10101e-02 DIIS/ADIIS
+   @DF-RHF iter   2:  -149.58573446084225   -2.21904e-02   2.91563e-03 DIIS/ADIIS
+   @DF-RHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 DIIS/ADIIS
+   @DF-RHF iter   4:  -149.58714509680499   -1.11214e-04   1.37129e-04 DIIS/ADIIS
    @DF-RHF iter   5:  -149.58715039895961   -5.30215e-06   1.80355e-05 DIIS
    @DF-RHF iter   6:  -149.58715054109817   -1.42139e-07   2.57889e-06 DIIS
    @DF-RHF iter   7:  -149.58715054369765   -2.59948e-09   2.41536e-07 DIIS
@@ -1432,21 +1430,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:37 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:18 2022
 Module time:
-	user time   =       0.20 seconds =       0.00 minutes
+	user time   =       0.21 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
 	user time   =       2.19 seconds =       0.04 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
     Singlet MemDF RHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:37 2022
+*** at Mon Nov  7 11:04:18 2022
 
    => Loading Basis Set <=
 
@@ -1568,17 +1566,17 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RHF iter SAD:  -149.27713328631921   -1.49277e+02   0.00000e+00 
-   @RHF iter   1:  -149.56382697604784   -2.86694e-01   1.10975e-02 ADIIS/DIIS
-   @RHF iter   2:  -149.58629558037478   -2.24686e-02   2.92559e-03 ADIIS/DIIS
-   @RHF iter   3:  -149.58760428588187   -1.30871e-03   6.47395e-04 ADIIS/DIIS
-   @RHF iter   4:  -149.58772283023296   -1.18544e-04   1.38075e-04 ADIIS/DIIS
-   @RHF iter   5:  -149.58772855372331   -5.72349e-06   1.83160e-05 DIIS
-   @RHF iter   6:  -149.58772885952462   -3.05801e-07   2.47041e-06 DIIS
-   @RHF iter   7:  -149.58772885956972   -4.51053e-11   2.44347e-07 DIIS
+   @RHF iter   1:  -149.56382697604792   -2.86694e-01   1.10975e-02 DIIS/ADIIS
+   @RHF iter   2:  -149.58629558037478   -2.24686e-02   2.92559e-03 DIIS/ADIIS
+   @RHF iter   3:  -149.58760428588212   -1.30871e-03   6.47395e-04 DIIS/ADIIS
+   @RHF iter   4:  -149.58772283023296   -1.18544e-04   1.38075e-04 DIIS/ADIIS
+   @RHF iter   5:  -149.58772855372317   -5.72349e-06   1.83160e-05 DIIS
+   @RHF iter   6:  -149.58772885952450   -3.05801e-07   2.47041e-06 DIIS
+   @RHF iter   7:  -149.58772885956978   -4.52758e-11   2.44347e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @RHF iter   8:  -149.58722317116360    5.05688e-04   9.91149e-04 ADIIS/DIIS
+   @RHF iter   8:  -149.58722317116366    5.05688e-04   9.91149e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -1620,14 +1618,14 @@ Scratch directory: /scratch/dpoole34/
     NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  @RHF Final Energy:  -149.58722317116360
+  @RHF Final Energy:  -149.58722317116366
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.8059033672356009
-    Two-Electron Energy =                  86.4301879389083325
-    Total Energy =                       -149.5872231711636005
+    One-Electron Energy =                -266.8059033672359419
+    Two-Electron Energy =                  86.4301879389086025
+    Total Energy =                       -149.5872231711636857
 
 Computation Completed
 
@@ -1651,13 +1649,13 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:39 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:21 2022
 Module time:
-	user time   =       2.54 seconds =       0.04 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.58 seconds =       0.04 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =       4.76 seconds =       0.08 minutes
+	user time   =       4.79 seconds =       0.08 minutes
 	system time =       0.10 seconds =       0.00 minutes
 	total time  =          6 seconds =       0.10 minutes
     Singlet DFJ+COSX RHF energy...........................................................PASSED
@@ -1665,7 +1663,7 @@ Total time:
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:39 2022
+*** at Mon Nov  7 11:04:21 2022
 
    => Loading Basis Set <=
 
@@ -1784,10 +1782,10 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RHF iter SAD:  -149.27733086414963   -1.49277e+02   0.00000e+00 
-   @RHF iter   1:  -149.56365008860490   -2.86319e-01   1.10142e-02 ADIIS/DIIS
-   @RHF iter   2:  -149.58585218222908   -2.22021e-02   2.91422e-03 ADIIS/DIIS
-   @RHF iter   3:  -149.58715113835373   -1.29896e-03   6.40333e-04 ADIIS/DIIS
-   @RHF iter   4:  -149.58726227365065   -1.11135e-04   1.37172e-04 ADIIS/DIIS
+   @RHF iter   1:  -149.56365008860490   -2.86319e-01   1.10142e-02 DIIS/ADIIS
+   @RHF iter   2:  -149.58585218222908   -2.22021e-02   2.91422e-03 DIIS/ADIIS
+   @RHF iter   3:  -149.58715113835373   -1.29896e-03   6.40333e-04 DIIS/ADIIS
+   @RHF iter   4:  -149.58726227365065   -1.11135e-04   1.37172e-04 DIIS/ADIIS
    @RHF iter   5:  -149.58726757682930   -5.30318e-06   1.80326e-05 DIIS
    @RHF iter   6:  -149.58726771909232   -1.42263e-07   2.57489e-06 DIIS
    @RHF iter   7:  -149.58726772168643   -2.59411e-09   2.41117e-07 DIIS
@@ -1863,21 +1861,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:41 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:22 2022
 Module time:
-	user time   =       1.34 seconds =       0.02 minutes
+	user time   =       1.33 seconds =       0.02 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       6.12 seconds =       0.10 minutes
+	user time   =       6.15 seconds =       0.10 minutes
 	system time =       0.11 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	total time  =          7 seconds =       0.12 minutes
     Singlet DFJ+LinK RHF energy...........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:41 2022
+*** at Mon Nov  7 11:04:22 2022
 
    => Loading Basis Set <=
 
@@ -2004,10 +2002,10 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @UHF iter SAD:  -149.27731917078717   -1.49277e+02   0.00000e+00 
-   @UHF iter   1:  -149.56362429559402   -2.86305e-01   1.10129e-02 ADIIS/DIIS
-   @UHF iter   2:  -149.58582140635932   -2.21971e-02   2.91434e-03 ADIIS/DIIS
-   @UHF iter   3:  -149.58712033600358   -1.29893e-03   6.40033e-04 ADIIS/DIIS
-   @UHF iter   4:  -149.58723140197682   -1.11066e-04   1.37095e-04 ADIIS/DIIS
+   @UHF iter   1:  -149.56362429559402   -2.86305e-01   1.10129e-02 DIIS/ADIIS
+   @UHF iter   2:  -149.58582140635932   -2.21971e-02   2.91434e-03 DIIS/ADIIS
+   @UHF iter   3:  -149.58712033600358   -1.29893e-03   6.40033e-04 DIIS/ADIIS
+   @UHF iter   4:  -149.58723140197682   -1.11066e-04   1.37095e-04 DIIS/ADIIS
    @UHF iter   5:  -149.58723670345896   -5.30148e-06   1.80224e-05 DIIS
    @UHF iter   6:  -149.58723684553325   -1.42074e-07   2.57334e-06 DIIS
    @UHF iter   7:  -149.58723684812239   -2.58913e-09   2.40539e-07 DIIS
@@ -2127,21 +2125,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:41 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:26 2022
 Module time:
 	user time   =       0.42 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 Total time:
-	user time   =       6.57 seconds =       0.11 minutes
+	user time   =       6.60 seconds =       0.11 minutes
 	system time =       0.12 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	total time  =         11 seconds =       0.18 minutes
     Singlet PK UHF energy.................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:41 2022
+*** at Mon Nov  7 11:04:26 2022
 
    => Loading Basis Set <=
 
@@ -2283,10 +2281,10 @@ Scratch directory: /scratch/dpoole34/
                            Total Energy        Delta E     RMS |[F,P]|
 
    @DF-UHF iter SAD:  -149.27728822299315   -1.49277e+02   0.00000e+00 
-   @DF-UHF iter   1:  -149.56354408328301   -2.86256e-01   1.10101e-02 ADIIS/DIIS
-   @DF-UHF iter   2:  -149.58573446084222   -2.21904e-02   2.91563e-03 ADIIS/DIIS
-   @DF-UHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 ADIIS/DIIS
-   @DF-UHF iter   4:  -149.58714509680516   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-UHF iter   1:  -149.56354408328301   -2.86256e-01   1.10101e-02 DIIS/ADIIS
+   @DF-UHF iter   2:  -149.58573446084222   -2.21904e-02   2.91563e-03 DIIS/ADIIS
+   @DF-UHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 DIIS/ADIIS
+   @DF-UHF iter   4:  -149.58714509680516   -1.11214e-04   1.37129e-04 DIIS/ADIIS
    @DF-UHF iter   5:  -149.58715039895964   -5.30215e-06   1.80355e-05 DIIS
    @DF-UHF iter   6:  -149.58715054109825   -1.42139e-07   2.57889e-06 DIIS
    @DF-UHF iter   7:  -149.58715054369759   -2.59934e-09   2.41536e-07 DIIS
@@ -2423,21 +2421,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:42 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:27 2022
 Module time:
-	user time   =       0.89 seconds =       0.01 minutes
+	user time   =       0.88 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.50 seconds =       0.12 minutes
+	user time   =       7.52 seconds =       0.13 minutes
 	system time =       0.13 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	total time  =         12 seconds =       0.20 minutes
     Singlet Direct UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:42 2022
+*** at Mon Nov  7 11:04:27 2022
 
    => Loading Basis Set <=
 
@@ -2546,10 +2544,10 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @UHF iter SAD:  -149.27731917078719   -1.49277e+02   0.00000e+00 
-   @UHF iter   1:  -149.56362429559408   -2.86305e-01   1.10129e-02 ADIIS/DIIS
-   @UHF iter   2:  -149.58582140635937   -2.21971e-02   2.91434e-03 ADIIS/DIIS
-   @UHF iter   3:  -149.58712033600369   -1.29893e-03   6.40033e-04 ADIIS/DIIS
-   @UHF iter   4:  -149.58723140197694   -1.11066e-04   1.37095e-04 ADIIS/DIIS
+   @UHF iter   1:  -149.56362429559408   -2.86305e-01   1.10129e-02 DIIS/ADIIS
+   @UHF iter   2:  -149.58582140635937   -2.21971e-02   2.91434e-03 DIIS/ADIIS
+   @UHF iter   3:  -149.58712033600369   -1.29893e-03   6.40033e-04 DIIS/ADIIS
+   @UHF iter   4:  -149.58723140197694   -1.11066e-04   1.37095e-04 DIIS/ADIIS
    @UHF iter   5:  -149.58723670345893   -5.30148e-06   1.80224e-05 DIIS
    @UHF iter   6:  -149.58723684553314   -1.42074e-07   2.57334e-06 DIIS
    @UHF iter   7:  -149.58723684812236   -2.58922e-09   2.40539e-07 DIIS
@@ -2669,21 +2667,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:43 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:28 2022
 Module time:
 	user time   =       0.38 seconds =       0.01 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.90 seconds =       0.13 minutes
+	user time   =       7.93 seconds =       0.13 minutes
 	system time =       0.15 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	total time  =         13 seconds =       0.22 minutes
     Singlet Disk UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:43 2022
+*** at Mon Nov  7 11:04:28 2022
 
    => Loading Basis Set <=
 
@@ -2822,10 +2820,10 @@ Scratch directory: /scratch/dpoole34/
                            Total Energy        Delta E     RMS |[F,P]|
 
    @DF-UHF iter SAD:  -149.27728822299318   -1.49277e+02   0.00000e+00 
-   @DF-UHF iter   1:  -149.56354408328303   -2.86256e-01   1.10101e-02 ADIIS/DIIS
-   @DF-UHF iter   2:  -149.58573446084227   -2.21904e-02   2.91563e-03 ADIIS/DIIS
-   @DF-UHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 ADIIS/DIIS
-   @DF-UHF iter   4:  -149.58714509680505   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-UHF iter   1:  -149.56354408328303   -2.86256e-01   1.10101e-02 DIIS/ADIIS
+   @DF-UHF iter   2:  -149.58573446084227   -2.21904e-02   2.91563e-03 DIIS/ADIIS
+   @DF-UHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 DIIS/ADIIS
+   @DF-UHF iter   4:  -149.58714509680505   -1.11214e-04   1.37129e-04 DIIS/ADIIS
    @DF-UHF iter   5:  -149.58715039895972   -5.30215e-06   1.80355e-05 DIIS
    @DF-UHF iter   6:  -149.58715054109814   -1.42138e-07   2.57889e-06 DIIS
    @DF-UHF iter   7:  -149.58715054369765   -2.59951e-09   2.41536e-07 DIIS
@@ -2945,21 +2943,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:43 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:28 2022
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
+	user time   =       0.23 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.17 seconds =       0.14 minutes
+	user time   =       8.18 seconds =       0.14 minutes
 	system time =       0.15 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	total time  =         13 seconds =       0.22 minutes
     Singlet DiskDF UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:43 2022
+*** at Mon Nov  7 11:04:28 2022
 
    => Loading Basis Set <=
 
@@ -3099,10 +3097,10 @@ Scratch directory: /scratch/dpoole34/
                            Total Energy        Delta E     RMS |[F,P]|
 
    @DF-UHF iter SAD:  -149.27728822299315   -1.49277e+02   0.00000e+00 
-   @DF-UHF iter   1:  -149.56354408328301   -2.86256e-01   1.10101e-02 ADIIS/DIIS
-   @DF-UHF iter   2:  -149.58573446084222   -2.21904e-02   2.91563e-03 ADIIS/DIIS
-   @DF-UHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 ADIIS/DIIS
-   @DF-UHF iter   4:  -149.58714509680516   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-UHF iter   1:  -149.56354408328301   -2.86256e-01   1.10101e-02 DIIS/ADIIS
+   @DF-UHF iter   2:  -149.58573446084222   -2.21904e-02   2.91563e-03 DIIS/ADIIS
+   @DF-UHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 DIIS/ADIIS
+   @DF-UHF iter   4:  -149.58714509680516   -1.11214e-04   1.37129e-04 DIIS/ADIIS
    @DF-UHF iter   5:  -149.58715039895964   -5.30215e-06   1.80355e-05 DIIS
    @DF-UHF iter   6:  -149.58715054109825   -1.42139e-07   2.57889e-06 DIIS
    @DF-UHF iter   7:  -149.58715054369759   -2.59934e-09   2.41536e-07 DIIS
@@ -3222,21 +3220,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:43 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:29 2022
 Module time:
 	user time   =       0.23 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       8.42 seconds =       0.14 minutes
+	user time   =       8.44 seconds =       0.14 minutes
 	system time =       0.16 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
+	total time  =         14 seconds =       0.23 minutes
     Singlet MemDF UHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:43 2022
+*** at Mon Nov  7 11:04:29 2022
 
    => Loading Basis Set <=
 
@@ -3358,25 +3356,25 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @UHF iter SAD:  -149.27713328631921   -1.49277e+02   0.00000e+00 
-   @UHF iter   1:  -149.56382697604784   -2.86694e-01   1.10975e-02 ADIIS/DIIS
-   @UHF iter   2:  -149.58629558037475   -2.24686e-02   2.92559e-03 ADIIS/DIIS
-   @UHF iter   3:  -149.58760428588198   -1.30871e-03   6.47395e-04 ADIIS/DIIS
-   @UHF iter   4:  -149.58772283023285   -1.18544e-04   1.38075e-04 ADIIS/DIIS
+   @UHF iter   1:  -149.56382697604792   -2.86694e-01   1.10975e-02 DIIS/ADIIS
+   @UHF iter   2:  -149.58629558037478   -2.24686e-02   2.92559e-03 DIIS/ADIIS
+   @UHF iter   3:  -149.58760428588204   -1.30871e-03   6.47395e-04 DIIS/ADIIS
+   @UHF iter   4:  -149.58772283023285   -1.18544e-04   1.38075e-04 DIIS/ADIIS
    @UHF iter   5:  -149.58772855372325   -5.72349e-06   1.83160e-05 DIIS
-   @UHF iter   6:  -149.58772885952459   -3.05801e-07   2.47041e-06 DIIS
-   @UHF iter   7:  -149.58772885956961   -4.50200e-11   2.44347e-07 DIIS
+   @UHF iter   6:  -149.58772885952456   -3.05801e-07   2.47041e-06 DIIS
+   @UHF iter   7:  -149.58772885956972   -4.51621e-11   2.44347e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @UHF iter   8:  -149.58722317116369    5.05688e-04   9.91149e-04 ADIIS/DIIS
+   @UHF iter   8:  -149.58722317116366    5.05688e-04   9.91149e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   6.217248938E-15
+   @Spin Contamination Metric:   1.776356839E-15
    @S^2 Expected:                0.000000000E+00
-   @S^2 Observed:                6.217248938E-15
+   @S^2 Observed:                1.776356839E-15
    @S   Expected:                0.000000000E+00
    @S   Observed:                0.000000000E+00
 
@@ -3444,23 +3442,23 @@ Scratch directory: /scratch/dpoole34/
     NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  @UHF Final Energy:  -149.58722317116369
+  @UHF Final Energy:  -149.58722317116366
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.8059033672359988
-    Two-Electron Energy =                  86.4301879389086594
-    Total Energy =                       -149.5872231711636857
+    One-Electron Energy =                -266.8059033672354303
+    Two-Electron Energy =                  86.4301879389081193
+    Total Energy =                       -149.5872231711636573
 
   UHF NO Occupations:
-  HONO-2 :    2B1u 2.0000000
+  HONO-2 :    3 Ag 2.0000000
   HONO-1 :    1B3g 2.0000000
   HONO-0 :    1B2u 2.0000000
   LUNO+0 :    4 Ag 0.0000000
-  LUNO+1 :    2B3u 0.0000000
-  LUNO+2 :    3B3u 0.0000000
-  LUNO+3 :    3B1u 0.0000000
+  LUNO+1 :    5 Ag 0.0000000
+  LUNO+2 :    3B1u 0.0000000
+  LUNO+3 :    2B3u 0.0000000
 
 
 Computation Completed
@@ -3485,21 +3483,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:46 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:31 2022
 Module time:
-	user time   =       2.70 seconds =       0.05 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       2.68 seconds =       0.04 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
 	user time   =      11.14 seconds =       0.19 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =         16 seconds =       0.27 minutes
     Singlet DFJ+COSX UHF energy...........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:46 2022
+*** at Mon Nov  7 11:04:31 2022
 
    => Loading Basis Set <=
 
@@ -3618,10 +3616,10 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @UHF iter SAD:  -149.27733086414963   -1.49277e+02   0.00000e+00 
-   @UHF iter   1:  -149.56365008860490   -2.86319e-01   1.10142e-02 ADIIS/DIIS
-   @UHF iter   2:  -149.58585218222930   -2.22021e-02   2.91422e-03 ADIIS/DIIS
-   @UHF iter   3:  -149.58715113835379   -1.29896e-03   6.40333e-04 ADIIS/DIIS
-   @UHF iter   4:  -149.58726227365051   -1.11135e-04   1.37172e-04 ADIIS/DIIS
+   @UHF iter   1:  -149.56365008860490   -2.86319e-01   1.10142e-02 DIIS/ADIIS
+   @UHF iter   2:  -149.58585218222930   -2.22021e-02   2.91422e-03 DIIS/ADIIS
+   @UHF iter   3:  -149.58715113835379   -1.29896e-03   6.40333e-04 DIIS/ADIIS
+   @UHF iter   4:  -149.58726227365051   -1.11135e-04   1.37172e-04 DIIS/ADIIS
    @UHF iter   5:  -149.58726757682933   -5.30318e-06   1.80326e-05 DIIS
    @UHF iter   6:  -149.58726771909227   -1.42263e-07   2.57489e-06 DIIS
    @UHF iter   7:  -149.58726772168646   -2.59419e-09   2.41117e-07 DIIS
@@ -3741,21 +3739,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:47 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:33 2022
 Module time:
-	user time   =       1.41 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.45 seconds =       0.02 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      12.58 seconds =       0.21 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =         14 seconds =       0.23 minutes
+	user time   =      12.61 seconds =       0.21 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =         18 seconds =       0.30 minutes
     Singlet DFJ+LinK UHF energy...........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:47 2022
+*** at Mon Nov  7 11:04:33 2022
 
    => Loading Basis Set <=
 
@@ -3882,10 +3880,10 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @CUHF iter SAD:  -149.27731917078714   -1.49277e+02   0.00000e+00 
-   @CUHF iter   1:  -149.56362429559388   -2.86305e-01   1.10129e-02 ADIIS/DIIS
-   @CUHF iter   2:  -149.58582140635932   -2.21971e-02   2.91434e-03 ADIIS/DIIS
-   @CUHF iter   3:  -149.58712033600364   -1.29893e-03   6.40033e-04 ADIIS/DIIS
-   @CUHF iter   4:  -149.58723140197694   -1.11066e-04   1.37095e-04 ADIIS/DIIS
+   @CUHF iter   1:  -149.56362429559388   -2.86305e-01   1.10129e-02 DIIS/ADIIS
+   @CUHF iter   2:  -149.58582140635932   -2.21971e-02   2.91434e-03 DIIS/ADIIS
+   @CUHF iter   3:  -149.58712033600364   -1.29893e-03   6.40033e-04 DIIS/ADIIS
+   @CUHF iter   4:  -149.58723140197694   -1.11066e-04   1.37095e-04 DIIS/ADIIS
    @CUHF iter   5:  -149.58723670345898   -5.30148e-06   1.80224e-05 DIIS
    @CUHF iter   6:  -149.58723684553317   -1.42074e-07   2.57334e-06 DIIS
    @CUHF iter   7:  -149.58723684812225   -2.58908e-09   2.40539e-07 DIIS
@@ -3993,21 +3991,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:48 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:33 2022
 Module time:
 	user time   =       0.41 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      13.02 seconds =       0.22 minutes
+	user time   =      13.05 seconds =       0.22 minutes
 	system time =       0.19 seconds =       0.00 minutes
-	total time  =         15 seconds =       0.25 minutes
+	total time  =         18 seconds =       0.30 minutes
     Singlet PK CUHF energy................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:48 2022
+*** at Mon Nov  7 11:04:33 2022
 
    => Loading Basis Set <=
 
@@ -4149,10 +4147,10 @@ Scratch directory: /scratch/dpoole34/
                            Total Energy        Delta E     RMS |[F,P]|
 
    @DF-CUHF iter SAD:  -149.27728822299312   -1.49277e+02   0.00000e+00 
-   @DF-CUHF iter   1:  -149.56354408328309   -2.86256e-01   1.10101e-02 ADIIS/DIIS
-   @DF-CUHF iter   2:  -149.58573446084225   -2.21904e-02   2.91563e-03 ADIIS/DIIS
-   @DF-CUHF iter   3:  -149.58703388315297   -1.29942e-03   6.40386e-04 ADIIS/DIIS
-   @DF-CUHF iter   4:  -149.58714509680490   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-CUHF iter   1:  -149.56354408328309   -2.86256e-01   1.10101e-02 DIIS/ADIIS
+   @DF-CUHF iter   2:  -149.58573446084225   -2.21904e-02   2.91563e-03 DIIS/ADIIS
+   @DF-CUHF iter   3:  -149.58703388315297   -1.29942e-03   6.40386e-04 DIIS/ADIIS
+   @DF-CUHF iter   4:  -149.58714509680490   -1.11214e-04   1.37129e-04 DIIS/ADIIS
    @DF-CUHF iter   5:  -149.58715039895961   -5.30215e-06   1.80355e-05 DIIS
    @DF-CUHF iter   6:  -149.58715054109820   -1.42139e-07   2.57889e-06 DIIS
    @DF-CUHF iter   7:  -149.58715054369745   -2.59925e-09   2.41536e-07 DIIS
@@ -4277,21 +4275,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:49 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:34 2022
 Module time:
-	user time   =       0.88 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.87 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      13.92 seconds =       0.23 minutes
-	system time =       0.20 seconds =       0.00 minutes
-	total time  =         16 seconds =       0.27 minutes
+	user time   =      13.94 seconds =       0.23 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =         19 seconds =       0.32 minutes
     Singlet Direct CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:49 2022
+*** at Mon Nov  7 11:04:34 2022
 
    => Loading Basis Set <=
 
@@ -4400,10 +4398,10 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @CUHF iter SAD:  -149.27731917078719   -1.49277e+02   0.00000e+00 
-   @CUHF iter   1:  -149.56362429559400   -2.86305e-01   1.10129e-02 ADIIS/DIIS
-   @CUHF iter   2:  -149.58582140635932   -2.21971e-02   2.91434e-03 ADIIS/DIIS
-   @CUHF iter   3:  -149.58712033600366   -1.29893e-03   6.40033e-04 ADIIS/DIIS
-   @CUHF iter   4:  -149.58723140197691   -1.11066e-04   1.37095e-04 ADIIS/DIIS
+   @CUHF iter   1:  -149.56362429559400   -2.86305e-01   1.10129e-02 DIIS/ADIIS
+   @CUHF iter   2:  -149.58582140635932   -2.21971e-02   2.91434e-03 DIIS/ADIIS
+   @CUHF iter   3:  -149.58712033600366   -1.29893e-03   6.40033e-04 DIIS/ADIIS
+   @CUHF iter   4:  -149.58723140197691   -1.11066e-04   1.37095e-04 DIIS/ADIIS
    @CUHF iter   5:  -149.58723670345893   -5.30148e-06   1.80224e-05 DIIS
    @CUHF iter   6:  -149.58723684553323   -1.42074e-07   2.57334e-06 DIIS
    @CUHF iter   7:  -149.58723684812227   -2.58905e-09   2.40539e-07 DIIS
@@ -4511,21 +4509,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:49 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:35 2022
 Module time:
-	user time   =       0.35 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      14.30 seconds =       0.24 minutes
-	system time =       0.21 seconds =       0.00 minutes
-	total time  =         16 seconds =       0.27 minutes
+	user time   =      14.35 seconds =       0.24 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =         20 seconds =       0.33 minutes
     Singlet Disk CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:49 2022
+*** at Mon Nov  7 11:04:35 2022
 
    => Loading Basis Set <=
 
@@ -4664,10 +4662,10 @@ Scratch directory: /scratch/dpoole34/
                            Total Energy        Delta E     RMS |[F,P]|
 
    @DF-CUHF iter SAD:  -149.27728822299318   -1.49277e+02   0.00000e+00 
-   @DF-CUHF iter   1:  -149.56354408328306   -2.86256e-01   1.10101e-02 ADIIS/DIIS
-   @DF-CUHF iter   2:  -149.58573446084216   -2.21904e-02   2.91563e-03 ADIIS/DIIS
-   @DF-CUHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 ADIIS/DIIS
-   @DF-CUHF iter   4:  -149.58714509680505   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-CUHF iter   1:  -149.56354408328306   -2.86256e-01   1.10101e-02 DIIS/ADIIS
+   @DF-CUHF iter   2:  -149.58573446084216   -2.21904e-02   2.91563e-03 DIIS/ADIIS
+   @DF-CUHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 DIIS/ADIIS
+   @DF-CUHF iter   4:  -149.58714509680505   -1.11214e-04   1.37129e-04 DIIS/ADIIS
    @DF-CUHF iter   5:  -149.58715039895969   -5.30215e-06   1.80355e-05 DIIS
    @DF-CUHF iter   6:  -149.58715054109817   -1.42138e-07   2.57889e-06 DIIS
    @DF-CUHF iter   7:  -149.58715054369762   -2.59945e-09   2.41536e-07 DIIS
@@ -4775,21 +4773,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:50 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:35 2022
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.58 seconds =       0.24 minutes
+	user time   =      14.60 seconds =       0.24 minutes
 	system time =       0.22 seconds =       0.00 minutes
-	total time  =         17 seconds =       0.28 minutes
+	total time  =         20 seconds =       0.33 minutes
     Singlet DiskDF CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:50 2022
+*** at Mon Nov  7 11:04:35 2022
 
    => Loading Basis Set <=
 
@@ -4929,10 +4927,10 @@ Scratch directory: /scratch/dpoole34/
                            Total Energy        Delta E     RMS |[F,P]|
 
    @DF-CUHF iter SAD:  -149.27728822299312   -1.49277e+02   0.00000e+00 
-   @DF-CUHF iter   1:  -149.56354408328309   -2.86256e-01   1.10101e-02 ADIIS/DIIS
-   @DF-CUHF iter   2:  -149.58573446084225   -2.21904e-02   2.91563e-03 ADIIS/DIIS
-   @DF-CUHF iter   3:  -149.58703388315297   -1.29942e-03   6.40386e-04 ADIIS/DIIS
-   @DF-CUHF iter   4:  -149.58714509680490   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-CUHF iter   1:  -149.56354408328309   -2.86256e-01   1.10101e-02 DIIS/ADIIS
+   @DF-CUHF iter   2:  -149.58573446084225   -2.21904e-02   2.91563e-03 DIIS/ADIIS
+   @DF-CUHF iter   3:  -149.58703388315297   -1.29942e-03   6.40386e-04 DIIS/ADIIS
+   @DF-CUHF iter   4:  -149.58714509680490   -1.11214e-04   1.37129e-04 DIIS/ADIIS
    @DF-CUHF iter   5:  -149.58715039895961   -5.30215e-06   1.80355e-05 DIIS
    @DF-CUHF iter   6:  -149.58715054109820   -1.42139e-07   2.57889e-06 DIIS
    @DF-CUHF iter   7:  -149.58715054369745   -2.59925e-09   2.41536e-07 DIIS
@@ -5040,21 +5038,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:50 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:35 2022
 Module time:
-	user time   =       0.22 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.24 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.82 seconds =       0.25 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =         17 seconds =       0.28 minutes
+	user time   =      14.87 seconds =       0.25 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =         20 seconds =       0.33 minutes
     Singlet MemDF CUHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:50 2022
+*** at Mon Nov  7 11:04:35 2022
 
    => Loading Basis Set <=
 
@@ -5176,17 +5174,17 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @CUHF iter SAD:  -149.27713328631918   -1.49277e+02   0.00000e+00 
-   @CUHF iter   1:  -149.56382697604786   -2.86694e-01   1.10975e-02 ADIIS/DIIS
-   @CUHF iter   2:  -149.58629558037481   -2.24686e-02   2.92559e-03 ADIIS/DIIS
-   @CUHF iter   3:  -149.58760428588192   -1.30871e-03   6.47395e-04 ADIIS/DIIS
-   @CUHF iter   4:  -149.58772283023288   -1.18544e-04   1.38075e-04 ADIIS/DIIS
+   @CUHF iter   1:  -149.56382697604786   -2.86694e-01   1.10975e-02 DIIS/ADIIS
+   @CUHF iter   2:  -149.58629558037481   -2.24686e-02   2.92559e-03 DIIS/ADIIS
+   @CUHF iter   3:  -149.58760428588189   -1.30871e-03   6.47395e-04 DIIS/ADIIS
+   @CUHF iter   4:  -149.58772283023296   -1.18544e-04   1.38075e-04 DIIS/ADIIS
    @CUHF iter   5:  -149.58772855372328   -5.72349e-06   1.83160e-05 DIIS
    @CUHF iter   6:  -149.58772885952447   -3.05801e-07   2.47041e-06 DIIS
-   @CUHF iter   7:  -149.58772885956978   -4.53042e-11   2.44347e-07 DIIS
+   @CUHF iter   7:  -149.58772885956972   -4.52474e-11   2.44347e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @CUHF iter   8:  -149.58722317116374    5.05688e-04   9.91149e-04 ADIIS/DIIS
+   @CUHF iter   8:  -149.58722317116366    5.05688e-04   9.91149e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -5260,14 +5258,14 @@ Scratch directory: /scratch/dpoole34/
     NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  @CUHF Final Energy:  -149.58722317116374
+  @CUHF Final Energy:  -149.58722317116366
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.8059033672354303
-    Two-Electron Energy =                  86.4301879389080341
-    Total Energy =                       -149.5872231711637426
+    One-Electron Energy =                -266.8059033672357714
+    Two-Electron Energy =                  86.4301879389084604
+    Total Energy =                       -149.5872231711636573
 
 Computation Completed
 
@@ -5291,21 +5289,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:52 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:38 2022
 Module time:
-	user time   =       2.66 seconds =       0.04 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.68 seconds =       0.04 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      17.51 seconds =       0.29 minutes
+	user time   =      17.57 seconds =       0.29 minutes
 	system time =       0.23 seconds =       0.00 minutes
-	total time  =         19 seconds =       0.32 minutes
+	total time  =         23 seconds =       0.38 minutes
     Singlet DFJ+COSX CUHF energy..........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:52 2022
+*** at Mon Nov  7 11:04:38 2022
 
    => Loading Basis Set <=
 
@@ -5424,10 +5422,10 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @CUHF iter SAD:  -149.27733086414960   -1.49277e+02   0.00000e+00 
-   @CUHF iter   1:  -149.56365008860479   -2.86319e-01   1.10142e-02 ADIIS/DIIS
-   @CUHF iter   2:  -149.58585218222908   -2.22021e-02   2.91422e-03 ADIIS/DIIS
-   @CUHF iter   3:  -149.58715113835387   -1.29896e-03   6.40333e-04 ADIIS/DIIS
-   @CUHF iter   4:  -149.58726227365037   -1.11135e-04   1.37172e-04 ADIIS/DIIS
+   @CUHF iter   1:  -149.56365008860479   -2.86319e-01   1.10142e-02 DIIS/ADIIS
+   @CUHF iter   2:  -149.58585218222908   -2.22021e-02   2.91422e-03 DIIS/ADIIS
+   @CUHF iter   3:  -149.58715113835387   -1.29896e-03   6.40333e-04 DIIS/ADIIS
+   @CUHF iter   4:  -149.58726227365037   -1.11135e-04   1.37172e-04 DIIS/ADIIS
    @CUHF iter   5:  -149.58726757682930   -5.30318e-06   1.80326e-05 DIIS
    @CUHF iter   6:  -149.58726771909238   -1.42263e-07   2.57489e-06 DIIS
    @CUHF iter   7:  -149.58726772168640   -2.59402e-09   2.41117e-07 DIIS
@@ -5535,21 +5533,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:54 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:39 2022
 Module time:
-	user time   =       1.41 seconds =       0.02 minutes
+	user time   =       1.40 seconds =       0.02 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      18.95 seconds =       0.32 minutes
+	user time   =      19.00 seconds =       0.32 minutes
 	system time =       0.24 seconds =       0.00 minutes
-	total time  =         21 seconds =       0.35 minutes
+	total time  =         24 seconds =       0.40 minutes
     Singlet DFJ+LinK CUHF energy..........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:54 2022
+*** at Mon Nov  7 11:04:39 2022
 
    => Loading Basis Set <=
 
@@ -5684,10 +5682,10 @@ Scratch directory: /scratch/dpoole34/
 
    @UHF iter   1:  -131.02769686138831   -1.31028e+02   3.53809e-01 ADIIS
    @UHF iter   2:  -140.13786809233886   -9.11017e+00   1.85373e-01 ADIIS
-   @UHF iter   3:  -149.07892636084327   -8.94106e+00   6.21073e-02 ADIIS/DIIS
-   @UHF iter   4:  -149.65363562366332   -5.74709e-01   1.05419e-02 ADIIS/DIIS
-   @UHF iter   5:  -149.67031494578450   -1.66793e-02   1.87170e-03 ADIIS/DIIS
-   @UHF iter   6:  -149.67129417341366   -9.79228e-04   4.35106e-04 ADIIS/DIIS
+   @UHF iter   3:  -149.07892636084327   -8.94106e+00   6.21073e-02 DIIS/ADIIS
+   @UHF iter   4:  -149.65363562366332   -5.74709e-01   1.05419e-02 DIIS/ADIIS
+   @UHF iter   5:  -149.67031494578450   -1.66793e-02   1.87170e-03 DIIS/ADIIS
+   @UHF iter   6:  -149.67129417341366   -9.79228e-04   4.35106e-04 DIIS/ADIIS
    @UHF iter   7:  -149.67135318247261   -5.90091e-05   6.76805e-05 DIIS
    @UHF iter   8:  -149.67135514057824   -1.95811e-06   9.41668e-06 DIIS
    @UHF iter   9:  -149.67135517086550   -3.02873e-08   8.36275e-07 DIIS
@@ -5806,21 +5804,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:54 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:40 2022
 Module time:
-	user time   =       0.36 seconds =       0.01 minutes
+	user time   =       0.38 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      19.34 seconds =       0.32 minutes
+	user time   =      19.41 seconds =       0.32 minutes
 	system time =       0.25 seconds =       0.00 minutes
-	total time  =         21 seconds =       0.35 minutes
+	total time  =         25 seconds =       0.42 minutes
     Triplet PK UHF energy.................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:54 2022
+*** at Mon Nov  7 11:04:40 2022
 
    => Loading Basis Set <=
 
@@ -5970,10 +5968,10 @@ Scratch directory: /scratch/dpoole34/
 
    @DF-UHF iter   1:  -131.02345177007209   -1.31023e+02   3.54007e-01 ADIIS
    @DF-UHF iter   2:  -140.13876897996707   -9.11532e+00   1.85394e-01 ADIIS
-   @DF-UHF iter   3:  -149.07887534187844   -8.94011e+00   6.20999e-02 ADIIS/DIIS
-   @DF-UHF iter   4:  -149.65353829309876   -5.74663e-01   1.05459e-02 ADIIS/DIIS
-   @DF-UHF iter   5:  -149.67021624295950   -1.66779e-02   1.87099e-03 ADIIS/DIIS
-   @DF-UHF iter   6:  -149.67119529927663   -9.79056e-04   4.34543e-04 ADIIS/DIIS
+   @DF-UHF iter   3:  -149.07887534187844   -8.94011e+00   6.20999e-02 DIIS/ADIIS
+   @DF-UHF iter   4:  -149.65353829309876   -5.74663e-01   1.05459e-02 DIIS/ADIIS
+   @DF-UHF iter   5:  -149.67021624295950   -1.66779e-02   1.87099e-03 DIIS/ADIIS
+   @DF-UHF iter   6:  -149.67119529927663   -9.79056e-04   4.34543e-04 DIIS/ADIIS
    @DF-UHF iter   7:  -149.67125425357943   -5.89543e-05   6.76766e-05 DIIS
    @DF-UHF iter   8:  -149.67125621119939   -1.95762e-06   9.39479e-06 DIIS
    @DF-UHF iter   9:  -149.67125624137390   -3.01745e-08   8.37130e-07 DIIS
@@ -6108,21 +6106,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:55 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:41 2022
 Module time:
 	user time   =       0.66 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      20.02 seconds =       0.33 minutes
-	system time =       0.25 seconds =       0.00 minutes
-	total time  =         22 seconds =       0.37 minutes
+	user time   =      20.09 seconds =       0.33 minutes
+	system time =       0.26 seconds =       0.00 minutes
+	total time  =         26 seconds =       0.43 minutes
     Triplet Direct UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:55 2022
+*** at Mon Nov  7 11:04:41 2022
 
    => Loading Basis Set <=
 
@@ -6239,10 +6237,10 @@ Scratch directory: /scratch/dpoole34/
 
    @UHF iter   1:  -131.02769686138825   -1.31028e+02   3.53809e-01 ADIIS
    @UHF iter   2:  -140.13786809233764   -9.11017e+00   1.85373e-01 ADIIS
-   @UHF iter   3:  -149.07892636084318   -8.94106e+00   6.21073e-02 ADIIS/DIIS
-   @UHF iter   4:  -149.65363562366338   -5.74709e-01   1.05419e-02 ADIIS/DIIS
-   @UHF iter   5:  -149.67031494578438   -1.66793e-02   1.87170e-03 ADIIS/DIIS
-   @UHF iter   6:  -149.67129417341368   -9.79228e-04   4.35106e-04 ADIIS/DIIS
+   @UHF iter   3:  -149.07892636084318   -8.94106e+00   6.21073e-02 DIIS/ADIIS
+   @UHF iter   4:  -149.65363562366338   -5.74709e-01   1.05419e-02 DIIS/ADIIS
+   @UHF iter   5:  -149.67031494578438   -1.66793e-02   1.87170e-03 DIIS/ADIIS
+   @UHF iter   6:  -149.67129417341368   -9.79228e-04   4.35106e-04 DIIS/ADIIS
    @UHF iter   7:  -149.67135318247261   -5.90091e-05   6.76805e-05 DIIS
    @UHF iter   8:  -149.67135514057824   -1.95811e-06   9.41668e-06 DIIS
    @UHF iter   9:  -149.67135517086550   -3.02873e-08   8.36275e-07 DIIS
@@ -6361,21 +6359,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:55 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:41 2022
 Module time:
-	user time   =       0.28 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.33 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      20.33 seconds =       0.34 minutes
-	system time =       0.27 seconds =       0.00 minutes
-	total time  =         22 seconds =       0.37 minutes
+	user time   =      20.45 seconds =       0.34 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         26 seconds =       0.43 minutes
     Triplet Disk UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:55 2022
+*** at Mon Nov  7 11:04:41 2022
 
    => Loading Basis Set <=
 
@@ -6522,10 +6520,10 @@ Scratch directory: /scratch/dpoole34/
 
    @DF-UHF iter   1:  -131.02345177007214   -1.31023e+02   3.54007e-01 ADIIS
    @DF-UHF iter   2:  -140.13876897996718   -9.11532e+00   1.85394e-01 ADIIS
-   @DF-UHF iter   3:  -149.07887534187839   -8.94011e+00   6.20999e-02 ADIIS/DIIS
-   @DF-UHF iter   4:  -149.65353829309876   -5.74663e-01   1.05459e-02 ADIIS/DIIS
-   @DF-UHF iter   5:  -149.67021624295947   -1.66779e-02   1.87099e-03 ADIIS/DIIS
-   @DF-UHF iter   6:  -149.67119529927672   -9.79056e-04   4.34543e-04 ADIIS/DIIS
+   @DF-UHF iter   3:  -149.07887534187839   -8.94011e+00   6.20999e-02 DIIS/ADIIS
+   @DF-UHF iter   4:  -149.65353829309876   -5.74663e-01   1.05459e-02 DIIS/ADIIS
+   @DF-UHF iter   5:  -149.67021624295947   -1.66779e-02   1.87099e-03 DIIS/ADIIS
+   @DF-UHF iter   6:  -149.67119529927672   -9.79056e-04   4.34543e-04 DIIS/ADIIS
    @DF-UHF iter   7:  -149.67125425357938   -5.89543e-05   6.76766e-05 DIIS
    @DF-UHF iter   8:  -149.67125621119945   -1.95762e-06   9.39479e-06 DIIS
    @DF-UHF iter   9:  -149.67125624137401   -3.01746e-08   8.37130e-07 DIIS
@@ -6644,21 +6642,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:56 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:41 2022
 Module time:
-	user time   =       0.20 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.19 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      20.55 seconds =       0.34 minutes
-	system time =       0.28 seconds =       0.00 minutes
-	total time  =         23 seconds =       0.38 minutes
+	user time   =      20.67 seconds =       0.34 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         26 seconds =       0.43 minutes
     Triplet DiskDF UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:56 2022
+*** at Mon Nov  7 11:04:41 2022
 
    => Loading Basis Set <=
 
@@ -6806,10 +6804,10 @@ Scratch directory: /scratch/dpoole34/
 
    @DF-UHF iter   1:  -131.02345177007209   -1.31023e+02   3.54007e-01 ADIIS
    @DF-UHF iter   2:  -140.13876897996707   -9.11532e+00   1.85394e-01 ADIIS
-   @DF-UHF iter   3:  -149.07887534187844   -8.94011e+00   6.20999e-02 ADIIS/DIIS
-   @DF-UHF iter   4:  -149.65353829309876   -5.74663e-01   1.05459e-02 ADIIS/DIIS
-   @DF-UHF iter   5:  -149.67021624295950   -1.66779e-02   1.87099e-03 ADIIS/DIIS
-   @DF-UHF iter   6:  -149.67119529927663   -9.79056e-04   4.34543e-04 ADIIS/DIIS
+   @DF-UHF iter   3:  -149.07887534187844   -8.94011e+00   6.20999e-02 DIIS/ADIIS
+   @DF-UHF iter   4:  -149.65353829309876   -5.74663e-01   1.05459e-02 DIIS/ADIIS
+   @DF-UHF iter   5:  -149.67021624295950   -1.66779e-02   1.87099e-03 DIIS/ADIIS
+   @DF-UHF iter   6:  -149.67119529927663   -9.79056e-04   4.34543e-04 DIIS/ADIIS
    @DF-UHF iter   7:  -149.67125425357943   -5.89543e-05   6.76766e-05 DIIS
    @DF-UHF iter   8:  -149.67125621119939   -1.95762e-06   9.39479e-06 DIIS
    @DF-UHF iter   9:  -149.67125624137390   -3.01745e-08   8.37130e-07 DIIS
@@ -6928,21 +6926,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:56 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:42 2022
 Module time:
 	user time   =       0.19 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      20.76 seconds =       0.35 minutes
-	system time =       0.29 seconds =       0.00 minutes
-	total time  =         23 seconds =       0.38 minutes
+	user time   =      20.89 seconds =       0.35 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =         27 seconds =       0.45 minutes
     Triplet MemDF UHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:56 2022
+*** at Mon Nov  7 11:04:42 2022
 
    => Loading Basis Set <=
 
@@ -7071,18 +7069,18 @@ Scratch directory: /scratch/dpoole34/
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
    @UHF iter   1:  -131.02266731942416   -1.31023e+02   3.53990e-01 ADIIS
-   @UHF iter   2:  -140.14034734140625   -9.11768e+00   1.85365e-01 ADIIS
-   @UHF iter   3:  -149.07920849522230   -8.93886e+00   6.20863e-02 ADIIS/DIIS
-   @UHF iter   4:  -149.65391531644991   -5.74707e-01   1.05356e-02 ADIIS/DIIS
-   @UHF iter   5:  -149.67061947228302   -1.67042e-02   1.87593e-03 ADIIS/DIIS
-   @UHF iter   6:  -149.67160507761122   -9.85605e-04   4.33948e-04 ADIIS/DIIS
-   @UHF iter   7:  -149.67166177628386   -5.66987e-05   6.80300e-05 DIIS
-   @UHF iter   8:  -149.67166378928812   -2.01300e-06   9.42637e-06 DIIS
-   @UHF iter   9:  -149.67166383531955   -4.60314e-08   8.91526e-07 DIIS
+   @UHF iter   2:  -140.14034734140617   -9.11768e+00   1.85365e-01 ADIIS
+   @UHF iter   3:  -149.07920849522245   -8.93886e+00   6.20863e-02 DIIS/ADIIS
+   @UHF iter   4:  -149.65391531645002   -5.74707e-01   1.05356e-02 DIIS/ADIIS
+   @UHF iter   5:  -149.67061947228331   -1.67042e-02   1.87593e-03 DIIS/ADIIS
+   @UHF iter   6:  -149.67160507761122   -9.85605e-04   4.33948e-04 DIIS/ADIIS
+   @UHF iter   7:  -149.67166177628383   -5.66987e-05   6.80300e-05 DIIS
+   @UHF iter   8:  -149.67166378928798   -2.01300e-06   9.42637e-06 DIIS
+   @UHF iter   9:  -149.67166383531969   -4.60317e-08   8.91526e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @UHF iter  10:  -149.67132922569726    3.34610e-04   9.51899e-04 ADIIS/DIIS
+   @UHF iter  10:  -149.67132922569729    3.34610e-04   9.51899e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -7157,14 +7155,14 @@ Scratch directory: /scratch/dpoole34/
     NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  @UHF Final Energy:  -149.67132922569726
+  @UHF Final Energy:  -149.67132922569729
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.9129345756500129
-    Two-Electron Energy =                  86.4531130927890956
-    Total Energy =                       -149.6713292256972636
+    One-Electron Energy =                -266.9129345756497855
+    Two-Electron Energy =                  86.4531130927888256
+    Total Energy =                       -149.6713292256973205
 
   UHF NO Occupations:
   HONO-2 :    1B2u 1.9937328
@@ -7198,21 +7196,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:56:59 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:44 2022
 Module time:
-	user time   =       2.89 seconds =       0.05 minutes
+	user time   =       2.90 seconds =       0.05 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      23.67 seconds =       0.39 minutes
-	system time =       0.29 seconds =       0.00 minutes
-	total time  =         26 seconds =       0.43 minutes
+	user time   =      23.82 seconds =       0.40 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =         29 seconds =       0.48 minutes
     Triplet DFJ+COSX UHF energy...........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:56:59 2022
+*** at Mon Nov  7 11:04:45 2022
 
    => Loading Basis Set <=
 
@@ -7339,10 +7337,10 @@ Scratch directory: /scratch/dpoole34/
 
    @UHF iter   1:  -131.02824188718694   -1.31028e+02   3.53803e-01 ADIIS
    @UHF iter   2:  -140.14242970807607   -9.11419e+00   1.85341e-01 ADIIS
-   @UHF iter   3:  -149.07857131918411   -8.93614e+00   6.21257e-02 ADIIS/DIIS
-   @UHF iter   4:  -149.65363342630815   -5.75062e-01   1.05493e-02 ADIIS/DIIS
-   @UHF iter   5:  -149.67033333467208   -1.66999e-02   1.87124e-03 ADIIS/DIIS
-   @UHF iter   6:  -149.67131230279944   -9.78968e-04   4.34980e-04 ADIIS/DIIS
+   @UHF iter   3:  -149.07857131918411   -8.93614e+00   6.21257e-02 DIIS/ADIIS
+   @UHF iter   4:  -149.65363342630815   -5.75062e-01   1.05493e-02 DIIS/ADIIS
+   @UHF iter   5:  -149.67033333467208   -1.66999e-02   1.87124e-03 DIIS/ADIIS
+   @UHF iter   6:  -149.67131230279944   -9.78968e-04   4.34980e-04 DIIS/ADIIS
    @UHF iter   7:  -149.67137129107354   -5.89883e-05   6.76925e-05 DIIS
    @UHF iter   8:  -149.67137324958753   -1.95851e-06   9.40593e-06 DIIS
    @UHF iter   9:  -149.67137327981726   -3.02297e-08   8.35758e-07 DIIS
@@ -7461,21 +7459,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:02 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:46 2022
 Module time:
-	user time   =       1.67 seconds =       0.03 minutes
+	user time   =       1.63 seconds =       0.03 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      25.36 seconds =       0.42 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =         29 seconds =       0.48 minutes
+	user time   =      25.48 seconds =       0.42 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =         31 seconds =       0.52 minutes
     Triplet DFJ+LinK UHF energy...........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:02 2022
+*** at Mon Nov  7 11:04:46 2022
 
    => Loading Basis Set <=
 
@@ -7693,21 +7691,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:02 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:47 2022
 Module time:
-	user time   =       0.34 seconds =       0.01 minutes
+	user time   =       0.33 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      25.73 seconds =       0.43 minutes
-	system time =       0.31 seconds =       0.01 minutes
-	total time  =         29 seconds =       0.48 minutes
+	user time   =      25.84 seconds =       0.43 minutes
+	system time =       0.32 seconds =       0.01 minutes
+	total time  =         32 seconds =       0.53 minutes
     Triplet PK ROHF energy................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:02 2022
+*** at Mon Nov  7 11:04:47 2022
 
    => Loading Basis Set <=
 
@@ -7956,21 +7954,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:03 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:47 2022
 Module time:
-	user time   =       0.63 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.62 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      26.40 seconds =       0.44 minutes
+	user time   =      26.49 seconds =       0.44 minutes
 	system time =       0.32 seconds =       0.01 minutes
-	total time  =         30 seconds =       0.50 minutes
+	total time  =         32 seconds =       0.53 minutes
     Triplet Direct ROHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:03 2022
+*** at Mon Nov  7 11:04:47 2022
 
    => Loading Basis Set <=
 
@@ -8170,21 +8168,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:04 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:48 2022
 Module time:
-	user time   =       0.32 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.22 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      26.75 seconds =       0.45 minutes
-	system time =       0.33 seconds =       0.01 minutes
-	total time  =         31 seconds =       0.52 minutes
+	user time   =      26.74 seconds =       0.45 minutes
+	system time =       0.34 seconds =       0.01 minutes
+	total time  =         33 seconds =       0.55 minutes
     Triplet Disk ROHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:04 2022
+*** at Mon Nov  7 11:04:48 2022
 
    => Loading Basis Set <=
 
@@ -8414,21 +8412,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:04 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:48 2022
 Module time:
-	user time   =       0.16 seconds =       0.00 minutes
+	user time   =       0.15 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
 	user time   =      26.94 seconds =       0.45 minutes
-	system time =       0.34 seconds =       0.01 minutes
-	total time  =         31 seconds =       0.52 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =         33 seconds =       0.55 minutes
     Triplet DiskDF ROHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:04 2022
+*** at Mon Nov  7 11:04:48 2022
 
    => Loading Basis Set <=
 
@@ -8659,21 +8657,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:04 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:48 2022
 Module time:
 	user time   =       0.14 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
 	user time   =      27.11 seconds =       0.45 minutes
-	system time =       0.34 seconds =       0.01 minutes
-	total time  =         31 seconds =       0.52 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =         33 seconds =       0.55 minutes
     Triplet MemDF ROHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:04 2022
+*** at Mon Nov  7 11:04:48 2022
 
    => Loading Basis Set <=
 
@@ -8803,13 +8801,13 @@ Scratch directory: /scratch/dpoole34/
 
    @ROHF iter   1:  -131.02266731942382   -1.31023e+02   2.71851e-01 DIIS
    @ROHF iter   2:  -139.64070004271159   -8.61803e+00   1.37369e-01 DIIS
-   @ROHF iter   3:  -148.99660951088319   -9.35591e+00   5.06619e-02 DIIS
-   @ROHF iter   4:  -149.63963700749684   -6.43027e-01   6.07525e-03 DIIS
-   @ROHF iter   5:  -149.65187157255187   -1.22346e-02   4.84799e-04 DIIS
-   @ROHF iter   6:  -149.65198834090879   -1.16768e-04   1.12106e-04 DIIS
-   @ROHF iter   7:  -149.65199670359939   -8.36269e-06   1.71152e-05 DIIS
-   @ROHF iter   8:  -149.65199683539879   -1.31799e-07   2.91717e-06 DIIS
-   @ROHF iter   9:  -149.65199681028335    2.51154e-08   3.52335e-07 DIIS
+   @ROHF iter   3:  -148.99660951088313   -9.35591e+00   5.06619e-02 DIIS
+   @ROHF iter   4:  -149.63963700749704   -6.43027e-01   6.07525e-03 DIIS
+   @ROHF iter   5:  -149.65187157255184   -1.22346e-02   4.84799e-04 DIIS
+   @ROHF iter   6:  -149.65198834090864   -1.16768e-04   1.12106e-04 DIIS
+   @ROHF iter   7:  -149.65199670359942   -8.36269e-06   1.71152e-05 DIIS
+   @ROHF iter   8:  -149.65199683539865   -1.31799e-07   2.91717e-06 DIIS
+   @ROHF iter   9:  -149.65199681028329    2.51154e-08   3.52335e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
@@ -8864,8 +8862,8 @@ Scratch directory: /scratch/dpoole34/
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.9107678299204736
-    Two-Electron Energy =                  86.4705866325295460
+    One-Electron Energy =                -266.9107678299205872
+    Two-Electron Energy =                  86.4705866325296597
     Total Energy =                       -149.6516889402272739
 
 Computation Completed
@@ -8890,21 +8888,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:07 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:51 2022
 Module time:
-	user time   =       2.90 seconds =       0.05 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.87 seconds =       0.05 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      30.04 seconds =       0.50 minutes
+	user time   =      30.00 seconds =       0.50 minutes
 	system time =       0.35 seconds =       0.01 minutes
-	total time  =         34 seconds =       0.57 minutes
+	total time  =         36 seconds =       0.60 minutes
     Triplet DFJ+COSX ROHF energy..........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:07 2022
+*** at Mon Nov  7 11:04:51 2022
 
    => Loading Basis Set <=
 
@@ -9114,21 +9112,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:09 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:52 2022
 Module time:
-	user time   =       1.64 seconds =       0.03 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       1.61 seconds =       0.03 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      31.70 seconds =       0.53 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =         36 seconds =       0.60 minutes
+	user time   =      31.63 seconds =       0.53 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =         37 seconds =       0.62 minutes
     Triplet DFJ+LinK ROHF energy..........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:09 2022
+*** at Mon Nov  7 11:04:53 2022
 
    => Loading Basis Set <=
 
@@ -9263,10 +9261,10 @@ Scratch directory: /scratch/dpoole34/
 
    @CUHF iter   1:  -131.02769686138825   -1.31028e+02   3.53708e-01 ADIIS
    @CUHF iter   2:  -140.10353912873543   -9.07584e+00   1.85166e-01 ADIIS
-   @CUHF iter   3:  -149.07256385046506   -8.96902e+00   6.18739e-02 ADIIS/DIIS
-   @CUHF iter   4:  -149.63818987448280   -5.65626e-01   1.00903e-02 ADIIS/DIIS
-   @CUHF iter   5:  -149.65122786458716   -1.30380e-02   1.50677e-03 ADIIS/DIIS
-   @CUHF iter   6:  -149.65168121631356   -4.53352e-04   2.17117e-04 ADIIS/DIIS
+   @CUHF iter   3:  -149.07256385046506   -8.96902e+00   6.18739e-02 DIIS/ADIIS
+   @CUHF iter   4:  -149.63818987448280   -5.65626e-01   1.00903e-02 DIIS/ADIIS
+   @CUHF iter   5:  -149.65122786458716   -1.30380e-02   1.50677e-03 DIIS/ADIIS
+   @CUHF iter   6:  -149.65168121631356   -4.53352e-04   2.17117e-04 DIIS/ADIIS
    @CUHF iter   7:  -149.65170871431565   -2.74980e-05   1.84194e-05 DIIS
    @CUHF iter   8:  -149.65170789138176    8.22934e-07   2.07188e-06 DIIS
    @CUHF iter   9:  -149.65170764199598    2.49386e-07   3.39347e-07 DIIS
@@ -9373,21 +9371,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:09 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:53 2022
 Module time:
-	user time   =       0.37 seconds =       0.01 minutes
+	user time   =       0.36 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      32.09 seconds =       0.53 minutes
-	system time =       0.37 seconds =       0.01 minutes
-	total time  =         36 seconds =       0.60 minutes
+	user time   =      32.04 seconds =       0.53 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =         38 seconds =       0.63 minutes
     Triplet PK CUHF energy................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:09 2022
+*** at Mon Nov  7 11:04:53 2022
 
    => Loading Basis Set <=
 
@@ -9537,10 +9535,10 @@ Scratch directory: /scratch/dpoole34/
 
    @DF-CUHF iter   1:  -131.02345177007203   -1.31023e+02   3.53905e-01 ADIIS
    @DF-CUHF iter   2:  -140.10421225181634   -9.08076e+00   1.85188e-01 ADIIS
-   @DF-CUHF iter   3:  -149.07251737243496   -8.96831e+00   6.18656e-02 ADIIS/DIIS
-   @DF-CUHF iter   4:  -149.63808950369364   -5.65572e-01   1.00945e-02 ADIIS/DIIS
-   @DF-CUHF iter   5:  -149.65112849378588   -1.30390e-02   1.50612e-03 ADIIS/DIIS
-   @DF-CUHF iter   6:  -149.65158147606775   -4.52982e-04   2.16998e-04 ADIIS/DIIS
+   @DF-CUHF iter   3:  -149.07251737243496   -8.96831e+00   6.18656e-02 DIIS/ADIIS
+   @DF-CUHF iter   4:  -149.63808950369364   -5.65572e-01   1.00945e-02 DIIS/ADIIS
+   @DF-CUHF iter   5:  -149.65112849378588   -1.30390e-02   1.50612e-03 DIIS/ADIIS
+   @DF-CUHF iter   6:  -149.65158147606775   -4.52982e-04   2.16998e-04 DIIS/ADIIS
    @DF-CUHF iter   7:  -149.65160902343251   -2.75474e-05   1.83726e-05 DIIS
    @DF-CUHF iter   8:  -149.65160819598432    8.27448e-07   2.07458e-06 DIIS
    @DF-CUHF iter   9:  -149.65160794655134    2.49433e-07   3.38450e-07 DIIS
@@ -9663,21 +9661,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:10 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:54 2022
 Module time:
-	user time   =       0.66 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.68 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
 	user time   =      32.77 seconds =       0.55 minutes
 	system time =       0.38 seconds =       0.01 minutes
-	total time  =         37 seconds =       0.62 minutes
+	total time  =         39 seconds =       0.65 minutes
     Triplet Direct CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:10 2022
+*** at Mon Nov  7 11:04:54 2022
 
    => Loading Basis Set <=
 
@@ -9794,10 +9792,10 @@ Scratch directory: /scratch/dpoole34/
 
    @CUHF iter   1:  -131.02769686138819   -1.31028e+02   3.53708e-01 ADIIS
    @CUHF iter   2:  -140.10353912873418   -9.07584e+00   1.85166e-01 ADIIS
-   @CUHF iter   3:  -149.07256385046523   -8.96902e+00   6.18739e-02 ADIIS/DIIS
-   @CUHF iter   4:  -149.63818987448269   -5.65626e-01   1.00903e-02 ADIIS/DIIS
-   @CUHF iter   5:  -149.65122786458724   -1.30380e-02   1.50677e-03 ADIIS/DIIS
-   @CUHF iter   6:  -149.65168121631359   -4.53352e-04   2.17117e-04 ADIIS/DIIS
+   @CUHF iter   3:  -149.07256385046523   -8.96902e+00   6.18739e-02 DIIS/ADIIS
+   @CUHF iter   4:  -149.63818987448269   -5.65626e-01   1.00903e-02 DIIS/ADIIS
+   @CUHF iter   5:  -149.65122786458724   -1.30380e-02   1.50677e-03 DIIS/ADIIS
+   @CUHF iter   6:  -149.65168121631359   -4.53352e-04   2.17117e-04 DIIS/ADIIS
    @CUHF iter   7:  -149.65170871431570   -2.74980e-05   1.84194e-05 DIIS
    @CUHF iter   8:  -149.65170789138173    8.22934e-07   2.07188e-06 DIIS
    @CUHF iter   9:  -149.65170764199598    2.49386e-07   3.39347e-07 DIIS
@@ -9904,21 +9902,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:10 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:54 2022
 Module time:
-	user time   =       0.28 seconds =       0.00 minutes
+	user time   =       0.34 seconds =       0.01 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      33.08 seconds =       0.55 minutes
+	user time   =      33.14 seconds =       0.55 minutes
 	system time =       0.40 seconds =       0.01 minutes
-	total time  =         37 seconds =       0.62 minutes
+	total time  =         39 seconds =       0.65 minutes
     Triplet Disk CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:10 2022
+*** at Mon Nov  7 11:04:54 2022
 
    => Loading Basis Set <=
 
@@ -10065,10 +10063,10 @@ Scratch directory: /scratch/dpoole34/
 
    @DF-CUHF iter   1:  -131.02345177007209   -1.31023e+02   3.53905e-01 ADIIS
    @DF-CUHF iter   2:  -140.10421225181673   -9.08076e+00   1.85188e-01 ADIIS
-   @DF-CUHF iter   3:  -149.07251737243493   -8.96831e+00   6.18656e-02 ADIIS/DIIS
-   @DF-CUHF iter   4:  -149.63808950369372   -5.65572e-01   1.00945e-02 ADIIS/DIIS
-   @DF-CUHF iter   5:  -149.65112849378588   -1.30390e-02   1.50612e-03 ADIIS/DIIS
-   @DF-CUHF iter   6:  -149.65158147606783   -4.52982e-04   2.16998e-04 ADIIS/DIIS
+   @DF-CUHF iter   3:  -149.07251737243493   -8.96831e+00   6.18656e-02 DIIS/ADIIS
+   @DF-CUHF iter   4:  -149.63808950369372   -5.65572e-01   1.00945e-02 DIIS/ADIIS
+   @DF-CUHF iter   5:  -149.65112849378588   -1.30390e-02   1.50612e-03 DIIS/ADIIS
+   @DF-CUHF iter   6:  -149.65158147606783   -4.52982e-04   2.16998e-04 DIIS/ADIIS
    @DF-CUHF iter   7:  -149.65160902343254   -2.75474e-05   1.83726e-05 DIIS
    @DF-CUHF iter   8:  -149.65160819598424    8.27448e-07   2.07458e-06 DIIS
    @DF-CUHF iter   9:  -149.65160794655139    2.49433e-07   3.38450e-07 DIIS
@@ -10175,21 +10173,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:10 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:54 2022
 Module time:
-	user time   =       0.19 seconds =       0.00 minutes
+	user time   =       0.18 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      33.31 seconds =       0.56 minutes
+	user time   =      33.34 seconds =       0.56 minutes
 	system time =       0.40 seconds =       0.01 minutes
-	total time  =         37 seconds =       0.62 minutes
+	total time  =         39 seconds =       0.65 minutes
     Triplet DiskDF CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:11 2022
+*** at Mon Nov  7 11:04:54 2022
 
    => Loading Basis Set <=
 
@@ -10337,10 +10335,10 @@ Scratch directory: /scratch/dpoole34/
 
    @DF-CUHF iter   1:  -131.02345177007203   -1.31023e+02   3.53905e-01 ADIIS
    @DF-CUHF iter   2:  -140.10421225181634   -9.08076e+00   1.85188e-01 ADIIS
-   @DF-CUHF iter   3:  -149.07251737243496   -8.96831e+00   6.18656e-02 ADIIS/DIIS
-   @DF-CUHF iter   4:  -149.63808950369364   -5.65572e-01   1.00945e-02 ADIIS/DIIS
-   @DF-CUHF iter   5:  -149.65112849378588   -1.30390e-02   1.50612e-03 ADIIS/DIIS
-   @DF-CUHF iter   6:  -149.65158147606775   -4.52982e-04   2.16998e-04 ADIIS/DIIS
+   @DF-CUHF iter   3:  -149.07251737243496   -8.96831e+00   6.18656e-02 DIIS/ADIIS
+   @DF-CUHF iter   4:  -149.63808950369364   -5.65572e-01   1.00945e-02 DIIS/ADIIS
+   @DF-CUHF iter   5:  -149.65112849378588   -1.30390e-02   1.50612e-03 DIIS/ADIIS
+   @DF-CUHF iter   6:  -149.65158147606775   -4.52982e-04   2.16998e-04 DIIS/ADIIS
    @DF-CUHF iter   7:  -149.65160902343251   -2.75474e-05   1.83726e-05 DIIS
    @DF-CUHF iter   8:  -149.65160819598432    8.27448e-07   2.07458e-06 DIIS
    @DF-CUHF iter   9:  -149.65160794655134    2.49433e-07   3.38450e-07 DIIS
@@ -10447,21 +10445,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:11 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:55 2022
 Module time:
 	user time   =       0.18 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      33.52 seconds =       0.56 minutes
+	user time   =      33.54 seconds =       0.56 minutes
 	system time =       0.40 seconds =       0.01 minutes
-	total time  =         38 seconds =       0.63 minutes
+	total time  =         40 seconds =       0.67 minutes
     Triplet MemDF CUHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:11 2022
+*** at Mon Nov  7 11:04:55 2022
 
    => Loading Basis Set <=
 
@@ -10590,18 +10588,18 @@ Scratch directory: /scratch/dpoole34/
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
    @CUHF iter   1:  -131.02266731942410   -1.31023e+02   3.53890e-01 ADIIS
-   @CUHF iter   2:  -140.10621696114706   -9.08355e+00   1.85157e-01 ADIIS
-   @CUHF iter   3:  -149.07283195574351   -8.96661e+00   6.18535e-02 ADIIS/DIIS
-   @CUHF iter   4:  -149.63845093676014   -5.65619e-01   1.00842e-02 ADIIS/DIIS
-   @CUHF iter   5:  -149.65151108189124   -1.30601e-02   1.51377e-03 ADIIS/DIIS
-   @CUHF iter   6:  -149.65197130478208   -4.60223e-04   2.18032e-04 ADIIS/DIIS
-   @CUHF iter   7:  -149.65199790962743   -2.66048e-05   1.85204e-05 DIIS
+   @CUHF iter   2:  -140.10621696114717   -9.08355e+00   1.85157e-01 ADIIS
+   @CUHF iter   3:  -149.07283195574354   -8.96661e+00   6.18535e-02 DIIS/ADIIS
+   @CUHF iter   4:  -149.63845093676019   -5.65619e-01   1.00842e-02 DIIS/ADIIS
+   @CUHF iter   5:  -149.65151108189110   -1.30601e-02   1.51377e-03 DIIS/ADIIS
+   @CUHF iter   6:  -149.65197130478225   -4.60223e-04   2.18032e-04 DIIS/ADIIS
+   @CUHF iter   7:  -149.65199790962745   -2.66048e-05   1.85204e-05 DIIS
    @CUHF iter   8:  -149.65199703995123    8.69676e-07   2.10529e-06 DIIS
-   @CUHF iter   9:  -149.65199679272936    2.47222e-07   3.47492e-07 DIIS
+   @CUHF iter   9:  -149.65199679272925    2.47222e-07   3.47492e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @CUHF iter  10:  -149.65168894016244    3.07853e-04   9.18132e-04 ADIIS/DIIS
+   @CUHF iter  10:  -149.65168894016242    3.07853e-04   9.18132e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -10674,13 +10672,13 @@ Scratch directory: /scratch/dpoole34/
     NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  @CUHF Final Energy:  -149.65168894016244
+  @CUHF Final Energy:  -149.65168894016242
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.9107736954303505
-    Two-Electron Energy =                  86.4705924981042529
+    One-Electron Energy =                -266.9107736954306347
+    Two-Electron Energy =                  86.4705924981045513
     Total Energy =                       -149.6516889401624439
 
 Computation Completed
@@ -10705,21 +10703,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:14 2022
+*** tstop() called on ds6 at Mon Nov  7 11:04:58 2022
 Module time:
-	user time   =       2.92 seconds =       0.05 minutes
+	user time   =       2.90 seconds =       0.05 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
 	user time   =      36.47 seconds =       0.61 minutes
 	system time =       0.41 seconds =       0.01 minutes
-	total time  =         41 seconds =       0.68 minutes
+	total time  =         43 seconds =       0.72 minutes
     Triplet DFJ+COSX CUHF energy..........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 10:57:14 2022
+*** at Mon Nov  7 11:04:58 2022
 
    => Loading Basis Set <=
 
@@ -10846,10 +10844,10 @@ Scratch directory: /scratch/dpoole34/
 
    @CUHF iter   1:  -131.02824188718688   -1.31028e+02   3.53702e-01 ADIIS
    @CUHF iter   2:  -140.10809986937551   -9.07986e+00   1.85134e-01 ADIIS
-   @CUHF iter   3:  -149.07220799997776   -8.96411e+00   6.18921e-02 ADIIS/DIIS
-   @CUHF iter   4:  -149.63818696514187   -5.65979e-01   1.00981e-02 ADIIS/DIIS
-   @CUHF iter   5:  -149.65124590648077   -1.30589e-02   1.50640e-03 ADIIS/DIIS
-   @CUHF iter   6:  -149.65169910490732   -4.53198e-04   2.17102e-04 ADIIS/DIIS
+   @CUHF iter   3:  -149.07220799997776   -8.96411e+00   6.18921e-02 DIIS/ADIIS
+   @CUHF iter   4:  -149.63818696514187   -5.65979e-01   1.00981e-02 DIIS/ADIIS
+   @CUHF iter   5:  -149.65124590648077   -1.30589e-02   1.50640e-03 DIIS/ADIIS
+   @CUHF iter   6:  -149.65169910490732   -4.53198e-04   2.17102e-04 DIIS/ADIIS
    @CUHF iter   7:  -149.65172663379934   -2.75289e-05   1.84171e-05 DIIS
    @CUHF iter   8:  -149.65172580983565    8.23964e-07   2.07767e-06 DIIS
    @CUHF iter   9:  -149.65172556019772    2.49638e-07   3.39954e-07 DIIS
@@ -10956,18 +10954,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 10:57:15 2022
+*** tstop() called on ds6 at Mon Nov  7 11:05:04 2022
 Module time:
-	user time   =       1.64 seconds =       0.03 minutes
+	user time   =       1.66 seconds =       0.03 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          6 seconds =       0.10 minutes
 Total time:
-	user time   =      38.14 seconds =       0.64 minutes
+	user time   =      38.15 seconds =       0.64 minutes
 	system time =       0.42 seconds =       0.01 minutes
-	total time  =         42 seconds =       0.70 minutes
+	total time  =         49 seconds =       0.82 minutes
     Triplet DFJ+LinK CUHF energy..........................................................PASSED
 
-    Psi4 stopped on: Monday, 07 November 2022 10:57AM
-    Psi4 wall time for execution: 0:00:42.15
+    Psi4 stopped on: Monday, 07 November 2022 11:05AM
+    Psi4 wall time for execution: 0:00:48.89
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/scf5/output.ref
+++ b/tests/scf5/output.ref
@@ -30,9 +30,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Thursday, 10 November 2022 10:42AM
+    Psi4 started on: Thursday, 10 November 2022 11:02AM
 
-    Process ID: 10800
+    Process ID: 11143
     Host:       ds6
     PSIDATADIR: /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4
     Memory:     500.0 MiB
@@ -128,11 +128,10 @@ E = energy('scf')
 compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF RHF energy') #TEST
 
 for method in Eref["Singlet"]["Composite"].keys():
+    set scf_type $method 
     if method == "COSX": 
-      set scf_type cosx # NOTE: if I knew how to directly assign scf_type to the value in method in Psithon here, I would
       set screening csam
-    elif method == "LinK":
-      set scf_type link 
+    else:
       set screening density
 
     E = energy('scf')
@@ -163,11 +162,10 @@ E = energy('scf')
 compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF UHF energy') #TEST
 
 for method in Eref["Singlet"]["Composite"].keys():
+    set scf_type $method 
     if method == "COSX": 
-      set scf_type cosx 
       set screening csam
-    elif method == "LinK":
-      set scf_type link 
+    else:
       set screening density
 
     E = energy('scf')
@@ -198,11 +196,10 @@ E = energy('scf')
 compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF CUHF energy') #TEST
 
 for method in Eref["Singlet"]["Composite"].keys():
+    set scf_type $method 
     if method == "COSX": 
-      set scf_type cosx 
       set screening csam
-    elif method == "LinK":
-      set scf_type link 
+    else:
       set screening density
 
     E = energy('scf')
@@ -241,11 +238,10 @@ E = energy('scf')
 compare_values(Eref["Triplet UHF"]["DF"], E, 6, 'Triplet MemDF UHF energy') #TEST
 
 for method in Eref["Triplet UHF"]["Composite"].keys():
+    set scf_type $method 
     if method == "COSX": 
-      set scf_type cosx 
       set screening csam
-    elif method == "LinK":
-      set scf_type link 
+    else:
       set screening density
 
     E = energy('scf')
@@ -281,11 +277,10 @@ E = energy('scf')
 compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF ROHF energy') #TEST
 
 for method in Eref["Triplet ROHF"]["Composite"].keys():
+    set scf_type $method 
     if method == "COSX": 
-      set scf_type cosx 
       set screening csam
-    elif method == "LinK":
-      set scf_type link 
+    else:
       set screening density
 
     E = energy('scf')
@@ -321,11 +316,10 @@ E = energy('scf')
 compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF CUHF energy') #TEST
 
 for method in Eref["Triplet ROHF"]["Composite"].keys():
+    set scf_type $method 
     if method == "COSX": 
-      set scf_type cosx 
       set screening csam
-    elif method == "LinK":
-      set scf_type link 
+    else:
       set screening density
 
     E = energy('scf')
@@ -337,7 +331,7 @@ for method in Eref["Triplet ROHF"]["Composite"].keys():
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:42:59 2022
+*** at Thu Nov 10 11:02:58 2022
 
    => Loading Basis Set <=
 
@@ -543,21 +537,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:42:59 2022
+*** tstop() called on ds6 at Thu Nov 10 11:02:59 2022
 Module time:
-	user time   =       0.49 seconds =       0.01 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.49 seconds =       0.01 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.45 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
     Singlet PK RHF energy.................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:42:59 2022
+*** at Thu Nov 10 11:02:59 2022
 
    => Loading Basis Set <=
 
@@ -795,21 +789,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:00 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:00 2022
 Module time:
-	user time   =       0.83 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.78 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.35 seconds =       0.02 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       1.26 seconds =       0.02 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
     Singlet Direct RHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:00 2022
+*** at Thu Nov 10 11:03:00 2022
 
    => Loading Basis Set <=
 
@@ -997,21 +991,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:01 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:00 2022
 Module time:
-	user time   =       0.36 seconds =       0.01 minutes
+	user time   =       0.34 seconds =       0.01 minutes
 	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.74 seconds =       0.03 minutes
-	system time =       0.09 seconds =       0.00 minutes
+	user time   =       1.63 seconds =       0.03 minutes
+	system time =       0.06 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
     Singlet Disk RHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:01 2022
+*** at Thu Nov 10 11:03:00 2022
 
    => Loading Basis Set <=
 
@@ -1229,21 +1223,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:01 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:00 2022
 Module time:
-	user time   =       0.24 seconds =       0.00 minutes
+	user time   =       0.21 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.01 seconds =       0.03 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =       1.87 seconds =       0.03 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
     Singlet DiskDF RHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:01 2022
+*** at Thu Nov 10 11:03:00 2022
 
    => Loading Basis Set <=
 
@@ -1462,21 +1456,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:01 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:01 2022
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
+	user time   =       0.21 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.28 seconds =       0.04 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.10 seconds =       0.03 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
     Singlet MemDF RHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:01 2022
+*** at Thu Nov 10 11:03:01 2022
 
    => Loading Basis Set <=
 
@@ -1601,14 +1595,14 @@ Scratch directory: /scratch/dpoole34/
    @RHF iter   1:  -149.56382697604778   -2.86694e-01   1.10975e-02 DIIS/ADIIS
    @RHF iter   2:  -149.58629558037464   -2.24686e-02   2.92559e-03 DIIS/ADIIS
    @RHF iter   3:  -149.58760428588204   -1.30871e-03   6.47395e-04 DIIS/ADIIS
-   @RHF iter   4:  -149.58772283023293   -1.18544e-04   1.38075e-04 DIIS/ADIIS
+   @RHF iter   4:  -149.58772283023299   -1.18544e-04   1.38075e-04 DIIS/ADIIS
    @RHF iter   5:  -149.58772855372328   -5.72349e-06   1.83160e-05 DIIS
    @RHF iter   6:  -149.58772885952453   -3.05801e-07   2.47041e-06 DIIS
-   @RHF iter   7:  -149.58772885956969   -4.51621e-11   2.44347e-07 DIIS
+   @RHF iter   7:  -149.58772885956967   -4.51337e-11   2.44347e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @RHF iter   8:  -149.58722317116374    5.05688e-04   9.91149e-04 DIIS/ADIIS
+   @RHF iter   8:  -149.58722317116363    5.05688e-04   9.91149e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -1650,14 +1644,14 @@ Scratch directory: /scratch/dpoole34/
     NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  @RHF Final Energy:  -149.58722317116374
+  @RHF Final Energy:  -149.58722317116363
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.8059033672350893
-    Two-Electron Energy =                  86.4301879389076930
-    Total Energy =                       -149.5872231711637426
+    One-Electron Energy =                -266.8059033672358851
+    Two-Electron Energy =                  86.4301879389086025
+    Total Energy =                       -149.5872231711636289
 
 Computation Completed
 
@@ -1681,21 +1675,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:04 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:04 2022
 Module time:
-	user time   =       2.66 seconds =       0.04 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.61 seconds =       0.04 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =       4.96 seconds =       0.08 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       4.74 seconds =       0.08 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
     Singlet COSX RHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:04 2022
+*** at Thu Nov 10 11:03:05 2022
 
    => Loading Basis Set <=
 
@@ -1893,21 +1887,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:05 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:06 2022
 Module time:
-	user time   =       1.39 seconds =       0.02 minutes
+	user time   =       1.36 seconds =       0.02 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       6.39 seconds =       0.11 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	user time   =       6.13 seconds =       0.10 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
     Singlet LinK RHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:06 2022
+*** at Thu Nov 10 11:03:06 2022
 
    => Loading Basis Set <=
 
@@ -2157,21 +2151,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:06 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:06 2022
 Module time:
-	user time   =       0.43 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.85 seconds =       0.11 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
+	user time   =       6.56 seconds =       0.11 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
     Singlet PK UHF energy.................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:06 2022
+*** at Thu Nov 10 11:03:06 2022
 
    => Loading Basis Set <=
 
@@ -2453,21 +2447,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:07 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:07 2022
 Module time:
-	user time   =       0.87 seconds =       0.01 minutes
+	user time   =       0.89 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.77 seconds =       0.13 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          8 seconds =       0.13 minutes
+	user time   =       7.49 seconds =       0.12 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
     Singlet Direct UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:07 2022
+*** at Thu Nov 10 11:03:07 2022
 
    => Loading Basis Set <=
 
@@ -2699,21 +2693,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:08 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:08 2022
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       8.17 seconds =       0.14 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =       7.90 seconds =       0.13 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
     Singlet Disk UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:08 2022
+*** at Thu Nov 10 11:03:08 2022
 
    => Loading Basis Set <=
 
@@ -2975,21 +2969,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:08 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:08 2022
 Module time:
-	user time   =       0.24 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.44 seconds =       0.14 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =       8.16 seconds =       0.14 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
     Singlet DiskDF UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:08 2022
+*** at Thu Nov 10 11:03:08 2022
 
    => Loading Basis Set <=
 
@@ -3252,21 +3246,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:08 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:09 2022
 Module time:
-	user time   =       0.24 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       8.71 seconds =       0.15 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
+	user time   =       8.41 seconds =       0.14 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =         11 seconds =       0.18 minutes
     Singlet MemDF UHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:08 2022
+*** at Thu Nov 10 11:03:09 2022
 
    => Loading Basis Set <=
 
@@ -3390,11 +3384,11 @@ Scratch directory: /scratch/dpoole34/
    @UHF iter SAD:  -149.27713328631921   -1.49277e+02   0.00000e+00 
    @UHF iter   1:  -149.56382697604786   -2.86694e-01   1.10975e-02 DIIS/ADIIS
    @UHF iter   2:  -149.58629558037481   -2.24686e-02   2.92559e-03 DIIS/ADIIS
-   @UHF iter   3:  -149.58760428588201   -1.30871e-03   6.47395e-04 DIIS/ADIIS
-   @UHF iter   4:  -149.58772283023276   -1.18544e-04   1.38075e-04 DIIS/ADIIS
-   @UHF iter   5:  -149.58772855372328   -5.72349e-06   1.83160e-05 DIIS
-   @UHF iter   6:  -149.58772885952453   -3.05801e-07   2.47041e-06 DIIS
-   @UHF iter   7:  -149.58772885956986   -4.53326e-11   2.44347e-07 DIIS
+   @UHF iter   3:  -149.58760428588195   -1.30871e-03   6.47395e-04 DIIS/ADIIS
+   @UHF iter   4:  -149.58772283023293   -1.18544e-04   1.38075e-04 DIIS/ADIIS
+   @UHF iter   5:  -149.58772855372322   -5.72349e-06   1.83160e-05 DIIS
+   @UHF iter   6:  -149.58772885952450   -3.05801e-07   2.47041e-06 DIIS
+   @UHF iter   7:  -149.58772885956964   -4.51337e-11   2.44347e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
@@ -3404,9 +3398,9 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:  -3.552713679E-15
+   @Spin Contamination Metric:   0.000000000E+00
    @S^2 Expected:                0.000000000E+00
-   @S^2 Observed:               -3.552713679E-15
+   @S^2 Observed:                0.000000000E+00
    @S   Expected:                0.000000000E+00
    @S   Observed:                0.000000000E+00
 
@@ -3479,18 +3473,18 @@ Scratch directory: /scratch/dpoole34/
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.8059033672356009
-    Two-Electron Energy =                  86.4301879389082899
+    One-Electron Energy =                -266.8059033672356577
+    Two-Electron Energy =                  86.4301879389083609
     Total Energy =                       -149.5872231711636573
 
   UHF NO Occupations:
-  HONO-2 :    3 Ag 2.0000000
-  HONO-1 :    1B3g 2.0000000
+  HONO-2 :    1B3g 2.0000000
+  HONO-1 :    3 Ag 2.0000000
   HONO-0 :    1B2u 2.0000000
-  LUNO+0 :    2B3g 0.0000000
-  LUNO+1 :    2B2u 0.0000000
-  LUNO+2 :    4 Ag 0.0000000
-  LUNO+3 :    3B1u 0.0000000
+  LUNO+0 :    2B2u 0.0000000
+  LUNO+1 :    2B3g 0.0000000
+  LUNO+2 :    2B3u 0.0000000
+  LUNO+3 :    4 Ag 0.0000000
 
 
 Computation Completed
@@ -3515,21 +3509,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:11 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:11 2022
 Module time:
 	user time   =       2.68 seconds =       0.04 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      11.42 seconds =       0.19 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =      11.12 seconds =       0.19 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =         13 seconds =       0.22 minutes
     Singlet COSX UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:11 2022
+*** at Thu Nov 10 11:03:11 2022
 
    => Loading Basis Set <=
 
@@ -3771,21 +3765,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:12 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:13 2022
 Module time:
-	user time   =       1.43 seconds =       0.02 minutes
+	user time   =       1.41 seconds =       0.02 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      12.88 seconds =       0.21 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =      12.56 seconds =       0.21 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =         15 seconds =       0.25 minutes
     Singlet LinK UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:12 2022
+*** at Thu Nov 10 11:03:13 2022
 
    => Loading Basis Set <=
 
@@ -4023,21 +4017,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:13 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:13 2022
 Module time:
-	user time   =       0.41 seconds =       0.01 minutes
+	user time   =       0.42 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      13.32 seconds =       0.22 minutes
-	system time =       0.20 seconds =       0.00 minutes
-	total time  =         14 seconds =       0.23 minutes
+	user time   =      13.00 seconds =       0.22 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =         15 seconds =       0.25 minutes
     Singlet PK CUHF energy................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:13 2022
+*** at Thu Nov 10 11:03:13 2022
 
    => Loading Basis Set <=
 
@@ -4307,21 +4301,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:14 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:14 2022
 Module time:
 	user time   =       0.87 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      14.22 seconds =       0.24 minutes
-	system time =       0.21 seconds =       0.00 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =      13.90 seconds =       0.23 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =         16 seconds =       0.27 minutes
     Singlet Direct CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:14 2022
+*** at Thu Nov 10 11:03:14 2022
 
    => Loading Basis Set <=
 
@@ -4541,21 +4535,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:14 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:15 2022
 Module time:
-	user time   =       0.40 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.35 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      14.65 seconds =       0.24 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =         15 seconds =       0.25 minutes
+	user time   =      14.27 seconds =       0.24 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =         17 seconds =       0.28 minutes
     Singlet Disk CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:14 2022
+*** at Thu Nov 10 11:03:15 2022
 
    => Loading Basis Set <=
 
@@ -4805,21 +4799,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:15 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:15 2022
 Module time:
 	user time   =       0.23 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.90 seconds =       0.25 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =         16 seconds =       0.27 minutes
+	user time   =      14.52 seconds =       0.24 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =         17 seconds =       0.28 minutes
     Singlet DiskDF CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:15 2022
+*** at Thu Nov 10 11:03:15 2022
 
    => Loading Basis Set <=
 
@@ -5070,21 +5064,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:15 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:15 2022
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
+	user time   =       0.22 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      15.16 seconds =       0.25 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =         16 seconds =       0.27 minutes
+	user time   =      14.77 seconds =       0.25 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =         17 seconds =       0.28 minutes
     Singlet MemDF CUHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:15 2022
+*** at Thu Nov 10 11:03:15 2022
 
    => Loading Basis Set <=
 
@@ -5206,17 +5200,17 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @CUHF iter SAD:  -149.27713328631918   -1.49277e+02   0.00000e+00 
-   @CUHF iter   1:  -149.56382697604781   -2.86694e-01   1.10975e-02 DIIS/ADIIS
-   @CUHF iter   2:  -149.58629558037472   -2.24686e-02   2.92559e-03 DIIS/ADIIS
-   @CUHF iter   3:  -149.58760428588195   -1.30871e-03   6.47395e-04 DIIS/ADIIS
-   @CUHF iter   4:  -149.58772283023291   -1.18544e-04   1.38075e-04 DIIS/ADIIS
-   @CUHF iter   5:  -149.58772855372325   -5.72349e-06   1.83160e-05 DIIS
-   @CUHF iter   6:  -149.58772885952445   -3.05801e-07   2.47041e-06 DIIS
-   @CUHF iter   7:  -149.58772885956975   -4.53042e-11   2.44347e-07 DIIS
+   @CUHF iter   1:  -149.56382697604786   -2.86694e-01   1.10975e-02 DIIS/ADIIS
+   @CUHF iter   2:  -149.58629558037481   -2.24686e-02   2.92559e-03 DIIS/ADIIS
+   @CUHF iter   3:  -149.58760428588192   -1.30871e-03   6.47395e-04 DIIS/ADIIS
+   @CUHF iter   4:  -149.58772283023288   -1.18544e-04   1.38075e-04 DIIS/ADIIS
+   @CUHF iter   5:  -149.58772855372328   -5.72349e-06   1.83160e-05 DIIS
+   @CUHF iter   6:  -149.58772885952450   -3.05801e-07   2.47041e-06 DIIS
+   @CUHF iter   7:  -149.58772885956967   -4.51621e-11   2.44347e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @CUHF iter   8:  -149.58722317116366    5.05688e-04   9.91149e-04 DIIS/ADIIS
+   @CUHF iter   8:  -149.58722317116371    5.05688e-04   9.91149e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -5290,14 +5284,14 @@ Scratch directory: /scratch/dpoole34/
     NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  @CUHF Final Energy:  -149.58722317116366
+  @CUHF Final Energy:  -149.58722317116371
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.8059033672359988
-    Two-Electron Energy =                  86.4301879389086878
-    Total Energy =                       -149.5872231711636573
+    One-Electron Energy =                -266.8059033672353166
+    Two-Electron Energy =                  86.4301879389079630
+    Total Energy =                       -149.5872231711637141
 
 Computation Completed
 
@@ -5321,21 +5315,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:18 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:18 2022
 Module time:
-	user time   =       2.69 seconds =       0.04 minutes
+	user time   =       2.66 seconds =       0.04 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      17.88 seconds =       0.30 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =         19 seconds =       0.32 minutes
+	user time   =      17.46 seconds =       0.29 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =         20 seconds =       0.33 minutes
     Singlet COSX CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:18 2022
+*** at Thu Nov 10 11:03:18 2022
 
    => Loading Basis Set <=
 
@@ -5565,21 +5559,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:19 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:19 2022
 Module time:
 	user time   =       1.42 seconds =       0.02 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      19.32 seconds =       0.32 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =         20 seconds =       0.33 minutes
+	user time   =      18.90 seconds =       0.32 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =         21 seconds =       0.35 minutes
     Singlet LinK CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:19 2022
+*** at Thu Nov 10 11:03:19 2022
 
    => Loading Basis Set <=
 
@@ -5836,21 +5830,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:19 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:20 2022
 Module time:
-	user time   =       0.35 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      19.70 seconds =       0.33 minutes
-	system time =       0.26 seconds =       0.00 minutes
-	total time  =         20 seconds =       0.33 minutes
+	user time   =      19.29 seconds =       0.32 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =         22 seconds =       0.37 minutes
     Triplet PK UHF energy.................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:19 2022
+*** at Thu Nov 10 11:03:20 2022
 
    => Loading Basis Set <=
 
@@ -6138,21 +6132,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:20 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:20 2022
 Module time:
 	user time   =       0.67 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      20.40 seconds =       0.34 minutes
-	system time =       0.27 seconds =       0.00 minutes
-	total time  =         21 seconds =       0.35 minutes
+	user time   =      19.98 seconds =       0.33 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =         22 seconds =       0.37 minutes
     Triplet Direct UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:20 2022
+*** at Thu Nov 10 11:03:20 2022
 
    => Loading Basis Set <=
 
@@ -6391,21 +6385,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:21 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:21 2022
 Module time:
 	user time   =       0.32 seconds =       0.01 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      20.75 seconds =       0.35 minutes
-	system time =       0.29 seconds =       0.00 minutes
-	total time  =         22 seconds =       0.37 minutes
+	user time   =      20.32 seconds =       0.34 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =         23 seconds =       0.38 minutes
     Triplet Disk UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:21 2022
+*** at Thu Nov 10 11:03:21 2022
 
    => Loading Basis Set <=
 
@@ -6674,21 +6668,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:21 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:21 2022
 Module time:
-	user time   =       0.19 seconds =       0.00 minutes
+	user time   =       0.20 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      20.97 seconds =       0.35 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =         22 seconds =       0.37 minutes
+	user time   =      20.54 seconds =       0.34 minutes
+	system time =       0.26 seconds =       0.00 minutes
+	total time  =         23 seconds =       0.38 minutes
     Triplet DiskDF UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:21 2022
+*** at Thu Nov 10 11:03:21 2022
 
    => Loading Basis Set <=
 
@@ -6958,21 +6952,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:21 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:21 2022
 Module time:
 	user time   =       0.17 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      21.16 seconds =       0.35 minutes
-	system time =       0.31 seconds =       0.01 minutes
-	total time  =         22 seconds =       0.37 minutes
+	user time   =      20.74 seconds =       0.35 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =         23 seconds =       0.38 minutes
     Triplet MemDF UHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:21 2022
+*** at Thu Nov 10 11:03:21 2022
 
    => Loading Basis Set <=
 
@@ -7101,18 +7095,18 @@ Scratch directory: /scratch/dpoole34/
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
    @UHF iter   1:  -131.02266731942416   -1.31023e+02   3.53990e-01 ADIIS
-   @UHF iter   2:  -140.14034734140617   -9.11768e+00   1.85365e-01 ADIIS
-   @UHF iter   3:  -149.07920849522245   -8.93886e+00   6.20863e-02 DIIS/ADIIS
-   @UHF iter   4:  -149.65391531645002   -5.74707e-01   1.05356e-02 DIIS/ADIIS
+   @UHF iter   2:  -140.14034734140628   -9.11768e+00   1.85365e-01 ADIIS
+   @UHF iter   3:  -149.07920849522228   -8.93886e+00   6.20863e-02 DIIS/ADIIS
+   @UHF iter   4:  -149.65391531645000   -5.74707e-01   1.05356e-02 DIIS/ADIIS
    @UHF iter   5:  -149.67061947228331   -1.67042e-02   1.87593e-03 DIIS/ADIIS
-   @UHF iter   6:  -149.67160507761122   -9.85605e-04   4.33948e-04 DIIS/ADIIS
-   @UHF iter   7:  -149.67166177628394   -5.66987e-05   6.80300e-05 DIIS
-   @UHF iter   8:  -149.67166378928829   -2.01300e-06   9.42637e-06 DIIS
-   @UHF iter   9:  -149.67166383531969   -4.60314e-08   8.91526e-07 DIIS
+   @UHF iter   6:  -149.67160507761128   -9.85605e-04   4.33948e-04 DIIS/ADIIS
+   @UHF iter   7:  -149.67166177628386   -5.66987e-05   6.80300e-05 DIIS
+   @UHF iter   8:  -149.67166378928806   -2.01300e-06   9.42637e-06 DIIS
+   @UHF iter   9:  -149.67166383531955   -4.60315e-08   8.91526e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @UHF iter  10:  -149.67132922569735    3.34610e-04   9.51899e-04 DIIS/ADIIS
+   @UHF iter  10:  -149.67132922569729    3.34610e-04   9.51899e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -7187,14 +7181,14 @@ Scratch directory: /scratch/dpoole34/
     NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  @UHF Final Energy:  -149.67132922569735
+  @UHF Final Energy:  -149.67132922569729
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.9129345756499561
-    Two-Electron Energy =                  86.4531130927889535
-    Total Energy =                       -149.6713292256973489
+    One-Electron Energy =                -266.9129345756500129
+    Two-Electron Energy =                  86.4531130927890672
+    Total Energy =                       -149.6713292256972920
 
   UHF NO Occupations:
   HONO-2 :    1B2u 1.9937328
@@ -7228,21 +7222,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:24 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:24 2022
 Module time:
-	user time   =       2.91 seconds =       0.05 minutes
+	user time   =       2.92 seconds =       0.05 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      24.10 seconds =       0.40 minutes
-	system time =       0.31 seconds =       0.01 minutes
-	total time  =         25 seconds =       0.42 minutes
+	user time   =      23.68 seconds =       0.39 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =         26 seconds =       0.43 minutes
     Triplet COSX UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:24 2022
+*** at Thu Nov 10 11:03:24 2022
 
    => Loading Basis Set <=
 
@@ -7491,21 +7485,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:26 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:26 2022
 Module time:
 	user time   =       1.62 seconds =       0.03 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      25.75 seconds =       0.43 minutes
-	system time =       0.32 seconds =       0.01 minutes
-	total time  =         27 seconds =       0.45 minutes
+	user time   =      25.34 seconds =       0.42 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         28 seconds =       0.47 minutes
     Triplet LinK UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:26 2022
+*** at Thu Nov 10 11:03:26 2022
 
    => Loading Basis Set <=
 
@@ -7723,21 +7717,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:26 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:26 2022
 Module time:
 	user time   =       0.34 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      26.12 seconds =       0.44 minutes
-	system time =       0.33 seconds =       0.01 minutes
-	total time  =         27 seconds =       0.45 minutes
+	user time   =      25.71 seconds =       0.43 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         28 seconds =       0.47 minutes
     Triplet PK ROHF energy................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:26 2022
+*** at Thu Nov 10 11:03:26 2022
 
    => Loading Basis Set <=
 
@@ -7986,21 +7980,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:27 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:27 2022
 Module time:
-	user time   =       0.64 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.63 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      26.80 seconds =       0.45 minutes
-	system time =       0.34 seconds =       0.01 minutes
-	total time  =         28 seconds =       0.47 minutes
+	user time   =      26.36 seconds =       0.44 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         29 seconds =       0.48 minutes
     Triplet Direct ROHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:27 2022
+*** at Thu Nov 10 11:03:27 2022
 
    => Loading Basis Set <=
 
@@ -8200,21 +8194,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:27 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:27 2022
 Module time:
-	user time   =       0.34 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.33 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      27.17 seconds =       0.45 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =         28 seconds =       0.47 minutes
+	user time   =      26.72 seconds =       0.45 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =         29 seconds =       0.48 minutes
     Triplet Disk ROHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:27 2022
+*** at Thu Nov 10 11:03:28 2022
 
    => Loading Basis Set <=
 
@@ -8444,21 +8438,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:28 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:28 2022
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.15 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      27.38 seconds =       0.46 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =         29 seconds =       0.48 minutes
+	user time   =      26.90 seconds =       0.45 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =         30 seconds =       0.50 minutes
     Triplet DiskDF ROHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:28 2022
+*** at Thu Nov 10 11:03:28 2022
 
    => Loading Basis Set <=
 
@@ -8689,21 +8683,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:28 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:28 2022
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
+	user time   =       0.16 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      27.58 seconds =       0.46 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =         29 seconds =       0.48 minutes
+	user time   =      27.08 seconds =       0.45 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =         30 seconds =       0.50 minutes
     Triplet MemDF ROHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:28 2022
+*** at Thu Nov 10 11:03:28 2022
 
    => Loading Basis Set <=
 
@@ -8832,18 +8826,18 @@ Scratch directory: /scratch/dpoole34/
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
    @ROHF iter   1:  -131.02266731942382   -1.31023e+02   2.71851e-01 DIIS
-   @ROHF iter   2:  -139.64070004271170   -8.61803e+00   1.37369e-01 DIIS
-   @ROHF iter   3:  -148.99660951088302   -9.35591e+00   5.06619e-02 DIIS
-   @ROHF iter   4:  -149.63963700749687   -6.43027e-01   6.07525e-03 DIIS
-   @ROHF iter   5:  -149.65187157255181   -1.22346e-02   4.84799e-04 DIIS
-   @ROHF iter   6:  -149.65198834090884   -1.16768e-04   1.12106e-04 DIIS
-   @ROHF iter   7:  -149.65199670359928   -8.36269e-06   1.71152e-05 DIIS
-   @ROHF iter   8:  -149.65199683539865   -1.31799e-07   2.91717e-06 DIIS
-   @ROHF iter   9:  -149.65199681028338    2.51153e-08   3.52335e-07 DIIS
+   @ROHF iter   2:  -139.64070004271176   -8.61803e+00   1.37369e-01 DIIS
+   @ROHF iter   3:  -148.99660951088310   -9.35591e+00   5.06619e-02 DIIS
+   @ROHF iter   4:  -149.63963700749699   -6.43027e-01   6.07525e-03 DIIS
+   @ROHF iter   5:  -149.65187157255190   -1.22346e-02   4.84799e-04 DIIS
+   @ROHF iter   6:  -149.65198834090887   -1.16768e-04   1.12106e-04 DIIS
+   @ROHF iter   7:  -149.65199670359948   -8.36269e-06   1.71152e-05 DIIS
+   @ROHF iter   8:  -149.65199683539856   -1.31799e-07   2.91717e-06 DIIS
+   @ROHF iter   9:  -149.65199681028338    2.51152e-08   3.52335e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @ROHF iter  10:  -149.65168894022727    3.07870e-04   6.55828e-04 DIIS
+   @ROHF iter  10:  -149.65168894022710    3.07870e-04   6.55828e-04 DIIS
   Energy and wave function converged.
 
 
@@ -8889,14 +8883,14 @@ Scratch directory: /scratch/dpoole34/
     NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  @ROHF Final Energy:  -149.65168894022727
+  @ROHF Final Energy:  -149.65168894022710
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.9107678299203030
-    Two-Electron Energy =                  86.4705866325293755
-    Total Energy =                       -149.6516889402272739
+    One-Electron Energy =                -266.9107678299204167
+    Two-Electron Energy =                  86.4705866325296597
+    Total Energy =                       -149.6516889402271033
 
 Computation Completed
 
@@ -8920,21 +8914,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:31 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:31 2022
 Module time:
-	user time   =       2.91 seconds =       0.05 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.87 seconds =       0.05 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      30.52 seconds =       0.51 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =         32 seconds =       0.53 minutes
+	user time   =      29.98 seconds =       0.50 minutes
+	system time =       0.32 seconds =       0.01 minutes
+	total time  =         33 seconds =       0.55 minutes
     Triplet COSX ROHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:31 2022
+*** at Thu Nov 10 11:03:31 2022
 
    => Loading Basis Set <=
 
@@ -9144,21 +9138,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:32 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:32 2022
 Module time:
-	user time   =       1.63 seconds =       0.03 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.62 seconds =       0.03 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      32.18 seconds =       0.54 minutes
-	system time =       0.37 seconds =       0.01 minutes
-	total time  =         33 seconds =       0.55 minutes
+	user time   =      31.63 seconds =       0.53 minutes
+	system time =       0.32 seconds =       0.01 minutes
+	total time  =         34 seconds =       0.57 minutes
     Triplet LinK ROHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:32 2022
+*** at Thu Nov 10 11:03:32 2022
 
    => Loading Basis Set <=
 
@@ -9403,21 +9397,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:33 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:33 2022
 Module time:
 	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      32.59 seconds =       0.54 minutes
-	system time =       0.39 seconds =       0.01 minutes
-	total time  =         34 seconds =       0.57 minutes
+	user time   =      32.03 seconds =       0.53 minutes
+	system time =       0.33 seconds =       0.01 minutes
+	total time  =         35 seconds =       0.58 minutes
     Triplet PK CUHF energy................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:33 2022
+*** at Thu Nov 10 11:03:33 2022
 
    => Loading Basis Set <=
 
@@ -9693,21 +9687,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:34 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:34 2022
 Module time:
-	user time   =       0.66 seconds =       0.01 minutes
+	user time   =       0.67 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      33.28 seconds =       0.55 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =         35 seconds =       0.58 minutes
+	user time   =      32.72 seconds =       0.55 minutes
+	system time =       0.34 seconds =       0.01 minutes
+	total time  =         36 seconds =       0.60 minutes
     Triplet Direct CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:34 2022
+*** at Thu Nov 10 11:03:34 2022
 
    => Loading Basis Set <=
 
@@ -9934,21 +9928,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:34 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:35 2022
 Module time:
-	user time   =       0.31 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.33 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      33.62 seconds =       0.56 minutes
-	system time =       0.41 seconds =       0.01 minutes
-	total time  =         35 seconds =       0.58 minutes
+	user time   =      33.09 seconds =       0.55 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =         37 seconds =       0.62 minutes
     Triplet Disk CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:34 2022
+*** at Thu Nov 10 11:03:35 2022
 
    => Loading Basis Set <=
 
@@ -10205,21 +10199,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:34 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:35 2022
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.21 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      33.84 seconds =       0.56 minutes
-	system time =       0.42 seconds =       0.01 minutes
-	total time  =         35 seconds =       0.58 minutes
+	user time   =      33.33 seconds =       0.56 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =         37 seconds =       0.62 minutes
     Triplet DiskDF CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:34 2022
+*** at Thu Nov 10 11:03:35 2022
 
    => Loading Basis Set <=
 
@@ -10477,21 +10471,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:34 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:35 2022
 Module time:
-	user time   =       0.19 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       0.17 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      34.06 seconds =       0.57 minutes
-	system time =       0.42 seconds =       0.01 minutes
-	total time  =         35 seconds =       0.58 minutes
+	user time   =      33.52 seconds =       0.56 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =         37 seconds =       0.62 minutes
     Triplet MemDF CUHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:35 2022
+*** at Thu Nov 10 11:03:35 2022
 
    => Loading Basis Set <=
 
@@ -10621,13 +10615,13 @@ Scratch directory: /scratch/dpoole34/
 
    @CUHF iter   1:  -131.02266731942410   -1.31023e+02   3.53890e-01 ADIIS
    @CUHF iter   2:  -140.10621696114706   -9.08355e+00   1.85157e-01 ADIIS
-   @CUHF iter   3:  -149.07283195574351   -8.96661e+00   6.18535e-02 DIIS/ADIIS
-   @CUHF iter   4:  -149.63845093676014   -5.65619e-01   1.00842e-02 DIIS/ADIIS
-   @CUHF iter   5:  -149.65151108189107   -1.30601e-02   1.51377e-03 DIIS/ADIIS
-   @CUHF iter   6:  -149.65197130478214   -4.60223e-04   2.18032e-04 DIIS/ADIIS
-   @CUHF iter   7:  -149.65199790962745   -2.66048e-05   1.85204e-05 DIIS
-   @CUHF iter   8:  -149.65199703995131    8.69676e-07   2.10529e-06 DIIS
-   @CUHF iter   9:  -149.65199679272925    2.47222e-07   3.47492e-07 DIIS
+   @CUHF iter   3:  -149.07283195574362   -8.96661e+00   6.18535e-02 DIIS/ADIIS
+   @CUHF iter   4:  -149.63845093676022   -5.65619e-01   1.00842e-02 DIIS/ADIIS
+   @CUHF iter   5:  -149.65151108189113   -1.30601e-02   1.51377e-03 DIIS/ADIIS
+   @CUHF iter   6:  -149.65197130478222   -4.60223e-04   2.18032e-04 DIIS/ADIIS
+   @CUHF iter   7:  -149.65199790962754   -2.66048e-05   1.85204e-05 DIIS
+   @CUHF iter   8:  -149.65199703995120    8.69676e-07   2.10529e-06 DIIS
+   @CUHF iter   9:  -149.65199679272919    2.47222e-07   3.47492e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
@@ -10709,8 +10703,8 @@ Scratch directory: /scratch/dpoole34/
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.9107736954308621
-    Two-Electron Energy =                  86.4705924981047787
+    One-Electron Energy =                -266.9107736954306915
+    Two-Electron Energy =                  86.4705924981046081
     Total Energy =                       -149.6516889401624439
 
 Computation Completed
@@ -10735,21 +10729,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:37 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:38 2022
 Module time:
-	user time   =       2.94 seconds =       0.05 minutes
+	user time   =       2.91 seconds =       0.05 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      37.02 seconds =       0.62 minutes
-	system time =       0.43 seconds =       0.01 minutes
-	total time  =         38 seconds =       0.63 minutes
+	user time   =      36.46 seconds =       0.61 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =         40 seconds =       0.67 minutes
     Triplet COSX CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Nov 10 10:43:38 2022
+*** at Thu Nov 10 11:03:38 2022
 
    => Loading Basis Set <=
 
@@ -10986,18 +10980,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Nov 10 10:43:39 2022
+*** tstop() called on ds6 at Thu Nov 10 11:03:40 2022
 Module time:
-	user time   =       1.66 seconds =       0.03 minutes
+	user time   =       1.63 seconds =       0.03 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      38.71 seconds =       0.65 minutes
-	system time =       0.44 seconds =       0.01 minutes
-	total time  =         40 seconds =       0.67 minutes
+	user time   =      38.11 seconds =       0.64 minutes
+	system time =       0.38 seconds =       0.01 minutes
+	total time  =         42 seconds =       0.70 minutes
     Triplet LinK CUHF energy..............................................................PASSED
 
-    Psi4 stopped on: Thursday, 10 November 2022 10:43AM
-    Psi4 wall time for execution: 0:00:40.60
+    Psi4 stopped on: Thursday, 10 November 2022 11:03AM
+    Psi4 wall time for execution: 0:00:41.45
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/scf5/output.ref
+++ b/tests/scf5/output.ref
@@ -1,27 +1,40 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.7a1.dev93 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {dpoole34/jk-test-coverage} e6a3fdf 
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, and A. Jiang
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:39PM
+    Psi4 started on: Monday, 07 November 2022 10:56AM
 
-    Process ID:  19647
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 29881
+    Host:       ds6
+    PSIDATADIR: /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -30,12 +43,12 @@
 --------------------------------------------------------------------------
 #! Test of all different algorithms and reference types for SCF, on singlet and triplet O2, using the cc-pVTZ basis set.
 
-print_stdout(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet O2') #TEST
+print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet O2') #TEST
 
 #Ensure that the checkpoint file is always nuked
 psi4_io.set_specific_retention(32,False)
 
-Eref_nuc      =   30.78849213614545 #TEST
+Eref_nuc      =   30.7884922572     #TEST
 Eref_sing_can = -149.58723684929720 #TEST
 Eref_sing_df  = -149.58715054487624 #TEST
 Eref_uhf_can  = -149.67135517240553 #TEST
@@ -59,7 +72,7 @@ molecule triplet_o2 {
 singlet_o2.update_geometry()
 triplet_o2.update_geometry()
 
-print_stdout('   -Nuclear Repulsion:') #TEST
+print('   -Nuclear Repulsion:') #TEST
 compare_values(Eref_nuc, triplet_o2.nuclear_repulsion_energy(), 9, "Triplet nuclear repulsion energy")  #TEST
 compare_values(Eref_nuc, singlet_o2.nuclear_repulsion_energy(), 9, "Singlet nuclear repulsion energy")  #TEST
 
@@ -70,62 +83,104 @@ set {
     print 2
 }
 
-print_stdout('    -Singlet RHF:') #TEST
+print('    -Singlet RHF:') #TEST
 set scf reference rhf
+set screening csam
 
-set scf scf_type pk
+set scf_type pk
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet PK RHF energy') #TEST
 
-set scf scf_type direct
+set scf_type direct
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet Direct RHF energy') #TEST
 
-set scf scf_type out_of_core 
+set scf_type out_of_core
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet Disk RHF energy') #TEST
 
-set scf scf_type df 
+set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DF RHF energy') #TEST
+compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF RHF energy') #TEST
 
-print_stdout('    -Singlet UHF:') #TEST
+set scf_type mem_df
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet MemDF RHF energy') #TEST
+
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX RHF energy') #TEST
+
+set scf_type link
+set screening density
+E = energy('scf')
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK RHF energy') #TEST
+
+print('    -Singlet UHF:') #TEST
 set scf reference uhf
+set screening csam
 
-set scf scf_type pk
+set scf_type pk
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet PK UHF energy') #TEST
 
-set scf scf_type direct
+set scf_type direct
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet Direct UHF energy') #TEST
 
-set scf scf_type out_of_core 
+set scf_type out_of_core
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet Disk UHF energy') #TEST
 
-set scf scf_type df 
+set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DF UHF energy') #TEST
+compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF UHF energy') #TEST
 
-print_stdout('    -Singlet CUHF:') #TEST
+set scf_type mem_df
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet MemDF UHF energy') #TEST
+
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_sing_df, E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
+
+set scf_type link
+set screening density 
+E = energy('scf')
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK UHF energy') #TEST
+
+print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
+set screening csam 
 
-set scf scf_type pk
+set scf_type pk
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet PK CUHF energy') #TEST
 
-set scf scf_type direct
+set scf_type direct
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet Direct CUHF energy') #TEST
 
-set scf scf_type out_of_core
+set scf_type out_of_core
 E = energy('scf')
 compare_values(Eref_sing_can, E, 6, 'Singlet Disk CUHF energy') #TEST
 
-set scf scf_type df
+set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DF CUHF energy') #TEST
+compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF CUHF energy') #TEST
+
+set scf_type mem_df
+E = energy('scf')
+compare_values(Eref_sing_df, E, 6, 'Singlet MemDF CUHF energy') #TEST
+
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX CUHF energy') #TEST
+
+set scf_type link
+set screening density 
+E = energy('scf')
+compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK CUHF energy') #TEST
 
 activate(triplet_o2)
 set {
@@ -135,90 +190,137 @@ set {
     print 2
 }
 
-print_stdout('    -Triplet UHF:') #TEST
+print('    -Triplet UHF:') #TEST
 set scf reference uhf
+set screening csam 
 
-set scf scf_type pk
+set scf_type pk
 E = energy('scf')
 compare_values(Eref_uhf_can, E, 6, 'Triplet PK UHF energy') #TEST
 
-set scf scf_type direct
+set scf_type direct
 E = energy('scf')
 compare_values(Eref_uhf_can, E, 6, 'Triplet Direct UHF energy') #TEST
 
-set scf scf_type out_of_core 
+set scf_type out_of_core
 E = energy('scf')
 compare_values(Eref_uhf_can, E, 6, 'Triplet Disk UHF energy') #TEST
 
-set scf scf_type df 
+set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_uhf_df, E, 6, 'Triplet DF UHF energy') #TEST
+compare_values(Eref_uhf_df, E, 6, 'Triplet DiskDF UHF energy') #TEST
+
+set scf_type mem_df
+E = energy('scf')
+compare_values(Eref_uhf_df, E, 6, 'Triplet MemDF UHF energy') #TEST
+
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_uhf_can, E, 4, 'Triplet DFJ+COSX UHF energy') #TEST
+
+set scf_type link
+set screening density
+E = energy('scf')
+compare_values(Eref_uhf_can, E, 4, 'Triplet DFJ+LinK UHF energy') #TEST
 
 clean()
 
-print_stdout('    -Triplet ROHF:') #TEST
+print('    -Triplet ROHF:') #TEST
 set scf reference rohf
+set screening csam 
 
-set scf scf_type pk
+set scf_type pk
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 6, 'Triplet PK ROHF energy') #TEST
 clean()
 
-set scf scf_type direct
+set scf_type direct
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 6, 'Triplet Direct ROHF energy') #TEST
 clean()
 
-set scf scf_type out_of_core 
+set scf_type out_of_core
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 6, 'Triplet Disk ROHF energy') #TEST
 clean()
 
-set scf scf_type df 
+set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_rohf_df, E, 6, 'Triplet DF ROHF energy') #TEST
+compare_values(Eref_rohf_df, E, 6, 'Triplet DiskDF ROHF energy') #TEST
+
+set scf_type mem_df
+E = energy('scf')
+compare_values(Eref_rohf_df, E, 6, 'Triplet MemDF ROHF energy') #TEST
+
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX ROHF energy') #TEST
+
+set scf_type link
+set screening density 
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK ROHF energy') #TEST
 
 clean()
 
-print_stdout('    -Triplet CUHF:') #TEST
+print('    -Triplet CUHF:') #TEST
 set scf reference cuhf
+set screening csam 
 
-set scf scf_type pk
+set scf_type pk
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 6, 'Triplet PK CUHF energy') #TEST
 clean()
 
-set scf scf_type direct
+set scf_type direct
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 6, 'Triplet Direct CUHF energy') #TEST
 clean()
 
-set scf scf_type out_of_core
+set scf_type out_of_core
 E = energy('scf')
 compare_values(Eref_rohf_can, E, 6, 'Triplet Disk CUHF energy') #TEST
 clean()
 
-set scf scf_type df
+set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_rohf_df, E, 6, 'Triplet DF CUHF energy') #TEST
---------------------------------------------------------------------------
-	Triplet nuclear repulsion energy..................................PASSED
-	Singlet nuclear repulsion energy..................................PASSED
+compare_values(Eref_rohf_df, E, 6, 'Triplet DiskDF CUHF energy') #TEST
 
-*** tstart() called on psinet
-*** at Mon May 15 15:39:55 2017
+set scf_type mem_df
+E = energy('scf')
+compare_values(Eref_rohf_df, E, 6, 'Triplet MemDF CUHF energy') #TEST
+
+set scf_type cosx
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX CUHF energy') #TEST
+
+set scf_type link
+set screening density 
+E = energy('scf')
+compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST
+
+
+--------------------------------------------------------------------------
+    Triplet nuclear repulsion energy......................................................PASSED
+    Singlet nuclear repulsion energy......................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:33 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -232,14 +334,14 @@ compare_values(Eref_rohf_df, E, 6, 'Triplet DF CUHF energy') #TEST
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 1
@@ -256,7 +358,7 @@ compare_values(Eref_rohf_df, E, 6, 'Triplet DF CUHF energy') #TEST
   Guess Type is SAD.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -275,23 +377,6 @@ compare_values(Eref_rohf_df, E, 6, 'Triplet DF CUHF energy') #TEST
    ------ ------ --------------------------
        1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
        2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       8       8       8       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -310,128 +395,152 @@ compare_values(Eref_rohf_df, E, 6, 'Triplet DF CUHF energy') #TEST
   Using 3350730 doubles for integral storage.
   We computed 22155 shell quartets total.
   Whereas there are 22155 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -149.90298608706900   -1.49903e+02   9.01232e-02 
-   @RHF iter   1:  -149.57116658984000    3.31819e-01   9.24753e-03 
-   @RHF iter   2:  -149.58605846429731   -1.48919e-02   2.54023e-03 DIIS
-   @RHF iter   3:  -149.58715403809774   -1.09557e-03   5.55181e-04 DIIS
-   @RHF iter   4:  -149.58723434874673   -8.03106e-05   9.72979e-05 DIIS
-   @RHF iter   5:  -149.58723678917676   -2.44043e-06   1.52366e-05 DIIS
-   @RHF iter   6:  -149.58723684877015   -5.95934e-08   1.33189e-06 DIIS
-   @RHF iter   7:  -149.58723684935669   -5.86539e-10   1.37579e-07 DIIS
+   @RHF iter SAD:  -149.27731917078717   -1.49277e+02   0.00000e+00 
+   @RHF iter   1:  -149.56362429559402   -2.86305e-01   1.10129e-02 ADIIS/DIIS
+   @RHF iter   2:  -149.58582140635929   -2.21971e-02   2.91434e-03 ADIIS/DIIS
+   @RHF iter   3:  -149.58712033600358   -1.29893e-03   6.40033e-04 ADIIS/DIIS
+   @RHF iter   4:  -149.58723140197705   -1.11066e-04   1.37095e-04 ADIIS/DIIS
+   @RHF iter   5:  -149.58723670345904   -5.30148e-06   1.80224e-05 DIIS
+   @RHF iter   6:  -149.58723684553323   -1.42074e-07   2.57334e-06 DIIS
+   @RHF iter   7:  -149.58723684812222   -2.58899e-09   2.40539e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
-       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813264     3Ag    -0.769319  
-       1B2u   -0.708485     1B2g   -0.419982  
+       1Ag   -20.718067     1B1u  -20.716526     2Ag    -1.762422  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769320  
+       1B3u   -0.708485     1B3g   -0.419982  
 
     Virtual:                                                              
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
-       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
-       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639045     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928209     8Ag     4.120755     4B3g    4.258203  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
-       5B2u    5.102979     8B1u    5.124402     5B3u    5.144953  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
-       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
-      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066014     7B2g    8.112245    13Ag     8.185163  
+       1B2g    0.078685     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412881     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639045     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926932  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258203  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144953  
+       6B3u    5.265700     6B2u    5.266028    10Ag     5.555961  
+       5B2g    5.658925     5B3g    5.658932     9B1u    6.125748  
+       2Au     6.407199    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547959     3Au     6.781720    11B1u    6.782596  
+       6B2g    6.822795     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066014     7B3g    8.112245    13Ag     8.185163  
       13B1u   15.901523  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -149.58723684935669
+  @RHF Final Energy:  -149.58723684812222
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.8065684394666732
-    Two-Electron Energy =                  86.4308394539645661
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5872368493566569
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8065684414696648
+    Two-Electron Energy =                  86.4308393361837943
+    Total Energy =                       -149.5872368481222168
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:39:56 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:34 2022
 Module time:
-	user time   =       0.71 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       0.50 seconds =       0.01 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.71 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       0.50 seconds =       0.01 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-	Singlet PK RHF energy.............................................PASSED
+    Singlet PK RHF energy.................................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:39:56 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:34 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -445,14 +554,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 1
@@ -469,7 +578,7 @@ Total time:
   Guess Type is SAD.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -494,41 +603,25 @@ Total time:
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   228 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       8       8       8       0
-   -------------------------------------------------------
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   Starting with a DF guess...
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory (MB):               375
-    Algorithm:                Core
-    Integral Cache:           NONE
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -548,27 +641,43 @@ Total time:
        1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
        2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -149.90294846093738   -1.49903e+02   9.01226e-02 
-   @DF-RHF iter   1:  -149.57108660218529    3.31862e-01   9.24505e-03 
-   @DF-RHF iter   2:  -149.58597222763061   -1.48856e-02   2.54123e-03 DIIS
-   @DF-RHF iter   3:  -149.58706773148782   -1.09550e-03   5.55230e-04 DIIS
-   @DF-RHF iter   4:  -149.58714804814716   -8.03167e-05   9.72388e-05 DIIS
-   @DF-RHF iter   5:  -149.58715048478854   -2.43664e-06   1.52295e-05 DIIS
-   @DF-RHF iter   6:  -149.58715054434501   -5.95565e-08   1.33502e-06 DIIS
-   @DF-RHF iter   7:  -149.58715054493359   -5.88585e-10   1.38094e-07 DIIS
+   @DF-RHF iter SAD:  -149.27728822299315   -1.49277e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.56354408328301   -2.86256e-01   1.10101e-02 ADIIS/DIIS
+   @DF-RHF iter   2:  -149.58573446084225   -2.21904e-02   2.91563e-03 ADIIS/DIIS
+   @DF-RHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 ADIIS/DIIS
+   @DF-RHF iter   4:  -149.58714509680499   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-RHF iter   5:  -149.58715039895961   -5.30215e-06   1.80355e-05 DIIS
+   @DF-RHF iter   6:  -149.58715054109817   -1.42139e-07   2.57889e-06 DIIS
+   @DF-RHF iter   7:  -149.58715054369765   -2.59948e-09   2.41536e-07 DIIS
 
   DF guess converged.
-
-  ==> Integral Setup <==
 
   ==> DirectJK: Integral-Direct J/K Matrices <==
 
@@ -576,108 +685,114 @@ Total time:
     K tasked:                  Yes
     wK tasked:                  No
     Integrals threads:           1
-    Schwarz Cutoff:          1E-12
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
 
-   @RHF iter   8:  -149.58723673480554   -8.61899e-05   3.38769e-05 DIIS
-   @RHF iter   9:  -149.58723684741392   -1.12608e-07   3.66116e-06 DIIS
-   @RHF iter  10:  -149.58723684920656   -1.79264e-09   1.00261e-06 DIIS
-   @RHF iter  11:  -149.58723684935762   -1.51061e-10   1.38763e-07 DIIS
+   @RHF iter   8:  -149.58723673357812   -1.49587e+02   3.38768e-05 DIIS
+   @RHF iter   9:  -149.58723684619758   -1.12619e-07   3.66091e-06 DIIS
+   @RHF iter  10:  -149.58723684799020   -1.79261e-09   1.00186e-06 DIIS
+   @RHF iter  11:  -149.58723684814115   -1.50948e-10   1.38849e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
        1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708484     1B2g   -0.419982  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769319  
+       1B3u   -0.708484     1B3g   -0.419982  
 
     Virtual:                                                              
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
-       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       1B2g    0.078686     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
        5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928209     8Ag     4.120755     4B3g    4.258204  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
-       5B2u    5.102979     8B1u    5.124402     5B3u    5.144954  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       3B3u    1.639046     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926933  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258204  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144954  
+       6B3u    5.265700     6B2u    5.266029    10Ag     5.555961  
+       5B2g    5.658926     5B3g    5.658932     9B1u    6.125748  
        2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
       11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081949    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066015     7B2g    8.112246    13Ag     8.185163  
+       6B2g    6.822796     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081949    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066015     7B3g    8.112246    13Ag     8.185163  
       13B1u   15.901524  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -149.58723684935762
+  @RHF Final Energy:  -149.58723684814115
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.8065842970212316
-    Two-Electron Energy =                  86.4308553115181724
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5872368493576232
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8065845228919670
+    Two-Electron Energy =                  86.4308554175871677
+    Total Energy =                       -149.5872368481411456
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:39:58 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:35 2022
 Module time:
-	user time   =       1.54 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.78 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.26 seconds =       0.04 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
-	Singlet Direct RHF energy.........................................PASSED
+	user time   =       1.30 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+    Singlet Direct RHF energy.............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:39:58 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:35 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -691,14 +806,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 1
@@ -715,7 +830,7 @@ Total time:
   Guess Type is SAD.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -735,23 +850,6 @@ Total time:
        1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
        2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       8       8       8       0
-   -------------------------------------------------------
-
   ==> Integral Setup <==
 
   ==> DiskJK: Disk-Based J/K Matrices <==
@@ -759,122 +857,144 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:  -149.90298608706905   -1.49903e+02   9.01232e-02 
-   @RHF iter   1:  -149.57116658984020    3.31819e-01   9.24753e-03 
-   @RHF iter   2:  -149.58605846429742   -1.48919e-02   2.54023e-03 DIIS
-   @RHF iter   3:  -149.58715403809782   -1.09557e-03   5.55181e-04 DIIS
-   @RHF iter   4:  -149.58723434874682   -8.03106e-05   9.72979e-05 DIIS
-   @RHF iter   5:  -149.58723678917661   -2.44043e-06   1.52366e-05 DIIS
-   @RHF iter   6:  -149.58723684877012   -5.95935e-08   1.33189e-06 DIIS
-   @RHF iter   7:  -149.58723684935649   -5.86368e-10   1.37579e-07 DIIS
+   @RHF iter SAD:  -149.27731917078719   -1.49277e+02   0.00000e+00 
+   @RHF iter   1:  -149.56362429559408   -2.86305e-01   1.10129e-02 ADIIS/DIIS
+   @RHF iter   2:  -149.58582140635937   -2.21971e-02   2.91434e-03 ADIIS/DIIS
+   @RHF iter   3:  -149.58712033600364   -1.29893e-03   6.40033e-04 ADIIS/DIIS
+   @RHF iter   4:  -149.58723140197696   -1.11066e-04   1.37095e-04 ADIIS/DIIS
+   @RHF iter   5:  -149.58723670345884   -5.30148e-06   1.80224e-05 DIIS
+   @RHF iter   6:  -149.58723684553328   -1.42074e-07   2.57334e-06 DIIS
+   @RHF iter   7:  -149.58723684812233   -2.58905e-09   2.40539e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
-       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813264     3Ag    -0.769319  
-       1B2u   -0.708485     1B2g   -0.419982  
+       1Ag   -20.718067     1B1u  -20.716526     2Ag    -1.762422  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769320  
+       1B3u   -0.708485     1B3g   -0.419982  
 
     Virtual:                                                              
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
-       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
-       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639045     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928209     8Ag     4.120755     4B3g    4.258203  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
-       5B2u    5.102979     8B1u    5.124402     5B3u    5.144953  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
-       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
-      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066014     7B2g    8.112245    13Ag     8.185163  
+       1B2g    0.078685     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412881     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639045     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926932  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258203  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144953  
+       6B3u    5.265700     6B2u    5.266028    10Ag     5.555961  
+       5B2g    5.658925     5B3g    5.658932     9B1u    6.125748  
+       2Au     6.407199    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547959     3Au     6.781720    11B1u    6.782596  
+       6B2g    6.822795     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066014     7B3g    8.112245    13Ag     8.185163  
       13B1u   15.901523  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:  -149.58723684935649
+  @RHF Final Energy:  -149.58723684812233
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.8065684394664459
-    Two-Electron Energy =                  86.4308394539645519
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5872368493564579
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8065684414696079
+    Two-Electron Energy =                  86.4308393361836238
+    Total Energy =                       -149.5872368481223305
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:39:58 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:36 2022
 Module time:
-	user time   =       0.57 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.84 seconds =       0.05 minutes
-	system time =       0.08 seconds =       0.00 minutes
+	user time   =       1.70 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
-	Singlet Disk RHF energy...........................................PASSED
+    Singlet Disk RHF energy...............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:39:58 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:36 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -888,14 +1008,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 1
@@ -905,14 +1025,14 @@ Total time:
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DF.
+  SCF Algorithm Type is DISK_DF.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
   Guess Type is SAD.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -937,39 +1057,22 @@ Total time:
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   228 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       8       8       8       0
-   -------------------------------------------------------
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
     OpenMP threads:              1
     Integrals threads:           1
-    Memory (MB):               375
+    Memory [MiB]:              375
     Algorithm:                Core
     Integral Cache:           NONE
     Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
@@ -989,120 +1092,142 @@ Total time:
        1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
        2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   0:  -149.90294846093738   -1.49903e+02   9.01226e-02 
-   @DF-RHF iter   1:  -149.57108660218529    3.31862e-01   9.24505e-03 
-   @DF-RHF iter   2:  -149.58597222763061   -1.48856e-02   2.54123e-03 DIIS
-   @DF-RHF iter   3:  -149.58706773148782   -1.09550e-03   5.55230e-04 DIIS
-   @DF-RHF iter   4:  -149.58714804814716   -8.03167e-05   9.72388e-05 DIIS
-   @DF-RHF iter   5:  -149.58715048478854   -2.43664e-06   1.52295e-05 DIIS
-   @DF-RHF iter   6:  -149.58715054434501   -5.95565e-08   1.33502e-06 DIIS
-   @DF-RHF iter   7:  -149.58715054493359   -5.88585e-10   1.38094e-07 DIIS
+   @DF-RHF iter SAD:  -149.27728822299318   -1.49277e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.56354408328303   -2.86256e-01   1.10101e-02 ADIIS/DIIS
+   @DF-RHF iter   2:  -149.58573446084227   -2.21904e-02   2.91563e-03 ADIIS/DIIS
+   @DF-RHF iter   3:  -149.58703388315291   -1.29942e-03   6.40386e-04 ADIIS/DIIS
+   @DF-RHF iter   4:  -149.58714509680490   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-RHF iter   5:  -149.58715039895969   -5.30215e-06   1.80355e-05 DIIS
+   @DF-RHF iter   6:  -149.58715054109820   -1.42139e-07   2.57889e-06 DIIS
+   @DF-RHF iter   7:  -149.58715054369767   -2.59948e-09   2.41536e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
        1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
-       2B1u   -1.064399     1B3u   -0.813254     3Ag    -0.769333  
-       1B2u   -0.708490     1B2g   -0.420019  
+       2B1u   -1.064399     1B2u   -0.813254     3Ag    -0.769334  
+       1B3u   -0.708490     1B3g   -0.420019  
 
     Virtual:                                                              
 
-       1B3g    0.078675     3B1u    0.460375     2B2u    0.693541  
-       2B3u    0.696264     4Ag     0.713625     2B2g    0.825653  
-       2B3g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       1B2g    0.078675     3B1u    0.460375     2B3u    0.693540  
+       2B2u    0.696264     4Ag     0.713625     2B3g    0.825653  
+       2B2g    0.852603     5Ag     0.879289     4B1u    0.888916  
        5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
-       3B2u    1.639352     3B3u    1.641208     1Au     1.953829  
-       6B1u    1.954302     7Ag     2.484071     3B3g    2.532031  
-       7B1u    2.536801     3B2g    2.549181     4B2u    3.927538  
-       4B3u    3.928887     8Ag     4.122937     4B3g    4.258945  
-       4B2g    4.272670     2B1g    4.954074     9Ag     4.954589  
-       5B2u    5.109414     8B1u    5.125494     5B3u    5.151847  
-       6B2u    5.270830     6B3u    5.271178    10Ag     5.561366  
-       5B3g    5.664224     5B2g    5.664230     9B1u    6.128570  
-       2Au     6.413837    10B1u    6.415148     3B1g    6.555704  
+       3B3u    1.639352     3B2u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B2g    2.532031  
+       7B1u    2.536801     3B3g    2.549181     4B3u    3.927538  
+       4B2u    3.928887     8Ag     4.122937     4B2g    4.258945  
+       4B3g    4.272670     2B1g    4.954074     9Ag     4.954589  
+       5B3u    5.109414     8B1u    5.125493     5B2u    5.151847  
+       6B3u    5.270829     6B2u    5.271178    10Ag     5.561366  
+       5B2g    5.664224     5B3g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415147     3B1g    6.555704  
       11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
-       6B3g    6.829341     6B2g    6.860859     7B2u    7.050774  
-       7B3u    7.089664    12B1u    7.580301    12Ag     7.689595  
-       7B3g    8.072681     7B2g    8.119435    13Ag     8.191892  
+       6B2g    6.829341     6B3g    6.860859     7B3u    7.050774  
+       7B2u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B2g    8.072681     7B3g    8.119435    13Ag     8.191892  
       13B1u   15.905483  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @DF-RHF Final Energy:  -149.58715054493359
+  @DF-RHF Final Energy:  -149.58715054369767
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.8060021896083072
-    Two-Electron Energy =                  86.4303595085292784
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5871505449335928
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8060021671135473
+    Two-Electron Energy =                  86.4303593662522047
+    Total Energy =                       -149.5871505436977031
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:39:59 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:36 2022
 Module time:
-	user time   =       0.48 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.33 seconds =       0.06 minutes
+	user time   =       1.96 seconds =       0.03 minutes
 	system time =       0.10 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
-	Singlet DF RHF energy.............................................PASSED
+	total time  =          3 seconds =       0.05 minutes
+    Singlet DiskDF RHF energy.............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:39:59 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:36 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
-                              UHF Reference
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
@@ -1115,14 +1240,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 1
@@ -1132,14 +1257,14 @@ Total time:
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is PK.
+  SCF Algorithm Type is MEM_DF.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -1159,22 +1284,669 @@ Total time:
        1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
        2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ-JKFIT
+    Blend                  = CC-PVTZ-JKFIT
+    Total number of shells = 50
+    Number of primitives   = 50
+    Number of AO           = 192
+    Number of SO           = 158
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+       2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
   ==> Pre-Iterations <==
 
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       8       8       8       0
-   -------------------------------------------------------
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -149.27728822299315   -1.49277e+02   0.00000e+00 
+   @DF-RHF iter   1:  -149.56354408328301   -2.86256e-01   1.10101e-02 ADIIS/DIIS
+   @DF-RHF iter   2:  -149.58573446084225   -2.21904e-02   2.91563e-03 ADIIS/DIIS
+   @DF-RHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 ADIIS/DIIS
+   @DF-RHF iter   4:  -149.58714509680499   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-RHF iter   5:  -149.58715039895961   -5.30215e-06   1.80355e-05 DIIS
+   @DF-RHF iter   6:  -149.58715054109817   -1.42139e-07   2.57889e-06 DIIS
+   @DF-RHF iter   7:  -149.58715054369765   -2.59948e-09   2.41536e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
+       2B1u   -1.064399     1B2u   -0.813254     3Ag    -0.769334  
+       1B3u   -0.708490     1B3g   -0.420019  
+
+    Virtual:                                                              
+
+       1B2g    0.078675     3B1u    0.460375     2B3u    0.693540  
+       2B2u    0.696264     4Ag     0.713625     2B3g    0.825653  
+       2B2g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
+       3B3u    1.639352     3B2u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B2g    2.532031  
+       7B1u    2.536801     3B3g    2.549181     4B3u    3.927538  
+       4B2u    3.928887     8Ag     4.122937     4B2g    4.258945  
+       4B3g    4.272670     2B1g    4.954074     9Ag     4.954589  
+       5B3u    5.109414     8B1u    5.125493     5B2u    5.151847  
+       6B3u    5.270829     6B2u    5.271178    10Ag     5.561366  
+       5B2g    5.664224     5B3g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415147     3B1g    6.555704  
+      11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
+       6B2g    6.829341     6B3g    6.860859     7B3u    7.050774  
+       7B2u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B2g    8.072681     7B3g    8.119435    13Ag     8.191892  
+      13B1u   15.905483  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+
+  @DF-RHF Final Energy:  -149.58715054369765
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8060021671134336
+    Two-Electron Energy =                  86.4303593662521337
+    Total Energy =                       -149.5871505436976463
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:56:37 2022
+Module time:
+	user time   =       0.20 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       2.19 seconds =       0.04 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+    Singlet MemDF RHF energy..............................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:37 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is COSX.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DFJCOSK: Density-Fitted J and Semi-Numerical K <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    Integrals threads:            1
+    Memory [MiB]:               375
+    Incremental Fock :           No
+    J Screening Type:          CSAM
+    J Screening Cutoff:       1E-12
+    K Screening Cutoff:       1E-11
+    K Density Cutoff:         1E-10
+    K Basis Cutoff:           1E-10
+    K Overlap Fitting:          Yes
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:  -149.27713328631921   -1.49277e+02   0.00000e+00 
+   @RHF iter   1:  -149.56382697604784   -2.86694e-01   1.10975e-02 ADIIS/DIIS
+   @RHF iter   2:  -149.58629558037478   -2.24686e-02   2.92559e-03 ADIIS/DIIS
+   @RHF iter   3:  -149.58760428588187   -1.30871e-03   6.47395e-04 ADIIS/DIIS
+   @RHF iter   4:  -149.58772283023296   -1.18544e-04   1.38075e-04 ADIIS/DIIS
+   @RHF iter   5:  -149.58772855372331   -5.72349e-06   1.83160e-05 DIIS
+   @RHF iter   6:  -149.58772885952462   -3.05801e-07   2.47041e-06 DIIS
+   @RHF iter   7:  -149.58772885956972   -4.51053e-11   2.44347e-07 DIIS
+  Energy and wave function converged with early screening.
+  Performing final iteration with tighter screening.
+
+   @RHF iter   8:  -149.58722317116360    5.05688e-04   9.91149e-04 ADIIS/DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -20.718186     1B1u  -20.716591     2Ag    -1.762756  
+       2B1u   -1.064574     1B2u   -0.812724     3Ag    -0.770577  
+       1B3u   -0.707523     1B3g   -0.420229  
+
+    Virtual:                                                              
+
+       1B2g    0.078702     3B1u    0.460336     2B3u    0.693920  
+       2B2u    0.696563     4Ag     0.713064     2B3g    0.825214  
+       2B2g    0.852636     5Ag     0.879262     4B1u    0.889111  
+       5B1u    1.413064     1B1g    1.442922     6Ag     1.443938  
+       3B3u    1.637673     3B2u    1.642235     6B1u    1.953272  
+       1Au     1.954322     7Ag     2.483527     3B2g    2.530348  
+       7B1u    2.536977     3B3g    2.548923     4B3u    3.927463  
+       4B2u    3.928699     8Ag     4.116806     4B2g    4.259266  
+       4B3g    4.274563     2B1g    4.934640     9Ag     4.966106  
+       5B3u    5.111788     8B1u    5.123534     5B2u    5.157197  
+       6B2u    5.264086     6B3u    5.272739    10Ag     5.546638  
+       5B3g    5.659533     5B2g    5.666050     9B1u    6.117812  
+       2Au     6.397139    10B1u    6.421963     3B1g    6.546782  
+      11Ag     6.548540     3Au     6.775088    11B1u    6.791609  
+       6B2g    6.817736     6B3g    6.862237     7B3u    7.040086  
+       7B2u    7.090378    12B1u    7.574534    12Ag     7.686631  
+       7B2g    8.073746     7B3g    8.120090    13Ag     8.184818  
+      13B1u   15.899399  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+
+  @RHF Final Energy:  -149.58722317116360
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8059033672356009
+    Two-Electron Energy =                  86.4301879389083325
+    Total Energy =                       -149.5872231711636005
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:56:39 2022
+Module time:
+	user time   =       2.54 seconds =       0.04 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       4.76 seconds =       0.08 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+    Singlet DFJ+COSX RHF energy...........................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:39 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is LINK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DFJLinK: Density-Fitted J and Linear Exchange K <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Incremental Fock:           No
+    Screening Type:        DENSITY
+    J Screening Cutoff:      1E-12
+    K Screening Cutoff:      1E-12
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:  -149.27733086414963   -1.49277e+02   0.00000e+00 
+   @RHF iter   1:  -149.56365008860490   -2.86319e-01   1.10142e-02 ADIIS/DIIS
+   @RHF iter   2:  -149.58585218222908   -2.22021e-02   2.91422e-03 ADIIS/DIIS
+   @RHF iter   3:  -149.58715113835373   -1.29896e-03   6.40333e-04 ADIIS/DIIS
+   @RHF iter   4:  -149.58726227365065   -1.11135e-04   1.37172e-04 ADIIS/DIIS
+   @RHF iter   5:  -149.58726757682930   -5.30318e-06   1.80326e-05 DIIS
+   @RHF iter   6:  -149.58726771909232   -1.42263e-07   2.57489e-06 DIIS
+   @RHF iter   7:  -149.58726772168643   -2.59411e-09   2.41117e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -20.718071     1B1u  -20.716530     2Ag    -1.762433  
+       2B1u   -1.064390     1B2u   -0.813259     3Ag    -0.769342  
+       1B3u   -0.708496     1B3g   -0.420007  
+
+    Virtual:                                                              
+
+       1B2g    0.078681     3B1u    0.460327     2B3u    0.693384  
+       2B2u    0.696113     4Ag     0.713511     2B3g    0.825385  
+       2B2g    0.852393     5Ag     0.879194     4B1u    0.888887  
+       5B1u    1.412849     1B1g    1.443170     6Ag     1.444044  
+       3B3u    1.639004     3B2u    1.640861     1Au     1.953287  
+       6B1u    1.953762     7Ag     2.483724     3B2g    2.531509  
+       7B1u    2.536447     3B3g    2.548588     4B3u    3.926986  
+       4B2u    3.928307     8Ag     4.120730     4B2g    4.258300  
+       4B3g    4.271909     2B1g    4.948441     9Ag     4.948961  
+       5B3u    5.103003     8B1u    5.124465     5B2u    5.145236  
+       6B3u    5.265751     6B2u    5.266088    10Ag     5.555675  
+       5B2g    5.658990     5B3g    5.658996     9B1u    6.125723  
+       2Au     6.407176    10B1u    6.408484     3B1g    6.547508  
+      11Ag     6.547837     3Au     6.781590    11B1u    6.782559  
+       6B2g    6.822868     6B3g    6.853283     7B3u    7.043595  
+       7B2u    7.081934    12B1u    7.574355    12Ag     7.687859  
+       7B2g    8.066157     7B3g    8.112296    13Ag     8.185053  
+      13B1u   15.901574  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+
+  @RHF Final Energy:  -149.58726772168643
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8064578915614788
+    Two-Electron Energy =                  86.4306979127113948
+    Total Energy =                       -149.5872677216864304
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:56:41 2022
+Module time:
+	user time   =       1.34 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       6.12 seconds =       0.10 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
+    Singlet DFJ+LinK RHF energy...........................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:41 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
   ==> Integral Setup <==
 
@@ -1193,178 +1965,196 @@ Total time:
   Using 3350730 doubles for integral storage.
   We computed 22155 shell quartets total.
   Whereas there are 22155 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+   @UHF iter SAD:  -149.27731917078717   -1.49277e+02   0.00000e+00 
+   @UHF iter   1:  -149.56362429559402   -2.86305e-01   1.10129e-02 ADIIS/DIIS
+   @UHF iter   2:  -149.58582140635932   -2.21971e-02   2.91434e-03 ADIIS/DIIS
+   @UHF iter   3:  -149.58712033600358   -1.29893e-03   6.40033e-04 ADIIS/DIIS
+   @UHF iter   4:  -149.58723140197682   -1.11066e-04   1.37095e-04 ADIIS/DIIS
+   @UHF iter   5:  -149.58723670345896   -5.30148e-06   1.80224e-05 DIIS
+   @UHF iter   6:  -149.58723684553325   -1.42074e-07   2.57334e-06 DIIS
+   @UHF iter   7:  -149.58723684812239   -2.58913e-09   2.40539e-07 DIIS
+  Energy and wave function converged.
 
-   @UHF iter   1:  -142.88785540847203   -1.42888e+02   2.53565e-01 
-   @UHF iter   2:  -149.16634323167784   -6.27849e+00   4.38532e-02 DIIS
-   @UHF iter   3:  -149.53966641760138   -3.73323e-01   1.65676e-02 DIIS
-   @UHF iter   4:  -149.58424185672061   -4.45754e-02   2.54200e-03 DIIS
-   @UHF iter   5:  -149.58716684238325   -2.92499e-03   3.96051e-04 DIIS
-   @UHF iter   6:  -149.58723588184310   -6.90395e-05   5.26650e-05 DIIS
-   @UHF iter   7:  -149.58723681903354   -9.37190e-07   8.98806e-06 DIIS
-   @UHF iter   8:  -149.58723684893988   -2.99063e-08   1.20274e-06 DIIS
-   @UHF iter   9:  -149.58723684935887   -4.18993e-10   1.05493e-07 DIIS
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   3.552713679E-15
+   @Spin Contamination Metric:   5.329070518E-15
    @S^2 Expected:                0.000000000E+00
-   @S^2 Observed:                3.552713679E-15
+   @S^2 Observed:                5.329070518E-15
    @S   Expected:                0.000000000E+00
    @S   Observed:                0.000000000E+00
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
-       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708485     1B2g   -0.419982  
+       1Ag   -20.718067     1B1u  -20.716526     2Ag    -1.762422  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769320  
+       1B3u   -0.708485     1B3g   -0.419982  
 
     Alpha Virtual:                                                        
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
-       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
-       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639045     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928209     8Ag     4.120755     4B3g    4.258203  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
-       5B2u    5.102979     8B1u    5.124402     5B3u    5.144953  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
-       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
-      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066014     7B2g    8.112246    13Ag     8.185163  
+       1B2g    0.078685     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412881     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639045     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926932  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258203  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144953  
+       6B3u    5.265700     6B2u    5.266028    10Ag     5.555961  
+       5B2g    5.658925     5B3g    5.658932     9B1u    6.125748  
+       2Au     6.407199    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547959     3Au     6.781720    11B1u    6.782596  
+       6B2g    6.822795     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066014     7B3g    8.112245    13Ag     8.185163  
       13B1u   15.901523  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708485     1B2g   -0.419982  
+       1Ag   -20.718067     1B1u  -20.716526     2Ag    -1.762422  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769320  
+       1B3u   -0.708485     1B3g   -0.419982  
 
     Beta Virtual:                                                         
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
-       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
-       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639045     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928209     8Ag     4.120755     4B3g    4.258203  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
-       5B2u    5.102979     8B1u    5.124402     5B3u    5.144953  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
-       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
-      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066014     7B2g    8.112246    13Ag     8.185163  
+       1B2g    0.078685     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412881     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639045     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926932  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258203  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144953  
+       6B3u    5.265700     6B2u    5.266028    10Ag     5.555961  
+       5B2g    5.658925     5B3g    5.658932     9B1u    6.125748  
+       2Au     6.407199    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547959     3Au     6.781720    11B1u    6.782596  
+       6B2g    6.822795     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066014     7B3g    8.112245    13Ag     8.185163  
       13B1u   15.901523  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
     SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @UHF Final Energy:  -149.58723684935887
+  @UHF Final Energy:  -149.58723684812239
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.8065772995398675
-    Two-Electron Energy =                  86.4308483140355577
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5872368493588738
-
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8065684414698353
+    Two-Electron Energy =                  86.4308393361837943
+    Total Energy =                       -149.5872368481223873
 
   UHF NO Occupations:
-  HONO-2 :    2 Ag 2.0000000
-  HONO-1 :    2B1u 2.0000000
-  HONO-0 :    3 Ag 2.0000000
-  LUNO+0 :    2B3u 0.0000000
-  LUNO+1 :    2B2g 0.0000000
-  LUNO+2 :    4 Ag 0.0000000
-  LUNO+3 :    5 Ag 0.0000000
+  HONO-2 :    3 Ag 2.0000000
+  HONO-1 :    1B3g 2.0000000
+  HONO-0 :    1B2u 2.0000000
+  LUNO+0 :    4 Ag 0.0000000
+  LUNO+1 :    2B3u 0.0000000
+  LUNO+2 :    5 Ag 0.0000000
+  LUNO+3 :    2B3g 0.0000000
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:39:59 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:41 2022
 Module time:
-	user time   =       0.49 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       0.42 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.83 seconds =       0.06 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
-	Singlet PK UHF energy.............................................PASSED
+	user time   =       6.57 seconds =       0.11 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
+    Singlet PK UHF energy.................................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:39:59 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:41 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -1378,14 +2168,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 1
@@ -1399,10 +2189,10 @@ Total time:
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -1427,41 +2217,25 @@ Total time:
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   228 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       8       8       8       0
-   -------------------------------------------------------
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   Starting with a DF guess...
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory (MB):               375
-    Algorithm:                Core
-    Integral Cache:           NONE
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -1481,33 +2255,43 @@ Total time:
        1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
        2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
-
-   @DF-UHF iter   1:  -142.88808078095190   -1.42888e+02   2.53590e-01 
-   @DF-UHF iter   2:  -149.16586201577772   -6.27778e+00   4.38655e-02 DIIS
-   @DF-UHF iter   3:  -149.53949831480813   -3.73636e-01   1.65816e-02 DIIS
-   @DF-UHF iter   4:  -149.58414125175781   -4.46429e-02   2.54636e-03 DIIS
-   @DF-UHF iter   5:  -149.58708032830214   -2.93908e-03   3.96499e-04 DIIS
-   @DF-UHF iter   6:  -149.58714957814357   -6.92498e-05   5.26596e-05 DIIS
-   @DF-UHF iter   7:  -149.58715051460538   -9.36462e-07   8.98710e-06 DIIS
-   @DF-UHF iter   8:  -149.58715054451557   -2.99102e-08   1.20470e-06 DIIS
-   @DF-UHF iter   9:  -149.58715054493601   -4.20442e-10   1.05277e-07 DIIS
+   @DF-UHF iter SAD:  -149.27728822299315   -1.49277e+02   0.00000e+00 
+   @DF-UHF iter   1:  -149.56354408328301   -2.86256e-01   1.10101e-02 ADIIS/DIIS
+   @DF-UHF iter   2:  -149.58573446084222   -2.21904e-02   2.91563e-03 ADIIS/DIIS
+   @DF-UHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 ADIIS/DIIS
+   @DF-UHF iter   4:  -149.58714509680516   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-UHF iter   5:  -149.58715039895964   -5.30215e-06   1.80355e-05 DIIS
+   @DF-UHF iter   6:  -149.58715054109825   -1.42139e-07   2.57889e-06 DIIS
+   @DF-UHF iter   7:  -149.58715054369759   -2.59934e-09   2.41536e-07 DIIS
 
   DF guess converged.
-
-  ==> Integral Setup <==
 
   ==> DirectJK: Integral-Direct J/K Matrices <==
 
@@ -1515,152 +2299,158 @@ Total time:
     K tasked:                  Yes
     wK tasked:                  No
     Integrals threads:           1
-    Schwarz Cutoff:          1E-12
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
 
-   @UHF iter  10:  -149.58723673484786   -8.61899e-05   3.38733e-05 DIIS
-   @UHF iter  11:  -149.58723684741668   -1.12569e-07   3.66112e-06 DIIS
-   @UHF iter  12:  -149.58723684920679   -1.79011e-09   1.00224e-06 DIIS
-   @UHF iter  13:  -149.58723684935757   -1.50777e-10   1.38404e-07 DIIS
+   @UHF iter   8:  -149.58723673357812   -1.49587e+02   3.38768e-05 DIIS
+   @UHF iter   9:  -149.58723684619764   -1.12620e-07   3.66091e-06 DIIS
+   @UHF iter  10:  -149.58723684799031   -1.79267e-09   1.00186e-06 DIIS
+   @UHF iter  11:  -149.58723684814120   -1.50891e-10   1.38849e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   3.552713679E-15
+   @Spin Contamination Metric:  -1.776356839E-15
    @S^2 Expected:                0.000000000E+00
-   @S^2 Observed:                3.552713679E-15
+   @S^2 Observed:               -1.776356839E-15
    @S   Expected:                0.000000000E+00
    @S   Observed:                0.000000000E+00
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
        1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708484     1B2g   -0.419982  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769319  
+       1B3u   -0.708484     1B3g   -0.419982  
 
     Alpha Virtual:                                                        
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
-       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       1B2g    0.078686     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
        5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928209     8Ag     4.120755     4B3g    4.258204  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
-       5B2u    5.102979     8B1u    5.124402     5B3u    5.144954  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       3B3u    1.639046     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926933  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258204  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144954  
+       6B3u    5.265700     6B2u    5.266029    10Ag     5.555961  
+       5B2g    5.658926     5B3g    5.658932     9B1u    6.125748  
        2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
       11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066015     7B2g    8.112246    13Ag     8.185163  
+       6B2g    6.822796     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081949    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066015     7B3g    8.112246    13Ag     8.185163  
       13B1u   15.901524  
 
     Beta Occupied:                                                        
 
        1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708484     1B2g   -0.419982  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769319  
+       1B3u   -0.708484     1B3g   -0.419982  
 
     Beta Virtual:                                                         
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
-       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       1B2g    0.078686     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
        5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928209     8Ag     4.120755     4B3g    4.258204  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
-       5B2u    5.102979     8B1u    5.124402     5B3u    5.144954  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       3B3u    1.639046     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926933  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258204  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144954  
+       6B3u    5.265700     6B2u    5.266029    10Ag     5.555961  
+       5B2g    5.658926     5B3g    5.658932     9B1u    6.125748  
        2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
       11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066015     7B2g    8.112246    13Ag     8.185163  
+       6B2g    6.822796     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081949    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066015     7B3g    8.112246    13Ag     8.185163  
       13B1u   15.901524  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
     SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @UHF Final Energy:  -149.58723684935757
+  @UHF Final Energy:  -149.58723684814120
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.8065842838378785
-    Two-Electron Energy =                  86.4308552983348761
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5872368493575664
-
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8065845228919670
+    Two-Electron Energy =                  86.4308554175870967
+    Total Energy =                       -149.5872368481412309
 
   UHF NO Occupations:
-  HONO-2 :    2 Ag 2.0000000
-  HONO-1 :    2B1u 2.0000000
-  HONO-0 :    3 Ag 2.0000000
-  LUNO+0 :    4 Ag 0.0000000
-  LUNO+1 :    5 Ag 0.0000000
-  LUNO+2 :    2B3u 0.0000000
-  LUNO+3 :    2B2u 0.0000000
+  HONO-2 :    3 Ag 2.0000000
+  HONO-1 :    1B3g 2.0000000
+  HONO-0 :    1B2u 2.0000000
+  LUNO+0 :    2B3u 0.0000000
+  LUNO+1 :    2B2u 0.0000000
+  LUNO+2 :    2B3g 0.0000000
+  LUNO+3 :    4 Ag 0.0000000
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:01 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:42 2022
 Module time:
-	user time   =       1.52 seconds =       0.03 minutes
+	user time   =       0.89 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       5.36 seconds =       0.09 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
-	Singlet Direct UHF energy.........................................PASSED
+	user time   =       7.50 seconds =       0.12 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
+    Singlet Direct UHF energy.............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:01 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:42 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -1674,14 +2464,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 1
@@ -1695,10 +2485,10 @@ Total time:
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -1718,23 +2508,6 @@ Total time:
        1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
        2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       8       8       8       0
-   -------------------------------------------------------
-
   ==> Integral Setup <==
 
   ==> DiskJK: Disk-Based J/K Matrices <==
@@ -1742,172 +2515,188 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+   @UHF iter SAD:  -149.27731917078719   -1.49277e+02   0.00000e+00 
+   @UHF iter   1:  -149.56362429559408   -2.86305e-01   1.10129e-02 ADIIS/DIIS
+   @UHF iter   2:  -149.58582140635937   -2.21971e-02   2.91434e-03 ADIIS/DIIS
+   @UHF iter   3:  -149.58712033600369   -1.29893e-03   6.40033e-04 ADIIS/DIIS
+   @UHF iter   4:  -149.58723140197694   -1.11066e-04   1.37095e-04 ADIIS/DIIS
+   @UHF iter   5:  -149.58723670345893   -5.30148e-06   1.80224e-05 DIIS
+   @UHF iter   6:  -149.58723684553314   -1.42074e-07   2.57334e-06 DIIS
+   @UHF iter   7:  -149.58723684812236   -2.58922e-09   2.40539e-07 DIIS
+  Energy and wave function converged.
 
-   @UHF iter   1:  -142.88785540847167   -1.42888e+02   2.53565e-01 
-   @UHF iter   2:  -149.16634323167790   -6.27849e+00   4.38532e-02 DIIS
-   @UHF iter   3:  -149.53966641760138   -3.73323e-01   1.65676e-02 DIIS
-   @UHF iter   4:  -149.58424185672061   -4.45754e-02   2.54200e-03 DIIS
-   @UHF iter   5:  -149.58716684238328   -2.92499e-03   3.96051e-04 DIIS
-   @UHF iter   6:  -149.58723588184321   -6.90395e-05   5.26650e-05 DIIS
-   @UHF iter   7:  -149.58723681903348   -9.37190e-07   8.98806e-06 DIIS
-   @UHF iter   8:  -149.58723684893982   -2.99063e-08   1.20274e-06 DIIS
-   @UHF iter   9:  -149.58723684935893   -4.19107e-10   1.05493e-07 DIIS
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   3.552713679E-15
+   @Spin Contamination Metric:  -1.065814104E-14
    @S^2 Expected:                0.000000000E+00
-   @S^2 Observed:                3.552713679E-15
+   @S^2 Observed:               -1.065814104E-14
    @S   Expected:                0.000000000E+00
    @S   Observed:                0.000000000E+00
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
-       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708485     1B2g   -0.419982  
+       1Ag   -20.718067     1B1u  -20.716526     2Ag    -1.762422  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769320  
+       1B3u   -0.708485     1B3g   -0.419982  
 
     Alpha Virtual:                                                        
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
-       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
-       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639045     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928209     8Ag     4.120755     4B3g    4.258203  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
-       5B2u    5.102979     8B1u    5.124402     5B3u    5.144953  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
-       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
-      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066014     7B2g    8.112246    13Ag     8.185163  
+       1B2g    0.078685     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412881     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639045     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926932  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258203  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144953  
+       6B3u    5.265700     6B2u    5.266028    10Ag     5.555961  
+       5B2g    5.658925     5B3g    5.658932     9B1u    6.125748  
+       2Au     6.407199    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547959     3Au     6.781720    11B1u    6.782596  
+       6B2g    6.822795     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066014     7B3g    8.112245    13Ag     8.185163  
       13B1u   15.901523  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708485     1B2g   -0.419982  
+       1Ag   -20.718067     1B1u  -20.716526     2Ag    -1.762422  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769320  
+       1B3u   -0.708485     1B3g   -0.419982  
 
     Beta Virtual:                                                         
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
-       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
-       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639045     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928209     8Ag     4.120755     4B3g    4.258203  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
-       5B2u    5.102979     8B1u    5.124402     5B3u    5.144953  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
-       2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
-      11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081948    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066014     7B2g    8.112246    13Ag     8.185163  
+       1B2g    0.078685     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412881     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639045     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926932  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258203  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144953  
+       6B3u    5.265700     6B2u    5.266028    10Ag     5.555961  
+       5B2g    5.658925     5B3g    5.658932     9B1u    6.125748  
+       2Au     6.407199    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547959     3Au     6.781720    11B1u    6.782596  
+       6B2g    6.822795     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066014     7B3g    8.112245    13Ag     8.185163  
       13B1u   15.901523  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
     SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @UHF Final Energy:  -149.58723684935893
+  @UHF Final Energy:  -149.58723684812236
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.8065772995399243
-    Two-Electron Energy =                  86.4308483140355577
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5872368493589306
-
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8065684414697216
+    Two-Electron Energy =                  86.4308393361836806
+    Total Energy =                       -149.5872368481223873
 
   UHF NO Occupations:
-  HONO-2 :    2 Ag 2.0000000
-  HONO-1 :    2B1u 2.0000000
-  HONO-0 :    3 Ag 2.0000000
+  HONO-2 :    1B3g 2.0000000
+  HONO-1 :    3 Ag 2.0000000
+  HONO-0 :    1B2u 2.0000000
   LUNO+0 :    4 Ag 0.0000000
-  LUNO+1 :    5 Ag 0.0000000
-  LUNO+2 :    3B1u 0.0000000
-  LUNO+3 :    6 Ag 0.0000000
+  LUNO+1 :    2B3g 0.0000000
+  LUNO+2 :    5 Ag 0.0000000
+  LUNO+3 :    3B1u 0.0000000
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:01 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:43 2022
 Module time:
-	user time   =       0.44 seconds =       0.01 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       5.81 seconds =       0.10 minutes
-	system time =       0.18 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
-	Singlet Disk UHF energy...........................................PASSED
+	user time   =       7.90 seconds =       0.13 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+    Singlet Disk UHF energy...............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:01 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:43 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -1921,14 +2710,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 1
@@ -1938,14 +2727,14 @@ Total time:
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DF.
+  SCF Algorithm Type is DISK_DF.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is GWH.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -1970,39 +2759,22 @@ Total time:
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   228 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       8       8       8       0
-   -------------------------------------------------------
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
     OpenMP threads:              1
     Integrals threads:           1
-    Memory (MB):               375
+    Memory [MiB]:              375
     Algorithm:                Core
     Integral Cache:           NONE
     Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
@@ -2022,29 +2794,320 @@ Total time:
        1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
        2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+   @DF-UHF iter SAD:  -149.27728822299318   -1.49277e+02   0.00000e+00 
+   @DF-UHF iter   1:  -149.56354408328303   -2.86256e-01   1.10101e-02 ADIIS/DIIS
+   @DF-UHF iter   2:  -149.58573446084227   -2.21904e-02   2.91563e-03 ADIIS/DIIS
+   @DF-UHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 ADIIS/DIIS
+   @DF-UHF iter   4:  -149.58714509680505   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-UHF iter   5:  -149.58715039895972   -5.30215e-06   1.80355e-05 DIIS
+   @DF-UHF iter   6:  -149.58715054109814   -1.42138e-07   2.57889e-06 DIIS
+   @DF-UHF iter   7:  -149.58715054369765   -2.59951e-09   2.41536e-07 DIIS
+  Energy and wave function converged.
 
-   @DF-UHF iter   1:  -142.88808078095190   -1.42888e+02   2.53590e-01 
-   @DF-UHF iter   2:  -149.16586201577772   -6.27778e+00   4.38655e-02 DIIS
-   @DF-UHF iter   3:  -149.53949831480813   -3.73636e-01   1.65816e-02 DIIS
-   @DF-UHF iter   4:  -149.58414125175781   -4.46429e-02   2.54636e-03 DIIS
-   @DF-UHF iter   5:  -149.58708032830214   -2.93908e-03   3.96499e-04 DIIS
-   @DF-UHF iter   6:  -149.58714957814357   -6.92498e-05   5.26596e-05 DIIS
-   @DF-UHF iter   7:  -149.58715051460538   -9.36462e-07   8.98710e-06 DIIS
-   @DF-UHF iter   8:  -149.58715054451557   -2.99102e-08   1.20470e-06 DIIS
-   @DF-UHF iter   9:  -149.58715054493601   -4.20442e-10   1.05277e-07 DIIS
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   3.552713679E-15
+   @S^2 Expected:                0.000000000E+00
+   @S^2 Observed:                3.552713679E-15
+   @S   Expected:                0.000000000E+00
+   @S   Observed:                0.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
+       2B1u   -1.064399     1B2u   -0.813254     3Ag    -0.769334  
+       1B3u   -0.708490     1B3g   -0.420019  
+
+    Alpha Virtual:                                                        
+
+       1B2g    0.078675     3B1u    0.460375     2B3u    0.693540  
+       2B2u    0.696264     4Ag     0.713625     2B3g    0.825653  
+       2B2g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
+       3B3u    1.639352     3B2u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B2g    2.532031  
+       7B1u    2.536801     3B3g    2.549181     4B3u    3.927538  
+       4B2u    3.928887     8Ag     4.122937     4B2g    4.258945  
+       4B3g    4.272670     2B1g    4.954074     9Ag     4.954589  
+       5B3u    5.109414     8B1u    5.125493     5B2u    5.151847  
+       6B3u    5.270829     6B2u    5.271178    10Ag     5.561366  
+       5B2g    5.664224     5B3g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415147     3B1g    6.555704  
+      11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
+       6B2g    6.829341     6B3g    6.860859     7B3u    7.050774  
+       7B2u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B2g    8.072681     7B3g    8.119435    13Ag     8.191892  
+      13B1u   15.905483  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
+       2B1u   -1.064399     1B2u   -0.813254     3Ag    -0.769334  
+       1B3u   -0.708490     1B3g   -0.420019  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.078675     3B1u    0.460375     2B3u    0.693540  
+       2B2u    0.696264     4Ag     0.713625     2B3g    0.825653  
+       2B2g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
+       3B3u    1.639352     3B2u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B2g    2.532031  
+       7B1u    2.536801     3B3g    2.549181     4B3u    3.927538  
+       4B2u    3.928887     8Ag     4.122937     4B2g    4.258945  
+       4B3g    4.272670     2B1g    4.954074     9Ag     4.954589  
+       5B3u    5.109414     8B1u    5.125493     5B2u    5.151847  
+       6B3u    5.270829     6B2u    5.271178    10Ag     5.561366  
+       5B2g    5.664224     5B3g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415147     3B1g    6.555704  
+      11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
+       6B2g    6.829341     6B3g    6.860859     7B3u    7.050774  
+       7B2u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B2g    8.072681     7B3g    8.119435    13Ag     8.191892  
+      13B1u   15.905483  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+
+  @DF-UHF Final Energy:  -149.58715054369765
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8060021671136610
+    Two-Electron Energy =                  86.4303593662523468
+    Total Energy =                       -149.5871505436976463
+
+  UHF NO Occupations:
+  HONO-2 :    3 Ag 2.0000000
+  HONO-1 :    1B3g 2.0000000
+  HONO-0 :    1B2u 2.0000000
+  LUNO+0 :    3B1u 0.0000000
+  LUNO+1 :    4 Ag 0.0000000
+  LUNO+2 :    4B1u 0.0000000
+  LUNO+3 :    2B3g 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:56:43 2022
+Module time:
+	user time   =       0.25 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       8.17 seconds =       0.14 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+    Singlet DiskDF UHF energy.............................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:43 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is MEM_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ-JKFIT
+    Blend                  = CC-PVTZ-JKFIT
+    Total number of shells = 50
+    Number of primitives   = 50
+    Number of AO           = 192
+    Number of SO           = 158
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+       2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:  -149.27728822299315   -1.49277e+02   0.00000e+00 
+   @DF-UHF iter   1:  -149.56354408328301   -2.86256e-01   1.10101e-02 ADIIS/DIIS
+   @DF-UHF iter   2:  -149.58573446084222   -2.21904e-02   2.91563e-03 ADIIS/DIIS
+   @DF-UHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 ADIIS/DIIS
+   @DF-UHF iter   4:  -149.58714509680516   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-UHF iter   5:  -149.58715039895964   -5.30215e-06   1.80355e-05 DIIS
+   @DF-UHF iter   6:  -149.58715054109825   -1.42139e-07   2.57889e-06 DIIS
+   @DF-UHF iter   7:  -149.58715054369759   -2.59934e-09   2.41536e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
@@ -2054,389 +3117,140 @@ Total time:
    @S   Expected:                0.000000000E+00
    @S   Observed:                0.000000000E+00
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
        1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
-       2B1u   -1.064399     1B3u   -0.813254     3Ag    -0.769333  
-       1B2u   -0.708490     1B2g   -0.420019  
+       2B1u   -1.064399     1B2u   -0.813254     3Ag    -0.769334  
+       1B3u   -0.708490     1B3g   -0.420019  
 
     Alpha Virtual:                                                        
 
-       1B3g    0.078675     3B1u    0.460375     2B2u    0.693540  
-       2B3u    0.696264     4Ag     0.713625     2B2g    0.825653  
-       2B3g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       1B2g    0.078675     3B1u    0.460375     2B3u    0.693540  
+       2B2u    0.696264     4Ag     0.713625     2B3g    0.825653  
+       2B2g    0.852603     5Ag     0.879289     4B1u    0.888916  
        5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
-       3B2u    1.639352     3B3u    1.641208     1Au     1.953829  
-       6B1u    1.954302     7Ag     2.484071     3B3g    2.532031  
-       7B1u    2.536801     3B2g    2.549181     4B2u    3.927538  
-       4B3u    3.928887     8Ag     4.122937     4B3g    4.258945  
-       4B2g    4.272670     2B1g    4.954075     9Ag     4.954589  
-       5B2u    5.109414     8B1u    5.125494     5B3u    5.151847  
-       6B2u    5.270830     6B3u    5.271178    10Ag     5.561366  
-       5B3g    5.664224     5B2g    5.664230     9B1u    6.128570  
-       2Au     6.413837    10B1u    6.415148     3B1g    6.555705  
+       3B3u    1.639352     3B2u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B2g    2.532031  
+       7B1u    2.536801     3B3g    2.549181     4B3u    3.927538  
+       4B2u    3.928887     8Ag     4.122937     4B2g    4.258945  
+       4B3g    4.272670     2B1g    4.954074     9Ag     4.954589  
+       5B3u    5.109414     8B1u    5.125493     5B2u    5.151847  
+       6B3u    5.270829     6B2u    5.271178    10Ag     5.561366  
+       5B2g    5.664224     5B3g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415147     3B1g    6.555704  
       11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
-       6B3g    6.829341     6B2g    6.860859     7B2u    7.050774  
-       7B3u    7.089664    12B1u    7.580301    12Ag     7.689595  
-       7B3g    8.072681     7B2g    8.119435    13Ag     8.191892  
+       6B2g    6.829341     6B3g    6.860859     7B3u    7.050774  
+       7B2u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B2g    8.072681     7B3g    8.119435    13Ag     8.191892  
       13B1u   15.905483  
 
     Beta Occupied:                                                        
 
        1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
-       2B1u   -1.064399     1B3u   -0.813254     3Ag    -0.769333  
-       1B2u   -0.708490     1B2g   -0.420019  
+       2B1u   -1.064399     1B2u   -0.813254     3Ag    -0.769334  
+       1B3u   -0.708490     1B3g   -0.420019  
 
     Beta Virtual:                                                         
 
-       1B3g    0.078675     3B1u    0.460375     2B2u    0.693540  
-       2B3u    0.696264     4Ag     0.713625     2B2g    0.825653  
-       2B3g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       1B2g    0.078675     3B1u    0.460375     2B3u    0.693540  
+       2B2u    0.696264     4Ag     0.713625     2B3g    0.825653  
+       2B2g    0.852603     5Ag     0.879289     4B1u    0.888916  
        5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
-       3B2u    1.639352     3B3u    1.641208     1Au     1.953829  
-       6B1u    1.954302     7Ag     2.484071     3B3g    2.532031  
-       7B1u    2.536801     3B2g    2.549181     4B2u    3.927538  
-       4B3u    3.928887     8Ag     4.122937     4B3g    4.258945  
-       4B2g    4.272670     2B1g    4.954075     9Ag     4.954589  
-       5B2u    5.109414     8B1u    5.125494     5B3u    5.151847  
-       6B2u    5.270830     6B3u    5.271178    10Ag     5.561366  
-       5B3g    5.664224     5B2g    5.664230     9B1u    6.128570  
-       2Au     6.413837    10B1u    6.415148     3B1g    6.555705  
+       3B3u    1.639352     3B2u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B2g    2.532031  
+       7B1u    2.536801     3B3g    2.549181     4B3u    3.927538  
+       4B2u    3.928887     8Ag     4.122937     4B2g    4.258945  
+       4B3g    4.272670     2B1g    4.954074     9Ag     4.954589  
+       5B3u    5.109414     8B1u    5.125493     5B2u    5.151847  
+       6B3u    5.270829     6B2u    5.271178    10Ag     5.561366  
+       5B2g    5.664224     5B3g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415147     3B1g    6.555704  
       11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
-       6B3g    6.829341     6B2g    6.860859     7B2u    7.050774  
-       7B3u    7.089664    12B1u    7.580301    12Ag     7.689595  
-       7B3g    8.072681     7B2g    8.119435    13Ag     8.191892  
+       6B2g    6.829341     6B3g    6.860859     7B3u    7.050774  
+       7B2u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B2g    8.072681     7B3g    8.119435    13Ag     8.191892  
       13B1u   15.905483  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
     SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @DF-UHF Final Energy:  -149.58715054493601
+  @DF-UHF Final Energy:  -149.58715054369759
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.8060110757771781
-    Two-Electron Energy =                  86.4303683946957335
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5871505449360086
-
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8060021671134336
+    Two-Electron Energy =                  86.4303593662521763
+    Total Energy =                       -149.5871505436975895
 
   UHF NO Occupations:
-  HONO-2 :    2 Ag 2.0000000
-  HONO-1 :    2B1u 2.0000000
-  HONO-0 :    3 Ag 2.0000000
-  LUNO+0 :    2B2g 0.0000000
-  LUNO+1 :    4 Ag 0.0000000
-  LUNO+2 :    5 Ag 0.0000000
-  LUNO+3 :    2B3u 0.0000000
+  HONO-2 :    3 Ag 2.0000000
+  HONO-1 :    1B3g 2.0000000
+  HONO-0 :    1B2u 2.0000000
+  LUNO+0 :    3B1u 0.0000000
+  LUNO+1 :    2B3u 0.0000000
+  LUNO+2 :    4B1u 0.0000000
+  LUNO+3 :    2B2u 0.0000000
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the SCF density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+Computation Completed
 
 
-*** tstop() called on psinet at Mon May 15 15:40:02 2017
-Module time:
-	user time   =       0.36 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       6.18 seconds =       0.10 minutes
-	system time =       0.20 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
-	Singlet DF UHF energy.............................................PASSED
-
-*** tstart() called on psinet
-*** at Mon May 15 15:40:02 2017
-
-   => Loading Basis Set <=
-
-    Name: CC-PVTZ
-    Role: ORBITAL
-    Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
-
-
-         ---------------------------------------------------------
-                                   SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
-                             CUHF Reference
-                        1 Threads,    500 MiB Core
-         ---------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: d2h
-    Full point group: D_inf_h
-
-    Geometry (in Angstrom), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
-
-  Running in d2h symmetry.
-
-  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
-
-  Charge       = 0
-  Multiplicity = 1
-  Electrons    = 16
-  Nalpha       = 8
-  Nbeta        = 8
-
-  ==> Algorithm <==
-
-  SCF Algorithm Type is PK.
-  DIIS enabled.
-  MOM disabled.
-  Fractional occupation disabled.
-  Guess Type is CORE.
-  Energy threshold   = 1.00e-06
-  Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
-
-  ==> Primary Basis <==
-
-  -AO BASIS SET INFORMATION:
-    Name                   = CC-PVTZ
-    Blend                  = CC-PVTZ
-    Total number of shells = 20
-    Number of primitives   = 52
-    Number of AO           = 70
-    Number of SO           = 60
-    Maximum AM             = 3
-    Spherical Harmonics    = TRUE
-
-  -Contraction Scheme:
-    Atom   Type   All Primitives // Shells:
-   ------ ------ --------------------------
-       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
-       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       8       8       8       0
-   -------------------------------------------------------
-
-  ==> Integral Setup <==
-
-  Using in-core PK algorithm.
-   Calculation information:
-      Number of atoms:                   2
-      Number of AO shells:              20
-      Number of primitives:             52
-      Number of atomic orbitals:        70
-      Number of basis functions:        60
-
-      Integral cutoff                 1.00e-12
-      Number of threads:                 1
-
-  Performing in-core PK
-  Using 3350730 doubles for integral storage.
-  We computed 22155 shell quartets total.
-  Whereas there are 22155 unique shell quartets.
-  ==> DiskJK: Disk-Based J/K Matrices <==
-
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    Memory (MB):               375
-    Schwarz Cutoff:          1E-12
-
-    OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
-
-  SCF Guess: Core (One-Electron) Hamiltonian.
-
-  ==> Iterations <==
-
-                        Total Energy        Delta E     RMS |[F,P]|
-
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
-
-   @CUHF iter   1:  -129.99407460698794   -1.29994e+02   3.58550e-01 
-   @CUHF iter   2:  -138.91122982835142   -8.91716e+00   1.91751e-01 DIIS
-   @CUHF iter   3:  -149.13467923115158   -1.02234e+01   5.30906e-02 DIIS
-   @CUHF iter   4:  -149.57251389792143   -4.37835e-01   8.25153e-03 DIIS
-   @CUHF iter   5:  -149.58708122447911   -1.45673e-02   7.45658e-04 DIIS
-   @CUHF iter   6:  -149.58722634154825   -1.45117e-04   1.87887e-04 DIIS
-   @CUHF iter   7:  -149.58723665061424   -1.03091e-05   2.49027e-05 DIIS
-   @CUHF iter   8:  -149.58723684457513   -1.93961e-07   4.45839e-06 DIIS
-   @CUHF iter   9:  -149.58723684929706   -4.72193e-09   4.02710e-07 DIIS
-
-  ==> Post-Iterations <==
-
-
-  @Spin Contamination Metric:  0.00000
-  @S^2 Expected:               0.00000
-  @S^2 Observed:               0.00000
-    Orbital Energies (a.u.)
-    -----------------------
-
-    Alpha Occupied:                                                       
-
-       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708484     1B2g   -0.419982  
-
-    Alpha Virtual:                                                        
-
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696039     4Ag     0.713441     2B2g    0.825485  
-       2B3g    0.852363     5Ag     0.879239     4B1u    0.888853  
-       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483688     3B3g    2.531436  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928210     8Ag     4.120756     4B3g    4.258204  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948846  
-       5B2u    5.102980     8B1u    5.124403     5B3u    5.144954  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125749  
-       2Au     6.407200    10B1u    6.408469     3B1g    6.547735  
-      11Ag     6.547960     3Au     6.781721    11B1u    6.782597  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081949    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066015     7B2g    8.112246    13Ag     8.185164  
-      13B1u   15.901524  
-
-    Beta Occupied:                                                        
-
-       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708484     1B2g   -0.419982  
-
-    Beta Virtual:                                                         
-
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696039     4Ag     0.713441     2B2g    0.825485  
-       2B3g    0.852363     5Ag     0.879239     4B1u    0.888853  
-       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483688     3B3g    2.531436  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928210     8Ag     4.120756     4B3g    4.258204  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948846  
-       5B2u    5.102980     8B1u    5.124403     5B3u    5.144954  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125749  
-       2Au     6.407200    10B1u    6.408469     3B1g    6.547735  
-      11Ag     6.547960     3Au     6.781721    11B1u    6.782597  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081949    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066015     7B2g    8.112246    13Ag     8.185164  
-      13B1u   15.901524  
-
-    Final Occupation by Irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
-
-  Energy converged.
-
-  @CUHF Final Energy:  -149.58723684929706
-
-   => Energetics <=
-
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.8065625228703084
-    Two-Electron Energy =                  86.4308335374277874
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5872368492970850
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:02 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:43 2022
 Module time:
-	user time   =       0.48 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.23 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.67 seconds =       0.11 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
-	Singlet PK CUHF energy............................................PASSED
+	user time   =       8.42 seconds =       0.14 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =         10 seconds =       0.17 minutes
+    Singlet MemDF UHF energy..............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:02 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:43 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
-                             CUHF Reference
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
@@ -2449,14 +3263,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 1
@@ -2466,14 +3280,14 @@ Total time:
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECT.
+  SCF Algorithm Type is COSX.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is CORE.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -2498,41 +3312,796 @@ Total time:
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   228 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DFJCOSK: Density-Fitted J and Semi-Numerical K <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    Integrals threads:            1
+    Memory [MiB]:               375
+    Incremental Fock :           No
+    J Screening Type:          CSAM
+    J Screening Cutoff:       1E-12
+    K Screening Cutoff:       1E-11
+    K Density Cutoff:         1E-10
+    K Basis Cutoff:           1E-10
+    K Overlap Fitting:          Yes
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
 
   ==> Pre-Iterations <==
 
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       8       8       8       0
-   -------------------------------------------------------
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:  -149.27713328631921   -1.49277e+02   0.00000e+00 
+   @UHF iter   1:  -149.56382697604784   -2.86694e-01   1.10975e-02 ADIIS/DIIS
+   @UHF iter   2:  -149.58629558037475   -2.24686e-02   2.92559e-03 ADIIS/DIIS
+   @UHF iter   3:  -149.58760428588198   -1.30871e-03   6.47395e-04 ADIIS/DIIS
+   @UHF iter   4:  -149.58772283023285   -1.18544e-04   1.38075e-04 ADIIS/DIIS
+   @UHF iter   5:  -149.58772855372325   -5.72349e-06   1.83160e-05 DIIS
+   @UHF iter   6:  -149.58772885952459   -3.05801e-07   2.47041e-06 DIIS
+   @UHF iter   7:  -149.58772885956961   -4.50200e-11   2.44347e-07 DIIS
+  Energy and wave function converged with early screening.
+  Performing final iteration with tighter screening.
+
+   @UHF iter   8:  -149.58722317116369    5.05688e-04   9.91149e-04 ADIIS/DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.217248938E-15
+   @S^2 Expected:                0.000000000E+00
+   @S^2 Observed:                6.217248938E-15
+   @S   Expected:                0.000000000E+00
+   @S   Observed:                0.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718186     1B1u  -20.716591     2Ag    -1.762756  
+       2B1u   -1.064574     1B2u   -0.812724     3Ag    -0.770577  
+       1B3u   -0.707523     1B3g   -0.420229  
+
+    Alpha Virtual:                                                        
+
+       1B2g    0.078702     3B1u    0.460336     2B3u    0.693920  
+       2B2u    0.696563     4Ag     0.713064     2B3g    0.825214  
+       2B2g    0.852636     5Ag     0.879262     4B1u    0.889111  
+       5B1u    1.413064     1B1g    1.442922     6Ag     1.443938  
+       3B3u    1.637673     3B2u    1.642235     6B1u    1.953272  
+       1Au     1.954322     7Ag     2.483527     3B2g    2.530348  
+       7B1u    2.536977     3B3g    2.548923     4B3u    3.927463  
+       4B2u    3.928699     8Ag     4.116806     4B2g    4.259266  
+       4B3g    4.274563     2B1g    4.934640     9Ag     4.966106  
+       5B3u    5.111788     8B1u    5.123534     5B2u    5.157197  
+       6B2u    5.264086     6B3u    5.272739    10Ag     5.546638  
+       5B3g    5.659533     5B2g    5.666050     9B1u    6.117812  
+       2Au     6.397139    10B1u    6.421963     3B1g    6.546782  
+      11Ag     6.548540     3Au     6.775088    11B1u    6.791609  
+       6B2g    6.817736     6B3g    6.862237     7B3u    7.040086  
+       7B2u    7.090378    12B1u    7.574534    12Ag     7.686631  
+       7B2g    8.073746     7B3g    8.120090    13Ag     8.184818  
+      13B1u   15.899399  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718186     1B1u  -20.716591     2Ag    -1.762756  
+       2B1u   -1.064574     1B2u   -0.812724     3Ag    -0.770577  
+       1B3u   -0.707523     1B3g   -0.420229  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.078702     3B1u    0.460336     2B3u    0.693920  
+       2B2u    0.696563     4Ag     0.713064     2B3g    0.825214  
+       2B2g    0.852636     5Ag     0.879262     4B1u    0.889111  
+       5B1u    1.413064     1B1g    1.442922     6Ag     1.443938  
+       3B3u    1.637673     3B2u    1.642235     6B1u    1.953272  
+       1Au     1.954322     7Ag     2.483527     3B2g    2.530348  
+       7B1u    2.536977     3B3g    2.548923     4B3u    3.927463  
+       4B2u    3.928699     8Ag     4.116806     4B2g    4.259266  
+       4B3g    4.274563     2B1g    4.934640     9Ag     4.966106  
+       5B3u    5.111788     8B1u    5.123534     5B2u    5.157197  
+       6B2u    5.264086     6B3u    5.272739    10Ag     5.546638  
+       5B3g    5.659533     5B2g    5.666050     9B1u    6.117812  
+       2Au     6.397139    10B1u    6.421963     3B1g    6.546782  
+      11Ag     6.548540     3Au     6.775088    11B1u    6.791609  
+       6B2g    6.817736     6B3g    6.862237     7B3u    7.040086  
+       7B2u    7.090378    12B1u    7.574534    12Ag     7.686631  
+       7B2g    8.073746     7B3g    8.120090    13Ag     8.184818  
+      13B1u   15.899399  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+
+  @UHF Final Energy:  -149.58722317116369
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8059033672359988
+    Two-Electron Energy =                  86.4301879389086594
+    Total Energy =                       -149.5872231711636857
+
+  UHF NO Occupations:
+  HONO-2 :    2B1u 2.0000000
+  HONO-1 :    1B3g 2.0000000
+  HONO-0 :    1B2u 2.0000000
+  LUNO+0 :    4 Ag 0.0000000
+  LUNO+1 :    2B3u 0.0000000
+  LUNO+2 :    3B3u 0.0000000
+  LUNO+3 :    3B1u 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:56:46 2022
+Module time:
+	user time   =       2.70 seconds =       0.05 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =      11.14 seconds =       0.19 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =         13 seconds =       0.22 minutes
+    Singlet DFJ+COSX UHF energy...........................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:46 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is LINK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DFJLinK: Density-Fitted J and Linear Exchange K <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Incremental Fock:           No
+    Screening Type:        DENSITY
+    J Screening Cutoff:      1E-12
+    K Screening Cutoff:      1E-12
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:  -149.27733086414963   -1.49277e+02   0.00000e+00 
+   @UHF iter   1:  -149.56365008860490   -2.86319e-01   1.10142e-02 ADIIS/DIIS
+   @UHF iter   2:  -149.58585218222930   -2.22021e-02   2.91422e-03 ADIIS/DIIS
+   @UHF iter   3:  -149.58715113835379   -1.29896e-03   6.40333e-04 ADIIS/DIIS
+   @UHF iter   4:  -149.58726227365051   -1.11135e-04   1.37172e-04 ADIIS/DIIS
+   @UHF iter   5:  -149.58726757682933   -5.30318e-06   1.80326e-05 DIIS
+   @UHF iter   6:  -149.58726771909227   -1.42263e-07   2.57489e-06 DIIS
+   @UHF iter   7:  -149.58726772168646   -2.59419e-09   2.41117e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                0.000000000E+00
+   @S^2 Observed:                0.000000000E+00
+   @S   Expected:                0.000000000E+00
+   @S   Observed:                0.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718071     1B1u  -20.716530     2Ag    -1.762433  
+       2B1u   -1.064390     1B2u   -0.813259     3Ag    -0.769342  
+       1B3u   -0.708496     1B3g   -0.420007  
+
+    Alpha Virtual:                                                        
+
+       1B2g    0.078681     3B1u    0.460327     2B3u    0.693384  
+       2B2u    0.696113     4Ag     0.713511     2B3g    0.825385  
+       2B2g    0.852393     5Ag     0.879194     4B1u    0.888887  
+       5B1u    1.412849     1B1g    1.443170     6Ag     1.444044  
+       3B3u    1.639004     3B2u    1.640861     1Au     1.953287  
+       6B1u    1.953762     7Ag     2.483724     3B2g    2.531509  
+       7B1u    2.536447     3B3g    2.548588     4B3u    3.926986  
+       4B2u    3.928307     8Ag     4.120730     4B2g    4.258300  
+       4B3g    4.271909     2B1g    4.948441     9Ag     4.948961  
+       5B3u    5.103003     8B1u    5.124465     5B2u    5.145236  
+       6B3u    5.265751     6B2u    5.266088    10Ag     5.555675  
+       5B2g    5.658990     5B3g    5.658996     9B1u    6.125723  
+       2Au     6.407176    10B1u    6.408484     3B1g    6.547508  
+      11Ag     6.547837     3Au     6.781590    11B1u    6.782559  
+       6B2g    6.822868     6B3g    6.853283     7B3u    7.043595  
+       7B2u    7.081934    12B1u    7.574355    12Ag     7.687859  
+       7B2g    8.066157     7B3g    8.112296    13Ag     8.185053  
+      13B1u   15.901574  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718071     1B1u  -20.716530     2Ag    -1.762433  
+       2B1u   -1.064390     1B2u   -0.813259     3Ag    -0.769342  
+       1B3u   -0.708496     1B3g   -0.420007  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.078681     3B1u    0.460327     2B3u    0.693384  
+       2B2u    0.696113     4Ag     0.713511     2B3g    0.825385  
+       2B2g    0.852393     5Ag     0.879194     4B1u    0.888887  
+       5B1u    1.412849     1B1g    1.443170     6Ag     1.444044  
+       3B3u    1.639004     3B2u    1.640861     1Au     1.953287  
+       6B1u    1.953762     7Ag     2.483724     3B2g    2.531509  
+       7B1u    2.536447     3B3g    2.548588     4B3u    3.926986  
+       4B2u    3.928307     8Ag     4.120730     4B2g    4.258300  
+       4B3g    4.271909     2B1g    4.948441     9Ag     4.948961  
+       5B3u    5.103003     8B1u    5.124465     5B2u    5.145236  
+       6B3u    5.265751     6B2u    5.266088    10Ag     5.555675  
+       5B2g    5.658990     5B3g    5.658996     9B1u    6.125723  
+       2Au     6.407176    10B1u    6.408484     3B1g    6.547508  
+      11Ag     6.547837     3Au     6.781590    11B1u    6.782559  
+       6B2g    6.822868     6B3g    6.853283     7B3u    7.043595  
+       7B2u    7.081934    12B1u    7.574355    12Ag     7.687859  
+       7B2g    8.066157     7B3g    8.112296    13Ag     8.185053  
+      13B1u   15.901574  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+
+  @UHF Final Energy:  -149.58726772168646
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8064578915612515
+    Two-Electron Energy =                  86.4306979127111390
+    Total Energy =                       -149.5872677216864588
+
+  UHF NO Occupations:
+  HONO-2 :    3 Ag 2.0000000
+  HONO-1 :    1B3g 2.0000000
+  HONO-0 :    1B2u 2.0000000
+  LUNO+0 :    4 Ag 0.0000000
+  LUNO+1 :    5 Ag 0.0000000
+  LUNO+2 :    2B3g 0.0000000
+  LUNO+3 :    3B1u 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:56:47 2022
+Module time:
+	user time   =       1.41 seconds =       0.02 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      12.58 seconds =       0.21 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =         14 seconds =       0.23 minutes
+    Singlet DFJ+LinK UHF energy...........................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:47 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             CUHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              20
+      Number of primitives:             52
+      Number of atomic orbitals:        70
+      Number of basis functions:        60
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 3350730 doubles for integral storage.
+  We computed 22155 shell quartets total.
+  Whereas there are 22155 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @CUHF iter SAD:  -149.27731917078714   -1.49277e+02   0.00000e+00 
+   @CUHF iter   1:  -149.56362429559388   -2.86305e-01   1.10129e-02 ADIIS/DIIS
+   @CUHF iter   2:  -149.58582140635932   -2.21971e-02   2.91434e-03 ADIIS/DIIS
+   @CUHF iter   3:  -149.58712033600364   -1.29893e-03   6.40033e-04 ADIIS/DIIS
+   @CUHF iter   4:  -149.58723140197694   -1.11066e-04   1.37095e-04 ADIIS/DIIS
+   @CUHF iter   5:  -149.58723670345898   -5.30148e-06   1.80224e-05 DIIS
+   @CUHF iter   6:  -149.58723684553317   -1.42074e-07   2.57334e-06 DIIS
+   @CUHF iter   7:  -149.58723684812225   -2.58908e-09   2.40539e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric:  0.00000
+  @S^2 Expected:               0.00000
+  @S^2 Observed:               0.00000
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718067     1B1u  -20.716526     2Ag    -1.762422  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769320  
+       1B3u   -0.708485     1B3g   -0.419982  
+
+    Alpha Virtual:                                                        
+
+       1B2g    0.078685     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412881     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639045     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926932  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258203  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144953  
+       6B3u    5.265700     6B2u    5.266028    10Ag     5.555961  
+       5B2g    5.658925     5B3g    5.658932     9B1u    6.125748  
+       2Au     6.407199    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547959     3Au     6.781720    11B1u    6.782596  
+       6B2g    6.822795     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066014     7B3g    8.112245    13Ag     8.185163  
+      13B1u   15.901523  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718067     1B1u  -20.716526     2Ag    -1.762422  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769320  
+       1B3u   -0.708485     1B3g   -0.419982  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.078685     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412881     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639045     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926932  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258203  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144953  
+       6B3u    5.265700     6B2u    5.266028    10Ag     5.555961  
+       5B2g    5.658925     5B3g    5.658932     9B1u    6.125748  
+       2Au     6.407199    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547959     3Au     6.781720    11B1u    6.782596  
+       6B2g    6.822795     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066014     7B3g    8.112245    13Ag     8.185163  
+      13B1u   15.901523  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+
+  @CUHF Final Energy:  -149.58723684812225
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8065684414697785
+    Two-Electron Energy =                  86.4308393361838796
+    Total Energy =                       -149.5872368481222452
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:56:48 2022
+Module time:
+	user time   =       0.41 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      13.02 seconds =       0.22 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =         15 seconds =       0.25 minutes
+    Singlet PK CUHF energy................................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:48 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             CUHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DIRECT.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   Starting with a DF guess...
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory (MB):               375
-    Algorithm:                Core
-    Integral Cache:           NONE
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -2552,33 +4121,43 @@ Total time:
        1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
        2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Core (One-Electron) Hamiltonian.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
-
-   @DF-CUHF iter   1:  -129.98984071512987   -1.29990e+02   3.58757e-01 
-   @DF-CUHF iter   2:  -138.91391955950209   -8.92408e+00   1.91748e-01 DIIS
-   @DF-CUHF iter   3:  -149.13425927783311   -1.02203e+01   5.31048e-02 DIIS
-   @DF-CUHF iter   4:  -149.57240790092840   -4.38149e-01   8.25436e-03 DIIS
-   @DF-CUHF iter   5:  -149.58699441491106   -1.45865e-02   7.46842e-04 DIIS
-   @DF-CUHF iter   6:  -149.58713996382596   -1.45549e-04   1.88515e-04 DIIS
-   @DF-CUHF iter   7:  -149.58715034477746   -1.03810e-05   2.49652e-05 DIIS
-   @DF-CUHF iter   8:  -149.58715054014652   -1.95369e-07   4.45841e-06 DIIS
-   @DF-CUHF iter   9:  -149.58715054487391   -4.72738e-09   4.03688e-07 DIIS
+   @DF-CUHF iter SAD:  -149.27728822299312   -1.49277e+02   0.00000e+00 
+   @DF-CUHF iter   1:  -149.56354408328309   -2.86256e-01   1.10101e-02 ADIIS/DIIS
+   @DF-CUHF iter   2:  -149.58573446084225   -2.21904e-02   2.91563e-03 ADIIS/DIIS
+   @DF-CUHF iter   3:  -149.58703388315297   -1.29942e-03   6.40386e-04 ADIIS/DIIS
+   @DF-CUHF iter   4:  -149.58714509680490   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-CUHF iter   5:  -149.58715039895961   -5.30215e-06   1.80355e-05 DIIS
+   @DF-CUHF iter   6:  -149.58715054109820   -1.42139e-07   2.57889e-06 DIIS
+   @DF-CUHF iter   7:  -149.58715054369745   -2.59925e-09   2.41536e-07 DIIS
 
   DF guess converged.
-
-  ==> Integral Setup <==
 
   ==> DirectJK: Integral-Direct J/K Matrices <==
 
@@ -2586,12 +4165,16 @@ Total time:
     K tasked:                  Yes
     wK tasked:                  No
     Integrals threads:           1
-    Schwarz Cutoff:          1E-12
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
 
-   @CUHF iter  10:  -149.58723673471883   -8.61898e-05   3.38828e-05 DIIS
-   @CUHF iter  11:  -149.58723684740340   -1.12685e-07   3.67075e-06 DIIS
-   @CUHF iter  12:  -149.58723684920531   -1.80191e-09   1.00687e-06 DIIS
-   @CUHF iter  13:  -149.58723684935748   -1.52170e-10   1.38762e-07 DIIS
+   @CUHF iter   8:  -149.58723673357821   -1.49587e+02   3.38768e-05 DIIS
+   @CUHF iter   9:  -149.58723684619767   -1.12619e-07   3.66091e-06 DIIS
+   @CUHF iter  10:  -149.58723684799017   -1.79250e-09   1.00186e-06 DIIS
+   @CUHF iter  11:  -149.58723684814115   -1.50976e-10   1.38849e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
@@ -2599,127 +4182,129 @@ Total time:
   @Spin Contamination Metric:  0.00000
   @S^2 Expected:               0.00000
   @S^2 Observed:               0.00000
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
        1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708484     1B2g   -0.419982  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769319  
+       1B3u   -0.708484     1B3g   -0.419982  
 
     Alpha Virtual:                                                        
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
-       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       1B2g    0.078686     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
        5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928209     8Ag     4.120755     4B3g    4.258204  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
-       5B2u    5.102979     8B1u    5.124402     5B3u    5.144954  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       3B3u    1.639046     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926933  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258204  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144954  
+       6B3u    5.265700     6B2u    5.266029    10Ag     5.555961  
+       5B2g    5.658926     5B3g    5.658932     9B1u    6.125748  
        2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
       11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081949    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066015     7B2g    8.112246    13Ag     8.185163  
+       6B2g    6.822796     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081949    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066015     7B3g    8.112246    13Ag     8.185163  
       13B1u   15.901524  
 
     Beta Occupied:                                                        
 
        1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708484     1B2g   -0.419982  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769319  
+       1B3u   -0.708484     1B3g   -0.419982  
 
     Beta Virtual:                                                         
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696038     4Ag     0.713440     2B2g    0.825485  
-       2B3g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       1B2g    0.078686     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
        5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483687     3B3g    2.531435  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928209     8Ag     4.120755     4B3g    4.258204  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948845  
-       5B2u    5.102979     8B1u    5.124402     5B3u    5.144954  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125748  
+       3B3u    1.639046     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926933  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258204  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144954  
+       6B3u    5.265700     6B2u    5.266029    10Ag     5.555961  
+       5B2g    5.658926     5B3g    5.658932     9B1u    6.125748  
        2Au     6.407200    10B1u    6.408468     3B1g    6.547734  
       11Ag     6.547960     3Au     6.781720    11B1u    6.782596  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081949    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066015     7B2g    8.112246    13Ag     8.185163  
+       6B2g    6.822796     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081949    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066015     7B3g    8.112246    13Ag     8.185163  
       13B1u   15.901524  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
     SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @CUHF Final Energy:  -149.58723684935748
+  @CUHF Final Energy:  -149.58723684814115
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.8065842940815173
-    Two-Electron Energy =                  86.4308553085786002
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5872368493574811
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8065845228918533
+    Two-Electron Energy =                  86.4308554175870540
+    Total Energy =                       -149.5872368481411456
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:04 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:49 2022
 Module time:
-	user time   =       1.48 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.88 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       8.16 seconds =       0.14 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =          9 seconds =       0.15 minutes
-	Singlet Direct CUHF energy........................................PASSED
+	user time   =      13.92 seconds =       0.23 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =         16 seconds =       0.27 minutes
+    Singlet Direct CUHF energy............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:04 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:49 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                              CUHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -2733,14 +4318,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 1
@@ -2754,10 +4339,10 @@ Total time:
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is CORE.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -2777,23 +4362,6 @@ Total time:
        1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
        2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       8       8       8       0
-   -------------------------------------------------------
-
   ==> Integral Setup <==
 
   ==> DiskJK: Disk-Based J/K Matrices <==
@@ -2801,32 +4369,46 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Core (One-Electron) Hamiltonian.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+   @CUHF iter SAD:  -149.27731917078719   -1.49277e+02   0.00000e+00 
+   @CUHF iter   1:  -149.56362429559400   -2.86305e-01   1.10129e-02 ADIIS/DIIS
+   @CUHF iter   2:  -149.58582140635932   -2.21971e-02   2.91434e-03 ADIIS/DIIS
+   @CUHF iter   3:  -149.58712033600366   -1.29893e-03   6.40033e-04 ADIIS/DIIS
+   @CUHF iter   4:  -149.58723140197691   -1.11066e-04   1.37095e-04 ADIIS/DIIS
+   @CUHF iter   5:  -149.58723670345893   -5.30148e-06   1.80224e-05 DIIS
+   @CUHF iter   6:  -149.58723684553323   -1.42074e-07   2.57334e-06 DIIS
+   @CUHF iter   7:  -149.58723684812227   -2.58905e-09   2.40539e-07 DIIS
+  Energy and wave function converged.
 
-   @CUHF iter   1:  -129.99407460698828   -1.29994e+02   3.58550e-01 
-   @CUHF iter   2:  -138.91122982834688   -8.91716e+00   1.91751e-01 DIIS
-   @CUHF iter   3:  -149.13467923115113   -1.02234e+01   5.30906e-02 DIIS
-   @CUHF iter   4:  -149.57251389792148   -4.37835e-01   8.25153e-03 DIIS
-   @CUHF iter   5:  -149.58708122447905   -1.45673e-02   7.45658e-04 DIIS
-   @CUHF iter   6:  -149.58722634154813   -1.45117e-04   1.87887e-04 DIIS
-   @CUHF iter   7:  -149.58723665061424   -1.03091e-05   2.49027e-05 DIIS
-   @CUHF iter   8:  -149.58723684457510   -1.93961e-07   4.45839e-06 DIIS
-   @CUHF iter   9:  -149.58723684929714   -4.72204e-09   4.02710e-07 DIIS
 
   ==> Post-Iterations <==
 
@@ -2834,127 +4416,129 @@ Total time:
   @Spin Contamination Metric:  0.00000
   @S^2 Expected:               0.00000
   @S^2 Observed:               0.00000
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
-       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708484     1B2g   -0.419982  
+       1Ag   -20.718067     1B1u  -20.716526     2Ag    -1.762422  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769320  
+       1B3u   -0.708485     1B3g   -0.419982  
 
     Alpha Virtual:                                                        
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696039     4Ag     0.713441     2B2g    0.825485  
-       2B3g    0.852363     5Ag     0.879239     4B1u    0.888853  
-       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483688     3B3g    2.531436  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928210     8Ag     4.120756     4B3g    4.258204  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948846  
-       5B2u    5.102980     8B1u    5.124403     5B3u    5.144954  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125749  
-       2Au     6.407200    10B1u    6.408469     3B1g    6.547735  
-      11Ag     6.547960     3Au     6.781721    11B1u    6.782597  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081949    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066015     7B2g    8.112246    13Ag     8.185164  
-      13B1u   15.901524  
+       1B2g    0.078685     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412881     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639045     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926932  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258203  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144953  
+       6B3u    5.265700     6B2u    5.266028    10Ag     5.555961  
+       5B2g    5.658925     5B3g    5.658932     9B1u    6.125748  
+       2Au     6.407199    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547959     3Au     6.781720    11B1u    6.782596  
+       6B2g    6.822795     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066014     7B3g    8.112245    13Ag     8.185163  
+      13B1u   15.901523  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.718066     1B1u  -20.716525     2Ag    -1.762421  
-       2B1u   -1.064379     1B3u   -0.813263     3Ag    -0.769319  
-       1B2u   -0.708484     1B2g   -0.419982  
+       1Ag   -20.718067     1B1u  -20.716526     2Ag    -1.762422  
+       2B1u   -1.064379     1B2u   -0.813263     3Ag    -0.769320  
+       1B3u   -0.708485     1B3g   -0.419982  
 
     Beta Virtual:                                                         
 
-       1B3g    0.078686     3B1u    0.460203     2B2u    0.693361  
-       2B3u    0.696039     4Ag     0.713441     2B2g    0.825485  
-       2B3g    0.852363     5Ag     0.879239     4B1u    0.888853  
-       5B1u    1.412882     1B1g    1.443185     6Ag     1.444096  
-       3B2u    1.639046     3B3u    1.640898     1Au     1.953275  
-       6B1u    1.953758     7Ag     2.483688     3B3g    2.531436  
-       7B1u    2.536370     3B2g    2.548758     4B2u    3.926933  
-       4B3u    3.928210     8Ag     4.120756     4B3g    4.258204  
-       4B2g    4.271808     2B1g    4.948341     9Ag     4.948846  
-       5B2u    5.102980     8B1u    5.124403     5B3u    5.144954  
-       6B2u    5.265700     6B3u    5.266029    10Ag     5.555961  
-       5B3g    5.658926     5B2g    5.658932     9B1u    6.125749  
-       2Au     6.407200    10B1u    6.408469     3B1g    6.547735  
-      11Ag     6.547960     3Au     6.781721    11B1u    6.782597  
-       6B3g    6.822796     6B2g    6.853235     7B2u    7.043562  
-       7B3u    7.081949    12B1u    7.574642    12Ag     7.687791  
-       7B3g    8.066015     7B2g    8.112246    13Ag     8.185164  
-      13B1u   15.901524  
+       1B2g    0.078685     3B1u    0.460203     2B3u    0.693361  
+       2B2u    0.696038     4Ag     0.713440     2B3g    0.825485  
+       2B2g    0.852362     5Ag     0.879239     4B1u    0.888853  
+       5B1u    1.412881     1B1g    1.443185     6Ag     1.444096  
+       3B3u    1.639045     3B2u    1.640898     1Au     1.953275  
+       6B1u    1.953758     7Ag     2.483687     3B2g    2.531435  
+       7B1u    2.536370     3B3g    2.548758     4B3u    3.926932  
+       4B2u    3.928209     8Ag     4.120755     4B2g    4.258203  
+       4B3g    4.271808     2B1g    4.948341     9Ag     4.948845  
+       5B3u    5.102979     8B1u    5.124402     5B2u    5.144953  
+       6B3u    5.265700     6B2u    5.266028    10Ag     5.555961  
+       5B2g    5.658925     5B3g    5.658932     9B1u    6.125748  
+       2Au     6.407199    10B1u    6.408468     3B1g    6.547734  
+      11Ag     6.547959     3Au     6.781720    11B1u    6.782596  
+       6B2g    6.822795     6B3g    6.853235     7B3u    7.043562  
+       7B2u    7.081948    12B1u    7.574642    12Ag     7.687791  
+       7B2g    8.066014     7B3g    8.112245    13Ag     8.185163  
+      13B1u   15.901523  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
     SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @CUHF Final Energy:  -149.58723684929714
+  @CUHF Final Energy:  -149.58723684812227
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.8065625228701379
-    Two-Electron Energy =                  86.4308335374275885
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5872368492971134
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8065684414695511
+    Two-Electron Energy =                  86.4308393361836238
+    Total Energy =                       -149.5872368481222736
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:05 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:49 2022
 Module time:
-	user time   =       0.46 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.35 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.63 seconds =       0.14 minutes
-	system time =       0.27 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
-	Singlet Disk CUHF energy..........................................PASSED
+	user time   =      14.30 seconds =       0.24 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =         16 seconds =       0.27 minutes
+    Singlet Disk CUHF energy..............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:05 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:49 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                              CUHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -2968,14 +4552,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 1
@@ -2985,14 +4569,14 @@ Total time:
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DF.
+  SCF Algorithm Type is DISK_DF.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is CORE.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -3017,39 +4601,22 @@ Total time:
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   228 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       8       8       8       0
-   -------------------------------------------------------
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
     OpenMP threads:              1
     Integrals threads:           1
-    Memory (MB):               375
+    Memory [MiB]:              375
     Algorithm:                Core
     Integral Cache:           NONE
     Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
@@ -3069,29 +4636,43 @@ Total time:
        1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
        2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
 
-  SCF Guess: Core (One-Electron) Hamiltonian.
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-    Occupation by irrep:
-             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+   @DF-CUHF iter SAD:  -149.27728822299318   -1.49277e+02   0.00000e+00 
+   @DF-CUHF iter   1:  -149.56354408328306   -2.86256e-01   1.10101e-02 ADIIS/DIIS
+   @DF-CUHF iter   2:  -149.58573446084216   -2.21904e-02   2.91563e-03 ADIIS/DIIS
+   @DF-CUHF iter   3:  -149.58703388315294   -1.29942e-03   6.40386e-04 ADIIS/DIIS
+   @DF-CUHF iter   4:  -149.58714509680505   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-CUHF iter   5:  -149.58715039895969   -5.30215e-06   1.80355e-05 DIIS
+   @DF-CUHF iter   6:  -149.58715054109817   -1.42138e-07   2.57889e-06 DIIS
+   @DF-CUHF iter   7:  -149.58715054369762   -2.59945e-09   2.41536e-07 DIIS
+  Energy and wave function converged.
 
-   @DF-CUHF iter   1:  -129.98984071512987   -1.29990e+02   3.58757e-01 
-   @DF-CUHF iter   2:  -138.91391955950209   -8.92408e+00   1.91748e-01 DIIS
-   @DF-CUHF iter   3:  -149.13425927783311   -1.02203e+01   5.31048e-02 DIIS
-   @DF-CUHF iter   4:  -149.57240790092840   -4.38149e-01   8.25436e-03 DIIS
-   @DF-CUHF iter   5:  -149.58699441491106   -1.45865e-02   7.46842e-04 DIIS
-   @DF-CUHF iter   6:  -149.58713996382596   -1.45549e-04   1.88515e-04 DIIS
-   @DF-CUHF iter   7:  -149.58715034477746   -1.03810e-05   2.49652e-05 DIIS
-   @DF-CUHF iter   8:  -149.58715054014652   -1.95369e-07   4.45841e-06 DIIS
-   @DF-CUHF iter   9:  -149.58715054487391   -4.72738e-09   4.03688e-07 DIIS
 
   ==> Post-Iterations <==
 
@@ -3099,128 +4680,130 @@ Total time:
   @Spin Contamination Metric:  0.00000
   @S^2 Expected:               0.00000
   @S^2 Observed:               0.00000
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
-       1Ag   -20.718108     1B1u  -20.716567     2Ag    -1.762467  
-       2B1u   -1.064398     1B3u   -0.813254     3Ag    -0.769333  
-       1B2u   -0.708489     1B2g   -0.420019  
+       1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
+       2B1u   -1.064399     1B2u   -0.813254     3Ag    -0.769334  
+       1B3u   -0.708490     1B3g   -0.420019  
 
     Alpha Virtual:                                                        
 
-       1B3g    0.078676     3B1u    0.460375     2B2u    0.693541  
-       2B3u    0.696264     4Ag     0.713626     2B2g    0.825653  
-       2B3g    0.852604     5Ag     0.879290     4B1u    0.888916  
-       5B1u    1.413255     1B1g    1.443732     6Ag     1.444604  
-       3B2u    1.639352     3B3u    1.641209     1Au     1.953830  
-       6B1u    1.954302     7Ag     2.484071     3B3g    2.532031  
-       7B1u    2.536801     3B2g    2.549182     4B2u    3.927539  
-       4B3u    3.928887     8Ag     4.122938     4B3g    4.258945  
-       4B2g    4.272670     2B1g    4.954075     9Ag     4.954589  
-       5B2u    5.109415     8B1u    5.125494     5B3u    5.151848  
-       6B2u    5.270830     6B3u    5.271178    10Ag     5.561367  
-       5B3g    5.664225     5B2g    5.664231     9B1u    6.128570  
-       2Au     6.413838    10B1u    6.415148     3B1g    6.555705  
-      11Ag     6.556028     3Au     6.789297    11B1u    6.790264  
-       6B3g    6.829342     6B2g    6.860859     7B2u    7.050774  
-       7B3u    7.089665    12B1u    7.580302    12Ag     7.689596  
-       7B3g    8.072682     7B2g    8.119436    13Ag     8.191893  
+       1B2g    0.078675     3B1u    0.460375     2B3u    0.693540  
+       2B2u    0.696264     4Ag     0.713625     2B3g    0.825653  
+       2B2g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
+       3B3u    1.639352     3B2u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B2g    2.532031  
+       7B1u    2.536801     3B3g    2.549181     4B3u    3.927538  
+       4B2u    3.928887     8Ag     4.122937     4B2g    4.258945  
+       4B3g    4.272670     2B1g    4.954074     9Ag     4.954589  
+       5B3u    5.109414     8B1u    5.125493     5B2u    5.151847  
+       6B3u    5.270829     6B2u    5.271178    10Ag     5.561366  
+       5B2g    5.664224     5B3g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415147     3B1g    6.555704  
+      11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
+       6B2g    6.829341     6B3g    6.860859     7B3u    7.050774  
+       7B2u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B2g    8.072681     7B3g    8.119435    13Ag     8.191892  
       13B1u   15.905483  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.718108     1B1u  -20.716567     2Ag    -1.762467  
-       2B1u   -1.064398     1B3u   -0.813254     3Ag    -0.769333  
-       1B2u   -0.708489     1B2g   -0.420019  
+       1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
+       2B1u   -1.064399     1B2u   -0.813254     3Ag    -0.769334  
+       1B3u   -0.708490     1B3g   -0.420019  
 
     Beta Virtual:                                                         
 
-       1B3g    0.078676     3B1u    0.460375     2B2u    0.693541  
-       2B3u    0.696264     4Ag     0.713626     2B2g    0.825653  
-       2B3g    0.852604     5Ag     0.879290     4B1u    0.888916  
-       5B1u    1.413255     1B1g    1.443732     6Ag     1.444604  
-       3B2u    1.639352     3B3u    1.641209     1Au     1.953830  
-       6B1u    1.954302     7Ag     2.484071     3B3g    2.532031  
-       7B1u    2.536801     3B2g    2.549182     4B2u    3.927539  
-       4B3u    3.928887     8Ag     4.122938     4B3g    4.258945  
-       4B2g    4.272670     2B1g    4.954075     9Ag     4.954589  
-       5B2u    5.109415     8B1u    5.125494     5B3u    5.151848  
-       6B2u    5.270830     6B3u    5.271178    10Ag     5.561367  
-       5B3g    5.664225     5B2g    5.664231     9B1u    6.128570  
-       2Au     6.413838    10B1u    6.415148     3B1g    6.555705  
-      11Ag     6.556028     3Au     6.789297    11B1u    6.790264  
-       6B3g    6.829342     6B2g    6.860859     7B2u    7.050774  
-       7B3u    7.089665    12B1u    7.580302    12Ag     7.689596  
-       7B3g    8.072682     7B2g    8.119436    13Ag     8.191893  
+       1B2g    0.078675     3B1u    0.460375     2B3u    0.693540  
+       2B2u    0.696264     4Ag     0.713625     2B3g    0.825653  
+       2B2g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
+       3B3u    1.639352     3B2u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B2g    2.532031  
+       7B1u    2.536801     3B3g    2.549181     4B3u    3.927538  
+       4B2u    3.928887     8Ag     4.122937     4B2g    4.258945  
+       4B3g    4.272670     2B1g    4.954074     9Ag     4.954589  
+       5B3u    5.109414     8B1u    5.125493     5B2u    5.151847  
+       6B3u    5.270829     6B2u    5.271178    10Ag     5.561366  
+       5B2g    5.664224     5B3g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415147     3B1g    6.555704  
+      11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
+       6B2g    6.829341     6B3g    6.860859     7B3u    7.050774  
+       7B2u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B2g    8.072681     7B3g    8.119435    13Ag     8.191892  
       13B1u   15.905483  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
     SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @DF-CUHF Final Energy:  -149.58715054487391
+  @DF-CUHF Final Energy:  -149.58715054369762
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.8059964281358702
-    Two-Electron Energy =                  86.4303537471165555
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.5871505448738787
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8060021671134905
+    Two-Electron Energy =                  86.4303593662522189
+    Total Energy =                       -149.5871505436976179
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:05 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:50 2022
 Module time:
-	user time   =       0.34 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.25 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       8.98 seconds =       0.15 minutes
-	system time =       0.29 seconds =       0.00 minutes
-	total time  =         10 seconds =       0.17 minutes
-	Singlet DF CUHF energy............................................PASSED
+	user time   =      14.58 seconds =       0.24 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =         17 seconds =       0.28 minutes
+    Singlet DiskDF CUHF energy............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:05 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:50 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
-                              UHF Reference
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             CUHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
@@ -3229,35 +4812,35 @@ Total time:
     Molecular point group: d2h
     Full point group: D_inf_h
 
-    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
-  Multiplicity = 3
+  Multiplicity = 1
   Electrons    = 16
-  Nalpha       = 9
-  Nbeta        = 7
+  Nalpha       = 8
+  Nbeta        = 8
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is PK.
+  SCF Algorithm Type is MEM_DF.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
-  Guess Type is CORE.
+  Guess Type is SAD.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -3277,22 +4860,765 @@ Total time:
        1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
        2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ-JKFIT
+    Blend                  = CC-PVTZ-JKFIT
+    Total number of shells = 50
+    Number of primitives   = 50
+    Number of AO           = 192
+    Number of SO           = 158
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+       2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
   ==> Pre-Iterations <==
 
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       9       7       7       2
-   -------------------------------------------------------
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-CUHF iter SAD:  -149.27728822299312   -1.49277e+02   0.00000e+00 
+   @DF-CUHF iter   1:  -149.56354408328309   -2.86256e-01   1.10101e-02 ADIIS/DIIS
+   @DF-CUHF iter   2:  -149.58573446084225   -2.21904e-02   2.91563e-03 ADIIS/DIIS
+   @DF-CUHF iter   3:  -149.58703388315297   -1.29942e-03   6.40386e-04 ADIIS/DIIS
+   @DF-CUHF iter   4:  -149.58714509680490   -1.11214e-04   1.37129e-04 ADIIS/DIIS
+   @DF-CUHF iter   5:  -149.58715039895961   -5.30215e-06   1.80355e-05 DIIS
+   @DF-CUHF iter   6:  -149.58715054109820   -1.42139e-07   2.57889e-06 DIIS
+   @DF-CUHF iter   7:  -149.58715054369745   -2.59925e-09   2.41536e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric: -0.00000
+  @S^2 Expected:               0.00000
+  @S^2 Observed:              -0.00000
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
+       2B1u   -1.064399     1B2u   -0.813254     3Ag    -0.769334  
+       1B3u   -0.708490     1B3g   -0.420019  
+
+    Alpha Virtual:                                                        
+
+       1B2g    0.078675     3B1u    0.460375     2B3u    0.693540  
+       2B2u    0.696264     4Ag     0.713625     2B3g    0.825653  
+       2B2g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
+       3B3u    1.639352     3B2u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B2g    2.532031  
+       7B1u    2.536801     3B3g    2.549181     4B3u    3.927538  
+       4B2u    3.928887     8Ag     4.122937     4B2g    4.258945  
+       4B3g    4.272670     2B1g    4.954074     9Ag     4.954589  
+       5B3u    5.109414     8B1u    5.125493     5B2u    5.151847  
+       6B3u    5.270829     6B2u    5.271178    10Ag     5.561366  
+       5B2g    5.664224     5B3g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415147     3B1g    6.555704  
+      11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
+       6B2g    6.829341     6B3g    6.860859     7B3u    7.050774  
+       7B2u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B2g    8.072681     7B3g    8.119435    13Ag     8.191892  
+      13B1u   15.905483  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718109     1B1u  -20.716568     2Ag    -1.762467  
+       2B1u   -1.064399     1B2u   -0.813254     3Ag    -0.769334  
+       1B3u   -0.708490     1B3g   -0.420019  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.078675     3B1u    0.460375     2B3u    0.693540  
+       2B2u    0.696264     4Ag     0.713625     2B3g    0.825653  
+       2B2g    0.852603     5Ag     0.879289     4B1u    0.888916  
+       5B1u    1.413255     1B1g    1.443731     6Ag     1.444604  
+       3B3u    1.639352     3B2u    1.641208     1Au     1.953829  
+       6B1u    1.954302     7Ag     2.484071     3B2g    2.532031  
+       7B1u    2.536801     3B3g    2.549181     4B3u    3.927538  
+       4B2u    3.928887     8Ag     4.122937     4B2g    4.258945  
+       4B3g    4.272670     2B1g    4.954074     9Ag     4.954589  
+       5B3u    5.109414     8B1u    5.125493     5B2u    5.151847  
+       6B3u    5.270829     6B2u    5.271178    10Ag     5.561366  
+       5B2g    5.664224     5B3g    5.664230     9B1u    6.128570  
+       2Au     6.413837    10B1u    6.415147     3B1g    6.555704  
+      11Ag     6.556027     3Au     6.789297    11B1u    6.790263  
+       6B2g    6.829341     6B3g    6.860859     7B3u    7.050774  
+       7B2u    7.089664    12B1u    7.580301    12Ag     7.689595  
+       7B2g    8.072681     7B3g    8.119435    13Ag     8.191892  
+      13B1u   15.905483  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+
+  @DF-CUHF Final Energy:  -149.58715054369745
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8060021671132063
+    Two-Electron Energy =                  86.4303593662520910
+    Total Energy =                       -149.5871505436974758
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:56:50 2022
+Module time:
+	user time   =       0.22 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      14.82 seconds =       0.25 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =         17 seconds =       0.28 minutes
+    Singlet MemDF CUHF energy.............................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:50 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             CUHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is COSX.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DFJCOSK: Density-Fitted J and Semi-Numerical K <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    Integrals threads:            1
+    Memory [MiB]:               375
+    Incremental Fock :           No
+    J Screening Type:          CSAM
+    J Screening Cutoff:       1E-12
+    K Screening Cutoff:       1E-11
+    K Density Cutoff:         1E-10
+    K Basis Cutoff:           1E-10
+    K Overlap Fitting:          Yes
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @CUHF iter SAD:  -149.27713328631918   -1.49277e+02   0.00000e+00 
+   @CUHF iter   1:  -149.56382697604786   -2.86694e-01   1.10975e-02 ADIIS/DIIS
+   @CUHF iter   2:  -149.58629558037481   -2.24686e-02   2.92559e-03 ADIIS/DIIS
+   @CUHF iter   3:  -149.58760428588192   -1.30871e-03   6.47395e-04 ADIIS/DIIS
+   @CUHF iter   4:  -149.58772283023288   -1.18544e-04   1.38075e-04 ADIIS/DIIS
+   @CUHF iter   5:  -149.58772855372328   -5.72349e-06   1.83160e-05 DIIS
+   @CUHF iter   6:  -149.58772885952447   -3.05801e-07   2.47041e-06 DIIS
+   @CUHF iter   7:  -149.58772885956978   -4.53042e-11   2.44347e-07 DIIS
+  Energy and wave function converged with early screening.
+  Performing final iteration with tighter screening.
+
+   @CUHF iter   8:  -149.58722317116374    5.05688e-04   9.91149e-04 ADIIS/DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric:  0.00000
+  @S^2 Expected:               0.00000
+  @S^2 Observed:               0.00000
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718186     1B1u  -20.716591     2Ag    -1.762756  
+       2B1u   -1.064574     1B2u   -0.812724     3Ag    -0.770577  
+       1B3u   -0.707523     1B3g   -0.420229  
+
+    Alpha Virtual:                                                        
+
+       1B2g    0.078702     3B1u    0.460336     2B3u    0.693920  
+       2B2u    0.696563     4Ag     0.713064     2B3g    0.825214  
+       2B2g    0.852636     5Ag     0.879262     4B1u    0.889111  
+       5B1u    1.413064     1B1g    1.442922     6Ag     1.443938  
+       3B3u    1.637673     3B2u    1.642235     6B1u    1.953272  
+       1Au     1.954322     7Ag     2.483527     3B2g    2.530348  
+       7B1u    2.536977     3B3g    2.548923     4B3u    3.927463  
+       4B2u    3.928699     8Ag     4.116806     4B2g    4.259266  
+       4B3g    4.274563     2B1g    4.934640     9Ag     4.966106  
+       5B3u    5.111788     8B1u    5.123534     5B2u    5.157197  
+       6B2u    5.264086     6B3u    5.272739    10Ag     5.546638  
+       5B3g    5.659533     5B2g    5.666050     9B1u    6.117812  
+       2Au     6.397139    10B1u    6.421963     3B1g    6.546782  
+      11Ag     6.548540     3Au     6.775088    11B1u    6.791609  
+       6B2g    6.817736     6B3g    6.862237     7B3u    7.040086  
+       7B2u    7.090378    12B1u    7.574534    12Ag     7.686631  
+       7B2g    8.073746     7B3g    8.120090    13Ag     8.184818  
+      13B1u   15.899399  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718186     1B1u  -20.716591     2Ag    -1.762756  
+       2B1u   -1.064574     1B2u   -0.812724     3Ag    -0.770577  
+       1B3u   -0.707523     1B3g   -0.420229  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.078702     3B1u    0.460336     2B3u    0.693920  
+       2B2u    0.696563     4Ag     0.713064     2B3g    0.825214  
+       2B2g    0.852636     5Ag     0.879262     4B1u    0.889111  
+       5B1u    1.413064     1B1g    1.442922     6Ag     1.443938  
+       3B3u    1.637673     3B2u    1.642235     6B1u    1.953272  
+       1Au     1.954322     7Ag     2.483527     3B2g    2.530348  
+       7B1u    2.536977     3B3g    2.548923     4B3u    3.927463  
+       4B2u    3.928699     8Ag     4.116806     4B2g    4.259266  
+       4B3g    4.274563     2B1g    4.934640     9Ag     4.966106  
+       5B3u    5.111788     8B1u    5.123534     5B2u    5.157197  
+       6B2u    5.264086     6B3u    5.272739    10Ag     5.546638  
+       5B3g    5.659533     5B2g    5.666050     9B1u    6.117812  
+       2Au     6.397139    10B1u    6.421963     3B1g    6.546782  
+      11Ag     6.548540     3Au     6.775088    11B1u    6.791609  
+       6B2g    6.817736     6B3g    6.862237     7B3u    7.040086  
+       7B2u    7.090378    12B1u    7.574534    12Ag     7.686631  
+       7B2g    8.073746     7B3g    8.120090    13Ag     8.184818  
+      13B1u   15.899399  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+
+  @CUHF Final Energy:  -149.58722317116374
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8059033672354303
+    Two-Electron Energy =                  86.4301879389080341
+    Total Energy =                       -149.5872231711637426
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:56:52 2022
+Module time:
+	user time   =       2.66 seconds =       0.04 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      17.51 seconds =       0.29 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =         19 seconds =       0.32 minutes
+    Singlet DFJ+COSX CUHF energy..........................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:52 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             CUHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 16
+  Nalpha       = 8
+  Nbeta        = 8
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is LINK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DFJLinK: Density-Fitted J and Linear Exchange K <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Incremental Fock:           No
+    Screening Type:        DENSITY
+    J Screening Cutoff:      1E-12
+    K Screening Cutoff:      1E-12
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        13      13 
+     B1g        3       3 
+     B2g        7       7 
+     B3g        7       7 
+     Au         3       3 
+     B1u       13      13 
+     B2u        7       7 
+     B3u        7       7 
+   -------------------------
+    Total      60      60
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @CUHF iter SAD:  -149.27733086414960   -1.49277e+02   0.00000e+00 
+   @CUHF iter   1:  -149.56365008860479   -2.86319e-01   1.10142e-02 ADIIS/DIIS
+   @CUHF iter   2:  -149.58585218222908   -2.22021e-02   2.91422e-03 ADIIS/DIIS
+   @CUHF iter   3:  -149.58715113835387   -1.29896e-03   6.40333e-04 ADIIS/DIIS
+   @CUHF iter   4:  -149.58726227365037   -1.11135e-04   1.37172e-04 ADIIS/DIIS
+   @CUHF iter   5:  -149.58726757682930   -5.30318e-06   1.80326e-05 DIIS
+   @CUHF iter   6:  -149.58726771909238   -1.42263e-07   2.57489e-06 DIIS
+   @CUHF iter   7:  -149.58726772168640   -2.59402e-09   2.41117e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric:  0.00000
+  @S^2 Expected:               0.00000
+  @S^2 Observed:               0.00000
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.718071     1B1u  -20.716530     2Ag    -1.762433  
+       2B1u   -1.064390     1B2u   -0.813259     3Ag    -0.769342  
+       1B3u   -0.708496     1B3g   -0.420007  
+
+    Alpha Virtual:                                                        
+
+       1B2g    0.078681     3B1u    0.460327     2B3u    0.693384  
+       2B2u    0.696113     4Ag     0.713511     2B3g    0.825385  
+       2B2g    0.852393     5Ag     0.879194     4B1u    0.888887  
+       5B1u    1.412849     1B1g    1.443170     6Ag     1.444044  
+       3B3u    1.639004     3B2u    1.640861     1Au     1.953287  
+       6B1u    1.953762     7Ag     2.483724     3B2g    2.531509  
+       7B1u    2.536447     3B3g    2.548588     4B3u    3.926986  
+       4B2u    3.928307     8Ag     4.120730     4B2g    4.258300  
+       4B3g    4.271909     2B1g    4.948441     9Ag     4.948961  
+       5B3u    5.103003     8B1u    5.124465     5B2u    5.145236  
+       6B3u    5.265751     6B2u    5.266088    10Ag     5.555675  
+       5B2g    5.658990     5B3g    5.658996     9B1u    6.125723  
+       2Au     6.407176    10B1u    6.408484     3B1g    6.547508  
+      11Ag     6.547837     3Au     6.781590    11B1u    6.782559  
+       6B2g    6.822868     6B3g    6.853283     7B3u    7.043595  
+       7B2u    7.081934    12B1u    7.574355    12Ag     7.687859  
+       7B2g    8.066157     7B3g    8.112296    13Ag     8.185053  
+      13B1u   15.901574  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.718071     1B1u  -20.716530     2Ag    -1.762433  
+       2B1u   -1.064390     1B2u   -0.813259     3Ag    -0.769342  
+       1B3u   -0.708496     1B3g   -0.420007  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.078681     3B1u    0.460327     2B3u    0.693384  
+       2B2u    0.696113     4Ag     0.713511     2B3g    0.825385  
+       2B2g    0.852393     5Ag     0.879194     4B1u    0.888887  
+       5B1u    1.412849     1B1g    1.443170     6Ag     1.444044  
+       3B3u    1.639004     3B2u    1.640861     1Au     1.953287  
+       6B1u    1.953762     7Ag     2.483724     3B2g    2.531509  
+       7B1u    2.536447     3B3g    2.548588     4B3u    3.926986  
+       4B2u    3.928307     8Ag     4.120730     4B2g    4.258300  
+       4B3g    4.271909     2B1g    4.948441     9Ag     4.948961  
+       5B3u    5.103003     8B1u    5.124465     5B2u    5.145236  
+       6B3u    5.265751     6B2u    5.266088    10Ag     5.555675  
+       5B2g    5.658990     5B3g    5.658996     9B1u    6.125723  
+       2Au     6.407176    10B1u    6.408484     3B1g    6.547508  
+      11Ag     6.547837     3Au     6.781590    11B1u    6.782559  
+       6B2g    6.822868     6B3g    6.853283     7B3u    7.043595  
+       7B2u    7.081934    12B1u    7.574355    12Ag     7.687859  
+       7B2g    8.066157     7B3g    8.112296    13Ag     8.185053  
+      13B1u   15.901574  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+
+  @CUHF Final Energy:  -149.58726772168640
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.8064578915613083
+    Two-Electron Energy =                  86.4306979127112527
+    Total Energy =                       -149.5872677216864020
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:56:54 2022
+Module time:
+	user time   =       1.41 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      18.95 seconds =       0.32 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =         21 seconds =       0.35 minutes
+    Singlet DFJ+LinK CUHF energy..........................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:54 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
   ==> Integral Setup <==
 
@@ -3311,19 +5637,39 @@ Total time:
   Using 3350730 doubles for integral storage.
   We computed 22155 shell quartets total.
   Whereas there are 22155 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -3333,156 +5679,161 @@ Total time:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-   @UHF iter   1:  -131.02769690362527   -1.31028e+02   3.53068e-01 
-   @UHF iter   2:  -140.13786814792073   -9.11017e+00   1.84782e-01 DIIS
-   @UHF iter   3:  -149.26306174143707   -9.12519e+00   5.05749e-02 DIIS
-   @UHF iter   4:  -149.65701792468548   -3.93956e-01   8.05490e-03 DIIS
-   @UHF iter   5:  -149.67101505766664   -1.39971e-02   9.14034e-04 DIIS
-   @UHF iter   6:  -149.67132932058533   -3.14263e-04   2.45665e-04 DIIS
-   @UHF iter   7:  -149.67135402427451   -2.47037e-05   5.39940e-05 DIIS
-   @UHF iter   8:  -149.67135512820715   -1.10393e-06   1.11821e-05 DIIS
-   @UHF iter   9:  -149.67135517195155   -4.37444e-08   1.32318e-06 DIIS
-   @UHF iter  10:  -149.67135517240558   -4.54037e-10   1.01049e-07 DIIS
+   @UHF iter   1:  -131.02769686138831   -1.31028e+02   3.53809e-01 ADIIS
+   @UHF iter   2:  -140.13786809233886   -9.11017e+00   1.85373e-01 ADIIS
+   @UHF iter   3:  -149.07892636084327   -8.94106e+00   6.21073e-02 ADIIS/DIIS
+   @UHF iter   4:  -149.65363562366332   -5.74709e-01   1.05419e-02 ADIIS/DIIS
+   @UHF iter   5:  -149.67031494578450   -1.66793e-02   1.87170e-03 ADIIS/DIIS
+   @UHF iter   6:  -149.67129417341366   -9.79228e-04   4.35106e-04 ADIIS/DIIS
+   @UHF iter   7:  -149.67135318247261   -5.90091e-05   6.76805e-05 DIIS
+   @UHF iter   8:  -149.67135514057824   -1.95811e-06   9.41668e-06 DIIS
+   @UHF iter   9:  -149.67135517086550   -3.02873e-08   8.36275e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   3.326638693E-02
+   @Spin Contamination Metric:   3.326840103E-02
    @S^2 Expected:                2.000000000E+00
-   @S^2 Observed:                2.033266387E+00
+   @S^2 Observed:                2.033268401E+00
    @S   Expected:                1.000000000E+00
    @S   Observed:                1.000000000E+00
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
-       1Ag   -20.730397     1B1u  -20.729247     2Ag    -1.812944  
-       2B1u   -1.163040     1B2u   -0.882848     1B3u   -0.882848  
-       3Ag    -0.797842     1B3g   -0.503772     1B2g   -0.503772  
+       1Ag   -20.730399     1B1u  -20.729248     2Ag    -1.812946  
+       2B1u   -1.163042     1B3u   -0.882850     1B2u   -0.882849  
+       3Ag    -0.797844     1B2g   -0.503774     1B3g   -0.503773  
 
     Alpha Virtual:                                                        
 
-       3B1u    0.444074     2B2u    0.670169     2B3u    0.670169  
-       4Ag     0.710743     2B3g    0.796950     2B2g    0.796951  
-       4B1u    0.864060     5Ag     0.873833     5B1u    1.396037  
-       6Ag     1.421898     1B1g    1.421898     3B3u    1.611980  
-       3B2u    1.611980     6B1u    1.908137     1Au     1.908137  
-       7Ag     2.465892     3B3g    2.517815     3B2g    2.517815  
-       7B1u    2.527679     4B2u    3.877498     4B3u    3.877498  
-       8Ag     4.116531     4B3g    4.219543     4B2g    4.219543  
-       9Ag     4.936094     2B1g    4.936094     8B1u    5.112053  
-       5B2u    5.114145     5B3u    5.114145     6B3u    5.240079  
-       6B2u    5.240079    10Ag     5.545104     5B2g    5.629471  
-       5B3g    5.629471     9B1u    6.112243    10B1u    6.380362  
-       2Au     6.380362    11Ag     6.491862     3B1g    6.491862  
-      11B1u    6.734804     3Au     6.734804     6B3g    6.811153  
-       6B2g    6.811153     7B2u    7.039321     7B3u    7.039321  
-      12B1u    7.563721    12Ag     7.661398     7B3g    8.077183  
-       7B2g    8.077183    13Ag     8.180540    13B1u   15.889141  
+       3B1u    0.444074     2B3u    0.670168     2B2u    0.670168  
+       4Ag     0.710742     2B2g    0.796950     2B3g    0.796950  
+       4B1u    0.864058     5Ag     0.873832     5B1u    1.396037  
+       1B1g    1.421897     6Ag     1.421897     3B2u    1.611980  
+       3B3u    1.611980     1Au     1.908137     6B1u    1.908137  
+       7Ag     2.465891     3B2g    2.517815     3B3g    2.517815  
+       7B1u    2.527679     4B3u    3.877496     4B2u    3.877497  
+       8Ag     4.116530     4B2g    4.219542     4B3g    4.219542  
+       2B1g    4.936093     9Ag     4.936093     8B1u    5.112052  
+       5B3u    5.114143     5B2u    5.114143     6B2u    5.240078  
+       6B3u    5.240078    10Ag     5.545103     5B3g    5.629470  
+       5B2g    5.629470     9B1u    6.112243     2Au     6.380361  
+      10B1u    6.380361     3B1g    6.491861    11Ag     6.491861  
+       3Au     6.734803    11B1u    6.734803     6B2g    6.811152  
+       6B3g    6.811152     7B3u    7.039320     7B2u    7.039320  
+      12B1u    7.563719    12Ag     7.661396     7B2g    8.077182  
+       7B3g    8.077182    13Ag     8.180539    13B1u   15.889139  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.677273     1B1u  -20.675406     2Ag    -1.697987  
-       2B1u   -0.956412     3Ag    -0.726305     1B3u   -0.632037  
-       1B2u   -0.632036  
+       1Ag   -20.677272     1B1u  -20.675406     2Ag    -1.697987  
+       2B1u   -0.956410     3Ag    -0.726304     1B2u   -0.632036  
+       1B3u   -0.632036  
 
     Beta Virtual:                                                         
 
-       1B2g    0.158291     1B3g    0.158291     3B1u    0.479671  
-       4Ag     0.719067     2B3u    0.727589     2B2u    0.727589  
-       5Ag     0.894526     2B2g    0.895011     2B3g    0.895011  
-       4B1u    0.930237     5B1u    1.437286     6Ag     1.472619  
-       1B1g    1.472619     3B3u    1.678790     3B2u    1.678790  
-       6B1u    2.006486     1Au     2.006486     7Ag     2.509575  
-       7B1u    2.554593     3B2g    2.569016     3B3g    2.569016  
-       4B3u    3.993529     4B2u    3.993529     8Ag     4.141603  
-       4B2g    4.325773     4B3g    4.325773     2B1g    4.972187  
-       9Ag     4.972187     5B3u    5.148956     5B2u    5.148956  
-       8B1u    5.150970     6B2u    5.300884     6B3u    5.300884  
-      10Ag     5.581928     5B2g    5.699443     5B3g    5.699443  
-       9B1u    6.154195    10B1u    6.445601     2Au     6.445601  
-      11Ag     6.620146     3B1g    6.620146    11B1u    6.844544  
-       3Au     6.844544     6B2g    6.879046     6B3g    6.879046  
-       7B3u    7.100563     7B2u    7.100563    12B1u    7.601591  
-      12Ag     7.730311     7B2g    8.113474     7B3g    8.113474  
+       1B3g    0.158291     1B2g    0.158292     3B1u    0.479670  
+       4Ag     0.719066     2B2u    0.727589     2B3u    0.727590  
+       5Ag     0.894525     2B3g    0.895011     2B2g    0.895011  
+       4B1u    0.930238     5B1u    1.437286     6Ag     1.472618  
+       1B1g    1.472618     3B2u    1.678789     3B3u    1.678789  
+       1Au     2.006485     6B1u    2.006485     7Ag     2.509575  
+       7B1u    2.554592     3B3g    2.569015     3B2g    2.569015  
+       4B2u    3.993529     4B3u    3.993529     8Ag     4.141603  
+       4B3g    4.325773     4B2g    4.325773     9Ag     4.972187  
+       2B1g    4.972187     5B2u    5.148955     5B3u    5.148955  
+       8B1u    5.150970     6B3u    5.300883     6B2u    5.300883  
+      10Ag     5.581928     5B2g    5.699442     5B3g    5.699442  
+       9B1u    6.154195    10B1u    6.445600     2Au     6.445600  
+       3B1g    6.620146    11Ag     6.620146     3Au     6.844545  
+      11B1u    6.844545     6B3g    6.879046     6B2g    6.879046  
+       7B2u    7.100563     7B3u    7.100563    12B1u    7.601591  
+      12Ag     7.730311     7B3g    8.113473     7B2g    8.113473  
       13Ag     8.204477    13B1u   15.932678  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @UHF Final Energy:  -149.67135517240558
+  @UHF Final Energy:  -149.67135517086550
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.9155258831183346
-    Two-Electron Energy =                  86.4556785745673153
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6713551724055833
-
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9155094087931275
+    Two-Electron Energy =                  86.4556619807639635
+    Total Energy =                       -149.6713551708655245
 
   UHF NO Occupations:
-  HONO-2 :    1B2u 1.9937501
+  HONO-2 :    1B3u 1.9937498
   HONO-1 :    1B2g 1.0000000
   HONO-0 :    1B3g 1.0000000
-  LUNO+0 :    2B2u 0.0062499
-  LUNO+1 :    2B3u 0.0062498
-  LUNO+2 :    3B1u 0.0031243
-  LUNO+3 :    4 Ag 0.0009741
+  LUNO+0 :    2B3u 0.0062502
+  LUNO+1 :    2B2u 0.0062501
+  LUNO+2 :    3B1u 0.0031245
+  LUNO+3 :    4 Ag 0.0009742
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:06 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:54 2022
 Module time:
-	user time   =       0.49 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.36 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       9.48 seconds =       0.16 minutes
-	system time =       0.31 seconds =       0.01 minutes
-	total time  =         11 seconds =       0.18 minutes
-	Triplet PK UHF energy.............................................PASSED
+	user time   =      19.34 seconds =       0.32 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =         21 seconds =       0.35 minutes
+    Triplet PK UHF energy.................................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:06 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:54 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -3496,14 +5847,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 3
@@ -3520,7 +5871,7 @@ Total time:
   Guess Type is CORE.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -3545,41 +5896,25 @@ Total time:
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   228 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       9       7       7       2
-   -------------------------------------------------------
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   Starting with a DF guess...
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory (MB):               375
-    Algorithm:                Core
-    Integral Cache:           NONE
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -3599,10 +5934,28 @@ Total time:
        1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
        2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -3612,21 +5965,20 @@ Total time:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-   @DF-UHF iter   1:  -131.02345181239073   -1.31023e+02   3.53263e-01 
-   @DF-UHF iter   2:  -140.13876903555135   -9.11532e+00   1.84802e-01 DIIS
-   @DF-UHF iter   3:  -149.26280525049356   -9.12404e+00   5.05764e-02 DIIS
-   @DF-UHF iter   4:  -149.65691280314451   -3.94108e-01   8.05234e-03 DIIS
-   @DF-UHF iter   5:  -149.67091585716943   -1.40031e-02   9.14627e-04 DIIS
-   @DF-UHF iter   6:  -149.67123029535077   -3.14438e-04   2.46163e-04 DIIS
-   @DF-UHF iter   7:  -149.67125508387804   -2.47885e-05   5.42145e-05 DIIS
-   @DF-UHF iter   8:  -149.67125619838112   -1.11450e-06   1.12239e-05 DIIS
-   @DF-UHF iter   9:  -149.67125624246347   -4.40824e-08   1.32496e-06 DIIS
-   @DF-UHF iter  10:  -149.67125624291742   -4.53952e-10   1.00526e-07 DIIS
+   @DF-UHF iter   1:  -131.02345177007209   -1.31023e+02   3.54007e-01 ADIIS
+   @DF-UHF iter   2:  -140.13876897996707   -9.11532e+00   1.85394e-01 ADIIS
+   @DF-UHF iter   3:  -149.07887534187844   -8.94011e+00   6.20999e-02 ADIIS/DIIS
+   @DF-UHF iter   4:  -149.65353829309876   -5.74663e-01   1.05459e-02 ADIIS/DIIS
+   @DF-UHF iter   5:  -149.67021624295950   -1.66779e-02   1.87099e-03 ADIIS/DIIS
+   @DF-UHF iter   6:  -149.67119529927663   -9.79056e-04   4.34543e-04 ADIIS/DIIS
+   @DF-UHF iter   7:  -149.67125425357943   -5.89543e-05   6.76766e-05 DIIS
+   @DF-UHF iter   8:  -149.67125621119939   -1.95762e-06   9.39479e-06 DIIS
+   @DF-UHF iter   9:  -149.67125624137390   -3.01745e-08   8.37130e-07 DIIS
 
   DF guess converged.
-
-  ==> Integral Setup <==
 
   ==> DirectJK: Integral-Direct J/K Matrices <==
 
@@ -3634,150 +5986,156 @@ Total time:
     K tasked:                  Yes
     wK tasked:                  No
     Integrals threads:           1
-    Schwarz Cutoff:          1E-12
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
 
-   @UHF iter  11:  -149.67135505906225   -9.88161e-05   3.40144e-05 DIIS
-   @UHF iter  12:  -149.67135517049178   -1.11430e-07   3.61220e-06 DIIS
-   @UHF iter  13:  -149.67135517225611   -1.76433e-09   9.53470e-07 DIIS
+   @UHF iter  10:  -149.67135505793141   -1.49671e+02   3.39799e-05 DIIS
+   @UHF iter  11:  -149.67135516917313   -1.11242e-07   3.60648e-06 DIIS
+   @UHF iter  12:  -149.67135517094351   -1.77039e-09   9.53617e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   3.326719947E-02
+   @Spin Contamination Metric:   3.326747045E-02
    @S^2 Expected:                2.000000000E+00
-   @S^2 Observed:                2.033267199E+00
+   @S^2 Observed:                2.033267470E+00
    @S   Expected:                1.000000000E+00
    @S   Observed:                1.000000000E+00
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
        1Ag   -20.730401     1B1u  -20.729250     2Ag    -1.812946  
-       2B1u   -1.163042     1B2u   -0.882849     1B3u   -0.882849  
-       3Ag    -0.797844     1B3g   -0.503774     1B2g   -0.503774  
+       2B1u   -1.163042     1B3u   -0.882850     1B2u   -0.882850  
+       3Ag    -0.797844     1B2g   -0.503774     1B3g   -0.503774  
 
     Alpha Virtual:                                                        
 
-       3B1u    0.444073     2B2u    0.670168     2B3u    0.670168  
-       4Ag     0.710742     2B3g    0.796950     2B2g    0.796950  
+       3B1u    0.444073     2B3u    0.670168     2B2u    0.670168  
+       4Ag     0.710742     2B2g    0.796950     2B3g    0.796950  
        4B1u    0.864058     5Ag     0.873832     5B1u    1.396036  
-       1B1g    1.421897     6Ag     1.421897     3B3u    1.611980  
-       3B2u    1.611980     1Au     1.908136     6B1u    1.908136  
-       7Ag     2.465890     3B3g    2.517814     3B2g    2.517814  
-       7B1u    2.527678     4B2u    3.877496     4B3u    3.877496  
-       8Ag     4.116530     4B3g    4.219542     4B2g    4.219542  
-       9Ag     4.936093     2B1g    4.936093     8B1u    5.112051  
-       5B2u    5.114143     5B3u    5.114143     6B3u    5.240078  
-       6B2u    5.240078    10Ag     5.545103     5B2g    5.629470  
-       5B3g    5.629470     9B1u    6.112241     2Au     6.380361  
+       1B1g    1.421897     6Ag     1.421897     3B2u    1.611980  
+       3B3u    1.611980     1Au     1.908136     6B1u    1.908136  
+       7Ag     2.465890     3B2g    2.517814     3B3g    2.517814  
+       7B1u    2.527678     4B3u    3.877496     4B2u    3.877496  
+       8Ag     4.116530     4B2g    4.219542     4B3g    4.219542  
+       2B1g    4.936093     9Ag     4.936093     8B1u    5.112051  
+       5B3u    5.114143     5B2u    5.114143     6B2u    5.240078  
+       6B3u    5.240078    10Ag     5.545103     5B3g    5.629470  
+       5B2g    5.629470     9B1u    6.112241     2Au     6.380361  
       10B1u    6.380361     3B1g    6.491860    11Ag     6.491860  
-       3Au     6.734802    11B1u    6.734802     6B3g    6.811151  
-       6B2g    6.811151     7B2u    7.039319     7B3u    7.039319  
-      12B1u    7.563719    12Ag     7.661396     7B3g    8.077181  
-       7B2g    8.077181    13Ag     8.180538    13B1u   15.889139  
+       3Au     6.734802    11B1u    6.734802     6B2g    6.811151  
+       6B3g    6.811151     7B3u    7.039319     7B2u    7.039319  
+      12B1u    7.563719    12Ag     7.661396     7B2g    8.077181  
+       7B3g    8.077181    13Ag     8.180538    13B1u   15.889139  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.677276     1B1u  -20.675409     2Ag    -1.697988  
-       2B1u   -0.956413     3Ag    -0.726306     1B3u   -0.632037  
-       1B2u   -0.632037  
+       1Ag   -20.677275     1B1u  -20.675409     2Ag    -1.697988  
+       2B1u   -0.956412     3Ag    -0.726306     1B2u   -0.632036  
+       1B3u   -0.632036  
 
     Beta Virtual:                                                         
 
-       1B2g    0.158290     1B3g    0.158290     3B1u    0.479670  
-       4Ag     0.719066     2B3u    0.727589     2B2u    0.727589  
-       5Ag     0.894525     2B2g    0.895011     2B3g    0.895011  
-       4B1u    0.930236     5B1u    1.437285     6Ag     1.472618  
-       1B1g    1.472618     3B3u    1.678789     3B2u    1.678789  
+       1B3g    0.158290     1B2g    0.158290     3B1u    0.479670  
+       4Ag     0.719066     2B2u    0.727590     2B3u    0.727590  
+       5Ag     0.894525     2B3g    0.895011     2B2g    0.895011  
+       4B1u    0.930237     5B1u    1.437285     6Ag     1.472618  
+       1B1g    1.472618     3B2u    1.678789     3B3u    1.678789  
        6B1u    2.006485     1Au     2.006485     7Ag     2.509574  
-       7B1u    2.554592     3B2g    2.569015     3B3g    2.569015  
-       4B3u    3.993527     4B2u    3.993527     8Ag     4.141602  
-       4B2g    4.325772     4B3g    4.325772     9Ag     4.972187  
-       2B1g    4.972187     5B3u    5.148955     5B2u    5.148955  
-       8B1u    5.150968     6B3u    5.300883     6B2u    5.300883  
+       7B1u    2.554592     3B3g    2.569015     3B2g    2.569015  
+       4B2u    3.993528     4B3u    3.993528     8Ag     4.141602  
+       4B3g    4.325772     4B2g    4.325772     9Ag     4.972187  
+       2B1g    4.972187     5B2u    5.148955     5B3u    5.148955  
+       8B1u    5.150969     6B2u    5.300883     6B3u    5.300883  
       10Ag     5.581927     5B2g    5.699442     5B3g    5.699442  
        9B1u    6.154193    10B1u    6.445600     2Au     6.445600  
-       3B1g    6.620144    11Ag     6.620144    11B1u    6.844543  
-       3Au     6.844543     6B2g    6.879044     6B3g    6.879044  
-       7B3u    7.100562     7B2u    7.100562    12B1u    7.601590  
-      12Ag     7.730309     7B2g    8.113473     7B3g    8.113473  
+      11Ag     6.620145     3B1g    6.620145    11B1u    6.844543  
+       3Au     6.844543     6B3g    6.879044     6B2g    6.879044  
+       7B2u    7.100562     7B3u    7.100562    12B1u    7.601590  
+      12Ag     7.730310     7B3g    8.113473     7B2g    8.113473  
       13Ag     8.204476    13B1u   15.932677  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @UHF Final Energy:  -149.67135517225611
+  @UHF Final Energy:  -149.67135517094351
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.9154388970318905
-    Two-Electron Energy =                  86.4555915886303410
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6713551722561135
-
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9154411243933964
+    Two-Electron Energy =                  86.4555936962862290
+    Total Energy =                       -149.6713551709435137
 
   UHF NO Occupations:
-  HONO-2 :    1B2u 1.9937500
+  HONO-2 :    1B3u 1.9937499
   HONO-1 :    1B2g 1.0000000
   HONO-0 :    1B3g 1.0000000
-  LUNO+0 :    2B2u 0.0062500
-  LUNO+1 :    2B3u 0.0062500
-  LUNO+2 :    3B1u 0.0031243
+  LUNO+0 :    2B3u 0.0062501
+  LUNO+1 :    2B2u 0.0062501
+  LUNO+2 :    3B1u 0.0031244
   LUNO+3 :    4 Ag 0.0009741
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:07 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:55 2022
 Module time:
-	user time   =       1.23 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      10.72 seconds =       0.18 minutes
-	system time =       0.33 seconds =       0.01 minutes
-	total time  =         12 seconds =       0.20 minutes
-	Triplet Direct UHF energy.........................................PASSED
+	user time   =      20.02 seconds =       0.33 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =         22 seconds =       0.37 minutes
+    Triplet Direct UHF energy.............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:07 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:55 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -3791,14 +6149,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 3
@@ -3815,7 +6173,7 @@ Total time:
   Guess Type is CORE.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -3835,23 +6193,6 @@ Total time:
        1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
        2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       9       7       7       2
-   -------------------------------------------------------
-
   ==> Integral Setup <==
 
   ==> DiskJK: Disk-Based J/K Matrices <==
@@ -3859,13 +6200,31 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -3875,156 +6234,161 @@ Total time:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-   @UHF iter   1:  -131.02769690362544   -1.31028e+02   3.53068e-01 
-   @UHF iter   2:  -140.13786814791851   -9.11017e+00   1.84782e-01 DIIS
-   @UHF iter   3:  -149.26306174143693   -9.12519e+00   5.05749e-02 DIIS
-   @UHF iter   4:  -149.65701792468542   -3.93956e-01   8.05490e-03 DIIS
-   @UHF iter   5:  -149.67101505766666   -1.39971e-02   9.14034e-04 DIIS
-   @UHF iter   6:  -149.67132932058533   -3.14263e-04   2.45665e-04 DIIS
-   @UHF iter   7:  -149.67135402427436   -2.47037e-05   5.39940e-05 DIIS
-   @UHF iter   8:  -149.67135512820715   -1.10393e-06   1.11821e-05 DIIS
-   @UHF iter   9:  -149.67135517195160   -4.37444e-08   1.32318e-06 DIIS
-   @UHF iter  10:  -149.67135517240564   -4.54037e-10   1.01049e-07 DIIS
+   @UHF iter   1:  -131.02769686138825   -1.31028e+02   3.53809e-01 ADIIS
+   @UHF iter   2:  -140.13786809233764   -9.11017e+00   1.85373e-01 ADIIS
+   @UHF iter   3:  -149.07892636084318   -8.94106e+00   6.21073e-02 ADIIS/DIIS
+   @UHF iter   4:  -149.65363562366338   -5.74709e-01   1.05419e-02 ADIIS/DIIS
+   @UHF iter   5:  -149.67031494578438   -1.66793e-02   1.87170e-03 ADIIS/DIIS
+   @UHF iter   6:  -149.67129417341368   -9.79228e-04   4.35106e-04 ADIIS/DIIS
+   @UHF iter   7:  -149.67135318247261   -5.90091e-05   6.76805e-05 DIIS
+   @UHF iter   8:  -149.67135514057824   -1.95811e-06   9.41668e-06 DIIS
+   @UHF iter   9:  -149.67135517086550   -3.02873e-08   8.36275e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   3.326638693E-02
+   @Spin Contamination Metric:   3.326840103E-02
    @S^2 Expected:                2.000000000E+00
-   @S^2 Observed:                2.033266387E+00
+   @S^2 Observed:                2.033268401E+00
    @S   Expected:                1.000000000E+00
    @S   Observed:                1.000000000E+00
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
-       1Ag   -20.730397     1B1u  -20.729247     2Ag    -1.812944  
-       2B1u   -1.163040     1B2u   -0.882848     1B3u   -0.882848  
-       3Ag    -0.797842     1B3g   -0.503772     1B2g   -0.503772  
+       1Ag   -20.730399     1B1u  -20.729248     2Ag    -1.812946  
+       2B1u   -1.163042     1B3u   -0.882850     1B2u   -0.882849  
+       3Ag    -0.797844     1B2g   -0.503774     1B3g   -0.503773  
 
     Alpha Virtual:                                                        
 
-       3B1u    0.444074     2B2u    0.670169     2B3u    0.670169  
-       4Ag     0.710743     2B3g    0.796950     2B2g    0.796951  
-       4B1u    0.864060     5Ag     0.873833     5B1u    1.396037  
-       6Ag     1.421898     1B1g    1.421898     3B3u    1.611980  
-       3B2u    1.611980     6B1u    1.908137     1Au     1.908137  
-       7Ag     2.465892     3B3g    2.517815     3B2g    2.517815  
-       7B1u    2.527679     4B2u    3.877498     4B3u    3.877498  
-       8Ag     4.116531     4B3g    4.219543     4B2g    4.219543  
-       9Ag     4.936094     2B1g    4.936094     8B1u    5.112053  
-       5B2u    5.114145     5B3u    5.114145     6B3u    5.240079  
-       6B2u    5.240079    10Ag     5.545104     5B2g    5.629471  
-       5B3g    5.629471     9B1u    6.112243    10B1u    6.380362  
-       2Au     6.380362    11Ag     6.491862     3B1g    6.491862  
-      11B1u    6.734804     3Au     6.734804     6B3g    6.811153  
-       6B2g    6.811153     7B2u    7.039321     7B3u    7.039321  
-      12B1u    7.563721    12Ag     7.661398     7B3g    8.077183  
-       7B2g    8.077183    13Ag     8.180540    13B1u   15.889141  
+       3B1u    0.444074     2B3u    0.670168     2B2u    0.670168  
+       4Ag     0.710742     2B2g    0.796950     2B3g    0.796950  
+       4B1u    0.864058     5Ag     0.873832     5B1u    1.396037  
+       1B1g    1.421897     6Ag     1.421897     3B2u    1.611980  
+       3B3u    1.611980     1Au     1.908137     6B1u    1.908137  
+       7Ag     2.465891     3B2g    2.517815     3B3g    2.517815  
+       7B1u    2.527679     4B3u    3.877496     4B2u    3.877497  
+       8Ag     4.116530     4B2g    4.219542     4B3g    4.219542  
+       2B1g    4.936093     9Ag     4.936093     8B1u    5.112052  
+       5B3u    5.114143     5B2u    5.114143     6B2u    5.240078  
+       6B3u    5.240078    10Ag     5.545103     5B3g    5.629470  
+       5B2g    5.629470     9B1u    6.112243     2Au     6.380361  
+      10B1u    6.380361     3B1g    6.491861    11Ag     6.491861  
+       3Au     6.734803    11B1u    6.734803     6B2g    6.811152  
+       6B3g    6.811152     7B3u    7.039320     7B2u    7.039320  
+      12B1u    7.563719    12Ag     7.661396     7B2g    8.077182  
+       7B3g    8.077182    13Ag     8.180539    13B1u   15.889139  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.677273     1B1u  -20.675406     2Ag    -1.697987  
-       2B1u   -0.956412     3Ag    -0.726305     1B3u   -0.632037  
-       1B2u   -0.632036  
+       1Ag   -20.677272     1B1u  -20.675406     2Ag    -1.697987  
+       2B1u   -0.956410     3Ag    -0.726304     1B2u   -0.632036  
+       1B3u   -0.632036  
 
     Beta Virtual:                                                         
 
-       1B2g    0.158291     1B3g    0.158291     3B1u    0.479671  
-       4Ag     0.719067     2B3u    0.727589     2B2u    0.727589  
-       5Ag     0.894526     2B2g    0.895011     2B3g    0.895011  
-       4B1u    0.930237     5B1u    1.437286     6Ag     1.472619  
-       1B1g    1.472619     3B3u    1.678790     3B2u    1.678790  
-       6B1u    2.006486     1Au     2.006486     7Ag     2.509575  
-       7B1u    2.554593     3B2g    2.569016     3B3g    2.569016  
-       4B3u    3.993529     4B2u    3.993529     8Ag     4.141603  
-       4B2g    4.325773     4B3g    4.325773     2B1g    4.972187  
-       9Ag     4.972187     5B3u    5.148956     5B2u    5.148956  
-       8B1u    5.150970     6B2u    5.300884     6B3u    5.300884  
-      10Ag     5.581928     5B3g    5.699443     5B2g    5.699443  
-       9B1u    6.154195    10B1u    6.445601     2Au     6.445601  
-      11Ag     6.620146     3B1g    6.620146    11B1u    6.844544  
-       3Au     6.844544     6B2g    6.879046     6B3g    6.879046  
-       7B3u    7.100563     7B2u    7.100563    12B1u    7.601591  
-      12Ag     7.730311     7B2g    8.113474     7B3g    8.113474  
+       1B3g    0.158291     1B2g    0.158292     3B1u    0.479670  
+       4Ag     0.719066     2B2u    0.727589     2B3u    0.727590  
+       5Ag     0.894525     2B3g    0.895011     2B2g    0.895011  
+       4B1u    0.930238     5B1u    1.437286     6Ag     1.472618  
+       1B1g    1.472618     3B2u    1.678789     3B3u    1.678789  
+       1Au     2.006485     6B1u    2.006485     7Ag     2.509575  
+       7B1u    2.554592     3B3g    2.569015     3B2g    2.569015  
+       4B2u    3.993529     4B3u    3.993529     8Ag     4.141603  
+       4B3g    4.325773     4B2g    4.325773     9Ag     4.972187  
+       2B1g    4.972187     5B2u    5.148955     5B3u    5.148955  
+       8B1u    5.150970     6B3u    5.300883     6B2u    5.300883  
+      10Ag     5.581928     5B2g    5.699442     5B3g    5.699442  
+       9B1u    6.154195    10B1u    6.445600     2Au     6.445600  
+       3B1g    6.620146    11Ag     6.620146     3Au     6.844545  
+      11B1u    6.844545     6B3g    6.879046     6B2g    6.879046  
+       7B2u    7.100563     7B3u    7.100563    12B1u    7.601591  
+      12Ag     7.730311     7B3g    8.113473     7B2g    8.113473  
       13Ag     8.204477    13B1u   15.932678  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @UHF Final Energy:  -149.67135517240564
+  @UHF Final Energy:  -149.67135517086550
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.9155258831182778
-    Two-Electron Energy =                  86.4556785745672158
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6713551724056401
-
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9155094087931275
+    Two-Electron Energy =                  86.4556619807639777
+    Total Energy =                       -149.6713551708654961
 
   UHF NO Occupations:
-  HONO-2 :    1B2u 1.9937501
-  HONO-1 :    1B3g 1.0000000
-  HONO-0 :    1B2g 1.0000000
-  LUNO+0 :    2B2u 0.0062499
-  LUNO+1 :    2B3u 0.0062498
-  LUNO+2 :    3B1u 0.0031243
-  LUNO+3 :    4 Ag 0.0009741
+  HONO-2 :    1B3u 1.9937498
+  HONO-1 :    1B2g 1.0000000
+  HONO-0 :    1B3g 1.0000000
+  LUNO+0 :    2B3u 0.0062502
+  LUNO+1 :    2B2u 0.0062501
+  LUNO+2 :    3B1u 0.0031245
+  LUNO+3 :    4 Ag 0.0009742
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:07 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:55 2022
 Module time:
-	user time   =       0.44 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       0.28 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      11.17 seconds =       0.19 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =         12 seconds =       0.20 minutes
-	Triplet Disk UHF energy...........................................PASSED
+	user time   =      20.33 seconds =       0.34 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =         22 seconds =       0.37 minutes
+    Triplet Disk UHF energy...............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:07 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:55 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -4038,14 +6402,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 3
@@ -4055,14 +6419,14 @@ Total time:
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DF.
+  SCF Algorithm Type is DISK_DF.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
   Guess Type is CORE.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -4087,39 +6451,22 @@ Total time:
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   228 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       9       7       7       2
-   -------------------------------------------------------
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
     OpenMP threads:              1
     Integrals threads:           1
-    Memory (MB):               375
+    Memory [MiB]:              375
     Algorithm:                Core
     Integral Cache:           NONE
     Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
@@ -4139,10 +6486,28 @@ Total time:
        1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
        2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -4152,157 +6517,162 @@ Total time:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-   @DF-UHF iter   1:  -131.02345181239073   -1.31023e+02   3.53263e-01 
-   @DF-UHF iter   2:  -140.13876903555135   -9.11532e+00   1.84802e-01 DIIS
-   @DF-UHF iter   3:  -149.26280525049356   -9.12404e+00   5.05764e-02 DIIS
-   @DF-UHF iter   4:  -149.65691280314451   -3.94108e-01   8.05234e-03 DIIS
-   @DF-UHF iter   5:  -149.67091585716943   -1.40031e-02   9.14627e-04 DIIS
-   @DF-UHF iter   6:  -149.67123029535077   -3.14438e-04   2.46163e-04 DIIS
-   @DF-UHF iter   7:  -149.67125508387804   -2.47885e-05   5.42145e-05 DIIS
-   @DF-UHF iter   8:  -149.67125619838112   -1.11450e-06   1.12239e-05 DIIS
-   @DF-UHF iter   9:  -149.67125624246347   -4.40824e-08   1.32496e-06 DIIS
-   @DF-UHF iter  10:  -149.67125624291742   -4.53952e-10   1.00526e-07 DIIS
+   @DF-UHF iter   1:  -131.02345177007214   -1.31023e+02   3.54007e-01 ADIIS
+   @DF-UHF iter   2:  -140.13876897996718   -9.11532e+00   1.85394e-01 ADIIS
+   @DF-UHF iter   3:  -149.07887534187839   -8.94011e+00   6.20999e-02 ADIIS/DIIS
+   @DF-UHF iter   4:  -149.65353829309876   -5.74663e-01   1.05459e-02 ADIIS/DIIS
+   @DF-UHF iter   5:  -149.67021624295947   -1.66779e-02   1.87099e-03 ADIIS/DIIS
+   @DF-UHF iter   6:  -149.67119529927672   -9.79056e-04   4.34543e-04 ADIIS/DIIS
+   @DF-UHF iter   7:  -149.67125425357938   -5.89543e-05   6.76766e-05 DIIS
+   @DF-UHF iter   8:  -149.67125621119945   -1.95762e-06   9.39479e-06 DIIS
+   @DF-UHF iter   9:  -149.67125624137401   -3.01746e-08   8.37130e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   3.326737155E-02
+   @Spin Contamination Metric:   3.326938858E-02
    @S^2 Expected:                2.000000000E+00
-   @S^2 Observed:                2.033267372E+00
+   @S^2 Observed:                2.033269389E+00
    @S   Expected:                1.000000000E+00
    @S   Observed:                1.000000000E+00
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
-       1Ag   -20.730437     1B1u  -20.729287     2Ag    -1.812990  
-       2B1u   -1.163057     1B2u   -0.882849     1B3u   -0.882849  
-       3Ag    -0.797858     1B3g   -0.503795     1B2g   -0.503795  
+       1Ag   -20.730439     1B1u  -20.729288     2Ag    -1.812993  
+       2B1u   -1.163060     1B3u   -0.882851     1B2u   -0.882851  
+       3Ag    -0.797859     1B2g   -0.503797     1B3g   -0.503797  
 
     Alpha Virtual:                                                        
 
-       3B1u    0.444228     2B2u    0.670343     2B3u    0.670343  
-       4Ag     0.710914     2B3g    0.797267     2B2g    0.797267  
-       4B1u    0.864170     5Ag     0.873881     5B1u    1.396519  
-       6Ag     1.422487     1B1g    1.422487     3B3u    1.612326  
-       3B2u    1.612326     6B1u    1.908884     1Au     1.908884  
-       7Ag     2.466355     3B3g    2.518504     3B2g    2.518504  
-       7B1u    2.528257     4B2u    3.878194     4B3u    3.878194  
-       8Ag     4.118821     4B3g    4.220494     4B2g    4.220494  
-       9Ag     4.942660     2B1g    4.942660     8B1u    5.113269  
-       5B2u    5.121535     5B3u    5.121535     6B3u    5.246660  
-       6B2u    5.246660    10Ag     5.551199     5B2g    5.636725  
-       5B3g    5.636725     9B1u    6.115912    10B1u    6.389411  
-       2Au     6.389411    11Ag     6.502927     3B1g    6.502927  
-      11B1u    6.745764     3Au     6.745764     6B3g    6.821002  
-       6B2g    6.821002     7B2u    7.049034     7B3u    7.049034  
-      12B1u    7.571289    12Ag     7.663672     7B3g    8.086585  
-       7B2g    8.086585    13Ag     8.189274    13B1u   15.894715  
+       3B1u    0.444228     2B3u    0.670342     2B2u    0.670342  
+       4Ag     0.710913     2B2g    0.797267     2B3g    0.797267  
+       4B1u    0.864169     5Ag     0.873880     5B1u    1.396518  
+       1B1g    1.422487     6Ag     1.422487     3B2u    1.612325  
+       3B3u    1.612325     1Au     1.908884     6B1u    1.908884  
+       7Ag     2.466354     3B2g    2.518504     3B3g    2.518504  
+       7B1u    2.528257     4B3u    3.878192     4B2u    3.878193  
+       8Ag     4.118820     4B2g    4.220492     4B3g    4.220493  
+       2B1g    4.942659     9Ag     4.942659     8B1u    5.113269  
+       5B3u    5.121533     5B2u    5.121533     6B2u    5.246659  
+       6B3u    5.246659    10Ag     5.551197     5B3g    5.636724  
+       5B2g    5.636724     9B1u    6.115912     2Au     6.389410  
+      10B1u    6.389410     3B1g    6.502925    11Ag     6.502925  
+       3Au     6.745763    11B1u    6.745763     6B2g    6.821000  
+       6B3g    6.821000     7B3u    7.049033     7B2u    7.049033  
+      12B1u    7.571288    12Ag     7.663670     7B2g    8.086584  
+       7B3g    8.086584    13Ag     8.189273    13B1u   15.894714  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.677311     1B1u  -20.675444     2Ag    -1.698033  
-       2B1u   -0.956428     3Ag    -0.726315     1B3u   -0.632028  
-       1B2u   -0.632028  
+       1Ag   -20.677310     1B1u  -20.675444     2Ag    -1.698033  
+       2B1u   -0.956427     3Ag    -0.726314     1B2u   -0.632028  
+       1B3u   -0.632028  
 
     Beta Virtual:                                                         
 
-       1B2g    0.158265     1B3g    0.158265     3B1u    0.479795  
-       4Ag     0.719225     2B3u    0.727817     2B2u    0.727817  
-       5Ag     0.894592     2B2g    0.895069     2B3g    0.895069  
-       4B1u    0.930255     5B1u    1.437507     6Ag     1.473088  
-       1B1g    1.473088     3B3u    1.679055     3B2u    1.679055  
-       6B1u    2.006824     1Au     2.006824     7Ag     2.509888  
-       7B1u    2.554916     3B2g    2.569302     3B3g    2.569302  
-       4B3u    3.994092     4B2u    3.994092     8Ag     4.143653  
-       4B2g    4.326400     4B3g    4.326400     2B1g    4.977139  
-       9Ag     4.977139     8B1u    5.151901     5B3u    5.154968  
-       5B2u    5.154968     6B3u    5.304600     6B2u    5.304600  
+       1B3g    0.158265     1B2g    0.158265     3B1u    0.479794  
+       4Ag     0.719225     2B2u    0.727817     2B3u    0.727817  
+       5Ag     0.894592     2B3g    0.895069     2B2g    0.895069  
+       4B1u    0.930255     5B1u    1.437507     6Ag     1.473087  
+       1B1g    1.473087     3B2u    1.679055     3B3u    1.679055  
+       1Au     2.006823     6B1u    2.006823     7Ag     2.509888  
+       7B1u    2.554916     3B3g    2.569302     3B2g    2.569302  
+       4B2u    3.994092     4B3u    3.994092     8Ag     4.143652  
+       4B3g    4.326399     4B2g    4.326400     9Ag     4.977138  
+       2B1g    4.977138     8B1u    5.151901     5B2u    5.154967  
+       5B3u    5.154967     6B3u    5.304599     6B2u    5.304599  
       10Ag     5.586628     5B2g    5.702873     5B3g    5.702873  
        9B1u    6.156238    10B1u    6.450017     2Au     6.450017  
-      11Ag     6.625337     3B1g    6.625337    11B1u    6.848995  
-       3Au     6.848995     6B2g    6.883538     6B3g    6.883538  
-       7B3u    7.105931     7B2u    7.105931    12B1u    7.605403  
-      12Ag     7.731633     7B2g    8.118002     7B3g    8.118002  
-      13Ag     8.209199    13B1u   15.935059  
+       3B1g    6.625337    11Ag     6.625337     3Au     6.848996  
+      11B1u    6.848996     6B3g    6.883538     6B2g    6.883538  
+       7B2u    7.105931     7B3u    7.105932    12B1u    7.605403  
+      12Ag     7.731634     7B3g    8.118001     7B2g    8.118002  
+      13Ag     8.209198    13B1u   15.935058  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @DF-UHF Final Energy:  -149.67125624291742
+  @DF-UHF Final Energy:  -149.67125624137401
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.9149875268774963
-    Two-Electron Energy =                  86.4552391478146376
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6712562429174227
-
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9149710326813647
+    Two-Electron Energy =                  86.4552225341436866
+    Total Energy =                       -149.6712562413740102
 
   UHF NO Occupations:
-  HONO-2 :    1B2u 1.9937497
+  HONO-2 :    1B3u 1.9937493
   HONO-1 :    1B2g 1.0000000
   HONO-0 :    1B3g 1.0000000
-  LUNO+0 :    2B2u 0.0062503
-  LUNO+1 :    2B3u 0.0062503
-  LUNO+2 :    3B1u 0.0031240
-  LUNO+3 :    4 Ag 0.0009740
+  LUNO+0 :    2B3u 0.0062507
+  LUNO+1 :    2B2u 0.0062505
+  LUNO+2 :    3B1u 0.0031242
+  LUNO+3 :    4 Ag 0.0009741
 
 
+Computation Completed
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:08 2017
+*** tstop() called on ds6 at Mon Nov  7 10:56:56 2022
 Module time:
-	user time   =       0.36 seconds =       0.01 minutes
+	user time   =       0.20 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      11.54 seconds =       0.19 minutes
-	system time =       0.37 seconds =       0.01 minutes
-	total time  =         13 seconds =       0.22 minutes
-	Triplet DF UHF energy.............................................PASSED
+	user time   =      20.55 seconds =       0.34 minutes
+	system time =       0.28 seconds =       0.00 minutes
+	total time  =         23 seconds =       0.38 minutes
+    Triplet DiskDF UHF energy.............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:08 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:56 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
-                             ROHF Reference
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
@@ -4315,14 +6685,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 3
@@ -4332,14 +6702,14 @@ Total time:
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is PK.
+  SCF Algorithm Type is MEM_DF.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
   Guess Type is CORE.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -4359,22 +6729,822 @@ Total time:
        1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
        2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ-JKFIT
+    Blend                  = CC-PVTZ-JKFIT
+    Total number of shells = 50
+    Number of primitives   = 50
+    Number of AO           = 192
+    Number of SO           = 158
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+       2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
   ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
 
    -------------------------------------------------------
     Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
    -------------------------------------------------------
-     Ag        13      13       0       0       0       0
+     Ag        13      13       3       2       2       1
      B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
      Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
    -------------------------------------------------------
     Total      60      60       9       7       7       2
    -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+   @DF-UHF iter   1:  -131.02345177007209   -1.31023e+02   3.54007e-01 ADIIS
+   @DF-UHF iter   2:  -140.13876897996707   -9.11532e+00   1.85394e-01 ADIIS
+   @DF-UHF iter   3:  -149.07887534187844   -8.94011e+00   6.20999e-02 ADIIS/DIIS
+   @DF-UHF iter   4:  -149.65353829309876   -5.74663e-01   1.05459e-02 ADIIS/DIIS
+   @DF-UHF iter   5:  -149.67021624295950   -1.66779e-02   1.87099e-03 ADIIS/DIIS
+   @DF-UHF iter   6:  -149.67119529927663   -9.79056e-04   4.34543e-04 ADIIS/DIIS
+   @DF-UHF iter   7:  -149.67125425357943   -5.89543e-05   6.76766e-05 DIIS
+   @DF-UHF iter   8:  -149.67125621119939   -1.95762e-06   9.39479e-06 DIIS
+   @DF-UHF iter   9:  -149.67125624137390   -3.01745e-08   8.37130e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   3.326938858E-02
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.033269389E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.730439     1B1u  -20.729288     2Ag    -1.812993  
+       2B1u   -1.163060     1B3u   -0.882851     1B2u   -0.882851  
+       3Ag    -0.797859     1B2g   -0.503797     1B3g   -0.503797  
+
+    Alpha Virtual:                                                        
+
+       3B1u    0.444228     2B3u    0.670342     2B2u    0.670342  
+       4Ag     0.710913     2B2g    0.797267     2B3g    0.797267  
+       4B1u    0.864169     5Ag     0.873880     5B1u    1.396518  
+       1B1g    1.422487     6Ag     1.422487     3B2u    1.612325  
+       3B3u    1.612325     1Au     1.908884     6B1u    1.908884  
+       7Ag     2.466354     3B2g    2.518504     3B3g    2.518504  
+       7B1u    2.528257     4B3u    3.878192     4B2u    3.878193  
+       8Ag     4.118820     4B2g    4.220492     4B3g    4.220493  
+       2B1g    4.942659     9Ag     4.942659     8B1u    5.113269  
+       5B3u    5.121533     5B2u    5.121533     6B2u    5.246659  
+       6B3u    5.246659    10Ag     5.551197     5B3g    5.636724  
+       5B2g    5.636724     9B1u    6.115912     2Au     6.389410  
+      10B1u    6.389410     3B1g    6.502925    11Ag     6.502925  
+       3Au     6.745763    11B1u    6.745763     6B2g    6.821000  
+       6B3g    6.821000     7B3u    7.049033     7B2u    7.049033  
+      12B1u    7.571288    12Ag     7.663670     7B2g    8.086584  
+       7B3g    8.086584    13Ag     8.189273    13B1u   15.894714  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.677310     1B1u  -20.675444     2Ag    -1.698033  
+       2B1u   -0.956427     3Ag    -0.726314     1B2u   -0.632028  
+       1B3u   -0.632028  
+
+    Beta Virtual:                                                         
+
+       1B3g    0.158265     1B2g    0.158265     3B1u    0.479794  
+       4Ag     0.719225     2B2u    0.727817     2B3u    0.727817  
+       5Ag     0.894592     2B3g    0.895069     2B2g    0.895069  
+       4B1u    0.930255     5B1u    1.437507     6Ag     1.473087  
+       1B1g    1.473087     3B2u    1.679055     3B3u    1.679055  
+       1Au     2.006823     6B1u    2.006823     7Ag     2.509888  
+       7B1u    2.554916     3B3g    2.569302     3B2g    2.569302  
+       4B2u    3.994092     4B3u    3.994092     8Ag     4.143652  
+       4B3g    4.326399     4B2g    4.326400     9Ag     4.977138  
+       2B1g    4.977138     8B1u    5.151901     5B2u    5.154967  
+       5B3u    5.154967     6B3u    5.304599     6B2u    5.304599  
+      10Ag     5.586628     5B2g    5.702873     5B3g    5.702873  
+       9B1u    6.156238    10B1u    6.450017     2Au     6.450017  
+       3B1g    6.625337    11Ag     6.625337     3Au     6.848996  
+      11B1u    6.848996     6B3g    6.883538     6B2g    6.883538  
+       7B2u    7.105931     7B3u    7.105932    12B1u    7.605403  
+      12Ag     7.731634     7B3g    8.118001     7B2g    8.118002  
+      13Ag     8.209198    13B1u   15.935058  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+  @DF-UHF Final Energy:  -149.67125624137390
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9149710326811373
+    Two-Electron Energy =                  86.4552225341436014
+    Total Energy =                       -149.6712562413738965
+
+  UHF NO Occupations:
+  HONO-2 :    1B3u 1.9937493
+  HONO-1 :    1B2g 1.0000000
+  HONO-0 :    1B3g 1.0000000
+  LUNO+0 :    2B3u 0.0062507
+  LUNO+1 :    2B2u 0.0062505
+  LUNO+2 :    3B1u 0.0031242
+  LUNO+3 :    4 Ag 0.0009741
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:56:56 2022
+Module time:
+	user time   =       0.19 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      20.76 seconds =       0.35 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         23 seconds =       0.38 minutes
+    Triplet MemDF UHF energy..............................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:56 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is COSX.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DFJCOSK: Density-Fitted J and Semi-Numerical K <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    Integrals threads:            1
+    Memory [MiB]:               375
+    Incremental Fock :           No
+    J Screening Type:          CSAM
+    J Screening Cutoff:       1E-12
+    K Screening Cutoff:       1E-11
+    K Density Cutoff:         1E-10
+    K Basis Cutoff:           1E-10
+    K Overlap Fitting:          Yes
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+   @UHF iter   1:  -131.02266731942416   -1.31023e+02   3.53990e-01 ADIIS
+   @UHF iter   2:  -140.14034734140625   -9.11768e+00   1.85365e-01 ADIIS
+   @UHF iter   3:  -149.07920849522230   -8.93886e+00   6.20863e-02 ADIIS/DIIS
+   @UHF iter   4:  -149.65391531644991   -5.74707e-01   1.05356e-02 ADIIS/DIIS
+   @UHF iter   5:  -149.67061947228302   -1.67042e-02   1.87593e-03 ADIIS/DIIS
+   @UHF iter   6:  -149.67160507761122   -9.85605e-04   4.33948e-04 ADIIS/DIIS
+   @UHF iter   7:  -149.67166177628386   -5.66987e-05   6.80300e-05 DIIS
+   @UHF iter   8:  -149.67166378928812   -2.01300e-06   9.42637e-06 DIIS
+   @UHF iter   9:  -149.67166383531955   -4.60314e-08   8.91526e-07 DIIS
+  Energy and wave function converged with early screening.
+  Performing final iteration with tighter screening.
+
+   @UHF iter  10:  -149.67132922569726    3.34610e-04   9.51899e-04 ADIIS/DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   3.331439764E-02
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.033314398E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.730772     1B1u  -20.729546     2Ag    -1.813740  
+       2B1u   -1.163314     1B2u   -0.882218     1B3u   -0.882217  
+       3Ag    -0.799384     1B3g   -0.503896     1B2g   -0.503896  
+
+    Alpha Virtual:                                                        
+
+       3B1u    0.444329     2B2u    0.670517     2B3u    0.670517  
+       4Ag     0.710348     2B3g    0.796947     2B2g    0.796947  
+       4B1u    0.864470     5Ag     0.873789     5B1u    1.396284  
+       6Ag     1.420281     1B1g    1.423107     3B3u    1.611149  
+       3B2u    1.611149     6B1u    1.906548     1Au     1.910584  
+       7Ag     2.466806     3B3g    2.517064     3B2g    2.517064  
+       7B1u    2.528119     4B2u    3.877939     4B3u    3.877940  
+       8Ag     4.113448     4B3g    4.221129     4B2g    4.221129  
+       2B1g    4.918101     9Ag     4.958232     8B1u    5.111120  
+       5B2u    5.122609     5B3u    5.122610     6B2u    5.244846  
+       6B3u    5.244846    10Ag     5.537812     5B3g    5.634550  
+       5B2g    5.634550     9B1u    6.107160     2Au     6.371874  
+      10B1u    6.392192    11Ag     6.485824     3B1g    6.499074  
+       3Au     6.730633    11B1u    6.743962     6B3g    6.810037  
+       6B2g    6.810038     7B2u    7.039126     7B3u    7.039126  
+      12B1u    7.566119    12Ag     7.660739     7B3g    8.084981  
+       7B2g    8.084981    13Ag     8.183011    13B1u   15.886740  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.677626     1B1u  -20.675725     2Ag    -1.698332  
+       2B1u   -0.956600     3Ag    -0.727310     1B3u   -0.631515  
+       1B2u   -0.631514  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.158086     1B3g    0.158086     3B1u    0.479650  
+       4Ag     0.718641     2B3u    0.728176     2B2u    0.728176  
+       5Ag     0.894457     2B2g    0.894882     2B3g    0.894883  
+       4B1u    0.930215     5B1u    1.437345     1B1g    1.470738  
+       6Ag     1.473601     3B3u    1.679369     3B2u    1.679369  
+       1Au     2.006168     6B1u    2.006660     7Ag     2.508370  
+       7B1u    2.555354     3B2g    2.568742     3B3g    2.568742  
+       4B3u    3.993805     4B2u    3.993805     8Ag     4.136447  
+       4B2g    4.327665     4B3g    4.327666     2B1g    4.962421  
+       9Ag     4.984749     8B1u    5.149979     5B3u    5.159861  
+       5B2u    5.159861     6B3u    5.302078     6B2u    5.302078  
+      10Ag     5.569946     5B2g    5.701790     5B3g    5.701790  
+       9B1u    6.143770     2Au     6.434583    10B1u    6.458656  
+       3B1g    6.611394    11Ag     6.626259     3Au     6.834872  
+      11B1u    6.853843     6B2g    6.884062     6B3g    6.884062  
+       7B3u    7.105647     7B2u    7.105647    12B1u    7.598863  
+      12Ag     7.728347     7B2g    8.121042     7B3g    8.121042  
+      13Ag     8.201263    13B1u   15.930411  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+  @UHF Final Energy:  -149.67132922569726
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9129345756500129
+    Two-Electron Energy =                  86.4531130927890956
+    Total Energy =                       -149.6713292256972636
+
+  UHF NO Occupations:
+  HONO-2 :    1B2u 1.9937328
+  HONO-1 :    1B2g 1.0000000
+  HONO-0 :    1B3g 1.0000000
+  LUNO+0 :    2B2u 0.0062672
+  LUNO+1 :    2B3u 0.0062670
+  LUNO+2 :    3B1u 0.0031082
+  LUNO+3 :    4 Ag 0.0009778
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:56:59 2022
+Module time:
+	user time   =       2.89 seconds =       0.05 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =      23.67 seconds =       0.39 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         26 seconds =       0.43 minutes
+    Triplet DFJ+COSX UHF energy...........................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:56:59 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is LINK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DFJLinK: Density-Fitted J and Linear Exchange K <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Incremental Fock:           No
+    Screening Type:        DENSITY
+    J Screening Cutoff:      1E-12
+    K Screening Cutoff:      1E-12
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+   @UHF iter   1:  -131.02824188718694   -1.31028e+02   3.53803e-01 ADIIS
+   @UHF iter   2:  -140.14242970807607   -9.11419e+00   1.85341e-01 ADIIS
+   @UHF iter   3:  -149.07857131918411   -8.93614e+00   6.21257e-02 ADIIS/DIIS
+   @UHF iter   4:  -149.65363342630815   -5.75062e-01   1.05493e-02 ADIIS/DIIS
+   @UHF iter   5:  -149.67033333467208   -1.66999e-02   1.87124e-03 ADIIS/DIIS
+   @UHF iter   6:  -149.67131230279944   -9.78968e-04   4.34980e-04 ADIIS/DIIS
+   @UHF iter   7:  -149.67137129107354   -5.89883e-05   6.76925e-05 DIIS
+   @UHF iter   8:  -149.67137324958753   -1.95851e-06   9.40593e-06 DIIS
+   @UHF iter   9:  -149.67137327981726   -3.02297e-08   8.35758e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   3.326831368E-02
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.033268314E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.730397     1B1u  -20.729246     2Ag    -1.812953  
+       2B1u   -1.163048     1B3u   -0.882848     1B2u   -0.882848  
+       3Ag    -0.797861     1B2g   -0.503784     1B3g   -0.503783  
+
+    Alpha Virtual:                                                        
+
+       3B1u    0.444168     2B3u    0.670212     2B2u    0.670212  
+       4Ag     0.710793     2B2g    0.796926     2B3g    0.796926  
+       4B1u    0.864100     5Ag     0.873799     5B1u    1.396020  
+       1B1g    1.421869     6Ag     1.421869     3B2u    1.611942  
+       3B3u    1.611942     1Au     1.908149     6B1u    1.908149  
+       7Ag     2.465936     3B2g    2.517762     3B3g    2.517762  
+       7B1u    2.527776     4B3u    3.877561     4B2u    3.877561  
+       8Ag     4.116498     4B2g    4.219634     4B3g    4.219635  
+       2B1g    4.936203     9Ag     4.936203     8B1u    5.112105  
+       5B3u    5.114308     5B2u    5.114308     6B2u    5.240119  
+       6B3u    5.240119    10Ag     5.544806     5B3g    5.629524  
+       5B2g    5.629524     9B1u    6.112206     2Au     6.380348  
+      10B1u    6.380348     3B1g    6.491701    11Ag     6.491701  
+       3Au     6.734750    11B1u    6.734750     6B2g    6.811242  
+       6B3g    6.811242     7B3u    7.039353     7B2u    7.039354  
+      12B1u    7.563428    12Ag     7.661449     7B2g    8.077288  
+       7B3g    8.077288    13Ag     8.180409    13B1u   15.889192  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.677269     1B1u  -20.675403     2Ag    -1.697996  
+       2B1u   -0.956417     3Ag    -0.726323     1B2u   -0.632035  
+       1B3u   -0.632034  
+
+    Beta Virtual:                                                         
+
+       1B3g    0.158277     1B2g    0.158278     3B1u    0.479779  
+       4Ag     0.719120     2B2u    0.727638     2B3u    0.727638  
+       5Ag     0.894491     2B3g    0.894994     2B2g    0.894995  
+       4B1u    0.930268     5B1u    1.437268     6Ag     1.472588  
+       1B1g    1.472588     3B2u    1.678750     3B3u    1.678750  
+       1Au     2.006498     6B1u    2.006498     7Ag     2.509623  
+       7B1u    2.554689     3B3g    2.568957     3B2g    2.568957  
+       4B2u    3.993592     4B3u    3.993593     8Ag     4.141570  
+       4B3g    4.325866     4B2g    4.325867     9Ag     4.972296  
+       2B1g    4.972296     5B2u    5.149118     5B3u    5.149118  
+       8B1u    5.151025     6B3u    5.300923     6B2u    5.300923  
+      10Ag     5.581631     5B2g    5.699495     5B3g    5.699495  
+       9B1u    6.154160    10B1u    6.445607     2Au     6.445607  
+       3B1g    6.619986    11Ag     6.619986     3Au     6.844470  
+      11B1u    6.844470     6B3g    6.879135     6B2g    6.879135  
+       7B2u    7.100598     7B3u    7.100598    12B1u    7.601296  
+      12Ag     7.730361     7B3g    8.113581     7B2g    8.113581  
+      13Ag     8.204348    13B1u   15.932731  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+  @UHF Final Energy:  -149.67137327981726
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9154789630230198
+    Two-Electron Energy =                  86.4556134260420919
+    Total Energy =                       -149.6713732798172600
+
+  UHF NO Occupations:
+  HONO-2 :    1B3u 1.9937498
+  HONO-1 :    1B2g 1.0000000
+  HONO-0 :    1B3g 1.0000000
+  LUNO+0 :    2B3u 0.0062502
+  LUNO+1 :    2B2u 0.0062501
+  LUNO+2 :    3B1u 0.0031245
+  LUNO+3 :    4 Ag 0.0009742
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:57:02 2022
+Module time:
+	user time   =       1.67 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =      25.36 seconds =       0.42 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =         29 seconds =       0.48 minutes
+    Triplet DFJ+LinK UHF energy...........................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:02 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             ROHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
   ==> Integral Setup <==
 
@@ -4393,19 +7563,39 @@ Total time:
   Using 3350730 doubles for integral storage.
   We computed 22155 shell quartets total.
   Whereas there are 22155 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -4415,116 +7605,122 @@ Total time:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-   @ROHF iter   1:  -131.02769690362535   -1.31028e+02   2.71717e-01 
-   @ROHF iter   2:  -139.63756203688141   -8.60987e+00   1.37369e-01 DIIS
-   @ROHF iter   3:  -148.99587881868288   -9.35832e+00   5.06973e-02 DIIS
-   @ROHF iter   4:  -149.63934883047077   -6.43470e-01   6.07016e-03 DIIS
-   @ROHF iter   5:  -149.65159034033218   -1.22415e-02   4.80913e-04 DIIS
-   @ROHF iter   6:  -149.65170031143239   -1.09971e-04   1.10255e-04 DIIS
-   @ROHF iter   7:  -149.65170750630924   -7.19488e-06   1.71076e-05 DIIS
-   @ROHF iter   8:  -149.65170765416386   -1.47855e-07   2.92758e-06 DIIS
-   @ROHF iter   9:  -149.65170765757185   -3.40799e-09   3.52982e-07 DIIS
+   @ROHF iter   1:  -131.02769686138816   -1.31028e+02   2.71717e-01 DIIS
+   @ROHF iter   2:  -139.63756198441072   -8.60987e+00   1.37369e-01 DIIS
+   @ROHF iter   3:  -148.99587881433192   -9.35832e+00   5.06973e-02 DIIS
+   @ROHF iter   4:  -149.63934882923110   -6.43470e-01   6.07016e-03 DIIS
+   @ROHF iter   5:  -149.65159033915612   -1.22415e-02   4.80913e-04 DIIS
+   @ROHF iter   6:  -149.65170031025437   -1.09971e-04   1.10255e-04 DIIS
+   @ROHF iter   7:  -149.65170750513116   -7.19488e-06   1.71076e-05 DIIS
+   @ROHF iter   8:  -149.65170765298578   -1.47855e-07   2.92758e-06 DIIS
+   @ROHF iter   9:  -149.65170765639351   -3.40773e-09   3.52982e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
        1Ag   -20.707859     1B1u  -20.706327     2Ag    -1.755521  
-       2B1u   -1.059143     3Ag    -0.763678     1B2u   -0.754308  
-       1B3u   -0.754308  
+       2B1u   -1.059143     3Ag    -0.763678     1B3u   -0.754308  
+       1B2u   -0.754308  
 
     Singly Occupied:                                                      
 
-       1B2g   -0.157800     1B3g   -0.157800  
+       1B3g   -0.157800     1B2g   -0.157800  
 
     Virtual:                                                              
 
-       3B1u    0.461626     2B2u    0.696594     2B3u    0.696594  
-       4Ag     0.715168     2B3g    0.832187     2B2g    0.832187  
+       3B1u    0.461626     2B3u    0.696594     2B2u    0.696594  
+       4Ag     0.715168     2B2g    0.832187     2B3g    0.832187  
        5Ag     0.883370     4B1u    0.894737     5B1u    1.415770  
-       1B1g    1.447074     6Ag     1.447074     3B2u    1.643324  
-       3B3u    1.643324     6B1u    1.957069     1Au     1.957069  
-       7Ag     2.486943     7B1u    2.540415     3B3g    2.542980  
-       3B2g    2.542980     4B2u    3.933560     4B3u    3.933560  
-       8Ag     4.127713     4B3g    4.270800     4B2g    4.270800  
+       1B1g    1.447074     6Ag     1.447074     3B3u    1.643324  
+       3B2u    1.643324     6B1u    1.957069     1Au     1.957069  
+       7Ag     2.486943     7B1u    2.540415     3B2g    2.542980  
+       3B3g    2.542980     4B3u    3.933560     4B2u    3.933560  
+       8Ag     4.127713     4B2g    4.270800     4B3g    4.270800  
        2B1g    4.953638     9Ag     4.953638     8B1u    5.130106  
-       5B2u    5.130734     5B3u    5.130734     6B3u    5.269979  
-       6B2u    5.269979    10Ag     5.562295     5B2g    5.663988  
-       5B3g    5.663988     9B1u    6.132429    10B1u    6.413114  
+       5B3u    5.130734     5B2u    5.130734     6B2u    5.269979  
+       6B3u    5.269979    10Ag     5.562295     5B3g    5.663988  
+       5B2g    5.663988     9B1u    6.132429    10B1u    6.413114  
        2Au     6.413114    11Ag     6.554650     3B1g    6.554650  
-      11B1u    6.787811     3Au     6.787811     6B3g    6.844055  
-       6B2g    6.844055     7B2u    7.068873     7B3u    7.068873  
-      12B1u    7.581212    12Ag     7.694005     7B3g    8.094631  
-       7B2g    8.094631    13Ag     8.191302    13B1u   15.908946  
+      11B1u    6.787811     3Au     6.787811     6B2g    6.844055  
+       6B3g    6.844055     7B3u    7.068873     7B2u    7.068873  
+      12B1u    7.581212    12Ag     7.694005     7B2g    8.094631  
+       7B3g    8.094631    13Ag     8.191302    13B1u   15.908946  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @ROHF Final Energy:  -149.65170765757185
+  @ROHF Final Energy:  -149.65170765639351
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.9132198610868727
-    Two-Electron Energy =                  86.4730200673695890
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6517076575718477
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9132200904491015
+    Two-Electron Energy =                  86.4730201768919358
+    Total Energy =                       -149.6517076563935120
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:08 2017
+*** tstop() called on ds6 at Mon Nov  7 10:57:02 2022
 Module time:
-	user time   =       0.45 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.34 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      12.00 seconds =       0.20 minutes
-	system time =       0.39 seconds =       0.01 minutes
-	total time  =         13 seconds =       0.22 minutes
-	Triplet PK ROHF energy............................................PASSED
+	user time   =      25.73 seconds =       0.43 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =         29 seconds =       0.48 minutes
+    Triplet PK ROHF energy................................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:08 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:02 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                              ROHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -4538,14 +7734,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 3
@@ -4562,7 +7758,7 @@ Total time:
   Guess Type is CORE.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -4587,41 +7783,25 @@ Total time:
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   228 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       9       7       7       2
-   -------------------------------------------------------
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   Starting with a DF guess...
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory (MB):               375
-    Algorithm:                Core
-    Integral Cache:           NONE
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -4641,10 +7821,28 @@ Total time:
        1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
        2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -4654,20 +7852,20 @@ Total time:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-   @DF-ROHF iter   1:  -131.02345181239073   -1.31023e+02   2.71866e-01 
-   @DF-ROHF iter   2:  -139.63848017547858   -8.61503e+00   1.37405e-01 DIIS
-   @DF-ROHF iter   3:  -148.99602731281809   -9.35755e+00   5.06816e-02 DIIS
-   @DF-ROHF iter   4:  -149.63927941443970   -6.43252e-01   6.05660e-03 DIIS
-   @DF-ROHF iter   5:  -149.65149023343153   -1.22108e-02   4.82235e-04 DIIS
-   @DF-ROHF iter   6:  -149.65160058036329   -1.10347e-04   1.10507e-04 DIIS
-   @DF-ROHF iter   7:  -149.65160781013830   -7.22978e-06   1.71514e-05 DIIS
-   @DF-ROHF iter   8:  -149.65160795866322   -1.48525e-07   2.92995e-06 DIIS
-   @DF-ROHF iter   9:  -149.65160796207854   -3.41532e-09   3.53720e-07 DIIS
+   @DF-ROHF iter   1:  -131.02345177007203   -1.31023e+02   2.71866e-01 DIIS
+   @DF-ROHF iter   2:  -139.63848012300397   -8.61503e+00   1.37405e-01 DIIS
+   @DF-ROHF iter   3:  -148.99602730846200   -9.35755e+00   5.06816e-02 DIIS
+   @DF-ROHF iter   4:  -149.63927941319787   -6.43252e-01   6.05660e-03 DIIS
+   @DF-ROHF iter   5:  -149.65149023225376   -1.22108e-02   4.82235e-04 DIIS
+   @DF-ROHF iter   6:  -149.65160057918348   -1.10347e-04   1.10507e-04 DIIS
+   @DF-ROHF iter   7:  -149.65160780895835   -7.22977e-06   1.71514e-05 DIIS
+   @DF-ROHF iter   8:  -149.65160795748335   -1.48525e-07   2.92995e-06 DIIS
+   @DF-ROHF iter   9:  -149.65160796089856   -3.41521e-09   3.53720e-07 DIIS
 
   DF guess converged.
-
-  ==> Integral Setup <==
 
   ==> DirectJK: Integral-Direct J/K Matrices <==
 
@@ -4675,111 +7873,117 @@ Total time:
     K tasked:                  Yes
     wK tasked:                  No
     Integrals threads:           1
-    Schwarz Cutoff:          1E-12
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
 
-   @ROHF iter  10:  -149.65170754318160   -9.95811e-05   2.46298e-05 DIIS
-   @ROHF iter  11:  -149.65170765561581   -1.12434e-07   2.81738e-06 DIIS
-   @ROHF iter  12:  -149.65170765742852   -1.81271e-09   8.14306e-07 DIIS
+   @ROHF iter  10:  -149.65170754200332   -1.49652e+02   2.46298e-05 DIIS
+   @ROHF iter  11:  -149.65170765443784   -1.12435e-07   2.81738e-06 DIIS
+   @ROHF iter  12:  -149.65170765625052   -1.81268e-09   8.14306e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
        1Ag   -20.707865     1B1u  -20.706333     2Ag    -1.755524  
-       2B1u   -1.059146     3Ag    -0.763680     1B2u   -0.754310  
-       1B3u   -0.754310  
+       2B1u   -1.059146     3Ag    -0.763680     1B3u   -0.754310  
+       1B2u   -0.754310  
 
     Singly Occupied:                                                      
 
-       1B3g   -0.157803     1B2g   -0.157803  
+       1B2g   -0.157803     1B3g   -0.157803  
 
     Virtual:                                                              
 
-       3B1u    0.461625     2B2u    0.696593     2B3u    0.696593  
-       4Ag     0.715167     2B3g    0.832186     2B2g    0.832186  
+       3B1u    0.461625     2B3u    0.696593     2B2u    0.696593  
+       4Ag     0.715167     2B2g    0.832186     2B3g    0.832186  
        5Ag     0.883369     4B1u    0.894734     5B1u    1.415769  
-       1B1g    1.447073     6Ag     1.447073     3B2u    1.643323  
-       3B3u    1.643323     1Au     1.957067     6B1u    1.957067  
-       7Ag     2.486941     7B1u    2.540413     3B3g    2.542979  
-       3B2g    2.542979     4B2u    3.933556     4B3u    3.933556  
-       8Ag     4.127710     4B3g    4.270797     4B2g    4.270797  
+       1B1g    1.447073     6Ag     1.447073     3B3u    1.643323  
+       3B2u    1.643323     1Au     1.957067     6B1u    1.957067  
+       7Ag     2.486941     7B1u    2.540413     3B2g    2.542979  
+       3B3g    2.542979     4B3u    3.933556     4B2u    3.933556  
+       8Ag     4.127710     4B2g    4.270797     4B3g    4.270797  
        9Ag     4.953635     2B1g    4.953635     8B1u    5.130102  
-       5B2u    5.130732     5B3u    5.130732     6B3u    5.269977  
-       6B2u    5.269977    10Ag     5.562292     5B2g    5.663985  
-       5B3g    5.663985     9B1u    6.132426    10B1u    6.413111  
-       2Au     6.413111     3B1g    6.554647    11Ag     6.554647  
-       3Au     6.787808    11B1u    6.787808     6B3g    6.844052  
-       6B2g    6.844052     7B3u    7.068870     7B2u    7.068870  
-      12B1u    7.581208    12Ag     7.694002     7B2g    8.094628  
-       7B3g    8.094628    13Ag     8.191298    13B1u   15.908942  
+       5B3u    5.130732     5B2u    5.130732     6B2u    5.269977  
+       6B3u    5.269977    10Ag     5.562292     5B3g    5.663985  
+       5B2g    5.663985     9B1u    6.132426    10B1u    6.413111  
+       2Au     6.413111    11Ag     6.554647     3B1g    6.554647  
+      11B1u    6.787808     3Au     6.787808     6B2g    6.844052  
+       6B3g    6.844052     7B2u    7.068870     7B3u    7.068870  
+      12B1u    7.581208    12Ag     7.694002     7B3g    8.094628  
+       7B2g    8.094628    13Ag     8.191298    13B1u   15.908942  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @ROHF Final Energy:  -149.65170765742852
+  @ROHF Final Energy:  -149.65170765625052
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.9131419776000484
-    Two-Electron Energy =                  86.4729421840260954
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6517076574285170
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9131422069586961
+    Two-Electron Energy =                  86.4729422935445200
+    Total Energy =                       -149.6517076562505224
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:10 2017
+*** tstop() called on ds6 at Mon Nov  7 10:57:03 2022
 Module time:
-	user time   =       1.21 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.63 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      13.22 seconds =       0.22 minutes
-	system time =       0.41 seconds =       0.01 minutes
-	total time  =         15 seconds =       0.25 minutes
-	Triplet Direct ROHF energy........................................PASSED
+	user time   =      26.40 seconds =       0.44 minutes
+	system time =       0.32 seconds =       0.01 minutes
+	total time  =         30 seconds =       0.50 minutes
+    Triplet Direct ROHF energy............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:10 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:03 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                              ROHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -4793,14 +7997,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 3
@@ -4817,7 +8021,7 @@ Total time:
   Guess Type is CORE.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -4837,23 +8041,6 @@ Total time:
        1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
        2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       9       7       7       2
-   -------------------------------------------------------
-
   ==> Integral Setup <==
 
   ==> DiskJK: Disk-Based J/K Matrices <==
@@ -4861,13 +8048,31 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -4877,116 +8082,122 @@ Total time:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-   @ROHF iter   1:  -131.02769690362541   -1.31028e+02   2.71717e-01 
-   @ROHF iter   2:  -139.63756203687845   -8.60987e+00   1.37369e-01 DIIS
-   @ROHF iter   3:  -148.99587881868254   -9.35832e+00   5.06973e-02 DIIS
-   @ROHF iter   4:  -149.63934883047082   -6.43470e-01   6.07016e-03 DIIS
-   @ROHF iter   5:  -149.65159034033221   -1.22415e-02   4.80913e-04 DIIS
-   @ROHF iter   6:  -149.65170031143234   -1.09971e-04   1.10255e-04 DIIS
-   @ROHF iter   7:  -149.65170750630924   -7.19488e-06   1.71076e-05 DIIS
-   @ROHF iter   8:  -149.65170765416397   -1.47855e-07   2.92758e-06 DIIS
-   @ROHF iter   9:  -149.65170765757176   -3.40779e-09   3.52982e-07 DIIS
+   @ROHF iter   1:  -131.02769686138816   -1.31028e+02   2.71717e-01 DIIS
+   @ROHF iter   2:  -139.63756198440947   -8.60987e+00   1.37369e-01 DIIS
+   @ROHF iter   3:  -148.99587881433175   -9.35832e+00   5.06973e-02 DIIS
+   @ROHF iter   4:  -149.63934882923107   -6.43470e-01   6.07016e-03 DIIS
+   @ROHF iter   5:  -149.65159033915609   -1.22415e-02   4.80913e-04 DIIS
+   @ROHF iter   6:  -149.65170031025426   -1.09971e-04   1.10255e-04 DIIS
+   @ROHF iter   7:  -149.65170750513113   -7.19488e-06   1.71076e-05 DIIS
+   @ROHF iter   8:  -149.65170765298595   -1.47855e-07   2.92758e-06 DIIS
+   @ROHF iter   9:  -149.65170765639365   -3.40771e-09   3.52982e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
        1Ag   -20.707859     1B1u  -20.706327     2Ag    -1.755521  
-       2B1u   -1.059143     3Ag    -0.763678     1B2u   -0.754308  
-       1B3u   -0.754308  
+       2B1u   -1.059143     3Ag    -0.763678     1B3u   -0.754308  
+       1B2u   -0.754308  
 
     Singly Occupied:                                                      
 
-       1B2g   -0.157800     1B3g   -0.157800  
+       1B3g   -0.157800     1B2g   -0.157800  
 
     Virtual:                                                              
 
-       3B1u    0.461626     2B2u    0.696594     2B3u    0.696594  
-       4Ag     0.715168     2B3g    0.832187     2B2g    0.832187  
+       3B1u    0.461626     2B3u    0.696594     2B2u    0.696594  
+       4Ag     0.715168     2B2g    0.832187     2B3g    0.832187  
        5Ag     0.883370     4B1u    0.894737     5B1u    1.415770  
-       1B1g    1.447074     6Ag     1.447074     3B2u    1.643324  
-       3B3u    1.643324     6B1u    1.957069     1Au     1.957069  
-       7Ag     2.486943     7B1u    2.540415     3B3g    2.542980  
-       3B2g    2.542980     4B2u    3.933560     4B3u    3.933560  
-       8Ag     4.127713     4B3g    4.270800     4B2g    4.270800  
+       1B1g    1.447074     6Ag     1.447074     3B3u    1.643324  
+       3B2u    1.643324     6B1u    1.957069     1Au     1.957069  
+       7Ag     2.486943     7B1u    2.540415     3B2g    2.542980  
+       3B3g    2.542980     4B3u    3.933560     4B2u    3.933560  
+       8Ag     4.127713     4B2g    4.270800     4B3g    4.270800  
        2B1g    4.953638     9Ag     4.953638     8B1u    5.130106  
-       5B2u    5.130734     5B3u    5.130734     6B3u    5.269979  
-       6B2u    5.269979    10Ag     5.562295     5B2g    5.663988  
-       5B3g    5.663988     9B1u    6.132429    10B1u    6.413114  
+       5B3u    5.130734     5B2u    5.130734     6B2u    5.269979  
+       6B3u    5.269979    10Ag     5.562295     5B3g    5.663988  
+       5B2g    5.663988     9B1u    6.132429    10B1u    6.413114  
        2Au     6.413114    11Ag     6.554650     3B1g    6.554650  
-      11B1u    6.787811     3Au     6.787811     6B3g    6.844055  
-       6B2g    6.844055     7B2u    7.068873     7B3u    7.068873  
-      12B1u    7.581212    12Ag     7.694005     7B3g    8.094631  
-       7B2g    8.094631    13Ag     8.191302    13B1u   15.908946  
+      11B1u    6.787811     3Au     6.787811     6B2g    6.844055  
+       6B3g    6.844055     7B3u    7.068873     7B2u    7.068873  
+      12B1u    7.581212    12Ag     7.694005     7B2g    8.094631  
+       7B3g    8.094631    13Ag     8.191302    13B1u   15.908946  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @ROHF Final Energy:  -149.65170765757176
+  @ROHF Final Energy:  -149.65170765639365
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.9132198610863043
-    Two-Electron Energy =                  86.4730200673691201
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6517076575717624
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9132200904492151
+    Two-Electron Energy =                  86.4730201768919073
+    Total Energy =                       -149.6517076563936541
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:11 2017
+*** tstop() called on ds6 at Mon Nov  7 10:57:04 2022
 Module time:
-	user time   =       0.52 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       0.32 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      13.76 seconds =       0.23 minutes
-	system time =       0.45 seconds =       0.01 minutes
-	total time  =         16 seconds =       0.27 minutes
-	Triplet Disk ROHF energy..........................................PASSED
+	user time   =      26.75 seconds =       0.45 minutes
+	system time =       0.33 seconds =       0.01 minutes
+	total time  =         31 seconds =       0.52 minutes
+    Triplet Disk ROHF energy..............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:11 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:04 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                              ROHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -5000,14 +8211,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 3
@@ -5017,14 +8228,14 @@ Total time:
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DF.
+  SCF Algorithm Type is DISK_DF.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
   Guess Type is CORE.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -5049,39 +8260,22 @@ Total time:
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   228 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       9       7       7       2
-   -------------------------------------------------------
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
     OpenMP threads:              1
     Integrals threads:           1
-    Memory (MB):               375
+    Memory [MiB]:              375
     Algorithm:                Core
     Integral Cache:           NONE
     Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
@@ -5101,10 +8295,28 @@ Total time:
        1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
        2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -5114,117 +8326,123 @@ Total time:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-   @DF-ROHF iter   1:  -131.02345181239073   -1.31023e+02   2.71866e-01 
-   @DF-ROHF iter   2:  -139.63848017547858   -8.61503e+00   1.37405e-01 DIIS
-   @DF-ROHF iter   3:  -148.99602731281809   -9.35755e+00   5.06816e-02 DIIS
-   @DF-ROHF iter   4:  -149.63927941443970   -6.43252e-01   6.05660e-03 DIIS
-   @DF-ROHF iter   5:  -149.65149023343153   -1.22108e-02   4.82235e-04 DIIS
-   @DF-ROHF iter   6:  -149.65160058036329   -1.10347e-04   1.10507e-04 DIIS
-   @DF-ROHF iter   7:  -149.65160781013830   -7.22978e-06   1.71514e-05 DIIS
-   @DF-ROHF iter   8:  -149.65160795866322   -1.48525e-07   2.92995e-06 DIIS
-   @DF-ROHF iter   9:  -149.65160796207854   -3.41532e-09   3.53720e-07 DIIS
+   @DF-ROHF iter   1:  -131.02345177007206   -1.31023e+02   2.71866e-01 DIIS
+   @DF-ROHF iter   2:  -139.63848012300417   -8.61503e+00   1.37405e-01 DIIS
+   @DF-ROHF iter   3:  -148.99602730846198   -9.35755e+00   5.06816e-02 DIIS
+   @DF-ROHF iter   4:  -149.63927941319798   -6.43252e-01   6.05660e-03 DIIS
+   @DF-ROHF iter   5:  -149.65149023225385   -1.22108e-02   4.82235e-04 DIIS
+   @DF-ROHF iter   6:  -149.65160057918351   -1.10347e-04   1.10507e-04 DIIS
+   @DF-ROHF iter   7:  -149.65160780895840   -7.22977e-06   1.71514e-05 DIIS
+   @DF-ROHF iter   8:  -149.65160795748335   -1.48525e-07   2.92995e-06 DIIS
+   @DF-ROHF iter   9:  -149.65160796089864   -3.41529e-09   3.53720e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
        1Ag   -20.707896     1B1u  -20.706365     2Ag    -1.755566  
-       2B1u   -1.059159     3Ag    -0.763689     1B2u   -0.754303  
-       1B3u   -0.754303  
+       2B1u   -1.059159     3Ag    -0.763689     1B3u   -0.754303  
+       1B2u   -0.754303  
 
     Singly Occupied:                                                      
 
-       1B2g   -0.157824     1B3g   -0.157824  
+       1B3g   -0.157824     1B2g   -0.157824  
 
     Virtual:                                                              
 
-       3B1u    0.461780     2B2u    0.696793     2B3u    0.696793  
-       4Ag     0.715339     2B3g    0.832386     2B2g    0.832386  
+       3B1u    0.461780     2B3u    0.696793     2B2u    0.696793  
+       4Ag     0.715339     2B2g    0.832386     2B3g    0.832386  
        5Ag     0.883425     4B1u    0.894801     5B1u    1.416132  
-       1B1g    1.447608     6Ag     1.447608     3B2u    1.643635  
-       3B3u    1.643635     6B1u    1.957623     1Au     1.957623  
-       7Ag     2.487334     7B1u    2.540858     3B3g    2.543482  
-       3B2g    2.543482     4B2u    3.934193     4B3u    3.934193  
-       8Ag     4.129891     4B3g    4.271595     4B2g    4.271595  
+       1B1g    1.447608     6Ag     1.447608     3B3u    1.643635  
+       3B2u    1.643635     6B1u    1.957623     1Au     1.957623  
+       7Ag     2.487334     7B1u    2.540858     3B2g    2.543482  
+       3B3g    2.543482     4B3u    3.934193     4B2u    3.934193  
+       8Ag     4.129891     4B2g    4.271595     4B3g    4.271595  
        2B1g    4.959384     9Ag     4.959384     8B1u    5.131186  
-       5B2u    5.137429     5B3u    5.137429     6B3u    5.275113  
-       6B2u    5.275113    10Ag     5.567698     5B2g    5.669314  
-       5B3g    5.669314     9B1u    6.135277    10B1u    6.419792  
+       5B3u    5.137429     5B2u    5.137429     6B2u    5.275113  
+       6B3u    5.275113    10Ag     5.567698     5B3g    5.669314  
+       5B2g    5.669314     9B1u    6.135277    10B1u    6.419792  
        2Au     6.419792    11Ag     6.562727     3B1g    6.562727  
-      11B1u    6.795495     3Au     6.795495     6B3g    6.851179  
-       6B2g    6.851179     7B2u    7.076375     7B3u    7.076375  
-      12B1u    7.586881    12Ag     7.695812     7B3g    8.101576  
-       7B2g    8.101576    13Ag     8.198018    13B1u   15.912912  
+      11B1u    6.795495     3Au     6.795495     6B2g    6.851179  
+       6B3g    6.851179     7B3u    7.076375     7B2u    7.076375  
+      12B1u    7.586881    12Ag     7.695812     7B2g    8.101576  
+       7B3g    8.101576    13Ag     8.198018    13B1u   15.912912  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @DF-ROHF Final Energy:  -149.65160796207854
+  @DF-ROHF Final Energy:  -149.65160796089864
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.9126966169234834
-    Two-Electron Energy =                  86.4725965186995040
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6516079620785433
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9126968462735476
+    Two-Electron Energy =                  86.4725966282112353
+    Total Energy =                       -149.6516079608986729
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:11 2017
+*** tstop() called on ds6 at Mon Nov  7 10:57:04 2022
 Module time:
-	user time   =       0.35 seconds =       0.01 minutes
+	user time   =       0.16 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.12 seconds =       0.24 minutes
-	system time =       0.47 seconds =       0.01 minutes
-	total time  =         16 seconds =       0.27 minutes
-	Triplet DF ROHF energy............................................PASSED
+	user time   =      26.94 seconds =       0.45 minutes
+	system time =       0.34 seconds =       0.01 minutes
+	total time  =         31 seconds =       0.52 minutes
+    Triplet DiskDF ROHF energy............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:11 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:04 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
-                             CUHF Reference
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             ROHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
@@ -5237,14 +8455,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 3
@@ -5254,14 +8472,14 @@ Total time:
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is PK.
+  SCF Algorithm Type is MEM_DF.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
   Guess Type is CORE.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -5281,22 +8499,705 @@ Total time:
        1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
        2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ-JKFIT
+    Blend                  = CC-PVTZ-JKFIT
+    Total number of shells = 50
+    Number of primitives   = 50
+    Number of AO           = 192
+    Number of SO           = 158
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+       2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
   ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
 
    -------------------------------------------------------
     Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
    -------------------------------------------------------
-     Ag        13      13       0       0       0       0
+     Ag        13      13       3       2       2       1
      B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
      Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
    -------------------------------------------------------
     Total      60      60       9       7       7       2
    -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+   @DF-ROHF iter   1:  -131.02345177007203   -1.31023e+02   2.71866e-01 DIIS
+   @DF-ROHF iter   2:  -139.63848012300397   -8.61503e+00   1.37405e-01 DIIS
+   @DF-ROHF iter   3:  -148.99602730846200   -9.35755e+00   5.06816e-02 DIIS
+   @DF-ROHF iter   4:  -149.63927941319787   -6.43252e-01   6.05660e-03 DIIS
+   @DF-ROHF iter   5:  -149.65149023225376   -1.22108e-02   4.82235e-04 DIIS
+   @DF-ROHF iter   6:  -149.65160057918348   -1.10347e-04   1.10507e-04 DIIS
+   @DF-ROHF iter   7:  -149.65160780895835   -7.22977e-06   1.71514e-05 DIIS
+   @DF-ROHF iter   8:  -149.65160795748335   -1.48525e-07   2.92995e-06 DIIS
+   @DF-ROHF iter   9:  -149.65160796089856   -3.41521e-09   3.53720e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -20.707896     1B1u  -20.706365     2Ag    -1.755566  
+       2B1u   -1.059159     3Ag    -0.763689     1B3u   -0.754303  
+       1B2u   -0.754303  
+
+    Singly Occupied:                                                      
+
+       1B3g   -0.157824     1B2g   -0.157824  
+
+    Virtual:                                                              
+
+       3B1u    0.461780     2B3u    0.696793     2B2u    0.696793  
+       4Ag     0.715339     2B2g    0.832386     2B3g    0.832386  
+       5Ag     0.883425     4B1u    0.894801     5B1u    1.416132  
+       1B1g    1.447608     6Ag     1.447608     3B3u    1.643635  
+       3B2u    1.643635     6B1u    1.957623     1Au     1.957623  
+       7Ag     2.487334     7B1u    2.540858     3B2g    2.543482  
+       3B3g    2.543482     4B3u    3.934193     4B2u    3.934193  
+       8Ag     4.129891     4B2g    4.271595     4B3g    4.271595  
+       2B1g    4.959384     9Ag     4.959384     8B1u    5.131186  
+       5B3u    5.137429     5B2u    5.137429     6B2u    5.275113  
+       6B3u    5.275113    10Ag     5.567698     5B3g    5.669314  
+       5B2g    5.669314     9B1u    6.135277    10B1u    6.419792  
+       2Au     6.419792    11Ag     6.562727     3B1g    6.562727  
+      11B1u    6.795495     3Au     6.795495     6B2g    6.851179  
+       6B3g    6.851179     7B3u    7.076375     7B2u    7.076375  
+      12B1u    7.586881    12Ag     7.695812     7B2g    8.101576  
+       7B3g    8.101576    13Ag     8.198018    13B1u   15.912912  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+  @DF-ROHF Final Energy:  -149.65160796089856
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9126968462732066
+    Two-Electron Energy =                  86.4725966282109937
+    Total Energy =                       -149.6516079608985592
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:57:04 2022
+Module time:
+	user time   =       0.14 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      27.11 seconds =       0.45 minutes
+	system time =       0.34 seconds =       0.01 minutes
+	total time  =         31 seconds =       0.52 minutes
+    Triplet MemDF ROHF energy.............................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:04 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             ROHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is COSX.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DFJCOSK: Density-Fitted J and Semi-Numerical K <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    Integrals threads:            1
+    Memory [MiB]:               375
+    Incremental Fock :           No
+    J Screening Type:          CSAM
+    J Screening Cutoff:       1E-12
+    K Screening Cutoff:       1E-11
+    K Density Cutoff:         1E-10
+    K Basis Cutoff:           1E-10
+    K Overlap Fitting:          Yes
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+   @ROHF iter   1:  -131.02266731942382   -1.31023e+02   2.71851e-01 DIIS
+   @ROHF iter   2:  -139.64070004271159   -8.61803e+00   1.37369e-01 DIIS
+   @ROHF iter   3:  -148.99660951088319   -9.35591e+00   5.06619e-02 DIIS
+   @ROHF iter   4:  -149.63963700749684   -6.43027e-01   6.07525e-03 DIIS
+   @ROHF iter   5:  -149.65187157255187   -1.22346e-02   4.84799e-04 DIIS
+   @ROHF iter   6:  -149.65198834090879   -1.16768e-04   1.12106e-04 DIIS
+   @ROHF iter   7:  -149.65199670359939   -8.36269e-06   1.71152e-05 DIIS
+   @ROHF iter   8:  -149.65199683539879   -1.31799e-07   2.91717e-06 DIIS
+   @ROHF iter   9:  -149.65199681028335    2.51154e-08   3.52335e-07 DIIS
+  Energy and wave function converged with early screening.
+  Performing final iteration with tighter screening.
+
+   @ROHF iter  10:  -149.65168894022727    3.07870e-04   6.55828e-04 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -20.708196     1B1u  -20.706609     2Ag    -1.756059  
+       2B1u   -1.059376     3Ag    -0.764921     1B3u   -0.753708  
+       1B2u   -0.753708  
+
+    Singly Occupied:                                                      
+
+       1B3g   -0.157985     1B2g   -0.157985  
+
+    Virtual:                                                              
+
+       3B1u    0.461735     2B3u    0.697063     2B2u    0.697063  
+       4Ag     0.714766     2B2g    0.832143     2B3g    0.832143  
+       5Ag     0.883327     4B1u    0.894980     5B1u    1.415920  
+       1B1g    1.446721     6Ag     1.446807     3B3u    1.643219  
+       3B2u    1.643219     6B1u    1.956426     1Au     1.958092  
+       7Ag     2.486772     7B1u    2.541010     3B2g    2.542497  
+       3B3g    2.542497     4B3u    3.933943     4B2u    3.933943  
+       8Ag     4.123615     4B2g    4.272558     4B3g    4.272558  
+       2B1g    4.939780     9Ag     4.971002     8B1u    5.129150  
+       5B3u    5.140622     5B2u    5.140622     6B2u    5.272852  
+       6B3u    5.272852    10Ag     5.552669     5B3g    5.667732  
+       5B2g    5.667732     9B1u    6.124645     2Au     6.402918  
+      10B1u    6.426259     3B1g    6.553807    11Ag     6.554789  
+       3Au     6.781299    11B1u    6.796430     6B2g    6.846007  
+       6B3g    6.846007     7B3u    7.071314     7B2u    7.071314  
+      12B1u    7.581090    12Ag     7.692732     7B2g    8.102333  
+       7B3g    8.102333    13Ag     8.190929    13B1u   15.906640  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+  @ROHF Final Energy:  -149.65168894022727
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9107678299204736
+    Two-Electron Energy =                  86.4705866325295460
+    Total Energy =                       -149.6516889402272739
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:57:07 2022
+Module time:
+	user time   =       2.90 seconds =       0.05 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =      30.04 seconds =       0.50 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =         34 seconds =       0.57 minutes
+    Triplet DFJ+COSX ROHF energy..........................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:07 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             ROHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is LINK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DFJLinK: Density-Fitted J and Linear Exchange K <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Incremental Fock:           No
+    Screening Type:        DENSITY
+    J Screening Cutoff:      1E-12
+    K Screening Cutoff:      1E-12
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+   @ROHF iter   1:  -131.02824188718682   -1.31028e+02   2.71714e-01 DIIS
+   @ROHF iter   2:  -139.64248621827869   -8.61424e+00   1.37347e-01 DIIS
+   @ROHF iter   3:  -148.99631152891027   -9.35383e+00   5.06779e-02 DIIS
+   @ROHF iter   4:  -149.63937032309826   -6.43059e-01   6.06814e-03 DIIS
+   @ROHF iter   5:  -149.65160824495248   -1.22379e-02   4.80885e-04 DIIS
+   @ROHF iter   6:  -149.65171822705017   -1.09982e-04   1.10279e-04 DIIS
+   @ROHF iter   7:  -149.65172542352070   -7.19647e-06   1.71093e-05 DIIS
+   @ROHF iter   8:  -149.65172557125476   -1.47734e-07   2.92802e-06 DIIS
+   @ROHF iter   9:  -149.65172557466224   -3.40748e-09   3.52763e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -20.707858     1B1u  -20.706326     2Ag    -1.755530  
+       2B1u   -1.059150     3Ag    -0.763697     1B3u   -0.754307  
+       1B2u   -0.754307  
+
+    Singly Occupied:                                                      
+
+       1B3g   -0.157812     1B2g   -0.157812  
+
+    Virtual:                                                              
+
+       3B1u    0.461736     2B3u    0.696641     2B2u    0.696641  
+       4Ag     0.715227     2B2g    0.832163     2B3g    0.832163  
+       5Ag     0.883333     4B1u    0.894773     5B1u    1.415748  
+       1B1g    1.447044     6Ag     1.447044     3B3u    1.643286  
+       3B2u    1.643286     6B1u    1.957079     1Au     1.957079  
+       7Ag     2.486988     7B1u    2.540503     3B2g    2.542930  
+       3B3g    2.542930     4B3u    3.933628     4B2u    3.933628  
+       8Ag     4.127685     4B2g    4.270895     4B3g    4.270895  
+       2B1g    4.953744     9Ag     4.953744     8B1u    5.130163  
+       5B3u    5.130893     5B2u    5.130893     6B2u    5.270024  
+       6B3u    5.270024    10Ag     5.562008     5B3g    5.664045  
+       5B2g    5.664045     9B1u    6.132402    10B1u    6.413114  
+       2Au     6.413114    11Ag     6.554488     3B1g    6.554488  
+      11B1u    6.787740     3Au     6.787740     6B2g    6.844132  
+       6B3g    6.844132     7B3u    7.068897     7B2u    7.068897  
+      12B1u    7.580928    12Ag     7.694062     7B2g    8.094735  
+       7B3g    8.094735    13Ag     8.191179    13B1u   15.908998  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+  @ROHF Final Energy:  -149.65172557466224
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9131721397234287
+    Two-Electron Energy =                  86.4729543078975382
+    Total Energy =                       -149.6517255746622368
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:57:09 2022
+Module time:
+	user time   =       1.64 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      31.70 seconds =       0.53 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =         36 seconds =       0.60 minutes
+    Triplet DFJ+LinK ROHF energy..........................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:09 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             CUHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
   ==> Integral Setup <==
 
@@ -5315,19 +9216,39 @@ Total time:
   Using 3350730 doubles for integral storage.
   We computed 22155 shell quartets total.
   Whereas there are 22155 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -5337,143 +9258,149 @@ Total time:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-   @CUHF iter   1:  -131.02769690362533   -1.31028e+02   3.52940e-01 
-   @CUHF iter   2:  -140.10353918415095   -9.07584e+00   1.84876e-01 DIIS
-   @CUHF iter   3:  -149.25243616104672   -9.14890e+00   5.00764e-02 DIIS
-   @CUHF iter   4:  -149.63817985442998   -3.85744e-01   8.24004e-03 DIIS
-   @CUHF iter   5:  -149.65162024791448   -1.34404e-02   5.96010e-04 DIIS
-   @CUHF iter   6:  -149.65170615921505   -8.59113e-05   1.68325e-04 DIIS
-   @CUHF iter   7:  -149.65170608248951    7.67255e-08   1.75800e-05 DIIS
-   @CUHF iter   8:  -149.65170750687167   -1.42438e-06   1.96161e-06 DIIS
-   @CUHF iter   9:  -149.65170767801641   -1.71145e-07   3.18125e-07 DIIS
+   @CUHF iter   1:  -131.02769686138825   -1.31028e+02   3.53708e-01 ADIIS
+   @CUHF iter   2:  -140.10353912873543   -9.07584e+00   1.85166e-01 ADIIS
+   @CUHF iter   3:  -149.07256385046506   -8.96902e+00   6.18739e-02 ADIIS/DIIS
+   @CUHF iter   4:  -149.63818987448280   -5.65626e-01   1.00903e-02 ADIIS/DIIS
+   @CUHF iter   5:  -149.65122786458716   -1.30380e-02   1.50677e-03 ADIIS/DIIS
+   @CUHF iter   6:  -149.65168121631356   -4.53352e-04   2.17117e-04 ADIIS/DIIS
+   @CUHF iter   7:  -149.65170871431565   -2.74980e-05   1.84194e-05 DIIS
+   @CUHF iter   8:  -149.65170789138176    8.22934e-07   2.07188e-06 DIIS
+   @CUHF iter   9:  -149.65170764199598    2.49386e-07   3.39347e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
 
-  @Spin Contamination Metric:  0.00000
+  @Spin Contamination Metric: -0.00000
   @S^2 Expected:               2.00000
   @S^2 Observed:               2.00000
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
-       1Ag   -20.728398     1B1u  -20.727317     2Ag    -1.805358  
-       2B1u   -1.148926     1B3u   -0.865420     1B2u   -0.865420  
-       3Ag    -0.800964     1B2g   -0.482421     1B3g   -0.482420  
+       1Ag   -20.728399     1B1u  -20.727318     2Ag    -1.805358  
+       2B1u   -1.148926     1B2u   -0.865420     1B3u   -0.865420  
+       3Ag    -0.800964     1B3g   -0.482421     1B2g   -0.482421  
 
     Alpha Virtual:                                                        
 
-       3B1u    0.445206     2B3u    0.672317     2B2u    0.672317  
-       4Ag     0.708739     2B2g    0.800671     2B3g    0.800671  
+       3B1u    0.445206     2B2u    0.672317     2B3u    0.672317  
+       4Ag     0.708739     2B3g    0.800671     2B2g    0.800671  
        4B1u    0.864363     5Ag     0.868581     5B1u    1.397473  
-       6Ag     1.417440     1B1g    1.417440     3B2u    1.606467  
-       3B3u    1.606467     6B1u    1.908620     1Au     1.908620  
-       7Ag     2.465527     3B2g    2.517400     3B3g    2.517400  
-       7B1u    2.526368     4B3u    3.885569     4B2u    3.885569  
-       8Ag     4.114424     4B2g    4.226227     4B3g    4.226227  
-       9Ag     4.935165     2B1g    4.935165     8B1u    5.113334  
+       1B1g    1.417439     6Ag     1.417439     3B2u    1.606467  
+       3B3u    1.606467     1Au     1.908620     6B1u    1.908620  
+       7Ag     2.465527     3B3g    2.517400     3B2g    2.517400  
+       7B1u    2.526368     4B2u    3.885569     4B3u    3.885569  
+       8Ag     4.114424     4B3g    4.226227     4B2g    4.226227  
+       2B1g    4.935165     9Ag     4.935165     8B1u    5.113334  
        5B2u    5.113951     5B3u    5.113951     6B3u    5.242036  
        6B2u    5.242036    10Ag     5.545666     5B2g    5.632396  
-       5B3g    5.632396     9B1u    6.112627    10B1u    6.383378  
-       2Au     6.383378    11Ag     6.502619     3B1g    6.502619  
-      11B1u    6.743007     3Au     6.743007     6B2g    6.815077  
-       6B3g    6.815077     7B2u    7.042409     7B3u    7.042409  
+       5B3g    5.632396     9B1u    6.112627     2Au     6.383378  
+      10B1u    6.383378     3B1g    6.502619    11Ag     6.502619  
+       3Au     6.743007    11B1u    6.743007     6B3g    6.815077  
+       6B2g    6.815077     7B2u    7.042408     7B3u    7.042408  
       12B1u    7.564791    12Ag     7.667198     7B3g    8.077952  
-       7B2g    8.077952    13Ag     8.179857    13B1u   15.891842  
+       7B2g    8.077952    13Ag     8.179857    13B1u   15.891841  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.687355     1B1u  -20.685384     2Ag    -1.707004  
-       2B1u   -0.969314     3Ag    -0.725037     1B3u   -0.643196  
-       1B2u   -0.643196  
+       1Ag   -20.687356     1B1u  -20.685385     2Ag    -1.707004  
+       2B1u   -0.969314     3Ag    -0.725037     1B2u   -0.643196  
+       1B3u   -0.643196  
 
     Beta Virtual:                                                         
 
-       1B2g    0.142303     1B3g    0.142303     3B1u    0.476687  
-       2B3u    0.720163     2B2u    0.720164     4Ag     0.721317  
-       2B2g    0.886306     2B3g    0.886306     5Ag     0.898292  
-       4B1u    0.926155     5B1u    1.434129     1B1g    1.476431  
-       6Ag     1.476431     3B3u    1.680294     3B2u    1.680294  
-       1Au     2.005182     6B1u    2.005182     7Ag     2.508285  
-       7B1u    2.554508     3B2g    2.569162     3B3g    2.569162  
+       1B2g    0.142302     1B3g    0.142302     3B1u    0.476687  
+       2B2u    0.720163     2B3u    0.720163     4Ag     0.721317  
+       2B2g    0.886305     2B3g    0.886305     5Ag     0.898292  
+       4B1u    0.926155     5B1u    1.434129     6Ag     1.476431  
+       1B1g    1.476431     3B2u    1.680293     3B3u    1.680293  
+       6B1u    2.005181     1Au     2.005181     7Ag     2.508284  
+       7B1u    2.554508     3B3g    2.569162     3B2g    2.569162  
        4B2u    3.981990     4B3u    3.981990     8Ag     4.141020  
-       4B3g    4.316497     4B2g    4.316497     2B1g    4.972124  
-       9Ag     4.972124     8B1u    5.146924     5B2u    5.147607  
-       5B3u    5.147607     6B3u    5.297922     6B2u    5.297922  
-      10Ag     5.578973     5B3g    5.695578     5B2g    5.695578  
-       9B1u    6.152246     2Au     6.441970    10B1u    6.441970  
-       3B1g    6.606944    11Ag     6.606944     3Au     6.833830  
-      11B1u    6.833830     6B3g    6.873085     6B2g    6.873085  
-       7B2u    7.095403     7B3u    7.095403    12B1u    7.597746  
-      12Ag     7.720940     7B3g    8.111447     7B2g    8.111447  
-      13Ag     8.202771    13B1u   15.926079  
+       4B2g    4.316496     4B3g    4.316496     9Ag     4.972124  
+       2B1g    4.972124     8B1u    5.146923     5B2u    5.147606  
+       5B3u    5.147606     6B3u    5.297922     6B2u    5.297922  
+      10Ag     5.578972     5B3g    5.695578     5B2g    5.695578  
+       9B1u    6.152246    10B1u    6.441970     2Au     6.441970  
+      11Ag     6.606944     3B1g    6.606944    11B1u    6.833830  
+       3Au     6.833830     6B3g    6.873084     6B2g    6.873084  
+       7B2u    7.095402     7B3u    7.095402    12B1u    7.597746  
+      12Ag     7.720940     7B3g    8.111446     7B2g    8.111446  
+      13Ag     8.202770    13B1u   15.926079  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @CUHF Final Energy:  -149.65170767801641
+  @CUHF Final Energy:  -149.65170764199598
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.9132748873976198
-    Two-Electron Energy =                  86.4730750732357762
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6517076780164075
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9132492797450595
+    Two-Electron Energy =                  86.4730493805854223
+    Total Energy =                       -149.6517076419959835
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:12 2017
+*** tstop() called on ds6 at Mon Nov  7 10:57:09 2022
 Module time:
-	user time   =       0.47 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.60 seconds =       0.24 minutes
-	system time =       0.50 seconds =       0.01 minutes
-	total time  =         17 seconds =       0.28 minutes
-	Triplet PK CUHF energy............................................PASSED
+	user time   =      32.09 seconds =       0.53 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =         36 seconds =       0.60 minutes
+    Triplet PK CUHF energy................................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:12 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:09 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                              CUHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -5487,14 +9414,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 3
@@ -5511,7 +9438,7 @@ Total time:
   Guess Type is CORE.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -5536,41 +9463,25 @@ Total time:
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   228 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       9       7       7       2
-   -------------------------------------------------------
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   Starting with a DF guess...
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
 
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    OpenMP threads:              1
-    Integrals threads:           1
-    Memory (MB):               375
-    Algorithm:                Core
-    Integral Cache:           NONE
-    Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
 
    => Auxiliary Basis Set <=
 
@@ -5590,10 +9501,28 @@ Total time:
        1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
        2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -5603,20 +9532,20 @@ Total time:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-   @DF-CUHF iter   1:  -131.02345181239073   -1.31023e+02   3.53137e-01 
-   @DF-CUHF iter   2:  -140.10421230723642   -9.08076e+00   1.84897e-01 DIIS
-   @DF-CUHF iter   3:  -149.25215682201255   -9.14794e+00   5.00787e-02 DIIS
-   @DF-CUHF iter   4:  -149.63807305829354   -3.85916e-01   8.23713e-03 DIIS
-   @DF-CUHF iter   5:  -149.65151993459835   -1.34469e-02   5.97253e-04 DIIS
-   @DF-CUHF iter   6:  -149.65160644610305   -8.65115e-05   1.68622e-04 DIIS
-   @DF-CUHF iter   7:  -149.65160638241099    6.36921e-08   1.76713e-05 DIIS
-   @DF-CUHF iter   8:  -149.65160780780127   -1.42539e-06   1.98195e-06 DIIS
-   @DF-CUHF iter   9:  -149.65160798263014   -1.74829e-07   3.19572e-07 DIIS
+   @DF-CUHF iter   1:  -131.02345177007203   -1.31023e+02   3.53905e-01 ADIIS
+   @DF-CUHF iter   2:  -140.10421225181634   -9.08076e+00   1.85188e-01 ADIIS
+   @DF-CUHF iter   3:  -149.07251737243496   -8.96831e+00   6.18656e-02 ADIIS/DIIS
+   @DF-CUHF iter   4:  -149.63808950369364   -5.65572e-01   1.00945e-02 ADIIS/DIIS
+   @DF-CUHF iter   5:  -149.65112849378588   -1.30390e-02   1.50612e-03 ADIIS/DIIS
+   @DF-CUHF iter   6:  -149.65158147606775   -4.52982e-04   2.16998e-04 ADIIS/DIIS
+   @DF-CUHF iter   7:  -149.65160902343251   -2.75474e-05   1.83726e-05 DIIS
+   @DF-CUHF iter   8:  -149.65160819598432    8.27448e-07   2.07458e-06 DIIS
+   @DF-CUHF iter   9:  -149.65160794655134    2.49433e-07   3.38450e-07 DIIS
 
   DF guess converged.
-
-  ==> Integral Setup <==
 
   ==> DirectJK: Integral-Direct J/K Matrices <==
 
@@ -5624,11 +9553,15 @@ Total time:
     K tasked:                  Yes
     wK tasked:                  No
     Integrals threads:           1
-    Schwarz Cutoff:          1E-12
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
 
-   @CUHF iter  10:  -149.65170754694796   -9.95643e-05   3.40716e-05 DIIS
-   @CUHF iter  11:  -149.65170747262351    7.43244e-08   3.62414e-06 DIIS
-   @CUHF iter  12:  -149.65170769435528   -2.21732e-07   9.72666e-07 DIIS
+   @CUHF iter  10:  -149.65170753973436   -1.49652e+02   3.40853e-05 DIIS
+   @CUHF iter  11:  -149.65170747128730    6.84471e-08   3.65908e-06 DIIS
+   @CUHF iter  12:  -149.65170769300599   -2.21719e-07   9.71682e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
@@ -5636,126 +9569,128 @@ Total time:
   @Spin Contamination Metric:  0.00000
   @S^2 Expected:               2.00000
   @S^2 Observed:               2.00000
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
        1Ag   -20.728403     1B1u  -20.727322     2Ag    -1.805360  
-       2B1u   -1.148928     1B3u   -0.865421     1B2u   -0.865421  
-       3Ag    -0.800966     1B2g   -0.482423     1B3g   -0.482423  
+       2B1u   -1.148928     1B2u   -0.865421     1B3u   -0.865421  
+       3Ag    -0.800966     1B3g   -0.482423     1B2g   -0.482423  
 
     Alpha Virtual:                                                        
 
-       3B1u    0.445206     2B3u    0.672317     2B2u    0.672317  
-       4Ag     0.708738     2B2g    0.800670     2B3g    0.800670  
+       3B1u    0.445206     2B2u    0.672317     2B3u    0.672317  
+       4Ag     0.708738     2B3g    0.800670     2B2g    0.800670  
        4B1u    0.864361     5Ag     0.868580     5B1u    1.397472  
-       6Ag     1.417439     1B1g    1.417439     3B2u    1.606466  
-       3B3u    1.606466     6B1u    1.908619     1Au     1.908619  
-       7Ag     2.465526     3B2g    2.517399     3B3g    2.517399  
-       7B1u    2.526367     4B3u    3.885567     4B2u    3.885567  
-       8Ag     4.114422     4B2g    4.226225     4B3g    4.226225  
-       9Ag     4.935163     2B1g    4.935163     8B1u    5.113332  
-       5B3u    5.113949     5B2u    5.113949     6B3u    5.242035  
+       1B1g    1.417439     6Ag     1.417439     3B3u    1.606466  
+       3B2u    1.606466     1Au     1.908619     6B1u    1.908619  
+       7Ag     2.465526     3B3g    2.517399     3B2g    2.517399  
+       7B1u    2.526367     4B2u    3.885567     4B3u    3.885567  
+       8Ag     4.114422     4B3g    4.226225     4B2g    4.226225  
+       2B1g    4.935163     9Ag     4.935163     8B1u    5.113332  
+       5B2u    5.113949     5B3u    5.113949     6B3u    5.242035  
        6B2u    5.242035    10Ag     5.545664     5B2g    5.632395  
-       5B3g    5.632395     9B1u    6.112625    10B1u    6.383377  
-       2Au     6.383377    11Ag     6.502617     3B1g    6.502617  
-      11B1u    6.743005     3Au     6.743005     6B2g    6.815074  
-       6B3g    6.815074     7B3u    7.042406     7B2u    7.042406  
-      12B1u    7.564788    12Ag     7.667196     7B3g    8.077950  
-       7B2g    8.077950    13Ag     8.179855    13B1u   15.891839  
+       5B3g    5.632395     9B1u    6.112625     2Au     6.383377  
+      10B1u    6.383377     3B1g    6.502617    11Ag     6.502617  
+       3Au     6.743005    11B1u    6.743005     6B3g    6.815074  
+       6B2g    6.815074     7B2u    7.042406     7B3u    7.042406  
+      12B1u    7.564788    12Ag     7.667196     7B2g    8.077950  
+       7B3g    8.077950    13Ag     8.179855    13B1u   15.891839  
 
     Beta Occupied:                                                        
 
        1Ag   -20.687360     1B1u  -20.685388     2Ag    -1.707006  
-       2B1u   -0.969316     3Ag    -0.725038     1B3u   -0.643197  
-       1B2u   -0.643197  
+       2B1u   -0.969316     3Ag    -0.725038     1B2u   -0.643197  
+       1B3u   -0.643197  
 
     Beta Virtual:                                                         
 
-       1B2g    0.142301     1B3g    0.142301     3B1u    0.476686  
-       2B3u    0.720163     2B2u    0.720163     4Ag     0.721316  
-       2B2g    0.886305     2B3g    0.886305     5Ag     0.898291  
-       4B1u    0.926153     5B1u    1.434128     6Ag     1.476430  
-       1B1g    1.476430     3B3u    1.680292     3B2u    1.680292  
-       1Au     2.005181     6B1u    2.005181     7Ag     2.508283  
-       7B1u    2.554507     3B2g    2.569161     3B3g    2.569161  
+       1B3g    0.142301     1B2g    0.142301     3B1u    0.476686  
+       2B2u    0.720163     2B3u    0.720163     4Ag     0.721316  
+       2B3g    0.886305     2B2g    0.886305     5Ag     0.898291  
+       4B1u    0.926153     5B1u    1.434128     1B1g    1.476430  
+       6Ag     1.476430     3B3u    1.680292     3B2u    1.680292  
+       6B1u    2.005181     1Au     2.005181     7Ag     2.508283  
+       7B1u    2.554507     3B3g    2.569161     3B2g    2.569161  
        4B3u    3.981988     4B2u    3.981988     8Ag     4.141018  
-       4B3g    4.316494     4B2g    4.316494     2B1g    4.972123  
-       9Ag     4.972123     8B1u    5.146921     5B2u    5.147605  
-       5B3u    5.147605     6B3u    5.297921     6B2u    5.297921  
+       4B2g    4.316494     4B3g    4.316494     9Ag     4.972123  
+       2B1g    4.972123     8B1u    5.146921     5B3u    5.147605  
+       5B2u    5.147605     6B3u    5.297921     6B2u    5.297921  
       10Ag     5.578970     5B2g    5.695577     5B3g    5.695577  
-       9B1u    6.152244     2Au     6.441969    10B1u    6.441969  
-       3B1g    6.606942    11Ag     6.606942     3Au     6.833828  
-      11B1u    6.833828     6B3g    6.873082     6B2g    6.873082  
-       7B2u    7.095400     7B3u    7.095400    12B1u    7.597744  
-      12Ag     7.720938     7B3g    8.111445     7B2g    8.111445  
+       9B1u    6.152244    10B1u    6.441969     2Au     6.441969  
+      11Ag     6.606942     3B1g    6.606942    11B1u    6.833828  
+       3Au     6.833828     6B2g    6.873082     6B3g    6.873082  
+       7B3u    7.095400     7B2u    7.095400    12B1u    7.597744  
+      12Ag     7.720938     7B2g    8.111445     7B3g    8.111445  
       13Ag     8.202768    13B1u   15.926076  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @CUHF Final Energy:  -149.65170769435528
+  @CUHF Final Energy:  -149.65170769300599
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.9131678875075409
-    Two-Electron Energy =                  86.4729680570068240
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6517076943552809
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9131682435818220
+    Two-Electron Energy =                  86.4729682934121939
+    Total Energy =                       -149.6517076930059602
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:13 2017
+*** tstop() called on ds6 at Mon Nov  7 10:57:10 2022
 Module time:
-	user time   =       1.21 seconds =       0.02 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      15.82 seconds =       0.26 minutes
-	system time =       0.52 seconds =       0.01 minutes
-	total time  =         18 seconds =       0.30 minutes
-	Triplet Direct CUHF energy........................................PASSED
+	user time   =      32.77 seconds =       0.55 minutes
+	system time =       0.38 seconds =       0.01 minutes
+	total time  =         37 seconds =       0.62 minutes
+    Triplet Direct CUHF energy............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:13 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:10 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                              CUHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -5769,14 +9704,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 3
@@ -5793,7 +9728,7 @@ Total time:
   Guess Type is CORE.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -5813,23 +9748,6 @@ Total time:
        1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
        2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
 
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       9       7       7       2
-   -------------------------------------------------------
-
   ==> Integral Setup <==
 
   ==> DiskJK: Disk-Based J/K Matrices <==
@@ -5837,13 +9755,31 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -5853,16 +9789,20 @@ Total time:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-   @CUHF iter   1:  -131.02769690362550   -1.31028e+02   3.52940e-01 
-   @CUHF iter   2:  -140.10353918414870   -9.07584e+00   1.84876e-01 DIIS
-   @CUHF iter   3:  -149.25243616104652   -9.14890e+00   5.00764e-02 DIIS
-   @CUHF iter   4:  -149.63817985442995   -3.85744e-01   8.24004e-03 DIIS
-   @CUHF iter   5:  -149.65162024791439   -1.34404e-02   5.96010e-04 DIIS
-   @CUHF iter   6:  -149.65170615921497   -8.59113e-05   1.68325e-04 DIIS
-   @CUHF iter   7:  -149.65170608248945    7.67255e-08   1.75800e-05 DIIS
-   @CUHF iter   8:  -149.65170750687179   -1.42438e-06   1.96161e-06 DIIS
-   @CUHF iter   9:  -149.65170767801644   -1.71145e-07   3.18125e-07 DIIS
+   @CUHF iter   1:  -131.02769686138819   -1.31028e+02   3.53708e-01 ADIIS
+   @CUHF iter   2:  -140.10353912873418   -9.07584e+00   1.85166e-01 ADIIS
+   @CUHF iter   3:  -149.07256385046523   -8.96902e+00   6.18739e-02 ADIIS/DIIS
+   @CUHF iter   4:  -149.63818987448269   -5.65626e-01   1.00903e-02 ADIIS/DIIS
+   @CUHF iter   5:  -149.65122786458724   -1.30380e-02   1.50677e-03 ADIIS/DIIS
+   @CUHF iter   6:  -149.65168121631359   -4.53352e-04   2.17117e-04 ADIIS/DIIS
+   @CUHF iter   7:  -149.65170871431570   -2.74980e-05   1.84194e-05 DIIS
+   @CUHF iter   8:  -149.65170789138173    8.22934e-07   2.07188e-06 DIIS
+   @CUHF iter   9:  -149.65170764199598    2.49386e-07   3.39347e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
@@ -5870,126 +9810,128 @@ Total time:
   @Spin Contamination Metric:  0.00000
   @S^2 Expected:               2.00000
   @S^2 Observed:               2.00000
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
-       1Ag   -20.728398     1B1u  -20.727317     2Ag    -1.805358  
-       2B1u   -1.148926     1B3u   -0.865420     1B2u   -0.865420  
-       3Ag    -0.800964     1B2g   -0.482421     1B3g   -0.482420  
+       1Ag   -20.728399     1B1u  -20.727318     2Ag    -1.805358  
+       2B1u   -1.148926     1B2u   -0.865420     1B3u   -0.865420  
+       3Ag    -0.800964     1B3g   -0.482421     1B2g   -0.482421  
 
     Alpha Virtual:                                                        
 
-       3B1u    0.445206     2B3u    0.672317     2B2u    0.672317  
-       4Ag     0.708739     2B2g    0.800671     2B3g    0.800671  
+       3B1u    0.445206     2B2u    0.672317     2B3u    0.672317  
+       4Ag     0.708739     2B3g    0.800671     2B2g    0.800671  
        4B1u    0.864363     5Ag     0.868581     5B1u    1.397473  
-       6Ag     1.417440     1B1g    1.417440     3B2u    1.606467  
-       3B3u    1.606467     6B1u    1.908620     1Au     1.908620  
-       7Ag     2.465527     3B2g    2.517400     3B3g    2.517400  
-       7B1u    2.526368     4B3u    3.885569     4B2u    3.885569  
-       8Ag     4.114424     4B2g    4.226227     4B3g    4.226227  
-       9Ag     4.935165     2B1g    4.935165     8B1u    5.113334  
+       1B1g    1.417439     6Ag     1.417439     3B2u    1.606467  
+       3B3u    1.606467     1Au     1.908620     6B1u    1.908620  
+       7Ag     2.465527     3B3g    2.517400     3B2g    2.517400  
+       7B1u    2.526368     4B2u    3.885569     4B3u    3.885569  
+       8Ag     4.114424     4B3g    4.226227     4B2g    4.226227  
+       2B1g    4.935165     9Ag     4.935165     8B1u    5.113334  
        5B2u    5.113951     5B3u    5.113951     6B3u    5.242036  
        6B2u    5.242036    10Ag     5.545666     5B2g    5.632396  
-       5B3g    5.632396     9B1u    6.112627    10B1u    6.383378  
-       2Au     6.383378    11Ag     6.502619     3B1g    6.502619  
-      11B1u    6.743007     3Au     6.743007     6B2g    6.815077  
-       6B3g    6.815077     7B2u    7.042409     7B3u    7.042409  
+       5B3g    5.632396     9B1u    6.112627     2Au     6.383378  
+      10B1u    6.383378     3B1g    6.502619    11Ag     6.502619  
+       3Au     6.743007    11B1u    6.743007     6B3g    6.815077  
+       6B2g    6.815077     7B2u    7.042408     7B3u    7.042408  
       12B1u    7.564791    12Ag     7.667198     7B3g    8.077952  
-       7B2g    8.077952    13Ag     8.179857    13B1u   15.891842  
+       7B2g    8.077952    13Ag     8.179857    13B1u   15.891841  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.687355     1B1u  -20.685384     2Ag    -1.707004  
-       2B1u   -0.969314     3Ag    -0.725037     1B3u   -0.643196  
-       1B2u   -0.643196  
+       1Ag   -20.687356     1B1u  -20.685385     2Ag    -1.707004  
+       2B1u   -0.969314     3Ag    -0.725037     1B2u   -0.643196  
+       1B3u   -0.643196  
 
     Beta Virtual:                                                         
 
-       1B2g    0.142303     1B3g    0.142303     3B1u    0.476687  
-       2B3u    0.720163     2B2u    0.720164     4Ag     0.721317  
-       2B2g    0.886306     2B3g    0.886306     5Ag     0.898292  
-       4B1u    0.926155     5B1u    1.434129     1B1g    1.476431  
-       6Ag     1.476431     3B3u    1.680294     3B2u    1.680294  
-       1Au     2.005182     6B1u    2.005182     7Ag     2.508285  
-       7B1u    2.554508     3B2g    2.569162     3B3g    2.569162  
+       1B2g    0.142302     1B3g    0.142302     3B1u    0.476687  
+       2B2u    0.720163     2B3u    0.720163     4Ag     0.721317  
+       2B2g    0.886305     2B3g    0.886305     5Ag     0.898292  
+       4B1u    0.926155     5B1u    1.434129     6Ag     1.476431  
+       1B1g    1.476431     3B2u    1.680293     3B3u    1.680293  
+       6B1u    2.005181     1Au     2.005181     7Ag     2.508284  
+       7B1u    2.554508     3B3g    2.569162     3B2g    2.569162  
        4B2u    3.981990     4B3u    3.981990     8Ag     4.141020  
-       4B3g    4.316497     4B2g    4.316497     2B1g    4.972124  
-       9Ag     4.972124     8B1u    5.146924     5B2u    5.147607  
-       5B3u    5.147607     6B3u    5.297922     6B2u    5.297922  
-      10Ag     5.578973     5B3g    5.695578     5B2g    5.695578  
-       9B1u    6.152246     2Au     6.441970    10B1u    6.441970  
-       3B1g    6.606944    11Ag     6.606944     3Au     6.833830  
-      11B1u    6.833830     6B3g    6.873085     6B2g    6.873085  
-       7B2u    7.095403     7B3u    7.095403    12B1u    7.597746  
-      12Ag     7.720940     7B3g    8.111447     7B2g    8.111447  
-      13Ag     8.202771    13B1u   15.926079  
+       4B2g    4.316496     4B3g    4.316496     9Ag     4.972124  
+       2B1g    4.972124     8B1u    5.146923     5B2u    5.147606  
+       5B3u    5.147606     6B3u    5.297922     6B2u    5.297922  
+      10Ag     5.578972     5B3g    5.695578     5B2g    5.695578  
+       9B1u    6.152246    10B1u    6.441970     2Au     6.441970  
+      11Ag     6.606944     3B1g    6.606944    11B1u    6.833830  
+       3Au     6.833830     6B3g    6.873084     6B2g    6.873084  
+       7B2u    7.095402     7B3u    7.095402    12B1u    7.597746  
+      12Ag     7.720940     7B3g    8.111446     7B2g    8.111446  
+      13Ag     8.202770    13B1u   15.926079  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @CUHF Final Energy:  -149.65170767801644
+  @CUHF Final Energy:  -149.65170764199598
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.9132748873976198
-    Two-Electron Energy =                  86.4730750732357478
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6517076780164359
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9132492797449459
+    Two-Electron Energy =                  86.4730493805853229
+    Total Energy =                       -149.6517076419959835
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:14 2017
+*** tstop() called on ds6 at Mon Nov  7 10:57:10 2022
 Module time:
-	user time   =       0.48 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.28 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      16.32 seconds =       0.27 minutes
-	system time =       0.55 seconds =       0.01 minutes
-	total time  =         19 seconds =       0.32 minutes
-	Triplet Disk CUHF energy..........................................PASSED
+	user time   =      33.08 seconds =       0.55 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =         37 seconds =       0.62 minutes
+    Triplet Disk CUHF energy..............................................................PASSED
 
-*** tstart() called on psinet
-*** at Mon May 15 15:40:14 2017
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:10 2022
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   247 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                              CUHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -6003,14 +9945,14 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.550000000000    15.994914619560
-           O          0.000000000000     0.000000000000     0.550000000000    15.994914619560
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
 
   Running in d2h symmetry.
 
   Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
-  Rotational constants: A = ************  B =  52225.17395  C =  52225.17395 [MHz]
-  Nuclear repulsion =   30.788492136145440
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
 
   Charge       = 0
   Multiplicity = 3
@@ -6020,14 +9962,14 @@ Total time:
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DF.
+  SCF Algorithm Type is DISK_DF.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
   Guess Type is CORE.
   Energy threshold   = 1.00e-06
   Density threshold  = 1.00e-06
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -6052,39 +9994,22 @@ Total time:
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   228 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/cc-pvtz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag        13      13       0       0       0       0
-     B1g        3       3       0       0       0       0
-     B2g        7       7       0       0       0       0
-     B3g        7       7       0       0       0       0
-     Au         3       3       0       0       0       0
-     B1u       13      13       0       0       0       0
-     B2u        7       7       0       0       0       0
-     B3u        7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      60      60       9       7       7       2
-   -------------------------------------------------------
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  ==> DFJK: Density-Fitted J/K Matrices <==
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
     OpenMP threads:              1
     Integrals threads:           1
-    Memory (MB):               375
+    Memory [MiB]:              375
     Algorithm:                Core
     Integral Cache:           NONE
     Schwarz Cutoff:          1E-12
-    Fitting Condition:       1E-12
+    Fitting Condition:       1E-10
 
    => Auxiliary Basis Set <=
 
@@ -6104,10 +10029,28 @@ Total time:
        1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
        2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
 
-  Minimum eigenvalue in the overlap matrix is 2.7007379178E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -6117,16 +10060,20 @@ Total time:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-   @DF-CUHF iter   1:  -131.02345181239073   -1.31023e+02   3.53137e-01 
-   @DF-CUHF iter   2:  -140.10421230723642   -9.08076e+00   1.84897e-01 DIIS
-   @DF-CUHF iter   3:  -149.25215682201255   -9.14794e+00   5.00787e-02 DIIS
-   @DF-CUHF iter   4:  -149.63807305829354   -3.85916e-01   8.23713e-03 DIIS
-   @DF-CUHF iter   5:  -149.65151993459835   -1.34469e-02   5.97253e-04 DIIS
-   @DF-CUHF iter   6:  -149.65160644610305   -8.65115e-05   1.68622e-04 DIIS
-   @DF-CUHF iter   7:  -149.65160638241099    6.36921e-08   1.76713e-05 DIIS
-   @DF-CUHF iter   8:  -149.65160780780127   -1.42539e-06   1.98195e-06 DIIS
-   @DF-CUHF iter   9:  -149.65160798263014   -1.74829e-07   3.19572e-07 DIIS
+   @DF-CUHF iter   1:  -131.02345177007209   -1.31023e+02   3.53905e-01 ADIIS
+   @DF-CUHF iter   2:  -140.10421225181673   -9.08076e+00   1.85188e-01 ADIIS
+   @DF-CUHF iter   3:  -149.07251737243493   -8.96831e+00   6.18656e-02 ADIIS/DIIS
+   @DF-CUHF iter   4:  -149.63808950369372   -5.65572e-01   1.00945e-02 ADIIS/DIIS
+   @DF-CUHF iter   5:  -149.65112849378588   -1.30390e-02   1.50612e-03 ADIIS/DIIS
+   @DF-CUHF iter   6:  -149.65158147606783   -4.52982e-04   2.16998e-04 ADIIS/DIIS
+   @DF-CUHF iter   7:  -149.65160902343254   -2.75474e-05   1.83726e-05 DIIS
+   @DF-CUHF iter   8:  -149.65160819598424    8.27448e-07   2.07458e-06 DIIS
+   @DF-CUHF iter   9:  -149.65160794655139    2.49433e-07   3.38450e-07 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
@@ -6134,110 +10081,893 @@ Total time:
   @Spin Contamination Metric:  0.00000
   @S^2 Expected:               2.00000
   @S^2 Observed:               2.00000
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Alpha Occupied:                                                       
 
        1Ag   -20.728437     1B1u  -20.727356     2Ag    -1.805402  
-       2B1u   -1.148942     1B3u   -0.865418     1B2u   -0.865418  
-       3Ag    -0.800976     1B2g   -0.482443     1B3g   -0.482443  
+       2B1u   -1.148943     1B2u   -0.865418     1B3u   -0.865418  
+       3Ag    -0.800976     1B3g   -0.482443     1B2g   -0.482443  
 
     Alpha Virtual:                                                        
 
-       3B1u    0.445379     2B3u    0.672516     2B2u    0.672516  
-       4Ag     0.708931     2B2g    0.801015     2B3g    0.801015  
+       3B1u    0.445379     2B2u    0.672516     2B3u    0.672516  
+       4Ag     0.708931     2B3g    0.801015     2B2g    0.801015  
        4B1u    0.864475     5Ag     0.868644     5B1u    1.398009  
-       6Ag     1.418034     1B1g    1.418034     3B2u    1.606817  
-       3B3u    1.606817     6B1u    1.909365     1Au     1.909365  
-       7Ag     2.465995     3B2g    2.518097     3B3g    2.518097  
-       7B1u    2.526939     4B3u    3.886281     4B2u    3.886281  
-       8Ag     4.116749     4B2g    4.227176     4B3g    4.227176  
-       9Ag     4.941673     2B1g    4.941673     8B1u    5.114579  
-       5B2u    5.121284     5B3u    5.121284     6B3u    5.248401  
+       1B1g    1.418034     6Ag     1.418034     3B2u    1.606817  
+       3B3u    1.606817     1Au     1.909365     6B1u    1.909365  
+       7Ag     2.465995     3B3g    2.518096     3B2g    2.518096  
+       7B1u    2.526939     4B2u    3.886281     4B3u    3.886281  
+       8Ag     4.116749     4B3g    4.227176     4B2g    4.227176  
+       2B1g    4.941673     9Ag     4.941673     8B1u    5.114579  
+       5B2u    5.121283     5B3u    5.121283     6B3u    5.248401  
        6B2u    5.248401    10Ag     5.551654     5B2g    5.639394  
-       5B3g    5.639394     9B1u    6.116138    10B1u    6.392135  
-       2Au     6.392135    11Ag     6.513061     3B1g    6.513061  
-      11B1u    6.753437     3Au     6.753437     6B2g    6.824515  
-       6B3g    6.824515     7B2u    7.051666     7B3u    7.051666  
-      12B1u    7.572154    12Ag     7.669410     7B3g    8.087162  
-       7B2g    8.087162    13Ag     8.188327    13B1u   15.897366  
+       5B3g    5.639394     9B1u    6.116138     2Au     6.392135  
+      10B1u    6.392135     3B1g    6.513061    11Ag     6.513061  
+       3Au     6.753437    11B1u    6.753437     6B3g    6.824515  
+       6B2g    6.824515     7B2u    7.051666     7B3u    7.051666  
+      12B1u    7.572154    12Ag     7.669409     7B3g    8.087162  
+       7B2g    8.087162    13Ag     8.188327    13B1u   15.897365  
 
     Beta Occupied:                                                        
 
-       1Ag   -20.687392     1B1u  -20.685421     2Ag    -1.707051  
-       2B1u   -0.969330     3Ag    -0.725047     1B3u   -0.643189  
-       1B2u   -0.643189  
+       1Ag   -20.687393     1B1u  -20.685422     2Ag    -1.707051  
+       2B1u   -0.969330     3Ag    -0.725048     1B2u   -0.643189  
+       1B3u   -0.643189  
 
     Beta Virtual:                                                         
 
        1B2g    0.142275     1B3g    0.142275     3B1u    0.476815  
-       2B3u    0.720362     2B2u    0.720362     4Ag     0.721466  
-       2B2g    0.886357     2B3g    0.886357     5Ag     0.898337  
-       4B1u    0.926176     5B1u    1.434313     1B1g    1.476900  
-       6Ag     1.476900     3B3u    1.680564     3B2u    1.680564  
-       1Au     2.005533     6B1u    2.005533     7Ag     2.508597  
-       7B1u    2.554825     3B2g    2.569468     3B3g    2.569468  
-       4B2u    3.982546     4B3u    3.982546     8Ag     4.143053  
-       4B3g    4.317139     4B2g    4.317139     2B1g    4.977108  
-       9Ag     4.977108     8B1u    5.147840     5B2u    5.153664  
+       2B2u    0.720362     2B3u    0.720362     4Ag     0.721466  
+       2B2g    0.886356     2B3g    0.886356     5Ag     0.898337  
+       4B1u    0.926175     5B1u    1.434313     6Ag     1.476900  
+       1B1g    1.476900     3B2u    1.680564     3B3u    1.680564  
+       6B1u    2.005533     1Au     2.005533     7Ag     2.508597  
+       7B1u    2.554824     3B3g    2.569468     3B2g    2.569468  
+       4B2u    3.982546     4B3u    3.982546     8Ag     4.143052  
+       4B2g    4.317139     4B3g    4.317139     9Ag     4.977108  
+       2B1g    4.977108     8B1u    5.147840     5B2u    5.153664  
        5B3u    5.153664     6B3u    5.301825     6B2u    5.301825  
-      10Ag     5.583795     5B2g    5.699234     5B3g    5.699234  
-       9B1u    6.154433     2Au     6.446604    10B1u    6.446604  
-       3B1g    6.612663    11Ag     6.612663     3Au     6.838745  
-      11B1u    6.838745     6B3g    6.877897     6B2g    6.877897  
+      10Ag     5.583794     5B2g    5.699233     5B3g    5.699233  
+       9B1u    6.154433    10B1u    6.446603     2Au     6.446603  
+      11Ag     6.612662     3B1g    6.612662    11B1u    6.838745  
+       3Au     6.838745     6B3g    6.877897     6B2g    6.877897  
        7B2u    7.101148     7B3u    7.101148    12B1u    7.601719  
-      12Ag     7.722339     7B3g    8.116129     7B2g    8.116129  
+      12Ag     7.722338     7B3g    8.116129     7B2g    8.116129  
       13Ag     8.207733    13B1u   15.928487  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  Energy converged.
-
-  @DF-CUHF Final Energy:  -149.65160798263014
+  @DF-CUHF Final Energy:  -149.65160794655139
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             30.7884921361454396
-    One-Electron Energy =                -266.9127520403167182
-    Two-Electron Energy =                  86.4726519215411429
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                       -149.6516079826301393
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9127261717288206
+    Two-Electron Energy =                  86.4726259680137730
+    Total Energy =                       -149.6516079465513940
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:40:14 2017
+*** tstop() called on ds6 at Mon Nov  7 10:57:10 2022
 Module time:
-	user time   =       0.34 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.19 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      16.67 seconds =       0.28 minutes
-	system time =       0.56 seconds =       0.01 minutes
-	total time  =         19 seconds =       0.32 minutes
-	Triplet DF CUHF energy............................................PASSED
+	user time   =      33.31 seconds =       0.56 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =         37 seconds =       0.62 minutes
+    Triplet DiskDF CUHF energy............................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:11 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             CUHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is MEM_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ-JKFIT
+    Blend                  = CC-PVTZ-JKFIT
+    Total number of shells = 50
+    Number of primitives   = 50
+    Number of AO           = 192
+    Number of SO           = 158
+    Maximum AM             = 4
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+       2     O     10s 7p 5d 2f 1g // 10s 7p 5d 2f 1g 
+
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+   @DF-CUHF iter   1:  -131.02345177007203   -1.31023e+02   3.53905e-01 ADIIS
+   @DF-CUHF iter   2:  -140.10421225181634   -9.08076e+00   1.85188e-01 ADIIS
+   @DF-CUHF iter   3:  -149.07251737243496   -8.96831e+00   6.18656e-02 ADIIS/DIIS
+   @DF-CUHF iter   4:  -149.63808950369364   -5.65572e-01   1.00945e-02 ADIIS/DIIS
+   @DF-CUHF iter   5:  -149.65112849378588   -1.30390e-02   1.50612e-03 ADIIS/DIIS
+   @DF-CUHF iter   6:  -149.65158147606775   -4.52982e-04   2.16998e-04 ADIIS/DIIS
+   @DF-CUHF iter   7:  -149.65160902343251   -2.75474e-05   1.83726e-05 DIIS
+   @DF-CUHF iter   8:  -149.65160819598432    8.27448e-07   2.07458e-06 DIIS
+   @DF-CUHF iter   9:  -149.65160794655134    2.49433e-07   3.38450e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric:  0.00000
+  @S^2 Expected:               2.00000
+  @S^2 Observed:               2.00000
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.728437     1B1u  -20.727356     2Ag    -1.805402  
+       2B1u   -1.148943     1B2u   -0.865418     1B3u   -0.865418  
+       3Ag    -0.800976     1B3g   -0.482443     1B2g   -0.482443  
+
+    Alpha Virtual:                                                        
+
+       3B1u    0.445379     2B2u    0.672516     2B3u    0.672516  
+       4Ag     0.708931     2B3g    0.801015     2B2g    0.801015  
+       4B1u    0.864475     5Ag     0.868644     5B1u    1.398009  
+       1B1g    1.418034     6Ag     1.418034     3B2u    1.606817  
+       3B3u    1.606817     1Au     1.909365     6B1u    1.909365  
+       7Ag     2.465995     3B3g    2.518096     3B2g    2.518096  
+       7B1u    2.526939     4B2u    3.886281     4B3u    3.886281  
+       8Ag     4.116749     4B3g    4.227176     4B2g    4.227176  
+       2B1g    4.941673     9Ag     4.941673     8B1u    5.114579  
+       5B2u    5.121283     5B3u    5.121283     6B3u    5.248401  
+       6B2u    5.248401    10Ag     5.551654     5B2g    5.639394  
+       5B3g    5.639394     9B1u    6.116138     2Au     6.392135  
+      10B1u    6.392135     3B1g    6.513061    11Ag     6.513061  
+       3Au     6.753437    11B1u    6.753437     6B3g    6.824515  
+       6B2g    6.824515     7B2u    7.051666     7B3u    7.051666  
+      12B1u    7.572154    12Ag     7.669409     7B3g    8.087162  
+       7B2g    8.087162    13Ag     8.188327    13B1u   15.897365  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.687393     1B1u  -20.685422     2Ag    -1.707051  
+       2B1u   -0.969330     3Ag    -0.725048     1B2u   -0.643189  
+       1B3u   -0.643189  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.142275     1B3g    0.142275     3B1u    0.476815  
+       2B2u    0.720362     2B3u    0.720362     4Ag     0.721466  
+       2B2g    0.886356     2B3g    0.886356     5Ag     0.898337  
+       4B1u    0.926175     5B1u    1.434313     6Ag     1.476900  
+       1B1g    1.476900     3B2u    1.680564     3B3u    1.680564  
+       6B1u    2.005533     1Au     2.005533     7Ag     2.508597  
+       7B1u    2.554824     3B3g    2.569468     3B2g    2.569468  
+       4B2u    3.982546     4B3u    3.982546     8Ag     4.143052  
+       4B2g    4.317139     4B3g    4.317139     9Ag     4.977108  
+       2B1g    4.977108     8B1u    5.147840     5B2u    5.153664  
+       5B3u    5.153664     6B3u    5.301825     6B2u    5.301825  
+      10Ag     5.583794     5B2g    5.699233     5B3g    5.699233  
+       9B1u    6.154433    10B1u    6.446603     2Au     6.446603  
+      11Ag     6.612662     3B1g    6.612662    11B1u    6.838745  
+       3Au     6.838745     6B3g    6.877897     6B2g    6.877897  
+       7B2u    7.101148     7B3u    7.101148    12B1u    7.601719  
+      12Ag     7.722338     7B3g    8.116129     7B2g    8.116129  
+      13Ag     8.207733    13B1u   15.928487  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+  @DF-CUHF Final Energy:  -149.65160794655134
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9127261717287070
+    Two-Electron Energy =                  86.4726259680137161
+    Total Energy =                       -149.6516079465513371
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:57:11 2022
+Module time:
+	user time   =       0.18 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      33.52 seconds =       0.56 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =         38 seconds =       0.63 minutes
+    Triplet MemDF CUHF energy.............................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:11 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             CUHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is COSX.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DFJCOSK: Density-Fitted J and Semi-Numerical K <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    Integrals threads:            1
+    Memory [MiB]:               375
+    Incremental Fock :           No
+    J Screening Type:          CSAM
+    J Screening Cutoff:       1E-12
+    K Screening Cutoff:       1E-11
+    K Density Cutoff:         1E-10
+    K Basis Cutoff:           1E-10
+    K Overlap Fitting:          Yes
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+   @CUHF iter   1:  -131.02266731942410   -1.31023e+02   3.53890e-01 ADIIS
+   @CUHF iter   2:  -140.10621696114706   -9.08355e+00   1.85157e-01 ADIIS
+   @CUHF iter   3:  -149.07283195574351   -8.96661e+00   6.18535e-02 ADIIS/DIIS
+   @CUHF iter   4:  -149.63845093676014   -5.65619e-01   1.00842e-02 ADIIS/DIIS
+   @CUHF iter   5:  -149.65151108189124   -1.30601e-02   1.51377e-03 ADIIS/DIIS
+   @CUHF iter   6:  -149.65197130478208   -4.60223e-04   2.18032e-04 ADIIS/DIIS
+   @CUHF iter   7:  -149.65199790962743   -2.66048e-05   1.85204e-05 DIIS
+   @CUHF iter   8:  -149.65199703995123    8.69676e-07   2.10529e-06 DIIS
+   @CUHF iter   9:  -149.65199679272936    2.47222e-07   3.47492e-07 DIIS
+  Energy and wave function converged with early screening.
+  Performing final iteration with tighter screening.
+
+   @CUHF iter  10:  -149.65168894016244    3.07853e-04   9.18132e-04 ADIIS/DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric:  0.00000
+  @S^2 Expected:               2.00000
+  @S^2 Observed:               2.00000
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.728757     1B1u  -20.727605     2Ag    -1.806087  
+       2B1u   -1.149189     1B2u   -0.864782     1B3u   -0.864782  
+       3Ag    -0.802389     1B3g   -0.482531     1B2g   -0.482530  
+
+    Alpha Virtual:                                                        
+
+       3B1u    0.445404     2B2u    0.672701     2B3u    0.672701  
+       4Ag     0.708346     2B3g    0.800654     2B2g    0.800654  
+       4B1u    0.864673     5Ag     0.868517     5B1u    1.397675  
+       6Ag     1.416201     1B1g    1.418214     3B2u    1.605883  
+       3B3u    1.605883     6B1u    1.907327     1Au     1.910657  
+       7Ag     2.466145     3B3g    2.516733     3B2g    2.516733  
+       7B1u    2.526836     4B2u    3.886011     4B3u    3.886011  
+       8Ag     4.111102     4B3g    4.227868     4B2g    4.227868  
+       2B1g    4.918417     9Ag     4.955901     8B1u    5.112410  
+       5B2u    5.122667     5B3u    5.122667     6B2u    5.246270  
+       6B3u    5.246270    10Ag     5.537965     5B3g    5.637117  
+       5B2g    5.637117     9B1u    6.106685     2Au     6.374536  
+      10B1u    6.395537    11Ag     6.498106     3B1g    6.507911  
+       3Au     6.738265    11B1u    6.751969     6B3g    6.814804  
+       6B2g    6.814804     7B2u    7.043000     7B3u    7.043000  
+      12B1u    7.566657    12Ag     7.666393     7B3g    8.085680  
+       7B2g    8.085680    13Ag     8.181368    13B1u   15.889469  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.687707     1B1u  -20.685696     2Ag    -1.707357  
+       2B1u   -0.969531     3Ag    -0.726113     1B3u   -0.642651  
+       1B2u   -0.642651  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.142081     1B3g    0.142081     3B1u    0.476720  
+       2B3u    0.720713     2B2u    0.720713     4Ag     0.720907  
+       2B2g    0.886189     2B3g    0.886189     5Ag     0.898254  
+       4B1u    0.926291     5B1u    1.434223     1B1g    1.474983  
+       6Ag     1.477090     3B3u    1.680645     3B2u    1.680645  
+       6B1u    2.005140     1Au     2.005229     7Ag     2.507342  
+       7B1u    2.555218     3B3g    2.568822     3B2g    2.568822  
+       4B3u    3.982298     4B2u    3.982298     8Ag     4.136137  
+       4B2g    4.318366     4B3g    4.318366     2B1g    4.961161  
+       9Ag     4.986073     8B1u    5.145922     5B3u    5.158455  
+       5B2u    5.158455     6B3u    5.299560     6B2u    5.299560  
+      10Ag     5.567425     5B2g    5.698314     5B3g    5.698314  
+       9B1u    6.142639     2Au     6.430950    10B1u    6.455303  
+       3B1g    6.599929    11Ag     6.611731     3Au     6.824983  
+      11B1u    6.842848     6B2g    6.877247     6B3g    6.877247  
+       7B3u    7.099689     7B2u    7.099689    12B1u    7.595597  
+      12Ag     7.719166     7B2g    8.119079     7B3g    8.119080  
+      13Ag     8.200488    13B1u   15.923821  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+  @CUHF Final Energy:  -149.65168894016244
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9107736954303505
+    Two-Electron Energy =                  86.4705924981042529
+    Total Energy =                       -149.6516889401624439
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:57:14 2022
+Module time:
+	user time   =       2.92 seconds =       0.05 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =      36.47 seconds =       0.61 minutes
+	system time =       0.41 seconds =       0.01 minutes
+	total time  =         41 seconds =       0.68 minutes
+    Triplet DFJ+COSX CUHF energy..........................................................PASSED
+
+Scratch directory: /scratch/dpoole34/
+
+*** tstart() called on ds6
+*** at Mon Nov  7 10:57:14 2022
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             CUHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.550000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.550000000000    15.994914619570
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.74204  C =      1.74204 [cm^-1]
+  Rotational constants: A = ************  B =  52225.17435  C =  52225.17435 [MHz]
+  Nuclear repulsion =   30.788492257163654
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is LINK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  -AO BASIS SET INFORMATION:
+    Name                   = CC-PVTZ
+    Blend                  = CC-PVTZ
+    Total number of shells = 20
+    Number of primitives   = 52
+    Number of AO           = 70
+    Number of SO           = 60
+    Maximum AM             = 3
+    Spherical Harmonics    = TRUE
+
+  -Contraction Scheme:
+    Atom   Type   All Primitives // Shells:
+   ------ ------ --------------------------
+       1     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+       2     O     18s 5p 2d 1f // 4s 3p 2d 1f 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DFJLinK: Density-Fitted J and Linear Exchange K <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Memory [MiB]:              375
+    Incremental Fock:           No
+    Screening Type:        DENSITY
+    J Screening Cutoff:      1E-12
+    K Screening Cutoff:      1E-12
+  Minimum eigenvalue in the overlap matrix is 4.8903815329E-03.
+  Reciprocal condition number of the overlap matrix is 1.3938644816E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        13      13       3       2       2       1
+     B1g        3       3       0       0       0       0
+     B2g        7       7       1       1       1       0
+     B3g        7       7       1       0       0       1
+     Au         3       3       0       0       0       0
+     B1u       13      13       2       2       2       0
+     B2u        7       7       1       1       1       0
+     B3u        7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      60      60       9       7       7       2
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+    Occupation by irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+   @CUHF iter   1:  -131.02824188718688   -1.31028e+02   3.53702e-01 ADIIS
+   @CUHF iter   2:  -140.10809986937551   -9.07986e+00   1.85134e-01 ADIIS
+   @CUHF iter   3:  -149.07220799997776   -8.96411e+00   6.18921e-02 ADIIS/DIIS
+   @CUHF iter   4:  -149.63818696514187   -5.65979e-01   1.00981e-02 ADIIS/DIIS
+   @CUHF iter   5:  -149.65124590648077   -1.30589e-02   1.50640e-03 ADIIS/DIIS
+   @CUHF iter   6:  -149.65169910490732   -4.53198e-04   2.17102e-04 ADIIS/DIIS
+   @CUHF iter   7:  -149.65172663379934   -2.75289e-05   1.84171e-05 DIIS
+   @CUHF iter   8:  -149.65172580983565    8.23964e-07   2.07767e-06 DIIS
+   @CUHF iter   9:  -149.65172556019772    2.49638e-07   3.39954e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+
+  @Spin Contamination Metric: -0.00000
+  @S^2 Expected:               2.00000
+  @S^2 Observed:               2.00000
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag   -20.728398     1B1u  -20.727317     2Ag    -1.805366  
+       2B1u   -1.148933     1B2u   -0.865419     1B3u   -0.865419  
+       3Ag    -0.800983     1B3g   -0.482430     1B2g   -0.482430  
+
+    Alpha Virtual:                                                        
+
+       3B1u    0.445310     2B2u    0.672363     2B3u    0.672363  
+       4Ag     0.708797     2B3g    0.800644     2B2g    0.800644  
+       4B1u    0.864404     5Ag     0.868543     5B1u    1.397451  
+       1B1g    1.417410     6Ag     1.417410     3B2u    1.606430  
+       3B3u    1.606430     1Au     1.908630     6B1u    1.908630  
+       7Ag     2.465571     3B3g    2.517352     3B2g    2.517352  
+       7B1u    2.526457     4B2u    3.885638     4B3u    3.885638  
+       8Ag     4.114396     4B3g    4.226322     4B2g    4.226322  
+       2B1g    4.935271     9Ag     4.935271     8B1u    5.113392  
+       5B2u    5.114110     5B3u    5.114110     6B3u    5.242081  
+       6B2u    5.242081    10Ag     5.545379     5B2g    5.632454  
+       5B3g    5.632454     9B1u    6.112599     2Au     6.383370  
+      10B1u    6.383370     3B1g    6.502457    11Ag     6.502457  
+       3Au     6.742945    11B1u    6.742945     6B3g    6.815154  
+       6B2g    6.815154     7B2u    7.042432     7B3u    7.042432  
+      12B1u    7.564508    12Ag     7.667256     7B3g    8.078056  
+       7B2g    8.078056    13Ag     8.179734    13B1u   15.891893  
+
+    Beta Occupied:                                                        
+
+       1Ag   -20.687355     1B1u  -20.685383     2Ag    -1.707015  
+       2B1u   -0.969322     3Ag    -0.725056     1B2u   -0.643196  
+       1B3u   -0.643196  
+
+    Beta Virtual:                                                         
+
+       1B2g    0.142287     1B3g    0.142287     3B1u    0.476802  
+       2B2u    0.720212     2B3u    0.720212     4Ag     0.721377  
+       2B2g    0.886285     2B3g    0.886285     5Ag     0.898254  
+       4B1u    0.926186     5B1u    1.434106     6Ag     1.476401  
+       1B1g    1.476401     3B2u    1.680255     3B3u    1.680255  
+       6B1u    2.005192     1Au     2.005192     7Ag     2.508330  
+       7B1u    2.554596     3B3g    2.569109     3B2g    2.569109  
+       4B2u    3.982057     4B3u    3.982057     8Ag     4.140992  
+       4B2g    4.316592     4B3g    4.316592     9Ag     4.972230  
+       2B1g    4.972230     8B1u    5.146981     5B2u    5.147764  
+       5B3u    5.147764     6B3u    5.297967     6B2u    5.297967  
+      10Ag     5.578685     5B3g    5.695636     5B2g    5.695636  
+       9B1u    6.152219    10B1u    6.441977     2Au     6.441977  
+      11Ag     6.606782     3B1g    6.606782    11B1u    6.833751  
+       3Au     6.833751     6B3g    6.873160     6B2g    6.873160  
+       7B2u    7.095426     7B3u    7.095426    12B1u    7.597461  
+      12Ag     7.720997     7B3g    8.111551     7B2g    8.111551  
+      13Ag     8.202647    13B1u   15.926131  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    SOCC [     0,    0,    1,    1,    0,    0,    0,    0 ]
+    NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+  @CUHF Final Energy:  -149.65172556019772
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             30.7884922571636537
+    One-Electron Energy =                -266.9132010587350692
+    Two-Electron Energy =                  86.4729832413736688
+    Total Energy =                       -149.6517255601977467
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on ds6 at Mon Nov  7 10:57:15 2022
+Module time:
+	user time   =       1.64 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      38.14 seconds =       0.64 minutes
+	system time =       0.42 seconds =       0.01 minutes
+	total time  =         42 seconds =       0.70 minutes
+    Triplet DFJ+LinK CUHF energy..........................................................PASSED
+
+    Psi4 stopped on: Monday, 07 November 2022 10:57AM
+    Psi4 wall time for execution: 0:00:42.15
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/scf5/output.ref
+++ b/tests/scf5/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev93 
+                               Psi4 1.7a1.dev101 
 
-                         Git: Rev {dpoole34/jk-test-coverage} e6a3fdf 
+                         Git: Rev {dpoole34/jk-test-coverage} 9d9dc37 
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,9 +30,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 07 November 2022 11:04AM
+    Psi4 started on: Thursday, 10 November 2022 10:42AM
 
-    Process ID: 30461
+    Process ID: 10800
     Host:       ds6
     PSIDATADIR: /theoryfs2/ds/dpoole34/Documents/Codes/psi4-scf5-tests/psi4-install/share/psi4
     Memory:     500.0 MiB
@@ -48,13 +48,33 @@ print(' Case Study Test of all SCF algorithms/spin-degeneracies: Singlet-Triplet
 #Ensure that the checkpoint file is always nuked
 psi4_io.set_specific_retention(32,False)
 
-Eref_nuc      =   30.7884922572     #TEST
-Eref_sing_can = -149.58723684929720 #TEST
-Eref_sing_df  = -149.58715054487624 #TEST
-Eref_uhf_can  = -149.67135517240553 #TEST
-Eref_uhf_df   = -149.67125624291961 #TEST
-Eref_rohf_can = -149.65170765757173 #TEST
-Eref_rohf_df  = -149.65160796208073 #TEST
+Eref = {  
+    "Nuclear"       :   30.7884922572,     #TEST
+    "Singlet": {
+        "Canonical" : -149.58723684929720, #TEST
+        "DF"        : -149.58715054487624, #TEST
+        "Composite": {
+          "COSX"    : -149.58722317236171, #TEST
+          "LinK"    : -149.58726772171027  #TEST
+        } 
+    },
+    "Triplet UHF": {
+        "Canonical" : -149.67135517240553, #TEST
+        "DF"        : -149.67125624291961, #TEST
+        "Composite": {
+          "COSX"    : -149.67132922581225, #TEST
+          "LinK"    : -149.67137328005577  #TEST
+        }
+    },
+    "Triplet ROHF": {
+        "Canonical" : -149.65170765757173, #TEST
+        "DF"        : -149.65160796208073, #TEST
+        "Composite": {
+          "COSX"    : -149.65168894156605, #TEST
+          "LinK"    : -149.65172557470324  #TEST
+        }
+    }
+}
 
 molecule singlet_o2 {
     0 1
@@ -73,8 +93,8 @@ singlet_o2.update_geometry()
 triplet_o2.update_geometry()
 
 print('   -Nuclear Repulsion:') #TEST
-compare_values(Eref_nuc, triplet_o2.nuclear_repulsion_energy(), 9, "Triplet nuclear repulsion energy")  #TEST
-compare_values(Eref_nuc, singlet_o2.nuclear_repulsion_energy(), 9, "Singlet nuclear repulsion energy")  #TEST
+compare_values(Eref["Nuclear"], triplet_o2.nuclear_repulsion_energy(), 9, "Triplet nuclear repulsion energy")  #TEST
+compare_values(Eref["Nuclear"], singlet_o2.nuclear_repulsion_energy(), 9, "Singlet nuclear repulsion energy")  #TEST
 
 activate(singlet_o2)
 set {
@@ -89,32 +109,34 @@ set screening csam
 
 set scf_type pk
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet PK RHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet PK RHF energy') #TEST
 
 set scf_type direct
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet Direct RHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet Direct RHF energy') #TEST
 
 set scf_type out_of_core
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet Disk RHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet Disk RHF energy') #TEST
 
 set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF RHF energy') #TEST
+compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet DiskDF RHF energy') #TEST
 
 set scf_type mem_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet MemDF RHF energy') #TEST
+compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF RHF energy') #TEST
 
-set scf_type cosx
-E = energy('scf')
-compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX RHF energy') #TEST
+for method in Eref["Singlet"]["Composite"].keys():
+    if method == "COSX": 
+      set scf_type cosx # NOTE: if I knew how to directly assign scf_type to the value in method in Psithon here, I would
+      set screening csam
+    elif method == "LinK":
+      set scf_type link 
+      set screening density
 
-set scf_type link
-set screening density
-E = energy('scf')
-compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK RHF energy') #TEST
+    E = energy('scf')
+    compare_values(Eref["Singlet"]["Composite"][method], E, 6, f'Singlet {method} RHF energy') #TEST
 
 print('    -Singlet UHF:') #TEST
 set scf reference uhf
@@ -122,32 +144,34 @@ set screening csam
 
 set scf_type pk
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet PK UHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet PK UHF energy') #TEST
 
 set scf_type direct
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet Direct UHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet Direct UHF energy') #TEST
 
 set scf_type out_of_core
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet Disk UHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet Disk UHF energy') #TEST
 
 set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF UHF energy') #TEST
+compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet DiskDF UHF energy') #TEST
 
 set scf_type mem_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet MemDF UHF energy') #TEST
+compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF UHF energy') #TEST
 
-set scf_type cosx
-E = energy('scf')
-compare_values(Eref_sing_df, E, 4, 'Singlet DFJ+COSX UHF energy') #TEST
+for method in Eref["Singlet"]["Composite"].keys():
+    if method == "COSX": 
+      set scf_type cosx 
+      set screening csam
+    elif method == "LinK":
+      set scf_type link 
+      set screening density
 
-set scf_type link
-set screening density
-E = energy('scf')
-compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK UHF energy') #TEST
+    E = energy('scf')
+    compare_values(Eref["Singlet"]["Composite"][method], E, 6, f'Singlet {method} UHF energy') #TEST
 
 print('    -Singlet CUHF:') #TEST
 set scf reference cuhf
@@ -155,32 +179,34 @@ set screening csam
 
 set scf_type pk
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet PK CUHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet PK CUHF energy') #TEST
 
 set scf_type direct
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet Direct CUHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet Direct CUHF energy') #TEST
 
 set scf_type out_of_core
 E = energy('scf')
-compare_values(Eref_sing_can, E, 6, 'Singlet Disk CUHF energy') #TEST
+compare_values(Eref["Singlet"]["Canonical"], E, 6, 'Singlet Disk CUHF energy') #TEST
 
 set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet DiskDF CUHF energy') #TEST
+compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet DiskDF CUHF energy') #TEST
 
 set scf_type mem_df
 E = energy('scf')
-compare_values(Eref_sing_df, E, 6, 'Singlet MemDF CUHF energy') #TEST
+compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF CUHF energy') #TEST
 
-set scf_type cosx
-E = energy('scf')
-compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+COSX CUHF energy') #TEST
+for method in Eref["Singlet"]["Composite"].keys():
+    if method == "COSX": 
+      set scf_type cosx 
+      set screening csam
+    elif method == "LinK":
+      set scf_type link 
+      set screening density
 
-set scf_type link
-set screening density
-E = energy('scf')
-compare_values(Eref_sing_can, E, 4, 'Singlet DFJ+LinK CUHF energy') #TEST
+    E = energy('scf')
+    compare_values(Eref["Singlet"]["Composite"][method], E, 6, f'Singlet {method} CUHF energy') #TEST
 
 activate(triplet_o2)
 set {
@@ -196,32 +222,34 @@ set screening csam
 
 set scf_type pk
 E = energy('scf')
-compare_values(Eref_uhf_can, E, 6, 'Triplet PK UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["Canonical"], E, 6, 'Triplet PK UHF energy') #TEST
 
 set scf_type direct
 E = energy('scf')
-compare_values(Eref_uhf_can, E, 6, 'Triplet Direct UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["Canonical"], E, 6, 'Triplet Direct UHF energy') #TEST
 
 set scf_type out_of_core
 E = energy('scf')
-compare_values(Eref_uhf_can, E, 6, 'Triplet Disk UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["Canonical"], E, 6, 'Triplet Disk UHF energy') #TEST
 
 set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_uhf_df, E, 6, 'Triplet DiskDF UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["DF"], E, 6, 'Triplet DiskDF UHF energy') #TEST
 
 set scf_type mem_df
 E = energy('scf')
-compare_values(Eref_uhf_df, E, 6, 'Triplet MemDF UHF energy') #TEST
+compare_values(Eref["Triplet UHF"]["DF"], E, 6, 'Triplet MemDF UHF energy') #TEST
 
-set scf_type cosx
-E = energy('scf')
-compare_values(Eref_uhf_can, E, 4, 'Triplet DFJ+COSX UHF energy') #TEST
+for method in Eref["Triplet UHF"]["Composite"].keys():
+    if method == "COSX": 
+      set scf_type cosx 
+      set screening csam
+    elif method == "LinK":
+      set scf_type link 
+      set screening density
 
-set scf_type link
-set screening density
-E = energy('scf')
-compare_values(Eref_uhf_can, E, 4, 'Triplet DFJ+LinK UHF energy') #TEST
+    E = energy('scf')
+    compare_values(Eref["Triplet UHF"]["Composite"][method], E, 6, f'Triplet {method} UHF energy') #TEST
 
 clean()
 
@@ -231,35 +259,37 @@ set screening csam
 
 set scf_type pk
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 6, 'Triplet PK ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 6, 'Triplet PK ROHF energy') #TEST
 clean()
 
 set scf_type direct
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 6, 'Triplet Direct ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 6, 'Triplet Direct ROHF energy') #TEST
 clean()
 
 set scf_type out_of_core
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 6, 'Triplet Disk ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 6, 'Triplet Disk ROHF energy') #TEST
 clean()
 
 set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_rohf_df, E, 6, 'Triplet DiskDF ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet DiskDF ROHF energy') #TEST
 
 set scf_type mem_df
 E = energy('scf')
-compare_values(Eref_rohf_df, E, 6, 'Triplet MemDF ROHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF ROHF energy') #TEST
 
-set scf_type cosx
-E = energy('scf')
-compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX ROHF energy') #TEST
+for method in Eref["Triplet ROHF"]["Composite"].keys():
+    if method == "COSX": 
+      set scf_type cosx 
+      set screening csam
+    elif method == "LinK":
+      set scf_type link 
+      set screening density
 
-set scf_type link
-set screening density
-E = energy('scf')
-compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK ROHF energy') #TEST
+    E = energy('scf')
+    compare_values(Eref["Triplet ROHF"]["Composite"][method], E, 6, f'Triplet {method} ROHF energy') #TEST
 
 clean()
 
@@ -269,35 +299,37 @@ set screening csam
 
 set scf_type pk
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 6, 'Triplet PK CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 6, 'Triplet PK CUHF energy') #TEST
 clean()
 
 set scf_type direct
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 6, 'Triplet Direct CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 6, 'Triplet Direct CUHF energy') #TEST
 clean()
 
 set scf_type out_of_core
 E = energy('scf')
-compare_values(Eref_rohf_can, E, 6, 'Triplet Disk CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["Canonical"], E, 6, 'Triplet Disk CUHF energy') #TEST
 clean()
 
 set scf_type disk_df
 E = energy('scf')
-compare_values(Eref_rohf_df, E, 6, 'Triplet DiskDF CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet DiskDF CUHF energy') #TEST
 
 set scf_type mem_df
 E = energy('scf')
-compare_values(Eref_rohf_df, E, 6, 'Triplet MemDF CUHF energy') #TEST
+compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF CUHF energy') #TEST
 
-set scf_type cosx
-E = energy('scf')
-compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+COSX CUHF energy') #TEST
+for method in Eref["Triplet ROHF"]["Composite"].keys():
+    if method == "COSX": 
+      set scf_type cosx 
+      set screening csam
+    elif method == "LinK":
+      set scf_type link 
+      set screening density
 
-set scf_type link
-set screening density
-E = energy('scf')
-compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST
+    E = energy('scf')
+    compare_values(Eref["Triplet ROHF"]["Composite"][method], E, 6, f'Triplet {method} CUHF energy') #TEST
 --------------------------------------------------------------------------
     Triplet nuclear repulsion energy......................................................PASSED
     Singlet nuclear repulsion energy......................................................PASSED
@@ -305,7 +337,7 @@ compare_values(Eref_rohf_can, E, 4, 'Triplet DFJ+LinK CUHF energy') #TEST
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:15 2022
+*** at Thu Nov 10 10:42:59 2022
 
    => Loading Basis Set <=
 
@@ -511,21 +543,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:16 2022
+*** tstop() called on ds6 at Thu Nov 10 10:42:59 2022
 Module time:
-	user time   =       0.52 seconds =       0.01 minutes
+	user time   =       0.49 seconds =       0.01 minutes
 	system time =       0.06 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.52 seconds =       0.01 minutes
+	user time   =       0.49 seconds =       0.01 minutes
 	system time =       0.06 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
     Singlet PK RHF energy.................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:16 2022
+*** at Thu Nov 10 10:42:59 2022
 
    => Loading Basis Set <=
 
@@ -763,21 +795,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:17 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:00 2022
 Module time:
-	user time   =       0.79 seconds =       0.01 minutes
+	user time   =       0.83 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.33 seconds =       0.02 minutes
+	user time   =       1.35 seconds =       0.02 minutes
 	system time =       0.07 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	total time  =          1 seconds =       0.02 minutes
     Singlet Direct RHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:17 2022
+*** at Thu Nov 10 10:43:00 2022
 
    => Loading Basis Set <=
 
@@ -965,13 +997,13 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:17 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:01 2022
 Module time:
 	user time   =       0.36 seconds =       0.01 minutes
 	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.71 seconds =       0.03 minutes
+	user time   =       1.74 seconds =       0.03 minutes
 	system time =       0.09 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
     Singlet Disk RHF energy...............................................................PASSED
@@ -979,7 +1011,7 @@ Total time:
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:17 2022
+*** at Thu Nov 10 10:43:01 2022
 
    => Loading Basis Set <=
 
@@ -1197,21 +1229,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:18 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:01 2022
 Module time:
-	user time   =       0.21 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.24 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.95 seconds =       0.03 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       2.01 seconds =       0.03 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
     Singlet DiskDF RHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:18 2022
+*** at Thu Nov 10 10:43:01 2022
 
    => Loading Basis Set <=
 
@@ -1430,21 +1462,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:18 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:01 2022
 Module time:
-	user time   =       0.21 seconds =       0.00 minutes
+	user time   =       0.25 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.19 seconds =       0.04 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       2.28 seconds =       0.04 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
     Singlet MemDF RHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:18 2022
+*** at Thu Nov 10 10:43:01 2022
 
    => Loading Basis Set <=
 
@@ -1566,17 +1598,17 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RHF iter SAD:  -149.27713328631921   -1.49277e+02   0.00000e+00 
-   @RHF iter   1:  -149.56382697604792   -2.86694e-01   1.10975e-02 DIIS/ADIIS
-   @RHF iter   2:  -149.58629558037478   -2.24686e-02   2.92559e-03 DIIS/ADIIS
-   @RHF iter   3:  -149.58760428588212   -1.30871e-03   6.47395e-04 DIIS/ADIIS
-   @RHF iter   4:  -149.58772283023296   -1.18544e-04   1.38075e-04 DIIS/ADIIS
-   @RHF iter   5:  -149.58772855372317   -5.72349e-06   1.83160e-05 DIIS
-   @RHF iter   6:  -149.58772885952450   -3.05801e-07   2.47041e-06 DIIS
-   @RHF iter   7:  -149.58772885956978   -4.52758e-11   2.44347e-07 DIIS
+   @RHF iter   1:  -149.56382697604778   -2.86694e-01   1.10975e-02 DIIS/ADIIS
+   @RHF iter   2:  -149.58629558037464   -2.24686e-02   2.92559e-03 DIIS/ADIIS
+   @RHF iter   3:  -149.58760428588204   -1.30871e-03   6.47395e-04 DIIS/ADIIS
+   @RHF iter   4:  -149.58772283023293   -1.18544e-04   1.38075e-04 DIIS/ADIIS
+   @RHF iter   5:  -149.58772855372328   -5.72349e-06   1.83160e-05 DIIS
+   @RHF iter   6:  -149.58772885952453   -3.05801e-07   2.47041e-06 DIIS
+   @RHF iter   7:  -149.58772885956969   -4.51621e-11   2.44347e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @RHF iter   8:  -149.58722317116366    5.05688e-04   9.91149e-04 DIIS/ADIIS
+   @RHF iter   8:  -149.58722317116374    5.05688e-04   9.91149e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -1618,14 +1650,14 @@ Scratch directory: /scratch/dpoole34/
     NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  @RHF Final Energy:  -149.58722317116366
+  @RHF Final Energy:  -149.58722317116374
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.8059033672359419
-    Two-Electron Energy =                  86.4301879389086025
-    Total Energy =                       -149.5872231711636857
+    One-Electron Energy =                -266.8059033672350893
+    Two-Electron Energy =                  86.4301879389076930
+    Total Energy =                       -149.5872231711637426
 
 Computation Completed
 
@@ -1649,21 +1681,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:21 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:04 2022
 Module time:
-	user time   =       2.58 seconds =       0.04 minutes
+	user time   =       2.66 seconds =       0.04 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =       4.79 seconds =       0.08 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
-    Singlet DFJ+COSX RHF energy...........................................................PASSED
+	user time   =       4.96 seconds =       0.08 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+    Singlet COSX RHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:21 2022
+*** at Thu Nov 10 10:43:04 2022
 
    => Loading Basis Set <=
 
@@ -1861,21 +1893,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:22 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:05 2022
 Module time:
-	user time   =       1.33 seconds =       0.02 minutes
+	user time   =       1.39 seconds =       0.02 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       6.15 seconds =       0.10 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          7 seconds =       0.12 minutes
-    Singlet DFJ+LinK RHF energy...........................................................PASSED
+	user time   =       6.39 seconds =       0.11 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+    Singlet LinK RHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:22 2022
+*** at Thu Nov 10 10:43:06 2022
 
    => Loading Basis Set <=
 
@@ -2125,21 +2157,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:26 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:06 2022
 Module time:
-	user time   =       0.42 seconds =       0.01 minutes
+	user time   =       0.43 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          4 seconds =       0.07 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.60 seconds =       0.11 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =         11 seconds =       0.18 minutes
+	user time   =       6.85 seconds =       0.11 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
     Singlet PK UHF energy.................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:26 2022
+*** at Thu Nov 10 10:43:06 2022
 
    => Loading Basis Set <=
 
@@ -2421,21 +2453,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:27 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:07 2022
 Module time:
-	user time   =       0.88 seconds =       0.01 minutes
+	user time   =       0.87 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.52 seconds =       0.13 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =         12 seconds =       0.20 minutes
+	user time   =       7.77 seconds =       0.13 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          8 seconds =       0.13 minutes
     Singlet Direct UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:27 2022
+*** at Thu Nov 10 10:43:07 2022
 
    => Loading Basis Set <=
 
@@ -2667,21 +2699,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:28 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:08 2022
 Module time:
 	user time   =       0.38 seconds =       0.01 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.93 seconds =       0.13 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =       8.17 seconds =       0.14 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
     Singlet Disk UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:28 2022
+*** at Thu Nov 10 10:43:08 2022
 
    => Loading Basis Set <=
 
@@ -2943,21 +2975,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:28 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:08 2022
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
+	user time   =       0.24 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.18 seconds =       0.14 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =         13 seconds =       0.22 minutes
+	user time   =       8.44 seconds =       0.14 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
     Singlet DiskDF UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:28 2022
+*** at Thu Nov 10 10:43:08 2022
 
    => Loading Basis Set <=
 
@@ -3220,21 +3252,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:29 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:08 2022
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
+	user time   =       0.24 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.44 seconds =       0.14 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =         14 seconds =       0.23 minutes
+	user time   =       8.71 seconds =       0.15 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          9 seconds =       0.15 minutes
     Singlet MemDF UHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:29 2022
+*** at Thu Nov 10 10:43:08 2022
 
    => Loading Basis Set <=
 
@@ -3356,13 +3388,13 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @UHF iter SAD:  -149.27713328631921   -1.49277e+02   0.00000e+00 
-   @UHF iter   1:  -149.56382697604792   -2.86694e-01   1.10975e-02 DIIS/ADIIS
-   @UHF iter   2:  -149.58629558037478   -2.24686e-02   2.92559e-03 DIIS/ADIIS
-   @UHF iter   3:  -149.58760428588204   -1.30871e-03   6.47395e-04 DIIS/ADIIS
-   @UHF iter   4:  -149.58772283023285   -1.18544e-04   1.38075e-04 DIIS/ADIIS
-   @UHF iter   5:  -149.58772855372325   -5.72349e-06   1.83160e-05 DIIS
-   @UHF iter   6:  -149.58772885952456   -3.05801e-07   2.47041e-06 DIIS
-   @UHF iter   7:  -149.58772885956972   -4.51621e-11   2.44347e-07 DIIS
+   @UHF iter   1:  -149.56382697604786   -2.86694e-01   1.10975e-02 DIIS/ADIIS
+   @UHF iter   2:  -149.58629558037481   -2.24686e-02   2.92559e-03 DIIS/ADIIS
+   @UHF iter   3:  -149.58760428588201   -1.30871e-03   6.47395e-04 DIIS/ADIIS
+   @UHF iter   4:  -149.58772283023276   -1.18544e-04   1.38075e-04 DIIS/ADIIS
+   @UHF iter   5:  -149.58772855372328   -5.72349e-06   1.83160e-05 DIIS
+   @UHF iter   6:  -149.58772885952453   -3.05801e-07   2.47041e-06 DIIS
+   @UHF iter   7:  -149.58772885956986   -4.53326e-11   2.44347e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
@@ -3372,9 +3404,9 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:   1.776356839E-15
+   @Spin Contamination Metric:  -3.552713679E-15
    @S^2 Expected:                0.000000000E+00
-   @S^2 Observed:                1.776356839E-15
+   @S^2 Observed:               -3.552713679E-15
    @S   Expected:                0.000000000E+00
    @S   Observed:                0.000000000E+00
 
@@ -3447,18 +3479,18 @@ Scratch directory: /scratch/dpoole34/
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.8059033672354303
-    Two-Electron Energy =                  86.4301879389081193
+    One-Electron Energy =                -266.8059033672356009
+    Two-Electron Energy =                  86.4301879389082899
     Total Energy =                       -149.5872231711636573
 
   UHF NO Occupations:
   HONO-2 :    3 Ag 2.0000000
   HONO-1 :    1B3g 2.0000000
   HONO-0 :    1B2u 2.0000000
-  LUNO+0 :    4 Ag 0.0000000
-  LUNO+1 :    5 Ag 0.0000000
-  LUNO+2 :    3B1u 0.0000000
-  LUNO+3 :    2B3u 0.0000000
+  LUNO+0 :    2B3g 0.0000000
+  LUNO+1 :    2B2u 0.0000000
+  LUNO+2 :    4 Ag 0.0000000
+  LUNO+3 :    3B1u 0.0000000
 
 
 Computation Completed
@@ -3483,21 +3515,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:31 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:11 2022
 Module time:
 	user time   =       2.68 seconds =       0.04 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      11.14 seconds =       0.19 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =         16 seconds =       0.27 minutes
-    Singlet DFJ+COSX UHF energy...........................................................PASSED
+	user time   =      11.42 seconds =       0.19 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =         12 seconds =       0.20 minutes
+    Singlet COSX UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:31 2022
+*** at Thu Nov 10 10:43:11 2022
 
    => Loading Basis Set <=
 
@@ -3739,21 +3771,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:33 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:12 2022
 Module time:
-	user time   =       1.45 seconds =       0.02 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       1.43 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      12.61 seconds =       0.21 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =         18 seconds =       0.30 minutes
-    Singlet DFJ+LinK UHF energy...........................................................PASSED
+	user time   =      12.88 seconds =       0.21 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =         13 seconds =       0.22 minutes
+    Singlet LinK UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:33 2022
+*** at Thu Nov 10 10:43:12 2022
 
    => Loading Basis Set <=
 
@@ -3991,21 +4023,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:33 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:13 2022
 Module time:
 	user time   =       0.41 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      13.05 seconds =       0.22 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =         18 seconds =       0.30 minutes
+	user time   =      13.32 seconds =       0.22 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =         14 seconds =       0.23 minutes
     Singlet PK CUHF energy................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:33 2022
+*** at Thu Nov 10 10:43:13 2022
 
    => Loading Basis Set <=
 
@@ -4275,21 +4307,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:34 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:14 2022
 Module time:
 	user time   =       0.87 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      13.94 seconds =       0.23 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =         19 seconds =       0.32 minutes
+	user time   =      14.22 seconds =       0.24 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =         15 seconds =       0.25 minutes
     Singlet Direct CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:34 2022
+*** at Thu Nov 10 10:43:14 2022
 
    => Loading Basis Set <=
 
@@ -4509,21 +4541,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:35 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:14 2022
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.35 seconds =       0.24 minutes
+	user time   =      14.65 seconds =       0.24 minutes
 	system time =       0.22 seconds =       0.00 minutes
-	total time  =         20 seconds =       0.33 minutes
+	total time  =         15 seconds =       0.25 minutes
     Singlet Disk CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:35 2022
+*** at Thu Nov 10 10:43:14 2022
 
    => Loading Basis Set <=
 
@@ -4773,21 +4805,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:35 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:15 2022
 Module time:
 	user time   =       0.23 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      14.60 seconds =       0.24 minutes
+	user time   =      14.90 seconds =       0.25 minutes
 	system time =       0.22 seconds =       0.00 minutes
-	total time  =         20 seconds =       0.33 minutes
+	total time  =         16 seconds =       0.27 minutes
     Singlet DiskDF CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:35 2022
+*** at Thu Nov 10 10:43:15 2022
 
    => Loading Basis Set <=
 
@@ -5038,21 +5070,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:35 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:15 2022
 Module time:
-	user time   =       0.24 seconds =       0.00 minutes
+	user time   =       0.23 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.87 seconds =       0.25 minutes
+	user time   =      15.16 seconds =       0.25 minutes
 	system time =       0.23 seconds =       0.00 minutes
-	total time  =         20 seconds =       0.33 minutes
+	total time  =         16 seconds =       0.27 minutes
     Singlet MemDF CUHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:35 2022
+*** at Thu Nov 10 10:43:15 2022
 
    => Loading Basis Set <=
 
@@ -5174,13 +5206,13 @@ Scratch directory: /scratch/dpoole34/
                         Total Energy        Delta E     RMS |[F,P]|
 
    @CUHF iter SAD:  -149.27713328631918   -1.49277e+02   0.00000e+00 
-   @CUHF iter   1:  -149.56382697604786   -2.86694e-01   1.10975e-02 DIIS/ADIIS
-   @CUHF iter   2:  -149.58629558037481   -2.24686e-02   2.92559e-03 DIIS/ADIIS
-   @CUHF iter   3:  -149.58760428588189   -1.30871e-03   6.47395e-04 DIIS/ADIIS
-   @CUHF iter   4:  -149.58772283023296   -1.18544e-04   1.38075e-04 DIIS/ADIIS
-   @CUHF iter   5:  -149.58772855372328   -5.72349e-06   1.83160e-05 DIIS
-   @CUHF iter   6:  -149.58772885952447   -3.05801e-07   2.47041e-06 DIIS
-   @CUHF iter   7:  -149.58772885956972   -4.52474e-11   2.44347e-07 DIIS
+   @CUHF iter   1:  -149.56382697604781   -2.86694e-01   1.10975e-02 DIIS/ADIIS
+   @CUHF iter   2:  -149.58629558037472   -2.24686e-02   2.92559e-03 DIIS/ADIIS
+   @CUHF iter   3:  -149.58760428588195   -1.30871e-03   6.47395e-04 DIIS/ADIIS
+   @CUHF iter   4:  -149.58772283023291   -1.18544e-04   1.38075e-04 DIIS/ADIIS
+   @CUHF iter   5:  -149.58772855372325   -5.72349e-06   1.83160e-05 DIIS
+   @CUHF iter   6:  -149.58772885952445   -3.05801e-07   2.47041e-06 DIIS
+   @CUHF iter   7:  -149.58772885956975   -4.53042e-11   2.44347e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
@@ -5263,8 +5295,8 @@ Scratch directory: /scratch/dpoole34/
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.8059033672357714
-    Two-Electron Energy =                  86.4301879389084604
+    One-Electron Energy =                -266.8059033672359988
+    Two-Electron Energy =                  86.4301879389086878
     Total Energy =                       -149.5872231711636573
 
 Computation Completed
@@ -5289,21 +5321,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:38 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:18 2022
 Module time:
-	user time   =       2.68 seconds =       0.04 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       2.69 seconds =       0.04 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      17.57 seconds =       0.29 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =         23 seconds =       0.38 minutes
-    Singlet DFJ+COSX CUHF energy..........................................................PASSED
+	user time   =      17.88 seconds =       0.30 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =         19 seconds =       0.32 minutes
+    Singlet COSX CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:38 2022
+*** at Thu Nov 10 10:43:18 2022
 
    => Loading Basis Set <=
 
@@ -5533,21 +5565,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:39 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:19 2022
 Module time:
-	user time   =       1.40 seconds =       0.02 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       1.42 seconds =       0.02 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      19.00 seconds =       0.32 minutes
+	user time   =      19.32 seconds =       0.32 minutes
 	system time =       0.24 seconds =       0.00 minutes
-	total time  =         24 seconds =       0.40 minutes
-    Singlet DFJ+LinK CUHF energy..........................................................PASSED
+	total time  =         20 seconds =       0.33 minutes
+    Singlet LinK CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:39 2022
+*** at Thu Nov 10 10:43:19 2022
 
    => Loading Basis Set <=
 
@@ -5804,21 +5836,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:40 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:19 2022
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.35 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      19.41 seconds =       0.32 minutes
-	system time =       0.25 seconds =       0.00 minutes
-	total time  =         25 seconds =       0.42 minutes
+	user time   =      19.70 seconds =       0.33 minutes
+	system time =       0.26 seconds =       0.00 minutes
+	total time  =         20 seconds =       0.33 minutes
     Triplet PK UHF energy.................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:40 2022
+*** at Thu Nov 10 10:43:19 2022
 
    => Loading Basis Set <=
 
@@ -6106,21 +6138,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:41 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:20 2022
 Module time:
-	user time   =       0.66 seconds =       0.01 minutes
+	user time   =       0.67 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      20.09 seconds =       0.33 minutes
-	system time =       0.26 seconds =       0.00 minutes
-	total time  =         26 seconds =       0.43 minutes
+	user time   =      20.40 seconds =       0.34 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =         21 seconds =       0.35 minutes
     Triplet Direct UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:41 2022
+*** at Thu Nov 10 10:43:20 2022
 
    => Loading Basis Set <=
 
@@ -6359,21 +6391,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:41 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:21 2022
 Module time:
-	user time   =       0.33 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.32 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      20.45 seconds =       0.34 minutes
+	user time   =      20.75 seconds =       0.35 minutes
 	system time =       0.29 seconds =       0.00 minutes
-	total time  =         26 seconds =       0.43 minutes
+	total time  =         22 seconds =       0.37 minutes
     Triplet Disk UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:41 2022
+*** at Thu Nov 10 10:43:21 2022
 
    => Loading Basis Set <=
 
@@ -6642,21 +6674,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:41 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:21 2022
 Module time:
 	user time   =       0.19 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      20.67 seconds =       0.34 minutes
-	system time =       0.29 seconds =       0.00 minutes
-	total time  =         26 seconds =       0.43 minutes
+	user time   =      20.97 seconds =       0.35 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =         22 seconds =       0.37 minutes
     Triplet DiskDF UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:41 2022
+*** at Thu Nov 10 10:43:21 2022
 
    => Loading Basis Set <=
 
@@ -6926,21 +6958,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:42 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:21 2022
 Module time:
-	user time   =       0.19 seconds =       0.00 minutes
+	user time   =       0.17 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      20.89 seconds =       0.35 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =         27 seconds =       0.45 minutes
+	user time   =      21.16 seconds =       0.35 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =         22 seconds =       0.37 minutes
     Triplet MemDF UHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:42 2022
+*** at Thu Nov 10 10:43:21 2022
 
    => Loading Basis Set <=
 
@@ -7074,13 +7106,13 @@ Scratch directory: /scratch/dpoole34/
    @UHF iter   4:  -149.65391531645002   -5.74707e-01   1.05356e-02 DIIS/ADIIS
    @UHF iter   5:  -149.67061947228331   -1.67042e-02   1.87593e-03 DIIS/ADIIS
    @UHF iter   6:  -149.67160507761122   -9.85605e-04   4.33948e-04 DIIS/ADIIS
-   @UHF iter   7:  -149.67166177628383   -5.66987e-05   6.80300e-05 DIIS
-   @UHF iter   8:  -149.67166378928798   -2.01300e-06   9.42637e-06 DIIS
-   @UHF iter   9:  -149.67166383531969   -4.60317e-08   8.91526e-07 DIIS
+   @UHF iter   7:  -149.67166177628394   -5.66987e-05   6.80300e-05 DIIS
+   @UHF iter   8:  -149.67166378928829   -2.01300e-06   9.42637e-06 DIIS
+   @UHF iter   9:  -149.67166383531969   -4.60314e-08   8.91526e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @UHF iter  10:  -149.67132922569729    3.34610e-04   9.51899e-04 DIIS/ADIIS
+   @UHF iter  10:  -149.67132922569735    3.34610e-04   9.51899e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -7155,14 +7187,14 @@ Scratch directory: /scratch/dpoole34/
     NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  @UHF Final Energy:  -149.67132922569729
+  @UHF Final Energy:  -149.67132922569735
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.9129345756497855
-    Two-Electron Energy =                  86.4531130927888256
-    Total Energy =                       -149.6713292256973205
+    One-Electron Energy =                -266.9129345756499561
+    Two-Electron Energy =                  86.4531130927889535
+    Total Energy =                       -149.6713292256973489
 
   UHF NO Occupations:
   HONO-2 :    1B2u 1.9937328
@@ -7196,21 +7228,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:44 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:24 2022
 Module time:
-	user time   =       2.90 seconds =       0.05 minutes
+	user time   =       2.91 seconds =       0.05 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      23.82 seconds =       0.40 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =         29 seconds =       0.48 minutes
-    Triplet DFJ+COSX UHF energy...........................................................PASSED
+	user time   =      24.10 seconds =       0.40 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =         25 seconds =       0.42 minutes
+    Triplet COSX UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:45 2022
+*** at Thu Nov 10 10:43:24 2022
 
    => Loading Basis Set <=
 
@@ -7459,21 +7491,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:46 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:26 2022
 Module time:
-	user time   =       1.63 seconds =       0.03 minutes
+	user time   =       1.62 seconds =       0.03 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      25.48 seconds =       0.42 minutes
-	system time =       0.31 seconds =       0.01 minutes
-	total time  =         31 seconds =       0.52 minutes
-    Triplet DFJ+LinK UHF energy...........................................................PASSED
+	user time   =      25.75 seconds =       0.43 minutes
+	system time =       0.32 seconds =       0.01 minutes
+	total time  =         27 seconds =       0.45 minutes
+    Triplet LinK UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:46 2022
+*** at Thu Nov 10 10:43:26 2022
 
    => Loading Basis Set <=
 
@@ -7691,21 +7723,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:47 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:26 2022
 Module time:
-	user time   =       0.33 seconds =       0.01 minutes
+	user time   =       0.34 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      25.84 seconds =       0.43 minutes
-	system time =       0.32 seconds =       0.01 minutes
-	total time  =         32 seconds =       0.53 minutes
+	user time   =      26.12 seconds =       0.44 minutes
+	system time =       0.33 seconds =       0.01 minutes
+	total time  =         27 seconds =       0.45 minutes
     Triplet PK ROHF energy................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:47 2022
+*** at Thu Nov 10 10:43:26 2022
 
    => Loading Basis Set <=
 
@@ -7954,21 +7986,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:47 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:27 2022
 Module time:
-	user time   =       0.62 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.64 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      26.49 seconds =       0.44 minutes
-	system time =       0.32 seconds =       0.01 minutes
-	total time  =         32 seconds =       0.53 minutes
+	user time   =      26.80 seconds =       0.45 minutes
+	system time =       0.34 seconds =       0.01 minutes
+	total time  =         28 seconds =       0.47 minutes
     Triplet Direct ROHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:47 2022
+*** at Thu Nov 10 10:43:27 2022
 
    => Loading Basis Set <=
 
@@ -8168,21 +8200,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:48 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:27 2022
 Module time:
-	user time   =       0.22 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.34 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      26.74 seconds =       0.45 minutes
-	system time =       0.34 seconds =       0.01 minutes
-	total time  =         33 seconds =       0.55 minutes
+	user time   =      27.17 seconds =       0.45 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =         28 seconds =       0.47 minutes
     Triplet Disk ROHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:48 2022
+*** at Thu Nov 10 10:43:27 2022
 
    => Loading Basis Set <=
 
@@ -8412,21 +8444,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:48 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:28 2022
 Module time:
-	user time   =       0.15 seconds =       0.00 minutes
+	user time   =       0.18 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      26.94 seconds =       0.45 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =         33 seconds =       0.55 minutes
+	user time   =      27.38 seconds =       0.46 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =         29 seconds =       0.48 minutes
     Triplet DiskDF ROHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:48 2022
+*** at Thu Nov 10 10:43:28 2022
 
    => Loading Basis Set <=
 
@@ -8657,21 +8689,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:48 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:28 2022
 Module time:
-	user time   =       0.14 seconds =       0.00 minutes
+	user time   =       0.18 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      27.11 seconds =       0.45 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =         33 seconds =       0.55 minutes
+	user time   =      27.58 seconds =       0.46 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =         29 seconds =       0.48 minutes
     Triplet MemDF ROHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:48 2022
+*** at Thu Nov 10 10:43:28 2022
 
    => Loading Basis Set <=
 
@@ -8800,14 +8832,14 @@ Scratch directory: /scratch/dpoole34/
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
    @ROHF iter   1:  -131.02266731942382   -1.31023e+02   2.71851e-01 DIIS
-   @ROHF iter   2:  -139.64070004271159   -8.61803e+00   1.37369e-01 DIIS
-   @ROHF iter   3:  -148.99660951088313   -9.35591e+00   5.06619e-02 DIIS
-   @ROHF iter   4:  -149.63963700749704   -6.43027e-01   6.07525e-03 DIIS
-   @ROHF iter   5:  -149.65187157255184   -1.22346e-02   4.84799e-04 DIIS
-   @ROHF iter   6:  -149.65198834090864   -1.16768e-04   1.12106e-04 DIIS
-   @ROHF iter   7:  -149.65199670359942   -8.36269e-06   1.71152e-05 DIIS
+   @ROHF iter   2:  -139.64070004271170   -8.61803e+00   1.37369e-01 DIIS
+   @ROHF iter   3:  -148.99660951088302   -9.35591e+00   5.06619e-02 DIIS
+   @ROHF iter   4:  -149.63963700749687   -6.43027e-01   6.07525e-03 DIIS
+   @ROHF iter   5:  -149.65187157255181   -1.22346e-02   4.84799e-04 DIIS
+   @ROHF iter   6:  -149.65198834090884   -1.16768e-04   1.12106e-04 DIIS
+   @ROHF iter   7:  -149.65199670359928   -8.36269e-06   1.71152e-05 DIIS
    @ROHF iter   8:  -149.65199683539865   -1.31799e-07   2.91717e-06 DIIS
-   @ROHF iter   9:  -149.65199681028329    2.51154e-08   3.52335e-07 DIIS
+   @ROHF iter   9:  -149.65199681028338    2.51153e-08   3.52335e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
@@ -8862,8 +8894,8 @@ Scratch directory: /scratch/dpoole34/
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.9107678299205872
-    Two-Electron Energy =                  86.4705866325296597
+    One-Electron Energy =                -266.9107678299203030
+    Two-Electron Energy =                  86.4705866325293755
     Total Energy =                       -149.6516889402272739
 
 Computation Completed
@@ -8888,21 +8920,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:51 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:31 2022
 Module time:
-	user time   =       2.87 seconds =       0.05 minutes
+	user time   =       2.91 seconds =       0.05 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      30.00 seconds =       0.50 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =         36 seconds =       0.60 minutes
-    Triplet DFJ+COSX ROHF energy..........................................................PASSED
+	user time   =      30.52 seconds =       0.51 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =         32 seconds =       0.53 minutes
+    Triplet COSX ROHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:51 2022
+*** at Thu Nov 10 10:43:31 2022
 
    => Loading Basis Set <=
 
@@ -9112,21 +9144,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:52 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:32 2022
 Module time:
-	user time   =       1.61 seconds =       0.03 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.63 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      31.63 seconds =       0.53 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =         37 seconds =       0.62 minutes
-    Triplet DFJ+LinK ROHF energy..........................................................PASSED
+	user time   =      32.18 seconds =       0.54 minutes
+	system time =       0.37 seconds =       0.01 minutes
+	total time  =         33 seconds =       0.55 minutes
+    Triplet LinK ROHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:53 2022
+*** at Thu Nov 10 10:43:32 2022
 
    => Loading Basis Set <=
 
@@ -9371,21 +9403,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:53 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:33 2022
 Module time:
-	user time   =       0.36 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      32.04 seconds =       0.53 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =         38 seconds =       0.63 minutes
+	user time   =      32.59 seconds =       0.54 minutes
+	system time =       0.39 seconds =       0.01 minutes
+	total time  =         34 seconds =       0.57 minutes
     Triplet PK CUHF energy................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:53 2022
+*** at Thu Nov 10 10:43:33 2022
 
    => Loading Basis Set <=
 
@@ -9661,21 +9693,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:54 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:34 2022
 Module time:
-	user time   =       0.68 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      32.77 seconds =       0.55 minutes
-	system time =       0.38 seconds =       0.01 minutes
-	total time  =         39 seconds =       0.65 minutes
+	user time   =      33.28 seconds =       0.55 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =         35 seconds =       0.58 minutes
     Triplet Direct CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:54 2022
+*** at Thu Nov 10 10:43:34 2022
 
    => Loading Basis Set <=
 
@@ -9902,21 +9934,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:54 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:34 2022
 Module time:
-	user time   =       0.34 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.31 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      33.14 seconds =       0.55 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =         39 seconds =       0.65 minutes
+	user time   =      33.62 seconds =       0.56 minutes
+	system time =       0.41 seconds =       0.01 minutes
+	total time  =         35 seconds =       0.58 minutes
     Triplet Disk CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:54 2022
+*** at Thu Nov 10 10:43:34 2022
 
    => Loading Basis Set <=
 
@@ -10173,21 +10205,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:54 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:34 2022
 Module time:
 	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      33.34 seconds =       0.56 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =         39 seconds =       0.65 minutes
+	user time   =      33.84 seconds =       0.56 minutes
+	system time =       0.42 seconds =       0.01 minutes
+	total time  =         35 seconds =       0.58 minutes
     Triplet DiskDF CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:54 2022
+*** at Thu Nov 10 10:43:34 2022
 
    => Loading Basis Set <=
 
@@ -10445,21 +10477,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:55 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:34 2022
 Module time:
-	user time   =       0.18 seconds =       0.00 minutes
+	user time   =       0.19 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      33.54 seconds =       0.56 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =         40 seconds =       0.67 minutes
+	user time   =      34.06 seconds =       0.57 minutes
+	system time =       0.42 seconds =       0.01 minutes
+	total time  =         35 seconds =       0.58 minutes
     Triplet MemDF CUHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:55 2022
+*** at Thu Nov 10 10:43:35 2022
 
    => Loading Basis Set <=
 
@@ -10588,13 +10620,13 @@ Scratch directory: /scratch/dpoole34/
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
    @CUHF iter   1:  -131.02266731942410   -1.31023e+02   3.53890e-01 ADIIS
-   @CUHF iter   2:  -140.10621696114717   -9.08355e+00   1.85157e-01 ADIIS
-   @CUHF iter   3:  -149.07283195574354   -8.96661e+00   6.18535e-02 DIIS/ADIIS
-   @CUHF iter   4:  -149.63845093676019   -5.65619e-01   1.00842e-02 DIIS/ADIIS
-   @CUHF iter   5:  -149.65151108189110   -1.30601e-02   1.51377e-03 DIIS/ADIIS
-   @CUHF iter   6:  -149.65197130478225   -4.60223e-04   2.18032e-04 DIIS/ADIIS
+   @CUHF iter   2:  -140.10621696114706   -9.08355e+00   1.85157e-01 ADIIS
+   @CUHF iter   3:  -149.07283195574351   -8.96661e+00   6.18535e-02 DIIS/ADIIS
+   @CUHF iter   4:  -149.63845093676014   -5.65619e-01   1.00842e-02 DIIS/ADIIS
+   @CUHF iter   5:  -149.65151108189107   -1.30601e-02   1.51377e-03 DIIS/ADIIS
+   @CUHF iter   6:  -149.65197130478214   -4.60223e-04   2.18032e-04 DIIS/ADIIS
    @CUHF iter   7:  -149.65199790962745   -2.66048e-05   1.85204e-05 DIIS
-   @CUHF iter   8:  -149.65199703995123    8.69676e-07   2.10529e-06 DIIS
+   @CUHF iter   8:  -149.65199703995131    8.69676e-07   2.10529e-06 DIIS
    @CUHF iter   9:  -149.65199679272925    2.47222e-07   3.47492e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
@@ -10677,8 +10709,8 @@ Scratch directory: /scratch/dpoole34/
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.9107736954306347
-    Two-Electron Energy =                  86.4705924981045513
+    One-Electron Energy =                -266.9107736954308621
+    Two-Electron Energy =                  86.4705924981047787
     Total Energy =                       -149.6516889401624439
 
 Computation Completed
@@ -10703,21 +10735,21 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:04:58 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:37 2022
 Module time:
-	user time   =       2.90 seconds =       0.05 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       2.94 seconds =       0.05 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      36.47 seconds =       0.61 minutes
-	system time =       0.41 seconds =       0.01 minutes
-	total time  =         43 seconds =       0.72 minutes
-    Triplet DFJ+COSX CUHF energy..........................................................PASSED
+	user time   =      37.02 seconds =       0.62 minutes
+	system time =       0.43 seconds =       0.01 minutes
+	total time  =         38 seconds =       0.63 minutes
+    Triplet COSX CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Mon Nov  7 11:04:58 2022
+*** at Thu Nov 10 10:43:38 2022
 
    => Loading Basis Set <=
 
@@ -10954,18 +10986,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Mon Nov  7 11:05:04 2022
+*** tstop() called on ds6 at Thu Nov 10 10:43:39 2022
 Module time:
 	user time   =       1.66 seconds =       0.03 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          6 seconds =       0.10 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      38.15 seconds =       0.64 minutes
-	system time =       0.42 seconds =       0.01 minutes
-	total time  =         49 seconds =       0.82 minutes
-    Triplet DFJ+LinK CUHF energy..........................................................PASSED
+	user time   =      38.71 seconds =       0.65 minutes
+	system time =       0.44 seconds =       0.01 minutes
+	total time  =         40 seconds =       0.67 minutes
+    Triplet LinK CUHF energy..............................................................PASSED
 
-    Psi4 stopped on: Monday, 07 November 2022 11:05AM
-    Psi4 wall time for execution: 0:00:48.89
+    Psi4 stopped on: Thursday, 10 November 2022 10:43AM
+    Psi4 wall time for execution: 0:00:40.60
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
The goal of this PR is to expand test coverage of the DFJCOSK and DFJLinK JK subclasses within Psi4 by including their testing within the scf5 test. The scf5 test in Psi4 tests a variety of combinations of SCF_TYPE and SCF reference for singlet and triplet O2. As it were, the COSX and LinK SCF_TYPES were missing from the list of methods analyzed within this test. This PR simply adds COSX and LinK to the list of methods tested in scf5, expanding testing of these two methods beyond what was previously present.

NOTE TO REVIEWERS: This PR is a general JK maintenance/cleanup/improvement PR and is independent of the developments occurring regarding CompositeJK and its direct implementation into Psi4. 

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] N/A

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Adds COSX and LINK to the list of SCF_TYPEs tested in the scf5 test option.

## Questions
- [ ] Is the methodology by which COSX and LinK tested acceptable? Unfortunately, the reference energies used in scf5 are either canonical (i.e., non-DF) or DF, neither of which fully describe the COSX and LINK methods. The approach I took is to compare each COSX and LINK energy to the corresponding canonical energy with an atol of 1E-4. Any feedback on this particular approach to testing COSX and LINK would be appreciated.

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
