### PR TITLE
Do not use or suggest the undocumented -H option for CMake

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -117,7 +117,7 @@ jobs:
       #   b/c their c++ symbols don't mix with the different Travis compilers. for other
       #   reasons, pkgs are being compiled less statically, sad for CI.
       # * can't enable trivial plugins b/c no psi4 for them to detect at start (e.g., snsmp2)
-      cmake -Bbuild -H. \
+      cmake -Bbuild -S. \
         -DCMAKE_CXX_COMPILER=${CXX_COMPILER} \
         -DCMAKE_C_COMPILER=${C_COMPILER} \
         -DCMAKE_Fortran_COMPILER=${F_COMPILER} \

--- a/cmake/autocmake_safeguards.cmake
+++ b/cmake/autocmake_safeguards.cmake
@@ -13,7 +13,7 @@
 #   CMAKE_BUILD_TYPE
 
 if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
-    message(FATAL_ERROR "In-source builds not allowed. Please run CMake from top directory and specify a build directory (e.g., cmake -H. -Bbuild).")
+    message(FATAL_ERROR "In-source builds not allowed. Please run CMake from top directory and specify a build directory (e.g., cmake -S. -Bbuild).")
 endif()
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" cmake_build_type_tolower)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
The `-H<path>` option for CMake is technically not part of the CMake public interface, it is not documented and was never meant for public use. Since CMake 3.13 there is a proper alternative, `-S<path>`, so Psi4 should use that and stop suggesting users to use `-H<path>`.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Psi4 no longer suggests users to use the undocumented `-H<path>` CMake option when building from source.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Replace `-H<path>`  with `-S<path>` in CMake invokations.

## Questions
- [ ] I have no idea where to make a PR for fixing this in psi4-path-advisor.

## Checklist
- [x] No new features
- [x] CI tests are passing

## Status
- [x] Ready for review
- [x] Ready for merge
