### PR TITLE
change raw pointer return in `libmints` to `std::unique_ptr`

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1304,7 +1304,7 @@ void export_mints(py::module& m) {
         .def("shell_significant", compute_shell_significant(&TwoBodyAOInt::shell_significant),
              "Determines if the P,Q,R,S shell combination is significant");
 
-    py::class_<Libint2ERI, std::shared_ptr<Libint2ERI>>(m, "ERI", pyTwoBodyAOInt,
+    py::class_<Libint2ERI, std::unique_ptr<Libint2ERI>>(m, "ERI", pyTwoBodyAOInt,
                                                         "Computes normal two electron repulsion integrals");
 #ifdef ENABLE_Libint1t
     py::class_<F12, std::shared_ptr<F12>>(m, "F12", pyTwoBodyAOInt, "Computes F12 electron repulsion integrals");

--- a/psi4/src/psi4/fisapt/fisapt.cc
+++ b/psi4/src/psi4/fisapt/fisapt.cc
@@ -525,7 +525,7 @@ void FISAPT::nuclear() {
 
     auto Vfact = std::make_shared<IntegralFactory>(primary_);
     std::shared_ptr<PotentialInt> Vint;
-    Vint = std::shared_ptr<PotentialInt>(static_cast<PotentialInt*>(Vfact->ao_potential()));
+    Vint = std::shared_ptr<PotentialInt>(static_cast<PotentialInt*>(Vfact->ao_potential().release()));
 
     // > Molecular Centers < //
 
@@ -3356,7 +3356,7 @@ void FISAPT::felst() {
 
     // => Nuclear Part (PITA) <= //
     auto Vfact2 = std::make_shared<IntegralFactory>(primary_);
-    std::shared_ptr<PotentialInt> Vint2(static_cast<PotentialInt*>(Vfact2->ao_potential()));
+    std::shared_ptr<PotentialInt> Vint2(static_cast<PotentialInt*>(Vfact2->ao_potential().release()));
     auto Vtemp2 = std::make_shared<Matrix>("Vtemp2", nn, nn);
 
 
@@ -3698,7 +3698,7 @@ void FISAPT::find() {
     // => Nuclear Part (PITA) <= //
 
     auto Vfact2 = std::make_shared<IntegralFactory>(primary_);
-    std::shared_ptr<PotentialInt> Vint2(static_cast<PotentialInt*>(Vfact2->ao_potential()));
+    std::shared_ptr<PotentialInt> Vint2(static_cast<PotentialInt*>(Vfact2->ao_potential().release()));
     auto Vtemp2 = std::make_shared<Matrix>("Vtemp2", nn, nn);
 
     double* ZAp = vectors_["ZA"]->pointer();

--- a/psi4/src/psi4/libcubeprop/csg.cc
+++ b/psi4/src/psi4/libcubeprop/csg.cc
@@ -439,7 +439,7 @@ void CubicScalarGrid::add_esp(double* v, std::shared_ptr<Matrix> D, const std::v
     std::vector<std::shared_ptr<PotentialInt>> VintT;
     for (int thread = 0; thread < nthreads; thread++) {
         VtempT.push_back(std::make_shared<Matrix>("Vtemp", naux, 1));
-        VintT.push_back(std::shared_ptr<PotentialInt>(static_cast<PotentialInt*>(Vfact->ao_potential())));
+        VintT.push_back(std::shared_ptr<PotentialInt>(static_cast<PotentialInt*>(Vfact->ao_potential().release())));
     }
 
 #pragma omp parallel for schedule(dynamic)

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -630,7 +630,7 @@ void DFJCOSK::build_K(std::vector<std::shared_ptr<Matrix>>& D, std::vector<std::
     // initialize per-thread objects
     IntegralFactory factory(primary_);
     for(size_t thread = 0; thread < nthreads_; thread++) {
-        int_computers[thread] = std::shared_ptr<ElectrostaticInt>(static_cast<ElectrostaticInt *>(factory.electrostatic()));
+        int_computers[thread] = std::shared_ptr<ElectrostaticInt>(static_cast<ElectrostaticInt *>(factory.electrostatic().release()));
         bf_computers[thread] = std::make_shared<BasisFunctions>(primary_, grid->max_points(), grid->max_functions());
         for(size_t jki = 0; jki < njk; jki++) {
             KT[jki][thread] = std::make_shared<Matrix>(nbf, nbf);

--- a/psi4/src/psi4/libmints/extern.cc
+++ b/psi4/src/psi4/libmints/extern.cc
@@ -116,7 +116,7 @@ SharedMatrix ExternalPotential::computePotentialMatrix(std::shared_ptr<BasisSet>
     for (size_t t = 0; t < nthreads; ++t) {
         V_charge.push_back(std::make_shared<Matrix>("External Potential (Charges)", n, n));
         V_charge[t]->zero();
-        pot.push_back(std::shared_ptr<PotentialInt>(static_cast<PotentialInt *>(fact->ao_potential())));
+        pot.push_back(std::shared_ptr<PotentialInt>(static_cast<PotentialInt *>(fact->ao_potential().release())));
         pot[t]->set_charge_field(Zxyz);
     }
 
@@ -247,7 +247,7 @@ SharedMatrix ExternalPotential::computePotentialGradients(std::shared_ptr<BasisS
     std::vector<std::shared_ptr<PotentialInt> > Vint;
     std::vector<SharedMatrix> Vtemps;
     for (int t = 0; t < threads; t++) {
-        Vint.push_back(std::shared_ptr<PotentialInt>(dynamic_cast<PotentialInt *>(fact->ao_potential(1))));
+        Vint.push_back(std::shared_ptr<PotentialInt>(dynamic_cast<PotentialInt *>(fact->ao_potential(1).release())));
         Vint[t]->set_charge_field(Zxyz);
         Vtemps.push_back(SharedMatrix(grad->clone()));
         Vtemps[t]->zero();
@@ -349,7 +349,7 @@ double ExternalPotential::computeNuclearEnergy(std::shared_ptr<Molecule> mol) {
 
             std::shared_ptr<BasisSet> zero = BasisSet::zero_ao_basis_set();
             auto fact = std::make_shared<IntegralFactory>(aux, zero, zero, zero);
-            std::shared_ptr<PotentialInt> pot(static_cast<PotentialInt *>(fact->ao_potential()));
+            std::shared_ptr<PotentialInt> pot(static_cast<PotentialInt *>(fact->ao_potential().release()));
             pot->set_charge_field(Zxyz);
             pot->compute(V);
 

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -132,24 +132,24 @@ std::unique_ptr<OneBodySOInt> IntegralFactory::so_ecp(int deriv) {
 #endif
 }
 
-OneBodyAOInt* IntegralFactory::ao_rel_potential(int deriv) {
-    return new RelPotentialInt(spherical_transforms_, bs1_, bs2_, deriv);
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_rel_potential(int deriv) {
+    return  std::make_unique<RelPotentialInt>(spherical_transforms_, bs1_, bs2_, deriv);
 }
 
-OneBodySOInt* IntegralFactory::so_rel_potential(int deriv) {
+std::unique_ptr<OneBodySOInt> IntegralFactory::so_rel_potential(int deriv) {
     std::shared_ptr<OneBodyAOInt> ao_int(ao_rel_potential(deriv));
-    return new RelPotentialSOInt(ao_int, this);
+    return std::make_unique<RelPotentialSOInt>(ao_int, this);
 }
 
-OneBodyAOInt* IntegralFactory::electrostatic() { return new ElectrostaticInt(spherical_transforms_, bs1_, bs2_, 0); }
+std::unique_ptr<OneBodyAOInt> IntegralFactory::electrostatic() { return std::make_unique<ElectrostaticInt>(spherical_transforms_, bs1_, bs2_, 0); }
 
-OneBodyAOInt* IntegralFactory::pcm_potentialint() { return new PCMPotentialInt(spherical_transforms_, bs1_, bs2_, 0); }
+std::unique_ptr<OneBodyAOInt> IntegralFactory::pcm_potentialint() { return  std::make_unique<PCMPotentialInt>(spherical_transforms_, bs1_, bs2_, 0); }
 
-OneBodyAOInt* IntegralFactory::ao_dipole(int deriv) { return new DipoleInt(spherical_transforms_, bs1_, bs2_, deriv); }
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_dipole(int deriv) { return  std::make_unique<DipoleInt>(spherical_transforms_, bs1_, bs2_, deriv); }
 
-OneBodySOInt* IntegralFactory::so_dipole(int deriv) {
+std::unique_ptr<OneBodySOInt> IntegralFactory::so_dipole(int deriv) {
     std::shared_ptr<OneBodyAOInt> ao_int(ao_dipole(deriv));
-    return new OneBodySOInt(ao_int, this);
+    return  std::make_unique<OneBodySOInt>(ao_int, this);
 }
 
 OneBodyAOInt* IntegralFactory::ao_nabla(int deriv) { return new NablaInt(spherical_transforms_, bs1_, bs2_, deriv); }
@@ -168,11 +168,11 @@ OneBodySOInt* IntegralFactory::so_angular_momentum(int deriv) {
     return new OneBodySOInt(ao_int, this);
 }
 
-OneBodyAOInt* IntegralFactory::ao_quadrupole() { return new QuadrupoleInt(spherical_transforms_, bs1_, bs2_); }
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_quadrupole() { return  std::make_unique<QuadrupoleInt>(spherical_transforms_, bs1_, bs2_); }
 
-OneBodySOInt* IntegralFactory::so_quadrupole() {
+std::unique_ptr<OneBodySOInt> IntegralFactory::so_quadrupole() {
     std::shared_ptr<OneBodyAOInt> ao_int(ao_quadrupole());
-    return new OneBodySOInt(ao_int, this);
+    return std::make_unique<OneBodySOInt>(ao_int, this);
 }
 
 OneBodyAOInt* IntegralFactory::ao_multipoles(int order, int deriv) {

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -106,13 +106,13 @@ std::unique_ptr<OneBodySOInt> IntegralFactory::so_kinetic(int deriv) {
     return std::make_unique<OneBodySOInt>(ao_int, this);
 }
 
-OneBodyAOInt* IntegralFactory::ao_potential(int deriv) {
-    return new PotentialInt(spherical_transforms_, bs1_, bs2_, deriv);
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_potential(int deriv) {
+    return std::make_unique<PotentialInt>(spherical_transforms_, bs1_, bs2_, deriv);
 }
 
-OneBodySOInt* IntegralFactory::so_potential(int deriv) {
+std::unique_ptr<OneBodySOInt> IntegralFactory::so_potential(int deriv) {
     std::shared_ptr<OneBodyAOInt> ao_int(ao_potential(deriv));
-    return new PotentialSOInt(ao_int, this);
+    return  std::make_unique<PotentialSOInt>(ao_int, this);
 }
 
 OneBodyAOInt* IntegralFactory::ao_ecp(int deriv) {

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -115,18 +115,18 @@ std::unique_ptr<OneBodySOInt> IntegralFactory::so_potential(int deriv) {
     return  std::make_unique<PotentialSOInt>(ao_int, this);
 }
 
-OneBodyAOInt* IntegralFactory::ao_ecp(int deriv) {
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_ecp(int deriv) {
 #ifdef USING_ecpint
-    return new ECPInt(spherical_transforms_, bs1_, bs2_, deriv);
+    return std::make_unique<ECPInt>(spherical_transforms_, bs1_, bs2_, deriv);
 #else
     throw PSIEXCEPTION("ECP shells requested but libecpint addon not enabled. Re-compile with `-D ENABLE_ecpint=ON`.");
 #endif
 }
 
-OneBodySOInt* IntegralFactory::so_ecp(int deriv) {
+std::unique_ptr<OneBodySOInt> IntegralFactory::so_ecp(int deriv) {
 #ifdef USING_ecpint
     std::shared_ptr<OneBodyAOInt> ao_int(ao_ecp(deriv));
-    return new ECPSOInt(ao_int, this);
+    return  std::make_unique<ECPSOInt>(ao_int, this);
 #else
     throw PSIEXCEPTION("ECP shells requested but libecpint addon not enabled. Re-compile with `-D ENABLE_ecpint=ON`.");
 #endif

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -197,19 +197,19 @@ std::unique_ptr<OneBodySOInt> IntegralFactory::so_traceless_quadrupole() {
     return std::make_unique<OneBodySOInt>(ao_int, this);
 }
 
-OneBodyAOInt* IntegralFactory::electric_field(int deriv) {
-    return new ElectricFieldInt(spherical_transforms_, bs1_, bs2_, deriv);
+std::unique_ptr<OneBodyAOInt> IntegralFactory::electric_field(int deriv) {
+    return  std::make_unique<ElectricFieldInt>(spherical_transforms_, bs1_, bs2_, deriv);
 }
 
-TwoBodyAOInt* IntegralFactory::erd_eri(int deriv, bool use_shell_pairs, bool needs_exchange) {
+std::unique_ptr<TwoBodyAOInt> IntegralFactory::erd_eri(int deriv, bool use_shell_pairs, bool needs_exchange) {
     auto integral_package = Process::environment.options.get_str("INTEGRAL_PACKAGE");
     auto threshold = Process::environment.options.get_double("INTS_TOLERANCE");
 #ifdef USING_simint
-    if (deriv == 0 && integral_package == "SIMINT") return new SimintERI(this, deriv, use_shell_pairs, needs_exchange);
+    if (deriv == 0 && integral_package == "SIMINT") return std::make_unique<SimintERI>(this, deriv, use_shell_pairs, needs_exchange);
 #endif
-    if (integral_package == "LIBINT2") return new Libint2ERI(this, threshold, deriv, use_shell_pairs, needs_exchange);
+    if (integral_package == "LIBINT2") return  std::make_unique<Libint2ERI>(this, threshold, deriv, use_shell_pairs, needs_exchange);
 #ifdef USING_erd
-    if (deriv == 0 && integral_package == "ERD") return new ERDERI(this, deriv, use_shell_pairs);
+    if (deriv == 0 && integral_package == "ERD") return  std::make_unique<ERDERI>(this, deriv, use_shell_pairs);
 #endif
     if (deriv > 0 && integral_package != "LIBINT1")
         outfile->Printf("ERI derivative integrals only available using Libint");
@@ -217,20 +217,20 @@ TwoBodyAOInt* IntegralFactory::erd_eri(int deriv, bool use_shell_pairs, bool nee
         outfile->Printf("Chosen integral package " + integral_package +
                         " unavailable.\nRecompile with the appropriate option set.\nFalling back to Libint");
 #ifdef ENABLE_Libint1t
-    return new ERI(this, deriv, use_shell_pairs);
+    return std::make_unique<ERI>(this, deriv, use_shell_pairs);
 #endif
     throw PSIEXCEPTION("No ERI object to return.");
 }
 
-TwoBodyAOInt* IntegralFactory::eri(int deriv, bool use_shell_pairs, bool needs_exchange) {
+std::unique_ptr<TwoBodyAOInt> IntegralFactory::eri(int deriv, bool use_shell_pairs, bool needs_exchange) {
     auto integral_package = Process::environment.options.get_str("INTEGRAL_PACKAGE");
     auto threshold = Process::environment.options.get_double("INTS_TOLERANCE");
 #ifdef USING_simint
-    if (deriv == 0 && integral_package == "SIMINT") return new SimintERI(this, deriv, use_shell_pairs, needs_exchange);
+    if (deriv == 0 && integral_package == "SIMINT") return  std::make_unique<SimintERI>(this, deriv, use_shell_pairs, needs_exchange);
 #endif
-    if (integral_package == "LIBINT2") return new Libint2ERI(this, threshold, deriv, use_shell_pairs, needs_exchange);
+    if (integral_package == "LIBINT2") return  std::make_unique<Libint2ERI>(this, threshold, deriv, use_shell_pairs, needs_exchange);
 #ifdef USING_erd
-    if (deriv == 0 && integral_package == "ERD") return new ERDERI(this, deriv, use_shell_pairs);
+    if (deriv == 0 && integral_package == "ERD") return std::make_unique<ERDERI>(this, deriv, use_shell_pairs);
 #endif
     if (deriv > 0 && integral_package != "LIBINT1")
         outfile->Printf("ERI derivative integrals only available using Libint");
@@ -238,55 +238,55 @@ TwoBodyAOInt* IntegralFactory::eri(int deriv, bool use_shell_pairs, bool needs_e
         outfile->Printf("Chosen integral package " + integral_package +
                         " unavailable.\nRecompile with the appropriate option set.\nFalling back to Libint");
 #ifdef ENABLE_Libint1t
-    return new ERI(this, deriv, use_shell_pairs);
+    return std::make_unique<ERI>(this, deriv, use_shell_pairs);
 #endif
     throw PSIEXCEPTION("No ERI object to return.");
 }
 
-TwoBodyAOInt* IntegralFactory::erf_eri(double omega, int deriv, bool use_shell_pairs, bool needs_exchange) {
+std::unique_ptr<TwoBodyAOInt> IntegralFactory::erf_eri(double omega, int deriv, bool use_shell_pairs, bool needs_exchange) {
     auto integral_package = Process::environment.options.get_str("INTEGRAL_PACKAGE");
     auto threshold = Process::environment.options.get_double("INTS_TOLERANCE");
     if (integral_package == "LIBINT2")
-        return new Libint2ErfERI(omega, this, threshold, deriv, use_shell_pairs, needs_exchange);
+        return std::make_unique<Libint2ErfERI>(omega, this, threshold, deriv, use_shell_pairs, needs_exchange);
 #ifdef ENABLE_Libint1t
-    return new ErfERI(omega, this, deriv, use_shell_pairs);
+    return std::make_unique<ErfERI>(omega, this, deriv, use_shell_pairs);
 #endif
     throw PSIEXCEPTION("No ERI object to return.");
 }
 
-TwoBodyAOInt* IntegralFactory::erf_complement_eri(double omega, int deriv, bool use_shell_pairs, bool needs_exchange) {
+std::unique_ptr<TwoBodyAOInt> IntegralFactory::erf_complement_eri(double omega, int deriv, bool use_shell_pairs, bool needs_exchange) {
     auto integral_package = Process::environment.options.get_str("INTEGRAL_PACKAGE");
     auto threshold = Process::environment.options.get_double("INTS_TOLERANCE");
     if (integral_package == "LIBINT2")
-        return new Libint2ErfComplementERI(omega, this, threshold, deriv, use_shell_pairs, needs_exchange);
+        return std::make_unique<Libint2ErfComplementERI>(omega, this, threshold, deriv, use_shell_pairs, needs_exchange);
 #ifdef ENABLE_Libint1t
-    return new ErfComplementERI(omega, this, deriv, use_shell_pairs);
+    return std::make_unique<ErfComplementERI>(omega, this, deriv, use_shell_pairs);
 #endif
     throw PSIEXCEPTION("No ERI object to return.");
 }
 
-TwoBodyAOInt* IntegralFactory::yukawa_eri(double zeta, int deriv, bool use_shell_pairs, bool needs_exchange) {
+std::unique_ptr<TwoBodyAOInt> IntegralFactory::yukawa_eri(double zeta, int deriv, bool use_shell_pairs, bool needs_exchange) {
     auto threshold = Process::environment.options.get_double("INTS_TOLERANCE");
-    return new Libint2YukawaERI(zeta, this, threshold, deriv, use_shell_pairs, needs_exchange);
+    return std::make_unique<Libint2YukawaERI>(zeta, this, threshold, deriv, use_shell_pairs, needs_exchange);
 }
 
-TwoBodyAOInt* IntegralFactory::f12(std::vector<std::pair<double, double>> exp_coeff, int deriv, bool use_shell_pairs) {
-    return new Libint2F12(exp_coeff, this, deriv, use_shell_pairs);
+std::unique_ptr<TwoBodyAOInt> IntegralFactory::f12(std::vector<std::pair<double, double>> exp_coeff, int deriv, bool use_shell_pairs) {
+    return  std::make_unique<Libint2F12>(exp_coeff, this, deriv, use_shell_pairs);
 }
 
-TwoBodyAOInt* IntegralFactory::f12_squared(std::vector<std::pair<double, double>> exp_coeff, int deriv,
+std::unique_ptr<TwoBodyAOInt> IntegralFactory::f12_squared(std::vector<std::pair<double, double>> exp_coeff, int deriv,
                                            bool use_shell_pairs) {
-    return new Libint2F12Squared(exp_coeff, this, deriv, use_shell_pairs);
+    return  std::make_unique<Libint2F12Squared>(exp_coeff, this, deriv, use_shell_pairs);
 }
 
-TwoBodyAOInt* IntegralFactory::f12g12(std::vector<std::pair<double, double>> exp_coeff, int deriv,
+std::unique_ptr<TwoBodyAOInt> IntegralFactory::f12g12(std::vector<std::pair<double, double>> exp_coeff, int deriv,
                                       bool use_shell_pairs) {
-    return new Libint2F12G12(exp_coeff, this, deriv, use_shell_pairs);
+    return std::make_unique<Libint2F12G12>(exp_coeff, this, deriv, use_shell_pairs);
 }
 
-TwoBodyAOInt* IntegralFactory::f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff, int deriv,
+std::unique_ptr<TwoBodyAOInt> IntegralFactory::f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff, int deriv,
                                                      bool use_shell_pairs) {
-    return new Libint2F12DoubleCommutator(exp_coeff, this, deriv, use_shell_pairs);
+    return std::make_unique<Libint2F12DoubleCommutator>(exp_coeff, this, deriv, use_shell_pairs);
 }
 
 void IntegralFactory::init_spherical_harmonics(int max_am) {

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -152,20 +152,20 @@ std::unique_ptr<OneBodySOInt> IntegralFactory::so_dipole(int deriv) {
     return  std::make_unique<OneBodySOInt>(ao_int, this);
 }
 
-OneBodyAOInt* IntegralFactory::ao_nabla(int deriv) { return new NablaInt(spherical_transforms_, bs1_, bs2_, deriv); }
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_nabla(int deriv) { return  std::make_unique<NablaInt>(spherical_transforms_, bs1_, bs2_, deriv); }
 
-OneBodySOInt* IntegralFactory::so_nabla(int deriv) {
+std::unique_ptr<OneBodySOInt> IntegralFactory::so_nabla(int deriv) {
     std::shared_ptr<OneBodyAOInt> ao_int(ao_nabla(deriv));
-    return new OneBodySOInt(ao_int, this);
+    return std::make_unique<OneBodySOInt>(ao_int, this);
 }
 
-OneBodyAOInt* IntegralFactory::ao_angular_momentum(int deriv) {
-    return new AngularMomentumInt(spherical_transforms_, bs1_, bs2_, deriv);
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_angular_momentum(int deriv) {
+    return std::make_unique<AngularMomentumInt>(spherical_transforms_, bs1_, bs2_, deriv);
 }
 
-OneBodySOInt* IntegralFactory::so_angular_momentum(int deriv) {
+std::unique_ptr<OneBodySOInt> IntegralFactory::so_angular_momentum(int deriv) {
     std::shared_ptr<OneBodyAOInt> ao_int(ao_angular_momentum(deriv));
-    return new OneBodySOInt(ao_int, this);
+    return std::make_unique<OneBodySOInt>(ao_int, this);
 }
 
 std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_quadrupole() { return  std::make_unique<QuadrupoleInt>(spherical_transforms_, bs1_, bs2_); }
@@ -175,26 +175,26 @@ std::unique_ptr<OneBodySOInt> IntegralFactory::so_quadrupole() {
     return std::make_unique<OneBodySOInt>(ao_int, this);
 }
 
-OneBodyAOInt* IntegralFactory::ao_multipoles(int order, int deriv) {
-    return new MultipoleInt(spherical_transforms_, bs1_, bs2_, order, deriv);
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_multipoles(int order, int deriv) {
+    return  std::make_unique<MultipoleInt>(spherical_transforms_, bs1_, bs2_, order, deriv);
 }
 
-OneBodyAOInt* IntegralFactory::ao_multipole_potential(int order, int deriv) {
-    return new MultipolePotentialInt(spherical_transforms_, bs1_, bs2_, order, deriv);
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_multipole_potential(int order, int deriv) {
+    return  std::make_unique<MultipolePotentialInt>(spherical_transforms_, bs1_, bs2_, order, deriv);
 }
 
-OneBodySOInt* IntegralFactory::so_multipoles(int order, int deriv) {
+std::unique_ptr<OneBodySOInt> IntegralFactory::so_multipoles(int order, int deriv) {
     std::shared_ptr<OneBodyAOInt> ao_int(ao_multipoles(order, deriv));
-    return new OneBodySOInt(ao_int, this);
+    return  std::make_unique<OneBodySOInt>(ao_int, this);
 }
 
-OneBodyAOInt* IntegralFactory::ao_traceless_quadrupole() {
-    return new TracelessQuadrupoleInt(spherical_transforms_, bs1_, bs2_);
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_traceless_quadrupole() {
+    return  std::make_unique<TracelessQuadrupoleInt>(spherical_transforms_, bs1_, bs2_);
 }
 
-OneBodySOInt* IntegralFactory::so_traceless_quadrupole() {
+std::unique_ptr<OneBodySOInt> IntegralFactory::so_traceless_quadrupole() {
     std::shared_ptr<OneBodyAOInt> ao_int(ao_traceless_quadrupole());
-    return new OneBodySOInt(ao_int, this);
+    return std::make_unique<OneBodySOInt>(ao_int, this);
 }
 
 OneBodyAOInt* IntegralFactory::electric_field(int deriv) {

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -86,16 +86,16 @@ void IntegralFactory::set_basis(std::shared_ptr<BasisSet> bs1, std::shared_ptr<B
     init_spherical_harmonics(8);
 }
 
-OneBodyAOInt* IntegralFactory::ao_overlap(int deriv) {
-    return new OverlapInt(spherical_transforms_, bs1_, bs2_, deriv);
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_overlap(int deriv) {
+    return std::make_unique<OverlapInt>(spherical_transforms_, bs1_, bs2_, deriv);
 }
 
-OneBodySOInt* IntegralFactory::so_overlap(int deriv) {
+std::unique_ptr<OneBodySOInt> IntegralFactory::so_overlap(int deriv) {
     std::shared_ptr<OneBodyAOInt> ao_int(ao_overlap(deriv));
-    return new OneBodySOInt(ao_int, this);
+    return std::make_unique<OneBodySOInt>(ao_int, this);
 }
 
-ThreeCenterOverlapInt* IntegralFactory::overlap_3c() { return new ThreeCenterOverlapInt(bs1_, bs2_, bs3_); }
+std::unique_ptr<ThreeCenterOverlapInt> IntegralFactory::overlap_3c() { return std::make_unique<ThreeCenterOverlapInt>(bs1_, bs2_, bs3_); }
 
 OneBodyAOInt* IntegralFactory::ao_kinetic(int deriv) {
     return new KineticInt(spherical_transforms_, bs1_, bs2_, deriv);

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -97,13 +97,13 @@ std::unique_ptr<OneBodySOInt> IntegralFactory::so_overlap(int deriv) {
 
 std::unique_ptr<ThreeCenterOverlapInt> IntegralFactory::overlap_3c() { return std::make_unique<ThreeCenterOverlapInt>(bs1_, bs2_, bs3_); }
 
-OneBodyAOInt* IntegralFactory::ao_kinetic(int deriv) {
-    return new KineticInt(spherical_transforms_, bs1_, bs2_, deriv);
+std::unique_ptr<OneBodyAOInt> IntegralFactory::ao_kinetic(int deriv) {
+    return std::make_unique<KineticInt>(spherical_transforms_, bs1_, bs2_, deriv);
 }
 
-OneBodySOInt* IntegralFactory::so_kinetic(int deriv) {
+std::unique_ptr<OneBodySOInt> IntegralFactory::so_kinetic(int deriv) {
     std::shared_ptr<OneBodyAOInt> ao_int(ao_kinetic(deriv));
-    return new OneBodySOInt(ao_int, this);
+    return std::make_unique<OneBodySOInt>(ao_int, this);
 }
 
 OneBodyAOInt* IntegralFactory::ao_potential(int deriv) {

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -446,8 +446,8 @@ class PSI_API IntegralFactory {
     virtual std::unique_ptr<OneBodySOInt> so_potential(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the ECP integral.
-    virtual OneBodyAOInt* ao_ecp(int deriv = 0);
-    virtual OneBodySOInt* so_ecp(int deriv = 0);
+    virtual std::unique_ptr<OneBodyAOInt> ao_ecp(int deriv = 0);
+    virtual std::unique_ptr<OneBodySOInt> so_ecp(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the relativistic nuclear attraction integral.
     virtual OneBodyAOInt* ao_rel_potential(int deriv = 0);

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -481,7 +481,7 @@ class PSI_API IntegralFactory {
     virtual std::unique_ptr<OneBodyAOInt> ao_multipole_potential(int order, int deriv = 0);
 
     /// Returns an OneBodyInt that computes the electric field
-    virtual OneBodyAOInt* electric_field(int deriv = 0);
+    virtual std::unique_ptr<OneBodyAOInt> electric_field(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the point electrostatic potential
     virtual std::unique_ptr<OneBodyAOInt> electrostatic();
@@ -491,36 +491,36 @@ class PSI_API IntegralFactory {
     virtual std::unique_ptr<OneBodyAOInt> pcm_potentialint();
 
     /// Returns an ERI integral object
-    virtual TwoBodyAOInt* eri(int deriv = 0, bool use_shell_pairs = true, bool needs_exchange = false);
+    virtual std::unique_ptr<TwoBodyAOInt> eri(int deriv = 0, bool use_shell_pairs = true, bool needs_exchange = false);
 
     /// Returns an ERD ERI integral object, if available.  Otherwise returns a libint integral object
-    virtual TwoBodyAOInt* erd_eri(int deriv = 0, bool use_shell_pairs = true, bool needs_exchange = false);
+    virtual std::unique_ptr<TwoBodyAOInt> erd_eri(int deriv = 0, bool use_shell_pairs = true, bool needs_exchange = false);
 
     /// Returns an erf ERI integral object (omega integral)
-    virtual TwoBodyAOInt* erf_eri(double omega, int deriv = 0, bool use_shell_pairs = true,
+    virtual std::unique_ptr<TwoBodyAOInt> erf_eri(double omega, int deriv = 0, bool use_shell_pairs = true,
                                   bool needs_exchange = false);
 
     /// Returns an erf complement ERI integral object (omega integral)
-    virtual TwoBodyAOInt* erf_complement_eri(double omega, int deriv = 0, bool use_shell_pairs = true,
+    virtual std::unique_ptr<TwoBodyAOInt> erf_complement_eri(double omega, int deriv = 0, bool use_shell_pairs = true,
                                              bool needs_exchange = false);
 
     /// Returns an Yukawa integral object (Slater-type geminal times Coulomb, e^(-z*r)/r)
-    virtual TwoBodyAOInt* yukawa_eri(double zeta, int deriv = 0, bool use_shell_pairs = true, bool needs_exchange = false);
+    virtual std::unique_ptr<TwoBodyAOInt> yukawa_eri(double zeta, int deriv = 0, bool use_shell_pairs = true, bool needs_exchange = false);
 
     /// Returns an F12 integral object
-    virtual TwoBodyAOInt* f12(std::vector<std::pair<double, double>> exp_coeff, int deriv = 0,
+    virtual std::unique_ptr<TwoBodyAOInt> f12(std::vector<std::pair<double, double>> exp_coeff, int deriv = 0,
                               bool use_shell_pairs = true);
 
     /// Returns an F12 squared integral object
-    virtual TwoBodyAOInt* f12_squared(std::vector<std::pair<double, double>> exp_coeff, int deriv = 0,
+    virtual std::unique_ptr<TwoBodyAOInt> f12_squared(std::vector<std::pair<double, double>> exp_coeff, int deriv = 0,
                                       bool use_shell_pairs = true);
 
     /// Returns an F12G12 integral object
-    virtual TwoBodyAOInt* f12g12(std::vector<std::pair<double, double>> exp_coeff, int deriv = 0,
+    virtual std::unique_ptr<TwoBodyAOInt> f12g12(std::vector<std::pair<double, double>> exp_coeff, int deriv = 0,
                                  bool use_shell_pairs = true);
 
     /// Returns an F12 double commutator integral object
-    virtual TwoBodyAOInt* f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff, int deriv = 0,
+    virtual std::unique_ptr<TwoBodyAOInt> f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff, int deriv = 0,
                                                 bool use_shell_pairs = true);
 
     /// Returns a general ERI iterator object for any (P Q | R S) in shells

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -462,23 +462,23 @@ class PSI_API IntegralFactory {
     virtual std::unique_ptr<OneBodySOInt> so_quadrupole();
 
     /// Returns an OneBodyInt that computes arbitrary-order multipole integrals.
-    virtual OneBodyAOInt* ao_multipoles(int order, int deriv = 0);
-    virtual OneBodySOInt* so_multipoles(int order, int deriv = 0);
+    virtual std::unique_ptr<OneBodyAOInt> ao_multipoles(int order, int deriv = 0);
+    virtual std::unique_ptr<OneBodySOInt> so_multipoles(int order, int deriv = 0);
 
     /// Returns an OneBodyInt that computes the traceless quadrupole integral.
-    virtual OneBodyAOInt* ao_traceless_quadrupole();
-    virtual OneBodySOInt* so_traceless_quadrupole();
+    virtual std::unique_ptr<OneBodyAOInt> ao_traceless_quadrupole();
+    virtual std::unique_ptr<OneBodySOInt> so_traceless_quadrupole();
 
     /// Returns an OneBodyInt that computes the nabla integral.
-    virtual OneBodyAOInt* ao_nabla(int deriv = 0);
-    virtual OneBodySOInt* so_nabla(int deriv = 0);
+    virtual std::unique_ptr<OneBodyAOInt> ao_nabla(int deriv = 0);
+    virtual std::unique_ptr<OneBodySOInt> so_nabla(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the nabla integral.
-    virtual OneBodyAOInt* ao_angular_momentum(int deriv = 0);
-    virtual OneBodySOInt* so_angular_momentum(int deriv = 0);
+    virtual std::unique_ptr<OneBodyAOInt> ao_angular_momentum(int deriv = 0);
+    virtual std::unique_ptr<OneBodySOInt> so_angular_momentum(int deriv = 0);
 
     /// Returns a OneBodyInt that computes the multipole potential integrals for PE and EFP
-    virtual OneBodyAOInt* ao_multipole_potential(int order, int deriv = 0);
+    virtual std::unique_ptr<OneBodyAOInt> ao_multipole_potential(int order, int deriv = 0);
 
     /// Returns an OneBodyInt that computes the electric field
     virtual OneBodyAOInt* electric_field(int deriv = 0);

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -450,16 +450,16 @@ class PSI_API IntegralFactory {
     virtual std::unique_ptr<OneBodySOInt> so_ecp(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the relativistic nuclear attraction integral.
-    virtual OneBodyAOInt* ao_rel_potential(int deriv = 0);
-    virtual OneBodySOInt* so_rel_potential(int deriv = 0);
+    virtual std::unique_ptr<OneBodyAOInt> ao_rel_potential(int deriv = 0);
+    virtual std::unique_ptr<OneBodySOInt> so_rel_potential(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the dipole integral.
-    virtual OneBodyAOInt* ao_dipole(int deriv = 0);
-    virtual OneBodySOInt* so_dipole(int deriv = 0);
+    virtual std::unique_ptr<OneBodyAOInt> ao_dipole(int deriv = 0);
+    virtual std::unique_ptr<OneBodySOInt> so_dipole(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the quadrupole integral.
-    virtual OneBodyAOInt* ao_quadrupole();
-    virtual OneBodySOInt* so_quadrupole();
+    virtual std::unique_ptr<OneBodyAOInt> ao_quadrupole();
+    virtual std::unique_ptr<OneBodySOInt> so_quadrupole();
 
     /// Returns an OneBodyInt that computes arbitrary-order multipole integrals.
     virtual OneBodyAOInt* ao_multipoles(int order, int deriv = 0);
@@ -484,11 +484,11 @@ class PSI_API IntegralFactory {
     virtual OneBodyAOInt* electric_field(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the point electrostatic potential
-    virtual OneBodyAOInt* electrostatic();
+    virtual std::unique_ptr<OneBodyAOInt> electrostatic();
 
     /// Returns an OneBodyInt that computes the electrostatic potential at desired points
     /// Want to change the name of this after the PCM dust settles
-    virtual OneBodyAOInt* pcm_potentialint();
+    virtual std::unique_ptr<OneBodyAOInt> pcm_potentialint();
 
     /// Returns an ERI integral object
     virtual TwoBodyAOInt* eri(int deriv = 0, bool use_shell_pairs = true, bool needs_exchange = false);

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -429,13 +429,13 @@ class PSI_API IntegralFactory {
                            std::shared_ptr<BasisSet> bs4);
 
     /// Returns an OneBodyInt that computes the overlap integral.
-    virtual OneBodyAOInt* ao_overlap(int deriv = 0);
+    virtual std::unique_ptr<OneBodyAOInt> ao_overlap(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the overlap integral.
-    virtual OneBodySOInt* so_overlap(int deriv = 0);
+    virtual std::unique_ptr<OneBodySOInt> so_overlap(int deriv = 0);
 
     /// Returns a ThreeCenterOverlapINt that computes the overlap between three centers
-    virtual ThreeCenterOverlapInt* overlap_3c();
+    virtual std::unique_ptr<ThreeCenterOverlapInt> overlap_3c();
 
     /// Returns an OneBodyInt that computes the kinetic energy integral.
     virtual OneBodyAOInt* ao_kinetic(int deriv = 0);

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -442,8 +442,8 @@ class PSI_API IntegralFactory {
     virtual std::unique_ptr<OneBodySOInt> so_kinetic(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the nuclear attraction integral.
-    virtual OneBodyAOInt* ao_potential(int deriv = 0);
-    virtual OneBodySOInt* so_potential(int deriv = 0);
+    virtual std::unique_ptr<OneBodyAOInt> ao_potential(int deriv = 0);
+    virtual std::unique_ptr<OneBodySOInt> so_potential(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the ECP integral.
     virtual OneBodyAOInt* ao_ecp(int deriv = 0);

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -438,8 +438,8 @@ class PSI_API IntegralFactory {
     virtual std::unique_ptr<ThreeCenterOverlapInt> overlap_3c();
 
     /// Returns an OneBodyInt that computes the kinetic energy integral.
-    virtual OneBodyAOInt* ao_kinetic(int deriv = 0);
-    virtual OneBodySOInt* so_kinetic(int deriv = 0);
+    virtual std::unique_ptr<OneBodyAOInt> ao_kinetic(int deriv = 0);
+    virtual std::unique_ptr<OneBodySOInt> so_kinetic(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the nuclear attraction integral.
     virtual OneBodyAOInt* ao_potential(int deriv = 0);

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1399,7 +1399,7 @@ void MintsHelper::add_dipole_perturbation(SharedMatrix potential_mat) {
 
     OperatorSymmetry msymm(1, molecule_, integral_, factory_);
     std::vector<SharedMatrix> dipoles = msymm.create_matrices("Dipole");
-    OneBodySOInt *so_dipole = integral_->so_dipole();
+    std::unique_ptr<OneBodySOInt> so_dipole = integral_->so_dipole();
     so_dipole->compute(dipoles);
 
     if (lambda[0] != 0.0) {

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1719,7 +1719,7 @@ std::vector<SharedMatrix> MintsHelper::electric_field(const std::vector<double> 
 SharedMatrix MintsHelper::induction_operator(SharedMatrix coords, SharedMatrix moments) {
     SharedMatrix mat = std::make_shared<Matrix>("Induction operator", basisset_->nbf(), basisset_->nbf());
     ContractOverDipolesFunctor dipfun(moments, mat);
-    auto field_integrals_ = static_cast<ElectricFieldInt *>(integral_->electric_field().release());
+    auto field_integrals_ = std::unique_ptr<ElectricFieldInt>(static_cast<ElectricFieldInt *>(integral_->electric_field().release()));
     field_integrals_->compute_with_functor(dipfun, coords);
     mat->scale(-1.0);
 
@@ -1727,7 +1727,7 @@ SharedMatrix MintsHelper::induction_operator(SharedMatrix coords, SharedMatrix m
 }
 
 SharedMatrix MintsHelper::electric_field_value(SharedMatrix coords, SharedMatrix D) {
-    auto field_integrals_ = static_cast<ElectricFieldInt *>(integral_->electric_field().release());
+    auto field_integrals_ = std::unique_ptr<ElectricFieldInt>(static_cast<ElectricFieldInt *>(integral_->electric_field().release()));
 
     SharedMatrix efields = std::make_shared<Matrix>("efields", coords->nrow(), 3);
     auto fieldfun = ContractOverDensityFieldFunctor(efields, D);

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1719,7 +1719,7 @@ std::vector<SharedMatrix> MintsHelper::electric_field(const std::vector<double> 
 SharedMatrix MintsHelper::induction_operator(SharedMatrix coords, SharedMatrix moments) {
     SharedMatrix mat = std::make_shared<Matrix>("Induction operator", basisset_->nbf(), basisset_->nbf());
     ContractOverDipolesFunctor dipfun(moments, mat);
-    auto field_integrals_ = static_cast<ElectricFieldInt *>(integral_->electric_field());
+    auto field_integrals_ = static_cast<ElectricFieldInt *>(integral_->electric_field().release());
     field_integrals_->compute_with_functor(dipfun, coords);
     mat->scale(-1.0);
 
@@ -1727,7 +1727,7 @@ SharedMatrix MintsHelper::induction_operator(SharedMatrix coords, SharedMatrix m
 }
 
 SharedMatrix MintsHelper::electric_field_value(SharedMatrix coords, SharedMatrix D) {
-    auto field_integrals_ = static_cast<ElectricFieldInt *>(integral_->electric_field());
+    auto field_integrals_ = static_cast<ElectricFieldInt *>(integral_->electric_field().release());
 
     SharedMatrix efields = std::make_shared<Matrix>("efields", coords->nrow(), 3);
     auto fieldfun = ContractOverDensityFieldFunctor(efields, D);

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -2108,7 +2108,7 @@ SharedMatrix MintsHelper::effective_core_potential_grad(SharedMatrix D) {
     std::vector<SharedMatrix> gradtemps;
     for (size_t i = 0; i < nthread_; i++) {
         gradtemps.push_back(grad->clone());
-        ecp_ints_vec.push_back(std::shared_ptr<ECPInt>(dynamic_cast<ECPInt*>(integral_->ao_ecp(1))));
+        ecp_ints_vec.push_back(std::shared_ptr<ECPInt>(dynamic_cast<ECPInt*>(integral_->ao_ecp(1).release())));
     }
 
     // Lower Triangle

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1042,7 +1042,7 @@ void OEProp::compute_esp_over_grid() { epc_.compute_esp_over_grid(true); }
 void ESPPropCalc::compute_esp_over_grid(bool print_output) {
     auto mol = basisset_->molecule();
 
-    std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic()));
+    std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic().release()));
 
     if (print_output) {
         outfile->Printf("\n Electrostatic potential computed on the grid and written to grid_esp.dat\n");
@@ -1094,7 +1094,7 @@ SharedVector ESPPropCalc::compute_esp_over_grid_in_memory(SharedMatrix input_gri
     SharedVector output = std::make_shared<Vector>(number_of_grid_points);
 
     std::shared_ptr<Molecule> mol = basisset_->molecule();
-    std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic()));
+    std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic().release()));
 
     SharedMatrix Dtot = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
     if (same_dens_) {
@@ -1132,7 +1132,7 @@ void OEProp::compute_field_over_grid() { epc_.compute_field_over_grid(true); }
 void ESPPropCalc::compute_field_over_grid(bool print_output) {
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
-    std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic()));
+    std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic().release()));
 
     if (print_output) {
         outfile->Printf("\n Field computed on the grid and written to grid_field.dat\n");
@@ -1241,7 +1241,7 @@ std::shared_ptr<std::vector<double>> ESPPropCalc::compute_esp_at_nuclei(bool pri
     std::shared_ptr<Molecule> mol = basisset_->molecule();
 
     auto nesps = std::make_shared<std::vector<double>>(mol->natom());
-    std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic()));
+    std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic().release()));
 
     int nbf = basisset_->nbf();
     int natoms = mol->natom();

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1145,7 +1145,7 @@ void ESPPropCalc::compute_field_over_grid(bool print_output) {
         Dtot->add(wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta"));
     }
 
-    std::shared_ptr<ElectricFieldInt> field_ints(dynamic_cast<ElectricFieldInt*>(wfn_->integral()->electric_field()));
+    std::shared_ptr<ElectricFieldInt> field_ints(dynamic_cast<ElectricFieldInt*>(wfn_->integral()->electric_field().release()));
 
     int nbf = basisset_->nbf();
     std::vector<SharedMatrix> intmats;
@@ -1196,7 +1196,7 @@ SharedMatrix ESPPropCalc::compute_field_over_grid_in_memory(SharedMatrix input_g
         Dtot->add(wfn_->Db_subset("AO"));
     }
 
-    std::shared_ptr<ElectricFieldInt> field_ints(dynamic_cast<ElectricFieldInt*>(wfn_->integral()->electric_field()));
+    std::shared_ptr<ElectricFieldInt> field_ints(dynamic_cast<ElectricFieldInt*>(wfn_->integral()->electric_field().release()));
 
     // Scale the coordinates if needed
     auto coords = input_grid;

--- a/psi4/src/psi4/libmints/orbitalspace.cc
+++ b/psi4/src/psi4/libmints/orbitalspace.cc
@@ -133,9 +133,9 @@ SharedMatrix OrbitalSpace::overlap(const OrbitalSpace &space1, const OrbitalSpac
     SharedMatrix Smat =
         std::make_shared<Matrix>("Overlap between space1 and space2", p1.SO_basisdim(), p2.SO_basisdim());
 
-    OneBodySOInt *S = mix_ints.so_overlap();
+    std::unique_ptr<OneBodySOInt> S = mix_ints.so_overlap();
     S->compute(Smat);
-    delete S;
+    S.reset();
 
     return Smat;
 }
@@ -148,9 +148,9 @@ SharedMatrix OrbitalSpace::overlap(const std::shared_ptr<BasisSet> &basis1, cons
     SharedMatrix Smat =
         std::make_shared<Matrix>("Overlap between space1 and space2", sobasis1.dimension(), sobasis2.dimension());
 
-    OneBodySOInt *S = mix_ints.so_overlap();
+    std::unique_ptr<OneBodySOInt> S = mix_ints.so_overlap();
     S->compute(Smat);
-    delete S;
+    S.reset();
 
     return Smat;
 }

--- a/psi4/src/psi4/libmints/orbitalspace.cc
+++ b/psi4/src/psi4/libmints/orbitalspace.cc
@@ -135,7 +135,6 @@ SharedMatrix OrbitalSpace::overlap(const OrbitalSpace &space1, const OrbitalSpac
 
     std::unique_ptr<OneBodySOInt> S = mix_ints.so_overlap();
     S->compute(Smat);
-    S.reset();
 
     return Smat;
 }
@@ -150,7 +149,6 @@ SharedMatrix OrbitalSpace::overlap(const std::shared_ptr<BasisSet> &basis1, cons
 
     std::unique_ptr<OneBodySOInt> S = mix_ints.so_overlap();
     S->compute(Smat);
-    S.reset();
 
     return Smat;
 }

--- a/psi4/src/psi4/libmints/x2cint.cc
+++ b/psi4/src/psi4/libmints/x2cint.cc
@@ -144,7 +144,7 @@ void X2CInt::compute_integrals() {
     if ((lambda_[0] != 0.0) or (lambda_[1] != 0) or (lambda_[2] != 0)) {
         OperatorSymmetry msymm(1, molecule_, integral_, soFactory_);
         std::vector<SharedMatrix> dipoles = msymm.create_matrices("Dipole");
-        OneBodySOInt *so_dipole = integral_->so_dipole();
+        std::unique_ptr<OneBodySOInt> so_dipole = integral_->so_dipole();
         so_dipole->compute(dipoles);
 
         std::vector<std::string> axis_label{"x", "y", "z"};

--- a/psi4/src/psi4/libpsipcm/psipcm.cc
+++ b/psi4/src/psi4/libpsipcm/psipcm.cc
@@ -149,7 +149,7 @@ PCM::PCM(const std::string &pcmsolver_parsed_fname, int print_level, std::shared
     PetiteList petite(basisset, integrals, true);
     my_aotoso_ = petite.aotoso();
 
-    potential_int_ = static_cast<PCMPotentialInt *>(integrals->pcm_potentialint());
+    potential_int_ = static_cast<PCMPotentialInt *>(integrals->pcm_potentialint().release());
 
     context_ = detail::init_PCMSolver(pcmsolver_parsed_fname_, molecule);
     outfile->Printf("  **PSI4:PCMSOLVER Interface Active**\n");

--- a/psi4/src/psi4/libsapt_solver/sapt.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt.cc
@@ -229,7 +229,7 @@ void SAPT::initialize(SharedWavefunction MonomerA, SharedWavefunction MonomerB) 
 
     free_block(sAJ);
 
-    auto potA = std::shared_ptr<PotentialInt>(dynamic_cast<PotentialInt *>(intfact->ao_potential()));
+    auto potA = std::shared_ptr<PotentialInt>(dynamic_cast<PotentialInt *>(intfact->ao_potential().release()));
     std::vector<std::pair<double, std::array<double, 3>>> ZxyzA;
     for (int n = 0, p = 0; n < monomerA->natom(); n++) {
         if (monomerA->Z(n)) {
@@ -240,7 +240,7 @@ void SAPT::initialize(SharedWavefunction MonomerA, SharedWavefunction MonomerB) 
     VAmat_ = std::make_shared<Matrix>(fact->create_matrix("Nuclear Attraction (Monomer A)"));
     potA->compute(VAmat_);
 
-    auto potB = std::shared_ptr<PotentialInt>(dynamic_cast<PotentialInt *>(intfact->ao_potential()));
+    auto potB = std::shared_ptr<PotentialInt>(dynamic_cast<PotentialInt *>(intfact->ao_potential().release()));
     std::vector<std::pair<double, std::array<double, 3>>> ZxyzB;
     for (int n = 0, p = 0; n < monomerB->natom(); n++) {
         if (monomerB->Z(n)) {

--- a/psi4/src/psi4/libscf_solver/sad.cc
+++ b/psi4/src/psi4/libscf_solver/sad.cc
@@ -426,7 +426,7 @@ void SADGuess::get_uhf_atomic_density(std::shared_ptr<BasisSet> bas, std::shared
     std::unique_ptr<OneBodyAOInt> T_ints = std::unique_ptr<OneBodyAOInt>(integral.ao_kinetic());
     std::unique_ptr<OneBodyAOInt> V_ints = std::unique_ptr<OneBodyAOInt>(integral.ao_potential());
 #ifdef USING_ecpint
-    auto ECP_ints = std::unique_ptr<ECPInt>(dynamic_cast<ECPInt*>(integral.ao_ecp()));
+    auto ECP_ints = std::unique_ptr<ECPInt>(dynamic_cast<ECPInt*>(integral.ao_ecp().release()));
 #endif
 
     // Compute overlap S and orthogonalizer X;

--- a/psi4/src/psi4/scfgrad/response.cc
+++ b/psi4/src/psi4/scfgrad/response.cc
@@ -501,7 +501,7 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response() {
 #ifdef USING_ecpint
     {
         // Effective core potential derivatives
-        std::shared_ptr<ECPInt> ecpint(dynamic_cast<ECPInt*>(integral_->ao_ecp(1)));
+        std::shared_ptr<ECPInt> ecpint(dynamic_cast<ECPInt*>(integral_->ao_ecp(1).release()));
 
         auto Emix = std::make_shared<Matrix>("Emix", nso, nocc);
         auto Emiy = std::make_shared<Matrix>("Emiy", nso, nocc);
@@ -3285,7 +3285,7 @@ void USCFDeriv::ecp_deriv(std::shared_ptr<Matrix> C,
                           std::shared_ptr<Matrix> Cocc,
                           int nso, int nocc, int nvir, bool alpha)
 {
-    std::shared_ptr<ECPInt> ecpint(dynamic_cast<ECPInt*>(integral_->ao_ecp(1)));
+    std::shared_ptr<ECPInt> ecpint(dynamic_cast<ECPInt*>(integral_->ao_ecp(1).release()));
     size_t nmo = nocc + nvir;
     int natom = molecule_->natom();
 

--- a/psi4/src/psi4/scfgrad/scf_grad.cc
+++ b/psi4/src/psi4/scfgrad/scf_grad.cc
@@ -509,7 +509,7 @@ SharedMatrix SCFDeriv::compute_hessian()
         hessian_terms.push_back("Effective Core Potential");
 
         // Potential energy derivatives
-        std::shared_ptr<ECPInt> ecpint(dynamic_cast<ECPInt*>(integral_->ao_ecp(2)));
+        std::shared_ptr<ECPInt> ecpint(dynamic_cast<ECPInt*>(integral_->ao_ecp(2).release()));
         const auto& buffers = ecpint->buffers();
 
         for (int P = 0; P < basisset_->nshell(); P++) {


### PR DESCRIPTION
Fixes #2493 

## Description
<!-- Provide a brief description of the PR's purpose here. -->

For memory safety, the integrals in libmints should be returned as unique_ptrs rather than raw pointers

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->


## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] All integrals in libmints now return a unique_ptr rather than a raw pointer
- [x] Call sites refactored to match
## Questions
- [x] Are my refactors to the call sites correct? Many are just an immediate release of the unique_pointer, with the assumption that the memory management / pointer deletion occurs elsewhere
- [x] Should iterators eg `CartesianIter` also return unique_ptrs?

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
