### PR TITLE
Modernize `cc` Virial Theorem

### DIFF
--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -741,7 +741,7 @@ def scf_print_energies(self):
         self.set_variable("DFT TOTAL ENERGY", dft_energy)  # overwritten later for DH  # P::e SCF
     else:
         potential = total_energy - ke
-        self.set_variable("HF KINETIC ENERGY", hf_energy)  # P::e SCF
+        self.set_variable("HF KINETIC ENERGY", ke)  # P::e SCF
         self.set_variable("HF POTENTIAL ENERGY", potential)  # P::e SCF
         if full_qm:
             self.set_variable("HF VIRIAL RATIO", - potential / ke)  # P::e SCF

--- a/psi4/src/psi4/cc/ccdensity/kinetic.cc
+++ b/psi4/src/psi4/cc/ccdensity/kinetic.cc
@@ -49,63 +49,27 @@
 namespace psi {
 namespace ccdensity {
 
-#define INDEX(i, j) ((i) >= (j) ? EXPLICIT_IOFF(i) + (j) : EXPLICIT_IOFF(j) + (i))
-
 void kinetic(std::shared_ptr<Wavefunction> wfn) {
-    int nmo, noei, stat, i, I, h, j, nclsd;
-    int *order, *doccpi;
-    double junk, tcorr, vcorr, tref, vref, ttot, vtot;
-    double **T, **scf_pitzer, **scf_qt, **X;
-
     /* RHF/ROHF only for now */
     if (params.ref == 2) return;
 
-    nmo = moinfo.nmo;
-    noei = nmo * (nmo + 1) / 2;
-
-    /*** Get the Pitzer -> QT reordering array ***/
-    order = init_int_array(nmo);
-
-    /* doccpi array must include frozen orbitals for reorder_qt() */
-    doccpi = init_int_array(moinfo.nirreps);
-    for (h = 0; h < moinfo.nirreps; h++) doccpi[h] = moinfo.frdocc[h] + moinfo.clsdpi[h];
-
-    reorder_qt(doccpi, moinfo.openpi, moinfo.frdocc, moinfo.fruocc, order, moinfo.orbspi, moinfo.nirreps);
-
-    /*** Reorder the SCF eigenvectors to QT ordering */
-    scf_pitzer = wfn->Ca()->to_block_matrix();
-
-    scf_qt = block_matrix(nmo, nmo);
-    for (i = 0; i < nmo; i++) {
-        I = order[i]; /* Pitzer --> QT */
-        for (j = 0; j < nmo; j++) scf_qt[j][I] = scf_pitzer[j][i];
-    }
+    auto Da = block_to_matrix(moinfo.opdm);
 
     /*** Transform the kinetic energy integrals to the MO basis ***/
-    T = wfn->mintshelper()->so_kinetic()->to_block_matrix();
-    X = block_matrix(nmo, nmo);
-
-    C_DGEMM('t', 'n', nmo, nmo, nmo, 1, &(scf_qt[0][0]), nmo, &(T[0][0]), nmo, 0, &(X[0][0]), nmo);
-    C_DGEMM('n', 'n', nmo, nmo, nmo, 1, &(X[0][0]), nmo, &(scf_qt[0][0]), nmo, 0, &(T[0][0]), nmo);
+    auto T = wfn->mintshelper()->so_kinetic();
+    T->transform(moinfo.Ca);
 
     /*** Contract the correlated kinetic energy ***/
+    auto tcorr = T->vector_dot(Da);
 
-    tcorr = 0.0;
-    for (i = 0; i < nmo; i++)
-        for (j = 0; j < nmo; j++) tcorr += T[i][j] * moinfo.opdm[i][j];
-
-    /*** Compute the SCF kinetic energy ***/
-
-    tref = 0.0;
-    nclsd = moinfo.nfzc + moinfo.nclsd;
-    for (i = 0; i < nclsd; i++) tref += T[i][i] * 2;
-    for (i = nclsd; i < nclsd + moinfo.nopen; i++) tref += T[i][i];
+    /*** Recall the SCF kinetic energy ***/
+    auto tref = wfn->scalar_variable("HF KINETIC ENERGY");
 
     /*** Compute the virial ratios ***/
-    ttot = tcorr + tref;
-    vtot = moinfo.eref + moinfo.ecc - ttot;
-    vref = moinfo.eref - tref;
-    vcorr = moinfo.ecc - tcorr;
+    auto ttot = tcorr + tref;
+    auto vtot = moinfo.eref + moinfo.ecc - ttot;
+    auto vref = moinfo.eref - tref;
+    auto vcorr = moinfo.ecc - tcorr;
 
     outfile->Printf("\n\tVirial Theorem Data:\n");
     outfile->Printf("\t--------------------\n");
@@ -121,14 +85,6 @@ void kinetic(std::shared_ptr<Wavefunction> wfn) {
     wfn->set_scalar_variable("CC CORRELATION POTENTIAL ENERGY", vcorr);
     wfn->set_scalar_variable("CC CORRELATION VIRIAL RATIO", -vcorr / tcorr);
     wfn->set_scalar_variable("CC VIRIAL RATIO", -vtot / ttot);
-
-    /*** Release memory ***/
-    free_block(X);
-    free_block(T);
-    free_block(scf_qt);
-    free_block(scf_pitzer);
-    free(doccpi);
-    free(order);
 }
 }  // namespace ccdensity
 }  // namespace psi

--- a/tests/cc1/input.dat
+++ b/tests/cc1/input.dat
@@ -10,14 +10,29 @@ set {
     basis 6-31G**
 }
 
-optimize('ccsd')
+wfn = optimize('ccsd', return_wfn=True)[1]
 
 refnuc   =   9.1654609427539  #TEST
 refscf   = -76.0229427274435  #TEST
 refccsd  = -0.20823570806196  #TEST
 reftotal = -76.2311784355056  #TEST
+scfT     =  75.7989532323351  #TEST
+scfVT    =   2.0029550473401  #TEST
+scfV     =   - scfVT * scfT   #TEST
+ccT      =   0.1474216520850  #TEST
+ccVT     =   2.4125178001909  #TEST
+ccV      =   -  ccVT *  ccT   #TEST
+totalVT  =   2.0037500611607  #TEST
 
 compare_values(refnuc,   h2o.nuclear_repulsion_energy(),          3, "Nuclear repulsion energy") #TEST
 compare_values(refscf,   variable("SCF total energy"),        5, "SCF energy")               #TEST
 compare_values(refccsd,  variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
 compare_values(reftotal, variable("Current energy"),          7, "Total energy")             #TEST
+compare_values(scfT,     variable("HF Kinetic Energy"),       5, "HF Kinetic Energy")        #TEST
+compare_values(scfV,     variable("HF Potential Energy"),     5, "HF Potential Energy")      #TEST
+compare_values(scfVT,    variable("HF Virial Ratio"),         5, "HF Virial Ratio")          #TEST
+compare_values(ccT,      wfn.variable("CC Correlation Kinetic Energy"),       5, "CC Correlation Kinetic Energy")        #TEST
+compare_values(ccV,      wfn.variable("CC Correlation Potential Energy"),     5, "CC Correlation Potential Energy")      #TEST
+compare_values(ccVT,     wfn.variable("CC Correlation Virial Ratio"),         5, "CC Correlation Virial Ratio")          #TEST
+compare_values(totalVT,  wfn.variable("CC Virial Ratio"),         5, "CC Virial Ratio")      #TEST
+


### PR DESCRIPTION
## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Modernize the `cc` virial theorem tech to use `Matrix` rather than `block_matrix`. This takes us one step closer to having `Matrix`-based densities.

## Questions
- [x] New code uses stored HF kinetic energy, rather than re-computing it. TDC, is this okay?
- [x] The variables are saved to the wavefunction, but not to globals. Lori, is that okay?

## Checklist
- [x] `cc1` passes

## Status
- [x] Ready for review
- [x] Ready for merge
