### PR TITLE
CompositeJK Part 1.5: DFJLinK/DFJCOSK IncFock Standardization

### DIFF
--- a/psi4/src/psi4/libfock/DFJLinK.cc
+++ b/psi4/src/psi4/libfock/DFJLinK.cc
@@ -182,12 +182,10 @@ void DFJLinK::incfock_setup() {
 }
 
 void DFJLinK::incfock_postiter() {
-    if (do_incfock_iter_) {
-        // Save a copy of the density for the next iteration
-        D_prev_.clear();
-        for(auto const &Di : D_ao_) {
-            D_prev_.push_back(Di->clone());
-        }
+    // Save a copy of the density for the next iteration
+    D_prev_.clear();
+    for(auto const &Di : D_ao_) {
+        D_prev_.push_back(Di->clone());
     }
 }
 

--- a/psi4/src/psi4/libfock/DFJLinK.cc
+++ b/psi4/src/psi4/libfock/DFJLinK.cc
@@ -164,8 +164,8 @@ void DFJLinK::incfock_setup() {
         size_t njk = D_ao_.size();
 
         // If there is no previous pseudo-density, this iteration is normal
-        if(initial_iteration_ || D_prev_.size() != njk) {
-	    initial_iteration_ = true;
+        if (initial_iteration_ || D_prev_.size() != njk) {
+	        initial_iteration_ = true;
 
             D_ref_ = D_ao_;
             zero();

--- a/psi4/src/psi4/libfock/DFJLinK.cc
+++ b/psi4/src/psi4/libfock/DFJLinK.cc
@@ -209,7 +209,7 @@ void DFJLinK::compute_JK() {
         if (!initial_iteration_ && (Dnorm >= incfock_conv)) incfock_count_ += 1;
 
 	incfock_setup();
-	
+        
 	timer_off("DFJLinK: INCFOCK Preprocessing");
     } else {
 	D_ref_ = D_ao_;
@@ -654,7 +654,7 @@ void DFJLinK::build_K(std::vector<SharedMatrix>& D, std::vector<SharedMatrix>& K
 #pragma omp parallel for num_threads(nthread) schedule(dynamic) reduction(+ : computed_shells)
     for (size_t ipair = 0L; ipair < natom_pair; ipair++) { // O(N) shell-pairs in asymptotic limit
         
-	int Patom = atom_pairs[ipair].first;
+        int Patom = atom_pairs[ipair].first;
         int Qatom = atom_pairs[ipair].second;
         
         // Number of shells per atom
@@ -674,7 +674,7 @@ void DFJLinK::build_K(std::vector<SharedMatrix>& D, std::vector<SharedMatrix>& K
         thread = omp_get_thread_num();
 #endif
 
-	// Keep track of contraction indices for stripeout (Towards end of this function)
+        // Keep track of contraction indices for stripeout (Towards end of this function)
         std::vector<std::unordered_set<int>> P_stripeout_list(nPshell);
         std::vector<std::unordered_set<int>> Q_stripeout_list(nQshell);
 
@@ -761,7 +761,7 @@ void DFJLinK::build_K(std::vector<SharedMatrix>& D, std::vector<SharedMatrix>& K
                     // Basis Function offset from first basis function in the atom
                     int shell_P_offset = basis_endpoints_for_shell[P] - basis_endpoints_for_shell[Pstart];
                     int shell_Q_offset = basis_endpoints_for_shell[Q] - basis_endpoints_for_shell[Qstart];
- 
+
                     for (size_t ind = 0; ind < D.size(); ind++) {
                         double** Kp = K[ind]->pointer();
                         double** Dp = D[ind]->pointer();

--- a/psi4/src/psi4/libfock/DFJLinK.cc
+++ b/psi4/src/psi4/libfock/DFJLinK.cc
@@ -496,15 +496,7 @@ void DFJLinK::build_J(std::vector<std::shared_ptr<Matrix>>& D, std::vector<std::
         for (size_t thread = 0; thread < nthreads_; thread++) {
             J[jki]->add(JT[jki][thread]);
         }
-	outfile->Printf("J 0 internal pre-Hermit (0,0): %f \n", J[jki]->pointer()[0][0]);
-	outfile->Printf("J 0 internal pre-Hermit (0,1): %f \n", J[jki]->pointer()[0][1]);
-	outfile->Printf("J 0 internal pre-Hermit (1,0): %f \n", J[jki]->pointer()[1][0]);
-
         J[jki]->hermitivitize();
-    
-    	outfile->Printf("J 0 internal post-Hermit (0,0): %f \n", J[jki]->pointer()[0][0]);
-	outfile->Printf("J 0 internal post-Hermit (0,1): %f \n", J[jki]->pointer()[0][1]);
-	outfile->Printf("J 0 internal post-Hermit (1,0): %f \n", J[jki]->pointer()[1][0]);
     }
 
 }
@@ -836,6 +828,9 @@ void DFJLinK::build_K(std::vector<SharedMatrix>& D, std::vector<SharedMatrix>& K
         if (!touched) continue;
 
         // => Stripe out (Writing to K matrix) <= //
+        for (auto& KTmat : KT[thread]) {
+            KTmat->scale(2.0);
+        }
 
         for (size_t ind = 0; ind < D.size(); ind++) {
             double** KTp = KT[thread][ind]->pointer();
@@ -895,16 +890,7 @@ void DFJLinK::build_K(std::vector<SharedMatrix>& D, std::vector<SharedMatrix>& K
     }  // End master task list
 
     for (auto& Kmat : K) {
-	outfile->Printf("K 0 internal pre-Hermit (0,0): %f \n", Kmat->pointer()[0][0]);
-	outfile->Printf("K 0 internal pre-Hermit (0,1): %f \n", Kmat->pointer()[0][1]);
-	outfile->Printf("K 0 internal pre-Hermit (1,0): %f \n", Kmat->pointer()[1][0]);
-    }
-    for (auto& Kmat : K) {
-        Kmat->scale(2.0);
         Kmat->hermitivitize();
-	outfile->Printf("K 0 internal post-Hermit (0,0): %f \n", Kmat->pointer()[0][0]);
-	outfile->Printf("K 0 internal post-Hermit (0,1): %f \n", Kmat->pointer()[0][1]);
-	outfile->Printf("K 0 internal post-Hermit (1,0): %f \n", Kmat->pointer()[1][0]);
     }
 
     if (bench_) {

--- a/psi4/src/psi4/libfock/DFJLinK.cc
+++ b/psi4/src/psi4/libfock/DFJLinK.cc
@@ -212,7 +212,7 @@ void DFJLinK::compute_JK() {
         
 	timer_off("DFJLinK: INCFOCK Preprocessing");
     } else {
-	D_ref_ = D_ao_;
+	    D_ref_ = D_ao_;
         zero();
     }
     

--- a/psi4/src/psi4/libfock/DFJLinK.cc
+++ b/psi4/src/psi4/libfock/DFJLinK.cc
@@ -208,7 +208,7 @@ void DFJLinK::compute_JK() {
         
         if (!initial_iteration_ && (Dnorm >= incfock_conv)) incfock_count_ += 1;
 
-	incfock_setup();
+	    incfock_setup();
         
 	timer_off("DFJLinK: INCFOCK Preprocessing");
     } else {

--- a/psi4/src/psi4/libfock/DFJLinK.cc
+++ b/psi4/src/psi4/libfock/DFJLinK.cc
@@ -169,7 +169,7 @@ void DFJLinK::incfock_setup() {
 
             D_ref_ = D_ao_;
             zero();
-        } else { // Otherwise, the iteraction is incremental
+        } else { // Otherwise, the iteration is incremental
             for (size_t jki = 0; jki < njk; jki++) {
                 D_ref_[jki] = D_ao_[jki]->clone();
                 D_ref_[jki]->subtract(D_prev_[jki]);

--- a/psi4/src/psi4/libfock/DFJLinK.cc
+++ b/psi4/src/psi4/libfock/DFJLinK.cc
@@ -160,66 +160,33 @@ void DFJLinK::print_header() const {
 void DFJLinK::preiterations() {}
 
 void DFJLinK::incfock_setup() {
+    if (do_incfock_iter_) {
+        size_t njk = D_ao_.size();
 
-    // The prev_D_ao_ condition is used to handle stability analysis case
-    if (initial_iteration_ || prev_D_ao_.size() != D_ao_.size()) {
-        initial_iteration_ = true;
+        // If there is no previous pseudo-density, this iteration is normal
+        if(initial_iteration_ || D_prev_.size() != njk) {
+	    initial_iteration_ = true;
 
-        prev_D_ao_.clear();
-        delta_D_ao_.clear();
-
-        if (do_J_) {
-            prev_J_ao_.clear();
-            delta_J_ao_.clear();
-        }
-
-        if (do_K_) {
-            prev_K_ao_.clear();
-            delta_K_ao_.clear();
-        }
-    
-        for (size_t N = 0; N < D_ao_.size(); N++) {
-            prev_D_ao_.push_back(std::make_shared<Matrix>("D Prev", D_ao_[N]->nrow(), D_ao_[N]->ncol()));
-            delta_D_ao_.push_back(std::make_shared<Matrix>("Delta D", D_ao_[N]->nrow(), D_ao_[N]->ncol()));
-
-            if (do_J_) {
-                prev_J_ao_.push_back(std::make_shared<Matrix>("J Prev", J_ao_[N]->nrow(), J_ao_[N]->ncol()));
-                delta_J_ao_.push_back(std::make_shared<Matrix>("Delta J", J_ao_[N]->nrow(), J_ao_[N]->ncol()));
-            }
-        
-            if (do_K_) {
-                prev_K_ao_.push_back(std::make_shared<Matrix>("K Prev", K_ao_[N]->nrow(), K_ao_[N]->ncol()));
-                delta_K_ao_.push_back(std::make_shared<Matrix>("Delta K", K_ao_[N]->nrow(), K_ao_[N]->ncol()));
+            D_ref_ = D_ao_;
+            zero();
+        } else { // Otherwise, the iteraction is incremental
+            for (size_t jki = 0; jki < njk; jki++) {
+                D_ref_[jki] = D_ao_[jki]->clone();
+                D_ref_[jki]->subtract(D_prev_[jki]);
             }
         }
     } else {
-        for (size_t N = 0; N < D_ao_.size(); N++) {
-            delta_D_ao_[N]->copy(D_ao_[N]);
-            delta_D_ao_[N]->subtract(prev_D_ao_[N]);
-        }
+        D_ref_ = D_ao_;
+        zero();
     }
 }
+
 void DFJLinK::incfock_postiter() {
     if (do_incfock_iter_) {
-        for (size_t N = 0; N < D_ao_.size(); N++) {
-
-            if (do_J_) {
-                prev_J_ao_[N]->add(delta_J_ao_[N]);
-                J_ao_[N]->copy(prev_J_ao_[N]);
-            }
-
-            if (do_K_) {
-                prev_K_ao_[N]->add(delta_K_ao_[N]);
-                K_ao_[N]->copy(prev_K_ao_[N]);
-            }
-
-            prev_D_ao_[N]->copy(D_ao_[N]);
-        }
-    } else {
-        for (size_t N = 0; N < D_ao_.size(); N++) {
-            if (do_J_) prev_J_ao_[N]->copy(J_ao_[N]);
-            if (do_K_) prev_K_ao_[N]->copy(K_ao_[N]);
-            prev_D_ao_[N]->copy(D_ao_[N]);
+        // Save a copy of the density for the next iteration
+        D_prev_.clear();
+        for(auto const &Di : D_ao_) {
+            D_prev_.push_back(Di->clone());
         }
     }
 }
@@ -229,13 +196,9 @@ void DFJLinK::compute_JK() {
     // wK not supported in DFJLinK yet
     if (do_wK_) throw PSIEXCEPTION("LINK does not support wK integrals yet!");
    
-    // => Set up Incremental Fock and Density Screening if required <= //
-    
     // explicit setup of Incfock for this SCF iteration
     if (incfock_) {
         timer_on("DFJLinK: INCFOCK Preprocessing");
-        
-	incfock_setup();
 
         int reset = options_.get_int("INCFOCK_FULL_FOCK_EVERY");
         double incfock_conv = options_.get_double("INCFOCK_CONVERGENCE");
@@ -244,43 +207,52 @@ void DFJLinK::compute_JK() {
         do_incfock_iter_ = (Dnorm >= incfock_conv) && !initial_iteration_ && (incfock_count_ % reset != reset - 1);
         
         if (!initial_iteration_ && (Dnorm >= incfock_conv)) incfock_count_ += 1;
-        
+
+	incfock_setup();
+	
 	timer_off("DFJLinK: INCFOCK Preprocessing");
+    } else {
+	D_ref_ = D_ao_;
+        zero();
     }
     
-    // define matrices to be used for J/K construction
-    std::vector<SharedMatrix>& D_ref = (do_incfock_iter_ ? delta_D_ao_ : D_ao_);
-    std::vector<SharedMatrix>& J_ref = (do_incfock_iter_ ? delta_J_ao_ : J_ao_);
-    std::vector<SharedMatrix>& K_ref = (do_incfock_iter_ ? delta_K_ao_ : K_ao_);
-
     // update ERI engine density matrices for density screening
     if (density_screening_) {
         for (auto eri_computer : eri_computers_["4-Center"]) {
-            eri_computer->update_density(D_ref);
+            eri_computer->update_density(D_ref_);
+	}
+        for (auto eri_computer : eri_computers_["3-Center"]) {
+            eri_computer->update_density(D_ref_);
 	}
     }
 
     // => Perform matrix calculations <= //
     
     // Direct DF-J
+    outfile->Printf("J SCF d Pre: %f \n", D_ref_[0]->pointer()[0][0]);
+    outfile->Printf("J 0 Pre: %f \n", J_ao_[0]->pointer()[0][0]);
     if (do_J_) {
         timer_on("DFJLinK: J");
         
-	for (auto& Jmat : J_ref) Jmat->zero();
-	build_J(D_ref, J_ref);
+	//for (auto& Jmat : J_ao_) Jmat->zero();
+	build_J(D_ref_, J_ao_);
         
 	timer_off("DFJLinK: J");
     }
+    outfile->Printf("J 0 Post: %f \n", J_ao_[0]->pointer()[0][0]);
     
     // LinK
+    outfile->Printf("K SCF d Pre: %f \n", D_ref_[0]->pointer()[0][0]);
+    outfile->Printf("K 0 Pre: %f \n", K_ao_[0]->pointer()[0][0]);
     if (do_K_) {
         timer_on("DFJLinK: K");
         
-	for (auto& Kmat : K_ref) Kmat->zero();
-        build_K(D_ref, K_ref);
+	//for (auto& Kmat : K_ao_) Kmat->zero();
+        build_K(D_ref_, K_ao_);
         
 	timer_off("DFJLinK: K");
     }
+    outfile->Printf("K 0 Post: %f \n", K_ao_[0]->pointer()[0][0]);
    
     // => Finalize Incremental Fock if required <= //
     
@@ -524,7 +496,15 @@ void DFJLinK::build_J(std::vector<std::shared_ptr<Matrix>>& D, std::vector<std::
         for (size_t thread = 0; thread < nthreads_; thread++) {
             J[jki]->add(JT[jki][thread]);
         }
+	outfile->Printf("J 0 internal pre-Hermit (0,0): %f \n", J[jki]->pointer()[0][0]);
+	outfile->Printf("J 0 internal pre-Hermit (0,1): %f \n", J[jki]->pointer()[0][1]);
+	outfile->Printf("J 0 internal pre-Hermit (1,0): %f \n", J[jki]->pointer()[1][0]);
+
         J[jki]->hermitivitize();
+    
+    	outfile->Printf("J 0 internal post-Hermit (0,0): %f \n", J[jki]->pointer()[0][0]);
+	outfile->Printf("J 0 internal post-Hermit (0,1): %f \n", J[jki]->pointer()[0][1]);
+	outfile->Printf("J 0 internal post-Hermit (1,0): %f \n", J[jki]->pointer()[1][0]);
     }
 
 }
@@ -692,8 +672,8 @@ void DFJLinK::build_K(std::vector<SharedMatrix>& D, std::vector<SharedMatrix>& K
 
 #pragma omp parallel for num_threads(nthread) schedule(dynamic) reduction(+ : computed_shells)
     for (size_t ipair = 0L; ipair < natom_pair; ipair++) { // O(N) shell-pairs in asymptotic limit
-
-        int Patom = atom_pairs[ipair].first;
+        
+	int Patom = atom_pairs[ipair].first;
         int Qatom = atom_pairs[ipair].second;
         
         // Number of shells per atom
@@ -713,7 +693,7 @@ void DFJLinK::build_K(std::vector<SharedMatrix>& D, std::vector<SharedMatrix>& K
         thread = omp_get_thread_num();
 #endif
 
-        // Keep track of contraction indices for stripeout (Towards end of this function)
+	// Keep track of contraction indices for stripeout (Towards end of this function)
         std::vector<std::unordered_set<int>> P_stripeout_list(nPshell);
         std::vector<std::unordered_set<int>> Q_stripeout_list(nQshell);
 
@@ -800,7 +780,7 @@ void DFJLinK::build_K(std::vector<SharedMatrix>& D, std::vector<SharedMatrix>& K
                     // Basis Function offset from first basis function in the atom
                     int shell_P_offset = basis_endpoints_for_shell[P] - basis_endpoints_for_shell[Pstart];
                     int shell_Q_offset = basis_endpoints_for_shell[Q] - basis_endpoints_for_shell[Qstart];
-
+ 
                     for (size_t ind = 0; ind < D.size(); ind++) {
                         double** Kp = K[ind]->pointer();
                         double** Dp = D[ind]->pointer();
@@ -915,8 +895,16 @@ void DFJLinK::build_K(std::vector<SharedMatrix>& D, std::vector<SharedMatrix>& K
     }  // End master task list
 
     for (auto& Kmat : K) {
+	outfile->Printf("K 0 internal pre-Hermit (0,0): %f \n", Kmat->pointer()[0][0]);
+	outfile->Printf("K 0 internal pre-Hermit (0,1): %f \n", Kmat->pointer()[0][1]);
+	outfile->Printf("K 0 internal pre-Hermit (1,0): %f \n", Kmat->pointer()[1][0]);
+    }
+    for (auto& Kmat : K) {
         Kmat->scale(2.0);
         Kmat->hermitivitize();
+	outfile->Printf("K 0 internal post-Hermit (0,0): %f \n", Kmat->pointer()[0][0]);
+	outfile->Printf("K 0 internal post-Hermit (0,1): %f \n", Kmat->pointer()[0][1]);
+	outfile->Printf("K 0 internal post-Hermit (1,0): %f \n", Kmat->pointer()[1][0]);
     }
 
     if (bench_) {

--- a/psi4/src/psi4/libfock/DFJLinK.cc
+++ b/psi4/src/psi4/libfock/DFJLinK.cc
@@ -653,7 +653,6 @@ void DFJLinK::build_K(std::vector<SharedMatrix>& D, std::vector<SharedMatrix>& K
 
 #pragma omp parallel for num_threads(nthread) schedule(dynamic) reduction(+ : computed_shells)
     for (size_t ipair = 0L; ipair < natom_pair; ipair++) { // O(N) shell-pairs in asymptotic limit
-        
         int Patom = atom_pairs[ipair].first;
         int Qatom = atom_pairs[ipair].second;
         

--- a/psi4/src/psi4/libfock/DFJLinK.cc
+++ b/psi4/src/psi4/libfock/DFJLinK.cc
@@ -221,9 +221,6 @@ void DFJLinK::compute_JK() {
         for (auto eri_computer : eri_computers_["4-Center"]) {
             eri_computer->update_density(D_ref_);
 	}
-        for (auto eri_computer : eri_computers_["3-Center"]) {
-            eri_computer->update_density(D_ref_);
-	}
     }
 
     // => Perform matrix calculations <= //

--- a/psi4/src/psi4/libfock/DFJLinK.cc
+++ b/psi4/src/psi4/libfock/DFJLinK.cc
@@ -226,30 +226,22 @@ void DFJLinK::compute_JK() {
     // => Perform matrix calculations <= //
     
     // Direct DF-J
-    outfile->Printf("J SCF d Pre: %f \n", D_ref_[0]->pointer()[0][0]);
-    outfile->Printf("J 0 Pre: %f \n", J_ao_[0]->pointer()[0][0]);
     if (do_J_) {
         timer_on("DFJLinK: J");
         
-	//for (auto& Jmat : J_ao_) Jmat->zero();
 	build_J(D_ref_, J_ao_);
         
 	timer_off("DFJLinK: J");
     }
-    outfile->Printf("J 0 Post: %f \n", J_ao_[0]->pointer()[0][0]);
     
     // LinK
-    outfile->Printf("K SCF d Pre: %f \n", D_ref_[0]->pointer()[0][0]);
-    outfile->Printf("K 0 Pre: %f \n", K_ao_[0]->pointer()[0][0]);
     if (do_K_) {
         timer_on("DFJLinK: K");
         
-	//for (auto& Kmat : K_ao_) Kmat->zero();
         build_K(D_ref_, K_ao_);
         
 	timer_off("DFJLinK: K");
     }
-    outfile->Printf("K 0 Post: %f \n", K_ao_[0]->pointer()[0][0]);
    
     // => Finalize Incremental Fock if required <= //
     

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1308,7 +1308,7 @@ class PSI_API DFJLinK : public JK {
 
     /// Pseudo-density matrix to be used this iteration
     std::vector<SharedMatrix> D_ref_;
-    
+
     // Is the JK currently on a guess iteration
     bool initial_iteration_ = true;
   

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1302,16 +1302,22 @@ class PSI_API DFJLinK : public JK {
     /// The number of times INCFOCK has been performed (includes resets)
     int incfock_count_;
     bool do_incfock_iter_;
- 
+
+    /// Previous iteration pseudo-density matrix
+    std::vector<SharedMatrix> D_prev_;
+
+    /// Pseudo-density matrix to be used this iteration
+    std::vector<SharedMatrix> D_ref_;
+    
     /// D, J, K Matrices from previous iteration, used in Incremental Fock Builds
-    std::vector<SharedMatrix> prev_D_ao_;
-    std::vector<SharedMatrix> prev_J_ao_;
-    std::vector<SharedMatrix> prev_K_ao_;
+    // std::vector<SharedMatrix> prev_D_ao_;
+    // std::vector<SharedMatrix> prev_J_ao_;
+    // std::vector<SharedMatrix> prev_K_ao_;
 
     // Delta D, J, K Matrices for Incremental Fock Build
-    std::vector<SharedMatrix> delta_D_ao_;
-    std::vector<SharedMatrix> delta_J_ao_;
-    std::vector<SharedMatrix> delta_K_ao_;
+    // std::vector<SharedMatrix> delta_D_ao_;
+    // std::vector<SharedMatrix> delta_J_ao_;
+    // std::vector<SharedMatrix> delta_K_ao_;
  
     // Is the JK currently on a guess iteration
     bool initial_iteration_ = true;

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1309,16 +1309,6 @@ class PSI_API DFJLinK : public JK {
     /// Pseudo-density matrix to be used this iteration
     std::vector<SharedMatrix> D_ref_;
     
-    /// D, J, K Matrices from previous iteration, used in Incremental Fock Builds
-    // std::vector<SharedMatrix> prev_D_ao_;
-    // std::vector<SharedMatrix> prev_J_ao_;
-    // std::vector<SharedMatrix> prev_K_ao_;
-
-    // Delta D, J, K Matrices for Incremental Fock Build
-    // std::vector<SharedMatrix> delta_D_ao_;
-    // std::vector<SharedMatrix> delta_J_ao_;
-    // std::vector<SharedMatrix> delta_K_ao_;
- 
     // Is the JK currently on a guess iteration
     bool initial_iteration_ = true;
   

--- a/tests/linK-1/input.dat
+++ b/tests/linK-1/input.dat
@@ -26,3 +26,4 @@ set {
 
 linK_energy = energy('scf')
 psi4.compare_values(ref_energy, linK_energy, 9, "HF Energy (Using LinK algo)")
+compare(1, variable("SCF ITERATIONS") < 12.0, "LinK Incfock Efficient")

--- a/tests/linK-2/input.dat
+++ b/tests/linK-2/input.dat
@@ -34,3 +34,4 @@ set {
 
 linK_energy = energy('b3lyp')
 psi4.compare_values(ref_energy, linK_energy, 8, "B3LYP Energy (using LinK algo)")
+compare(1, variable("SCF ITERATIONS") < 13.0, "LinK Incfock Efficient")

--- a/tests/linK-3/input.dat
+++ b/tests/linK-3/input.dat
@@ -36,7 +36,9 @@ set {
 
 uhf_energy = energy('scf')
 psi4.compare_values(uhf_energy, uhf_ref, 8, "UHF Energy (using LinK algo)")
+compare(1, variable("SCF ITERATIONS") < 19.0, "UHF LinK Incfock Efficient")
 
 set reference rohf
 rohf_energy = energy('scf')
 psi4.compare_values(rohf_energy, rohf_ref, 8, "ROHF Energy (using LinK algo)")
+compare(1, variable("SCF ITERATIONS") < 19.0, "ROHF LinK Incfock Efficient")


### PR DESCRIPTION
## Description
This PR is a rather important update to the DFJLinK JK subclass, counting both as the continuation of the CompositeJK development started in https://github.com/psi4/psi4/pull/2762 and the first PR in the new incremental Fock build standardization seen in https://github.com/psi4/psi4/pull/2682.

To describe the problem, as of now, different integral-direct JK algorithms use different implementations of the incremental Fock build formalism. DirectJK and DFJLinK use the same incremental Fock build formalism, while DFJCOSK uses its own methodology. This introduces two problems:

1. The next step of CompositeJK development is to combine DFJLinK and DFJCOSK into the pilot CompositeJK subclass. To ease this process, DFJLinK and DFJCOSK need to use the same incremental Fock process.
2. The incremental Fock formalism currently used by DirectJK and DFJLinK has a couple of extra bells and whistles that DFJCOSK does not have - mainly, the ability to recompute the full Fock matrix every couple of iterations and the ability to disable incremental Fock construction entirely past a specific convergence threshold. These bells and whistles can greatly improve the convergence capabilities of the calculation, while "normal" IncFock implementations without these bells and whistles run the risk of greatly increasing the number of SCF iterations needed to converge. This issue is meant to be addressed with https://github.com/psi4/psi4/pull/2682; however, the introduction of DFJLinK to the JK hierarchy has potentially changed how that PR should be handled.

This PR addresses both of the above issues by changing DFJLinK to use the same incremental Fock formalism as DFJCOSK. Using the DFJCOSK incremental Fock formalism is preferred because DFJCOSK stores fewer matrices in the DFJCOSK class for incremental Fock usage, reducing memory requirements from a practical perspective, and lowering the amount of state contained in DFJLinK from a code design perspective. In standardizing the DFJLinK and DFJCOSK incremental Fock processes, the next CompositeJK PR will be smoother, and CompositeJK development can continue parallel to the developments discussed in https://github.com/psi4/psi4/pull/2682. Additionally, this PR serves as a first step the to decomposition of https://github.com/psi4/psi4/pull/2682 as discussed in that PR's comments, allowing for the full standardization of IncFock among integral-direct JK subclasses.

For reviewers, since this PR is the bottleneck for two different routes of JK development (CompositeJK and IncFock standardization), it should be considered the highest-priority JK development PR to merge into Psi4 at the moment.

## User API & Changelog headlines
N/A

## Dev notes & details
- [X] Switches DFJLinK to using the incremental Fock build implementation used in DFJCOSK. This change standardizes the incremental Fock implementation between DFJLinK and DFJCOSK and improves the memory usage of DFJLinK in  the process.
- [X] Changes LinK machinery to support new incremental Fock formalism.

## Questions
- [ ] Since this PR specifically focuses on changes to DFJLinK, there are still a couple of small differences in IncFock between DFJLinK and DFJCOSK, mainly, refactorings and the aforementioned bells and whistles that DFJLinK has that DFJCOSK doesn't. Would it be better to make adjustments to DFJCOSK in this PR as well, to further standardize the two; or is it preferrable to punt that down to the next CompositeJK PR, when DFJLinK and DFJCOSK are combined into the pilot CompositeJK implementation? If we decide to make the changes to DFJCOSK this PR, it would essentially consist of refactoring the DFJCOSK IncFock to match that of DFJLinK, and adding the bells and whistles that DFJLinK currently has.
- [ ] Should the relevant test outputs be updated?

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge