### PR TITLE
Fix possible infinite recursion in psio_error when the scratch disk is completely full

### DIFF
--- a/psi4/src/psi4/libpsio/error.cc
+++ b/psi4/src/psi4/libpsio/error.cc
@@ -49,9 +49,12 @@ namespace psi {
  */
 void psio_error(size_t unit, size_t errval, std::string prev_msg /* = ""*/) {
     std::cerr << "PSIO_ERROR: unit = " << unit << ", errval = " << errval << std::endl;
-    /* Try to save the TOCs for all open units */
-    /* psio_tocwrite() does not call psio_error() so this is OK */
-    for (int i = 0; i < PSIO_MAXUNIT; i++) psio_tocwrite(i);
+    // Try to save the TOCs for all open units
+    // psio_tocwrite() may end up indirectly calling psio_error() again if a write keeps failing, possibly leading to
+    // infinite recursion. To avoid this, the TOCs are not saved if psio_error() is called with a write error.
+    if (errval != PSIO_ERROR_WRITE){
+        for (int i = 0; i < PSIO_MAXUNIT; i++) psio_tocwrite(i);
+    }
     if ((prev_msg.length() > 0) && (prev_msg.back() != '\n')) {
         prev_msg += '\n';
     }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
While testing PR https://github.com/psi4/psi4/pull/2756, I have discovered a regression introduced by an earlier PR (#2700) of mine.
Before `throw`ing, `psio_error()` tries to write some data to the scratch files. But if `psio_error()` is called due to a write error, and the scratch disk is completely full, then this write will also fail, leading to `psio_error()` getting called again, and an infinite recursion ensues. The source of the regression is that `psio_tocwrite()` ends up calling `wt_toclen()`, which has been enhanced in #2700 to use `psio_error()` if it fails.
This PR resolves the issue by not trying to write anything to scratch if `psio_error()` is called due to a write failure.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] None? This regression was new enough that no release suffered from it.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Do not call `psio_tocwrite()` in `psio_error()` if `errval == PSIO_ERROR_WRITE`

## Status
- [x] Ready for review
- [x] Ready for merge
