### PR TITLE
Restructure PCM functors

### DIFF
--- a/psi4/src/psi4/libmints/potentialint.cc
+++ b/psi4/src/psi4/libmints/potentialint.cc
@@ -45,4 +45,48 @@ PCMPotentialInt::PCMPotentialInt(std::vector<SphericalTransform>& trans, std::sh
     }
 }
 
+template <typename PCMPotentialIntFunctor>
+void PCMPotentialInt::compute(PCMPotentialIntFunctor &functor) {
+    bool bs1_equiv_bs2 = bs1_ == bs2_;
+    size_t npoints = Zxyz_.size();
+    size_t nthreads = engines_.size();
+    functor.initialize(nthreads);
+#pragma omp parallel for schedule(static) num_threads(nthreads)
+    for (int point = 0; point < npoints; ++point) {
+        size_t rank = 0;
+#ifdef _OPENMP
+        rank = omp_get_thread_num();
+#endif
+        engines_[rank]->set_params(std::vector<std::pair<double, std::array<double, 3>>>{Zxyz_[point]});
+        for (const auto &pair : shellpairs_) {
+            int p1 = pair.first;
+            int p2 = pair.second;
+
+            int ni = bs1_->shell(p1).nfunction();
+            int nj = bs2_->shell(p2).nfunction();
+            int i_offset = bs1_->shell_to_basis_function(p1);
+            int j_offset = bs2_->shell_to_basis_function(p2);
+
+            // Compute the shell
+            engines_[rank]->compute(bs1_->l2_shell(p1), bs2_->l2_shell(p2));
+            // For each integral that we got put in its contribution
+            const double *location = engines_[rank]->results()[0];
+            for (int p = 0; p < ni; ++p) {
+                for (int q = 0; q < nj; ++q) {
+                    functor(p + i_offset, q + j_offset, point, *location, rank);
+                    if (bs1_equiv_bs2 && p1 != p2) {
+                        functor(q + j_offset, p + i_offset, point, *location, rank);
+                    }
+                    ++location;
+                }
+            }
+        }
+    }
+    functor.finalize(nthreads);
+}
+
+template void PCMPotentialInt::compute(ContractOverChargesFunctor&);
+template void PCMPotentialInt::compute(PrintIntegralsFunctor&);
+template void PCMPotentialInt::compute(ContractOverDensityFunctor&);
+
 }  // namespace psi

--- a/psi4/src/psi4/libmints/potentialint.h
+++ b/psi4/src/psi4/libmints/potentialint.h
@@ -25,17 +25,15 @@
  *
  * @END LICENSE
  */
+#pragma once
 
-#ifndef _psi_src_lib_libmints_potentialint_h_
-#define _psi_src_lib_libmints_potentialint_h_
-
-#include "psi4/libmints/gshell.h"
+// #include "psi4/libmints/gshell.h"
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/potential.h"
-#include "psi4/libmints/matrix.h"
+// #include "psi4/libmints/matrix.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
-#include "libint2/engine.h"
+#include "psi4/libmints/integral.h"
 
 namespace psi {
 
@@ -63,46 +61,6 @@ class PCMPotentialInt : public PotentialInt {
     template <typename PCMPotentialIntFunctor>
     void compute(PCMPotentialIntFunctor &functor);
 };
-
-template <typename PCMPotentialIntFunctor>
-void PCMPotentialInt::compute(PCMPotentialIntFunctor &functor) {
-    bool bs1_equiv_bs2 = bs1_ == bs2_;
-    size_t npoints = Zxyz_.size();
-    size_t nthreads = engines_.size();
-    functor.initialize(nthreads);
-#pragma omp parallel for schedule(static) num_threads(nthreads)
-    for (int point = 0; point < npoints; ++point) {
-        size_t rank = 0;
-#ifdef _OPENMP
-        rank = omp_get_thread_num();
-#endif
-        engines_[rank]->set_params(std::vector<std::pair<double, std::array<double, 3>>>{Zxyz_[point]});
-        for (const auto &pair : shellpairs_) {
-            int p1 = pair.first;
-            int p2 = pair.second;
-
-            int ni = bs1_->shell(p1).nfunction();
-            int nj = bs2_->shell(p2).nfunction();
-            int i_offset = bs1_->shell_to_basis_function(p1);
-            int j_offset = bs2_->shell_to_basis_function(p2);
-
-            // Compute the shell
-            engines_[rank]->compute(bs1_->l2_shell(p1), bs2_->l2_shell(p2));
-            // For each integral that we got put in its contribution
-            const double *location = engines_[rank]->results()[0];
-            for (int p = 0; p < ni; ++p) {
-                for (int q = 0; q < nj; ++q) {
-                    functor(p + i_offset, q + j_offset, point, *location, rank);
-                    if (bs1_equiv_bs2 && p1 != p2) {
-                        functor(q + j_offset, p + i_offset, point, *location, rank);
-                    }
-                    ++location;
-                }
-            }
-        }
-    }
-    functor.finalize(nthreads);
-}
 
 class PrintIntegralsFunctor {
    public:
@@ -171,4 +129,3 @@ class ContractOverChargesFunctor {
 };
 
 }  // namespace psi
-#endif


### PR DESCRIPTION
## Description
Fixes a segfault discovered by @mfherbst while developing #2767.
It was caused by adding `#include "psi4/libmints/potentialint.h"` in `mintshelper.cc`, because `potentialint.h` included L2's `engine.h`.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Fix "future" segfault by reorganizing PCM functors (moved to `.cc` files to avoid L2 `engine.h` include). See discussion in #2767 

## Questions
- [ ] Question1

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
