### PR TITLE
Begin moving OPDM management out of libtrans

### DIFF
--- a/psi4/src/psi4/dct/dct_compute.cc
+++ b/psi4/src/psi4/dct/dct_compute.cc
@@ -90,6 +90,10 @@ double DCTSolver::compute_energy() {
         }
     }
 
+    // Enforce that ODPM is hermitian. This may fail when the non-OO DCT is used.
+    if (Da_) Da_->hermitivitize();
+    if (Db_) Db_->hermitivitize();
+
     // Free up memory and close files
     finalize();
 

--- a/psi4/src/psi4/libtrans/integraltransform.h
+++ b/psi4/src/psi4/libtrans/integraltransform.h
@@ -155,7 +155,9 @@ class PSI_API IntegralTransform {
     void transform_tei_first_half(const std::shared_ptr<MOSpace> s1, const std::shared_ptr<MOSpace> s2);
     void transform_tei_second_half(const std::shared_ptr<MOSpace> s1, const std::shared_ptr<MOSpace> s2,
                                    const std::shared_ptr<MOSpace> s3, const std::shared_ptr<MOSpace> s4);
-    void backtransform_density();
+    // WARNING! reset_oneel is set to true for backwards compatibility. Soon, this option will be removed
+    // and only the reset_oneel = false logic will be available.
+    void backtransform_density(bool reset_oneel = true);
     void backtransform_tpdm_restricted();
     void backtransform_tpdm_unrestricted();
     void print_dpd_lookup();

--- a/psi4/src/psi4/occ/ocepa_response_pdms.cc
+++ b/psi4/src/psi4/occ/ocepa_response_pdms.cc
@@ -89,6 +89,9 @@ void OCCWave::ocepa_response_pdms() {
         if (print_ > 1) {
             g1symm->print();
         }
+        Da_ = linalg::triplet(Ca_, g1symm, Ca_, false, false, true);
+        Da_->scale(0.5);
+        Db_->copy(Da_);
     }  // end if (reference_ == "RESTRICTED")
 
     else if (reference_ == "UNRESTRICTED") {
@@ -176,7 +179,8 @@ void OCCWave::ocepa_response_pdms() {
             g1symmA->print();
             g1symmB->print();
         }
-
+        Da_ = linalg::triplet(Ca_, g1symmA, Ca_, false, false, true);
+        Db_ = linalg::triplet(Cb_, g1symmB, Cb_, false, false, true);
     }  // end if (reference_ == "UNRESTRICTED")
 
     // use OPDMs in an unmodified way for REMP

--- a/psi4/src/psi4/occ/omp2_response_pdms.cc
+++ b/psi4/src/psi4/occ/omp2_response_pdms.cc
@@ -88,6 +88,9 @@ void OCCWave::omp2_response_pdms() {
 
         // print
         if (print_ > 2) g1symm->print();
+        Da_ = linalg::triplet(Ca_, g1symm, Ca_, false, false, true);
+        Da_->scale(0.5);
+        Db_->copy(Da_);
 
         // Build TPDM
         timer_on("TPDM OOVV");
@@ -192,6 +195,8 @@ void OCCWave::omp2_response_pdms() {
             g1symmA->print();
             g1symmB->print();
         }
+        Da_ = linalg::triplet(Ca_, g1symmA, Ca_, false, false, true);
+        Db_ = linalg::triplet(Cb_, g1symmB, Cb_, false, false, true);
 
         // TPDM
         timer_on("TPDM OOVV");

--- a/psi4/src/psi4/occ/omp3_response_pdms.cc
+++ b/psi4/src/psi4/occ/omp3_response_pdms.cc
@@ -90,6 +90,9 @@ void OCCWave::omp3_response_pdms() {
         if (print_ > 1) {
             g1symm->print();
         }
+        Da_ = linalg::triplet(Ca_, g1symm, Ca_, false, false, true);
+        Da_->scale(0.5);
+        Db_->copy(Da_);
 
         // TPDM
         timer_on("V int");
@@ -204,6 +207,8 @@ void OCCWave::omp3_response_pdms() {
             g1symmA->print();
             g1symmB->print();
         }
+        Da_ = linalg::triplet(Ca_, g1symmA, Ca_, false, false, true);
+        Db_ = linalg::triplet(Cb_, g1symmB, Cb_, false, false, true);
 
         // TPDM
         timer_on("V int");


### PR DESCRIPTION
At long last, some gradient refactoring. Supersedes [my previous attempt](https://github.com/psi4/psi4/pull/1745). Only the OPDM and Lagrangian are a 1.7 target.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Orbital-optimized `occ` densities now available on the wavefunction
- [x] DC-06 densities now symmetrized

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Conventional gradients now check whether the density and Lagrangian are set on the wavefunction. If so, it uses those rather than reading MO-basis quantities from disk. `dct` and `occ` use this new system. `cc` will use it in the next PR. The old system will be removed for 1.8. Old system vs new system is toggled by the `reset_oneel` flag.

## Questions
- [ ] How to create a warning that plugin developers should use new-style gradients?

## Checklist
- [x] All `dct`, `omp`, `mp`, `olccd`, lccd`, `cepa`, and `cc` tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
