### PR TITLE
Deprecate PSI_API diagonalizers rsp(...) and sq_rsp(...)

### DIFF
--- a/psi4/src/psi4/libciomr/libciomr.h
+++ b/psi4/src/psi4/libciomr/libciomr.h
@@ -73,7 +73,13 @@ PSI_API void arr_to_mat(double **a, double *b, int m, int n);
 PSI_API void print_array(double *a, int m, std::string out);
 PSI_API void print_mat(double **a, int rows, int cols, std::string out);
 
+PSI_DEPRECATED(
+    "The rsp diagonalizer is deprecated and 1.7 will be the last release to have it. Please use DSPEV from LAPACK "
+    "instead.")
 PSI_API void rsp(int nm, int n, int nv, double *array, double *evals, int matz, double **evecs, double toler);
+PSI_DEPRECATED(
+    "The sq_rsp diagonalizer is deprecated and 1.7 will be the last release to have it. Please use DSYEV from LAPACK "
+    "instead.")
 PSI_API void sq_rsp(int nm, int n, double **array, double *evals, int matz, double **evecs, double toler);
 PSI_API void sq_to_tri(double **bmat, double *amat, int size);
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
These functions are relics from Psi3 (or before?) and they have many issues, unfortunately one of them is their function signature. Stemming from the awful interface, users of `rsp(...)` and `sq_rsp(...)` never check if the diagonalization failed, because they _cannot_.

To keep the promise of not randomly breaking API without fair warning, this PR deprecates said functions but keeps them usable. After #2776, `rsp(...)` has no internal callers left. As for `sq_rsp(...)`:

- many former callers of `sq_rsp(...)` have turned out to be unused functions and have been removed
- If #2686 is merged the vast majority of remaining callers are migrated to a new wrapper around DSYEV
- The remaining call sites of `sq_rsp(...)` will all be in `dfocc`, which is not touched for the time being to avoid causing merge conflicts for the many pending PRs for that module

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] `PSI_API` function `void rsp(int nm, int n, int nv, double *array, double *evals, int matz, double **evecs, double toler)` is deprecated and 1.7 will be the last release with it present.
- [x] `PSI_API` function `void sq_rsp(int nm, int n, double **array, double *evals, int matz, double **evecs, double toler)` is deprecated and 1.7 will be the last release with it present.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Added deprecation notices to `rsp(...)` and `sq_rsp(...)`

## Checklist
- [x] No new features
- [x] Tests pass as per Lori

## Status
- [x] Ready for review
- [x] Ready for merge
