### PR TITLE
Remove `Array2d` from `kappa_orb_resp.cc`

### DIFF
--- a/psi4/src/psi4/occ/arrays.h
+++ b/psi4/src/psi4/occ/arrays.h
@@ -89,6 +89,7 @@ class Array1d {
     // dirprd: A1d_[i] = a[i] * b[i]
     void dirprd(Array1d* a, Array1d* b);
     std::string name() const { return name_; }
+    double* nonconst_array() const { return A1d_; }
     const double* array() const { return A1d_; }
 
     friend class Array2d;


### PR DESCRIPTION
## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Cleanup `occ` by migrating a custom Matrix class to use Matrix instead.
- [x] Note: We are not deleting some potentially large matrices. In those cases, there are no other demands on memory for the rest of the function, so we can let scope rules handle that resource management.

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
