### PR TITLE
Refactor `libmints::IntegralFactory.electric_field()` to return ElectricFieldInt

### DIFF
--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -197,7 +197,7 @@ OneBodySOInt* IntegralFactory::so_traceless_quadrupole() {
     return new OneBodySOInt(ao_int, this);
 }
 
-OneBodyAOInt* IntegralFactory::electric_field(int deriv) {
+ElectricFieldInt* IntegralFactory::electric_field(int deriv) {
     return new ElectricFieldInt(spherical_transforms_, bs1_, bs2_, deriv);
 }
 

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -38,6 +38,7 @@ PRAGMA_WARNING_POP
 
 #include "onebody.h"
 #include "twobody.h"
+#include "electricfield.h"
 
 
 namespace psi {
@@ -90,6 +91,7 @@ class GaussianShell;
 class OneBodyAOInt;
 class OneBodySOInt;
 class TwoBodyAOInt;
+class ElectricFieldInt;
 class ThreeCenterOverlapInt;
 class CartesianIter;
 class RedundantCartesianIter;
@@ -480,8 +482,8 @@ class PSI_API IntegralFactory {
     /// Returns a OneBodyInt that computes the multipole potential integrals for PE and EFP
     virtual OneBodyAOInt* ao_multipole_potential(int order, int deriv = 0);
 
-    /// Returns an OneBodyInt that computes the electric field
-    virtual OneBodyAOInt* electric_field(int deriv = 0);
+    /// Returns an ElectricFieldInt that computes the electric field
+    virtual ElectricFieldInt* electric_field(int deriv = 0);
 
     /// Returns an OneBodyInt that computes the point electrostatic potential
     virtual OneBodyAOInt* electrostatic();

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1719,7 +1719,7 @@ std::vector<SharedMatrix> MintsHelper::electric_field(const std::vector<double> 
 SharedMatrix MintsHelper::induction_operator(SharedMatrix coords, SharedMatrix moments) {
     SharedMatrix mat = std::make_shared<Matrix>("Induction operator", basisset_->nbf(), basisset_->nbf());
     ContractOverDipolesFunctor dipfun(moments, mat);
-    auto field_integrals_ = static_cast<ElectricFieldInt *>(integral_->electric_field());
+    auto field_integrals_ = integral_->electric_field();
     field_integrals_->compute_with_functor(dipfun, coords);
     mat->scale(-1.0);
 
@@ -1727,7 +1727,7 @@ SharedMatrix MintsHelper::induction_operator(SharedMatrix coords, SharedMatrix m
 }
 
 SharedMatrix MintsHelper::electric_field_value(SharedMatrix coords, SharedMatrix D) {
-    auto field_integrals_ = static_cast<ElectricFieldInt *>(integral_->electric_field());
+    auto field_integrals_ = integral_->electric_field();
 
     SharedMatrix efields = std::make_shared<Matrix>("efields", coords->nrow(), 3);
     auto fieldfun = ContractOverDensityFieldFunctor(efields, D);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

Refactor `electric_field()` to return ElectricFieldInt rather than OneBodyAOInt

Fixes #2793 

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] ElectricFieldInt returned now by `IntegralFactory.electric_field()`
- [x] Equivalent changes in `libmintshelper` made to stop immediate `static cast`


## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] ElectricFieldInt returned now by `IntegralFactory.electric_field()`
- [x] Equivalent changes in `libmintshelper`


## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge
