### PR TITLE
Use LAPACK for Linear Algebra in `occ`

### DIFF
--- a/doc/sphinxman/source/occ.rst
+++ b/doc/sphinxman/source/occ.rst
@@ -320,7 +320,6 @@ Advanced OCC Keywords
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /autodir_options_c/occ__opt_method.rst
-.. include:: /autodir_options_c/occ__lineq_solver.rst
 .. include:: /autodir_options_c/occ__orth_type.rst
 .. include:: /autodir_options_c/occ__mp2_os_scale.rst
 .. include:: /autodir_options_c/occ__mp2_ss_scale.rst

--- a/psi4/src/psi4/occ/arrays.cc
+++ b/psi4/src/psi4/occ/arrays.cc
@@ -422,18 +422,6 @@ void Array2d::cdgesv(Array1d* Xvec, int errcod) {
     }
 }  //
 
-void Array2d::lineq_flin(Array1d* Xvec, double* det) {
-    if (dim1_) {
-        flin(A2d_, Xvec->A1d_, dim1_, 1, det);
-    }
-}  //
-
-void Array2d::lineq_pople(Array1d* Xvec, int num_vecs, double cutoff) {
-    if (dim1_) {
-        pople(A2d_, Xvec->A1d_, dim1_, num_vecs, cutoff, "outfile", 0);
-    }
-}  //
-
 // TODO:
 // DGER compute the rank-one update of a general matrix: A <-- A + alpha * x * yT
 // dger(m, n, alpha, x, incx, y, incy, a, lda);

