### PR TITLE
Fix some incorrect printf format specifiers

### DIFF
--- a/psi4/src/psi4/cctransort/cctransort.cc
+++ b/psi4/src/psi4/cctransort/cctransort.cc
@@ -49,7 +49,7 @@ int **cacheprep_rhf(int level, int *cachefiles);
 void cachedone_uhf(int **cachelist);
 void cachedone_rhf(int **cachelist);
 
-void memcheck(int reference);
+void memcheck(const int reference);
 
 vector<int> pitzer2qt(vector<Dimension> &spaces);
 

--- a/psi4/src/psi4/cctransort/memcheck.cc
+++ b/psi4/src/psi4/cctransort/memcheck.cc
@@ -32,7 +32,7 @@
 namespace psi {
 namespace cctransort {
 
-void memcheck(int reference) {
+void memcheck(const int reference) {
     size_t irrep_size, size;
     dpdbuf4 Z;
 
@@ -44,7 +44,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of <ab|cd> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of <ab|cd> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -56,7 +56,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of <ia|bc> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of <ia|bc> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -68,7 +68,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of tijab amplitudes:  %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of tijab amplitudes:  %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -81,7 +81,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of <ab|cd> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of <ab|cd> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -93,7 +93,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of <ia|bc> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of <ia|bc> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -105,7 +105,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of tIjAb amplitudes:  %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of tIjAb amplitudes:  %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -118,7 +118,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of <AB|CD> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of <AB|CD> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -129,7 +129,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of <ab|cd> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of <ab|cd> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -140,7 +140,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of <Ab|Cd> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of <Ab|Cd> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -152,7 +152,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of <IA|BC> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of <IA|BC> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -164,7 +164,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of <ia|bc> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of <ia|bc> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -176,7 +176,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of <Ia|Bc> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of <Ia|Bc> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -188,7 +188,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of <iA|bC> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of <iA|bC> integrals: %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);
@@ -200,7 +200,7 @@ void memcheck(int reference) {
         for (int h = 0; h < Z.params->nirreps; h++) {
             irrep_size = (size_t)Z.params->rowtot[h] * Z.params->coltot[h];
             size += irrep_size;
-            outfile->Printf("\tSize of irrep %1lu of tIjAb amplitudes:  %10.3lf (MW) / %10.3lf (MB)\n", h,
+            outfile->Printf("\tSize of irrep %d of tIjAb amplitudes:  %10.3lf (MW) / %10.3lf (MB)\n", h,
                             irrep_size / 1e6, (irrep_size / 1e6) * sizeof(double));
         }
         global_dpd_->buf4_close(&Z);

--- a/psi4/src/psi4/detci/olsengraph.cc
+++ b/psi4/src/psi4/detci/olsengraph.cc
@@ -821,7 +821,7 @@ void print_ci_space(struct stringwr *strlist, int num_strings, int nirreps, int 
             outfile->Printf("   Links:\n");
             for (strsym = 0; strsym < strtypes; strsym++) {
                 for (j = 0; j < strlist->cnt[strsym]; j++) {
-                    outfile->Printf("   %3d [%3d] %c (%2d %3d)   %d\n", strlist->ij[strsym][j], strlist->oij[strsym][j],
+                    outfile->Printf("   %3d [%3d] %c (%2d %3zu)   %d\n", strlist->ij[strsym][j], strlist->oij[strsym][j],
                                     (strlist->sgn[strsym][j] == 1) ? '+' : '-', strsym, strlist->ridx[strsym][j],
                                     static_cast<int>(strlist->sgn[strsym][j]));
                 }

--- a/psi4/src/psi4/dlpno/mp2.cc
+++ b/psi4/src/psi4/dlpno/mp2.cc
@@ -1292,9 +1292,9 @@ void DLPNOMP2::print_aux_domains() {
     size_t naocc = lmo_to_ribfs_.size();
     outfile->Printf("\n");
     outfile->Printf("    Auxiliary BFs per Local MO:\n");
-    outfile->Printf("      Average = %4d AUX BFs (%d atoms)\n", total_bfs / naocc, total_atoms / naocc);
-    outfile->Printf("      Min     = %4d AUX BFs (%d atoms)\n", min_bfs, min_atoms);
-    outfile->Printf("      Max     = %4d AUX BFs (%d atoms)\n", max_bfs, max_atoms);
+    outfile->Printf("      Average = %4zu AUX BFs (%zu atoms)\n", total_bfs / naocc, total_atoms / naocc);
+    outfile->Printf("      Min     = %4zu AUX BFs (%zu atoms)\n", min_bfs, min_atoms);
+    outfile->Printf("      Max     = %4zu AUX BFs (%zu atoms)\n", max_bfs, max_atoms);
 }
 
 void DLPNOMP2::print_pao_domains() {
@@ -1315,9 +1315,9 @@ void DLPNOMP2::print_pao_domains() {
     size_t naocc = lmo_to_paos_.size();
     outfile->Printf("  \n");
     outfile->Printf("    Projected AOs per Local MO:\n");
-    outfile->Printf("      Average = %4d PAOs (%d atoms)\n", total_paos / naocc, total_atoms / naocc);
-    outfile->Printf("      Min     = %4d PAOs (%d atoms)\n", min_paos, min_atoms);
-    outfile->Printf("      Max     = %4d PAOs (%d atoms)\n", max_paos, max_atoms);
+    outfile->Printf("      Average = %4zu PAOs (%zu atoms)\n", total_paos / naocc, total_atoms / naocc);
+    outfile->Printf("      Min     = %4zu PAOs (%zu atoms)\n", min_paos, min_atoms);
+    outfile->Printf("      Max     = %4zu PAOs (%zu atoms)\n", max_paos, max_atoms);
 }
 
 void DLPNOMP2::print_lmo_domains() {

--- a/psi4/src/psi4/fnocc/lowmemory_triples.cc
+++ b/psi4/src/psi4/fnocc/lowmemory_triples.cc
@@ -230,7 +230,7 @@ PsiReturnType CoupledCluster::lowmemory_triples() {
             }
         }
     }
-    outfile->Printf("        Number of abc combinations: %i\n", nabc);
+    outfile->Printf("        Number of abc combinations: %li\n", nabc);
     outfile->Printf("\n");
 
     for (int i = 0; i < nthreads; i++) etrip[i] = 0.0;

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -501,7 +501,7 @@ void DirectJK::build_JK_matrices(std::vector<std::shared_ptr<TwoBodyAOInt>>& int
     if (debug_) {
         outfile->Printf("  ==> DirectJK: Task Blocking <==\n\n");
         for (size_t task = 0; task < ntask; task++) {
-            outfile->Printf("  Task: %3d, Task Start: %4d, Task End: %4d\n", task, task_starts[task],
+            outfile->Printf("  Task: %3zu, Task Start: %4d, Task End: %4d\n", task, task_starts[task],
                             task_starts[task + 1]);
             for (int P2 = task_starts[task]; P2 < task_starts[task + 1]; P2++) {
                 int P = task_shells[P2];

--- a/psi4/src/psi4/libfock/solver.cc
+++ b/psi4/src/psi4/libfock/solver.cc
@@ -1051,7 +1051,7 @@ void DLUSolver::eigenvals() {
         outfile->Printf("   > Eigenvalues <\n\n");
         for (size_t m = 0; m < E_.size(); m++) {
             for (size_t h = 0; h < E_[0].size(); ++h) {
-                outfile->Printf("    Eigenvalue %zu, Irrep %d = %24.16E\n", m, h, E_[m][h]);
+                outfile->Printf("    Eigenvalue %zu, Irrep %zu = %24.16E\n", m, h, E_[m][h]);
             }
         }
         outfile->Printf("\n");

--- a/psi4/src/psi4/libmints/cdsalclist.cc
+++ b/psi4/src/psi4/libmints/cdsalclist.cc
@@ -62,7 +62,7 @@ namespace psi {
 void CdSalc::print() const {
     outfile->Printf("\tirrep = %d, ncomponent = %ld\n", irrep_, ncomponent());
     for (size_t i = 0; i < ncomponent(); ++i) {
-        outfile->Printf("\t\t%d: atom %d, direction %c, coef % lf\n", i, components_[i].atom,
+        outfile->Printf("\t\t%zu: atom %d, direction %c, coef % lf\n", i, components_[i].atom,
                         direction(components_[i].xyz), components_[i].coef);
     }
 }
@@ -70,17 +70,17 @@ void CdSalc::print() const {
 void CdSalcWRTAtom::print() const {
     outfile->Printf("\tx component, size = %ld\n", x_.size());
     for (size_t i = 0; i < x_.size(); ++i) {
-        outfile->Printf("\t\t%d: salc %d, irrep %d, coef %lf\n", i, x_[i].salc, x_[i].irrep, x_[i].coef);
+        outfile->Printf("\t\t%zu: salc %d, irrep %d, coef %lf\n", i, x_[i].salc, x_[i].irrep, x_[i].coef);
     }
 
     outfile->Printf("\ty component, size = %ld\n", y_.size());
     for (size_t i = 0; i < y_.size(); ++i) {
-        outfile->Printf("\t\t%d: salc %d, irrep %d, coef %lf\n", i, y_[i].salc, y_[i].irrep, y_[i].coef);
+        outfile->Printf("\t\t%zu: salc %d, irrep %d, coef %lf\n", i, y_[i].salc, y_[i].irrep, y_[i].coef);
     }
 
     outfile->Printf("\tz component, size = %ld\n", z_.size());
     for (size_t i = 0; i < z_.size(); ++i) {
-        outfile->Printf("\t\t%d: salc %d, irrep %d, coef %lf\n", i, z_[i].salc, z_[i].irrep, z_[i].coef);
+        outfile->Printf("\t\t%zu: salc %d, irrep %d, coef %lf\n", i, z_[i].salc, z_[i].irrep, z_[i].coef);
     }
 }
 
@@ -374,7 +374,7 @@ void CdSalcList::print() const {
     outfile->Printf("\n  By Atomic Center:\n");
     outfile->Printf("  Number of atomic centers: %ld\n", atom_salcs_.size());
     for (size_t i = 0; i < atom_salcs_.size(); ++i) {
-        outfile->Printf("   Atomic Center %d:\n", i);
+        outfile->Printf("   Atomic Center %zu:\n", i);
         atom_salcs_[i].print();
     }
     outfile->Printf("\n");

--- a/psi4/src/psi4/libmints/extern.cc
+++ b/psi4/src/psi4/libmints/extern.cc
@@ -61,7 +61,7 @@ void ExternalPotential::addBasis(std::shared_ptr<BasisSet> basis, SharedVector c
     bases_.push_back(std::make_pair(basis, coefs));
 }
 
-void ExternalPotential::print(std::string out) const {
+void ExternalPotential::print(const std::string& out) const {
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
     printer->Printf("   => External Potential Field: %s <= \n\n", name_.c_str());
 
@@ -80,12 +80,12 @@ void ExternalPotential::print(std::string out) const {
     if (bases_.size()) {
         printer->Printf("    > Diffuse Bases < \n\n");
         for (size_t i = 0; i < bases_.size(); i++) {
-            printer->Printf("    Molecule %d\n\n", i + 1);
+            printer->Printf("    Molecule %zu\n\n", i + 1);
             bases_[i].first->molecule()->print();
-            printer->Printf("    Basis %d\n\n", i + 1);
+            printer->Printf("    Basis %zu\n\n", i + 1);
             bases_[i].first->print_by_level(out, print_);
             if (print_ > 2) {
-                printer->Printf("    Density Coefficients %d\n\n", i + 1);
+                printer->Printf("    Density Coefficients %zu\n\n", i + 1);
                 bases_[i].second->print();
             }
         }

--- a/psi4/src/psi4/libmints/extern.h
+++ b/psi4/src/psi4/libmints/extern.h
@@ -102,7 +102,7 @@ class PSI_API ExternalPotential {
     double computeExternExternInteraction(std::shared_ptr<ExternalPotential> other_extern);
 
     /// Print a trace of the external potential
-    void print(std::string out_fname = "outfile") const;
+    void print(const std::string& out_fname = "outfile") const;
 
     /// Python print helper
     void py_print() const { print("outfile"); }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Printf format specifiers are required to match the type of the variable being printed. Using an incorrect format specifier may be UB. This PR resolves instances where the format specifier was incorrect. At least some of these have been triggering GCC warnings, so Psi4 now compiles with a couple fewer warnings.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Likely no user-visible changes

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `cctransort/memcheck`: Replace 14 instances of `%1lu` being used for printing an `int`, with `%d`. Make argument `const`.
- [x] `detci/olsengraph.cc`: fix one instance of `%3d` being used for printing a `size_t` integer
- [x] `dlpno/mp2.cc`: fix 12 instances of %d being used for `size_t` integers
- [x] `fnocc/lowmemory_triples.cc`: fix `%i` being used to print a `long`
- [x] `libfock/DirectJK.cc`: fix %3d being used for `size_t` integer
- [x] `libfock/solver.cc`: fix %d being used for `size_t` integer
- [x] `libmints/cdsalclist.cc`: fix 5 instances of %d being used for `size_t` integers
- [x] `libmints/extern.cc`: fix 3 instances of %d being used for `size_t` integers. Make argument `const &`.

## Checklist
- [x] No new features
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
