### PR TITLE
Remove remnants of some old, defunct code for doing BS-USCF

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -424,7 +424,7 @@ def energy(name, **kwargs):
     """
     kwargs = p4util.kwargs_lower(kwargs)
 
-    # Bounce to MDI if mdi kwarg
+    # Bounce to MDI (MolSSI driver interface) if mdi kwarg
     use_mdi = kwargs.pop('mdi', False)
     if use_mdi:
         return mdi_run(name, **kwargs)

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -59,7 +59,7 @@ except ImportError:
 
 class MDIEngine():
     def __init__(self, scf_method: str, **kwargs):
-        """ Initialize an MDIEngine object for communication with MDI
+        """ Initialize an MDIEngine object for communication with MDI (MolSSI driver interface)
 
         Parameters
         ----------
@@ -454,7 +454,7 @@ def mdi_init(mdi_arguments):
 
 
 def mdi_run(scf_method: str, **kwargs):
-    """ Begin functioning as an MDI engine
+    """ Begin functioning as an MDI (MolSSI driver interface) engine
 
     Parameters
     ----------


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Sometime between https://github.com/psi4/psi4/commit/5b54376e4f358ec1318539d3ac0a2e42ea0483f8 and https://github.com/psi4/psi4/commit/7e4ecf968ec7920ab404cb357de827cf3785a254, the original(?) code for generating broken-symmetry guesses for UHF/UKS was disabled, and parts of it may have been removed since.
These days, the way to get a BS guess seems to be setting `guess_mix true`, which does not use the old BS code fragments in `scf_helper`.
So, as far as I can tell it is dead code. This PR removes it.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] None, option/feature has been defunct/superseded for 6+ years.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Defunct broken-symmetry code is removed from Python function `scf_helper`

## Checklist
- [x] No new features
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