--- a/psi4/src/psi4/occ/arrays.h
+++ b/psi4/src/psi4/occ/arrays.h
@@ -129,10 +129,6 @@ class Array2d {
     void copy(double** a);
     // cdgesv: solve a linear equation via lapack
     void cdgesv(Array1d* Xvec, int errcod);
-    // lineq_flin: solve a linear equation via FLIN
-    void lineq_flin(Array1d* Xvec, double* det);
-    // lineq_pople: solve a linear equation via Pople's algorithm
-    void lineq_pople(Array1d* Xvec, int num_vecs, double cutoff);
     // gemm: matrix multiplication
     void gemm(bool transa, bool transb, double alpha, const Array2d* a, const Array2d* b, double beta);
     /*

--- a/psi4/src/psi4/occ/kappa_orb_resp.cc
+++ b/psi4/src/psi4/occ/kappa_orb_resp.cc
@@ -143,19 +143,7 @@ void OCCWave::kappa_orb_resp() {
 
         // Solve the orb-resp equations
         pcg_conver = 0;  // here 0 means successfull
-        if (lineq == "CDGESV")
-            Aorb->cdgesv(kappaA, pcg_conver);
-        else if (lineq == "FLIN") {
-            double det = 0.0;
-            Aorb->lineq_flin(kappaA, &det);
-            if (std::fabs(det) < DIIS_MIN_DET) {
-                outfile->Printf("Warning!!! MO Hessian matrix is near-singular\n");
-                outfile->Printf("Determinant is %6.3E\n", det);
-
-                pcg_conver = 1;  // here 1 means unsuccessful
-            }
-        } else if (lineq == "POPLE")
-            Aorb->lineq_pople(kappaA, 6, cutoff);
+        Aorb->cdgesv(kappaA, pcg_conver);
         delete Aorb;
 
         // If LINEQ FAILED!
@@ -464,20 +452,7 @@ void OCCWave::kappa_orb_resp() {
 
         // Solve the orb-resp equations
         pcg_conver = 0;  // here 0 means successfull
-        if (lineq == "CDGESV")
-            Aorb->cdgesv(kappa, pcg_conver);
-        else if (lineq == "FLIN") {
-            double det = 0.0;
-            Aorb->lineq_flin(kappa, &det);
-            if (std::fabs(det) < DIIS_MIN_DET) {
-                // if (std::fabs(det) < 1e-2) {
-                outfile->Printf("Warning!!! MO Hessian matrix is near-singular\n");
-                outfile->Printf("Determinant is %6.3E\n", det);
-
-                pcg_conver = 1;  // here 1 means unsuccessful
-            }
-        } else if (lineq == "POPLE")
-            Aorb->lineq_pople(kappa, 6, cutoff);
+        Aorb->cdgesv(kappa, pcg_conver);
         delete Aorb;
 
         // Build kappaA and kappaB

--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -92,7 +92,6 @@ void OCCWave::common_init() {
     spin_scale_type_ = options_.get_str("SPIN_SCALE_TYPE");
     write_mo_coeff = options_.get_str("MO_WRITE");
     read_mo_coeff = options_.get_str("MO_READ");
-    lineq = options_.get_str("LINEQ_SOLVER");
     dertype = options_.get_str("DERTYPE");
     pcg_beta_type_ = options_.get_str("PCG_BETA_TYPE");
     twopdm_abcd_type = options_.get_str("TPDM_ABCD_TYPE");

--- a/psi4/src/psi4/occ/occwave.h
+++ b/psi4/src/psi4/occ/occwave.h
@@ -347,7 +347,6 @@ class OCCWave : public Wavefunction {
     std::string jobtype;
     std::string dertype;
     std::string basis;
-    std::string lineq;
     std::string orth_type;
     std::string natorb;
     std::string semicanonic;

--- a/psi4/src/psi4/occ/z_vector.cc
+++ b/psi4/src/psi4/occ/z_vector.cc
@@ -146,19 +146,7 @@ void OCCWave::z_vector() {
 
         // Solve the orb-resp equations
         pcg_conver = 0;  // here 0 means successfull
-        if (lineq == "CDGESV")
-            Aorb->cdgesv(zvectorA, pcg_conver);
-        else if (lineq == "FLIN") {
-            double det = 0.0;
-            Aorb->lineq_flin(zvectorA, &det);
-            if (std::fabs(det) < DIIS_MIN_DET) {
-                outfile->Printf("Warning!!! MO Hessian matrix is near-singular\n");
-                outfile->Printf("Determinant is %6.3E\n", det);
-
-                pcg_conver = 1;  // here 1 means unsuccessful
-            }
-        } else if (lineq == "POPLE")
-            Aorb->lineq_pople(zvectorA, 6, cutoff);
+        Aorb->cdgesv(zvectorA, pcg_conver);
         delete Aorb;
 
         // If LINEQ FAILED!
@@ -447,20 +435,7 @@ void OCCWave::z_vector() {
 
         // Solve the orb-resp equations
         pcg_conver = 0;  // here 0 means successfull
-        if (lineq == "CDGESV")
-            Aorb->cdgesv(zvector, pcg_conver);
-        else if (lineq == "FLIN") {
-            double det = 0.0;
-            Aorb->lineq_flin(zvector, &det);
-            if (std::fabs(det) < DIIS_MIN_DET) {
-                // if (std::fabs(det) < 1e-2) {
-                outfile->Printf("Warning!!! MO Hessian matrix is near-singular\n");
-                outfile->Printf("Determinant is %6.3E\n", det);
-
-                pcg_conver = 1;  // here 1 means unsuccessful
-            }
-        } else if (lineq == "POPLE")
-            Aorb->lineq_pople(zvector, 6, cutoff);
+        Aorb->cdgesv(zvector, pcg_conver);
         delete Aorb;
 
         // Build zvectorA and zvectorB

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2871,8 +2871,6 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- mixing parameter for the REMP hybrid perturbation theory, A specifies the Moller-Plesset fraction -*/
         options.add_double("REMP_A", 0.15E0);
 
-        /*- The solver will be used for simultaneous linear equations. -*/
-        options.add_str("LINEQ_SOLVER", "CDGESV", "CDGESV FLIN POPLE");
         /*- The algorithm for orthogonalization of MOs -*/
         options.add_str("ORTH_TYPE", "MGS", "GS MGS");
         /*- The optimization algorithm. Modified Steepest-Descent (MSD) takes a Newton-Raphson (NR) step


### PR DESCRIPTION
## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] The `LINEQ_SOLVER` option for `occ` has been removed.

## Dev notes & details
- [x] `occ` now uses LAPACK to solve Ax=b rather than the `pople` or `flin` algorithms. `LAPACK` just might be more reliable. This was an extremely obscure option, so I'm not worried about breaking anybody's input.

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
