### PR TITLE
Modernize SAPTDIIS label generation

### DIFF
--- a/psi4/src/psi4/libpsi4util/libpsi4util.h
+++ b/psi4/src/psi4/libpsi4util/libpsi4util.h
@@ -106,7 +106,7 @@ class PSI_API Timer {
 void generate_combinations(int n, int k, std::vector<std::vector<int>> &combinations);
 
 template <typename T>
-std::string to_str_width(const T, const size_t width);
-}
+std::string to_str_width(const T &input, const size_t width);
+}  // namespace psi
 
 #endif  // _psi_src_lib_libpsi4util_libpsi4util_h_

--- a/psi4/src/psi4/libpsi4util/libpsi4util.h
+++ b/psi4/src/psi4/libpsi4util/libpsi4util.h
@@ -104,6 +104,9 @@ class PSI_API Timer {
 };
 
 void generate_combinations(int n, int k, std::vector<std::vector<int>> &combinations);
+
+template <typename T>
+std::string to_str_width(const T, const size_t width);
 }
 
 #endif  // _psi_src_lib_libpsi4util_libpsi4util_h_

--- a/psi4/src/psi4/libpsi4util/libpsi4util.h
+++ b/psi4/src/psi4/libpsi4util/libpsi4util.h
@@ -105,8 +105,20 @@ class PSI_API Timer {
 
 void generate_combinations(int n, int k, std::vector<std::vector<int>> &combinations);
 
+/// @brief Converts an input type that is supported by std::to_string, to an std::string that is padded with spaces to a
+/// specified minimum width. This mimics some of the functionality of C-style formatting, eg. %3d.
+/// @tparam T : type of the variable to be converted
+/// @param input : variable to be converted
+/// @param width : pad the string with spaces until it is at least this wide, in a right-justified fashion
+/// @return std::string representation of the input variable, padded if required
 template <typename T>
-std::string to_str_width(const T &input, const size_t width);
+std::string to_str_width(const T &input, const size_t width) {
+    std::string str = std::to_string(input);
+    while (str.length() < width) {
+        str.insert(str.begin(), ' ');
+    }
+    return str;
+}
 }  // namespace psi
 
 #endif  // _psi_src_lib_libpsi4util_libpsi4util_h_

--- a/psi4/src/psi4/libpsi4util/process.h
+++ b/psi4/src/psi4/libpsi4util/process.h
@@ -105,6 +105,6 @@ class PSI_API Process {
 
     static Environment get_environment();
 };
-}
+}  // namespace psi
 
 #endif /* PROCESS_H_ */

--- a/psi4/src/psi4/libpsi4util/stl_string.cc
+++ b/psi4/src/psi4/libpsi4util/stl_string.cc
@@ -207,19 +207,4 @@ double Timer::get() {
     // Convert clock ticks to seconds
     return std::chrono::duration_cast<std::chrono::duration<double>>(duration).count();
 }
-
-/// @brief Converts an input type that is supported by std::to_string, to an std::string that is padded with spaces to a
-/// specified minimum width. This mimics some of the functionality of C-style formatting, eg. %3d.
-/// @tparam T : type of the variable to be converted
-/// @param input : variable to be converted
-/// @param width : pad the string with spaces until it is at least this wide, in a right-justified fashion
-/// @return std::string representation of the input variable, padded if required
-template <typename T>
-std::string to_str_width(const T &input, const size_t width) {
-    std::string str = std::to_string(input);
-    while (str.length() < width) {
-        str.insert(str.begin(), ' ');
-    }
-    return str;
-}
 }  // namespace psi

--- a/psi4/src/psi4/libpsi4util/stl_string.cc
+++ b/psi4/src/psi4/libpsi4util/stl_string.cc
@@ -207,4 +207,13 @@ double Timer::get() {
     // Convert clock ticks to seconds
     return std::chrono::duration_cast<std::chrono::duration<double>>(duration).count();
 }
+
+template <typename T>
+std::string to_str_width(const T, const size_t width){
+    std::string str = std::to_string(T);
+    while(str.length() < width){
+        str.insert(str.begin(),' ');
+    }
+    return str;
 }
+}  // namespace psi

--- a/psi4/src/psi4/libpsi4util/stl_string.cc
+++ b/psi4/src/psi4/libpsi4util/stl_string.cc
@@ -208,11 +208,17 @@ double Timer::get() {
     return std::chrono::duration_cast<std::chrono::duration<double>>(duration).count();
 }
 
+/// @brief Converts an input type that is supported by std::to_string, to an std::string that is padded with spaces to a
+/// specified minimum width. This mimics some of the functionality of C-style formatting, eg. %3d.
+/// @tparam T : type of the variable to be converted
+/// @param input : variable to be converted
+/// @param width : pad the string with spaces until it is at least this wide, in a right-justified fashion
+/// @return std::string representation of the input variable, padded if required
 template <typename T>
-std::string to_str_width(const T, const size_t width){
-    std::string str = std::to_string(T);
-    while(str.length() < width){
-        str.insert(str.begin(),' ');
+std::string to_str_width(const T &input, const size_t width) {
+    std::string str = std::to_string(input);
+    while (str.length() < width) {
+        str.insert(str.begin(), ' ');
     }
     return str;
 }

--- a/psi4/src/psi4/libsapt_solver/disp2ccd.cc
+++ b/psi4/src/psi4/libsapt_solver/disp2ccd.cc
@@ -35,6 +35,7 @@
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include <cmath>
 
@@ -2037,8 +2038,8 @@ SAPTDIIS::SAPTDIIS(int ampfile, const char *amplabel, const char *errlabel, size
 SAPTDIIS::~SAPTDIIS() { psio_->close(diis_file_, 0); }
 
 void SAPTDIIS::store_vectors() {
-    char *diis_vec_label = get_vec_label(curr_vec_);
-    char *diis_err_label = get_err_label(curr_vec_);
+    std::string diis_vec_label = get_vec_label(curr_vec_);
+    std::string diis_err_label = get_err_label(curr_vec_);
     curr_vec_ = (curr_vec_ + 1) % max_diis_vecs_;
     num_vecs_++;
     if (num_vecs_ > max_diis_vecs_) num_vecs_ = max_diis_vecs_;
@@ -2046,14 +2047,12 @@ void SAPTDIIS::store_vectors() {
     double *vec = init_array(vec_length_);
 
     psio_->read_entry(filenum_, vec_label_, (char *)&(vec[0]), vec_length_ * (size_t)sizeof(double));
-    psio_->write_entry(diis_file_, diis_vec_label, (char *)&(vec[0]), vec_length_ * (size_t)sizeof(double));
+    psio_->write_entry(diis_file_, diis_vec_label.data(), (char *)&(vec[0]), vec_length_ * (size_t)sizeof(double));
 
     psio_->read_entry(filenum_, err_label_, (char *)&(vec[0]), vec_length_ * (size_t)sizeof(double));
-    psio_->write_entry(diis_file_, diis_err_label, (char *)&(vec[0]), vec_length_ * (size_t)sizeof(double));
+    psio_->write_entry(diis_file_, diis_err_label.data(), (char *)&(vec[0]), vec_length_ * (size_t)sizeof(double));
 
     free(vec);
-    free(diis_vec_label);
-    free(diis_err_label);
 }
 
 void SAPTDIIS::get_new_vector() {
@@ -2069,15 +2068,13 @@ void SAPTDIIS::get_new_vector() {
     double *vec_j = init_array(vec_length_);
 
     for (int i = 0; i < num_vecs_; i++) {
-        char *err_label_i = get_err_label(i);
-        psio_->read_entry(diis_file_, err_label_i, (char *)&(vec_i[0]), vec_length_ * (size_t)sizeof(double));
+        std::string err_label_i = get_err_label(i);
+        psio_->read_entry(diis_file_, err_label_i.data(), (char *)&(vec_i[0]), vec_length_ * (size_t)sizeof(double));
         for (int j = 0; j <= i; j++) {
-            char *err_label_j = get_err_label(j);
-            psio_->read_entry(diis_file_, err_label_j, (char *)&(vec_j[0]), vec_length_ * (size_t)sizeof(double));
+            std::string err_label_j = get_err_label(j);
+            psio_->read_entry(diis_file_, err_label_j.data(), (char *)&(vec_j[0]), vec_length_ * (size_t)sizeof(double));
             Bmat[i][j] = Bmat[j][i] = C_DDOT(vec_length_, vec_i, 1, vec_j, 1);
-            free(err_label_j);
         }
-        free(err_label_i);
     }
 
     for (int i = 0; i < num_vecs_; i++) {
@@ -2094,10 +2091,9 @@ void SAPTDIIS::get_new_vector() {
     memset(vec_j, '\0', sizeof(double) * vec_length_);
 
     for (int i = 0; i < num_vecs_; i++) {
-        char *vec_label_i = get_vec_label(i);
-        psio_->read_entry(diis_file_, vec_label_i, (char *)&(vec_i[0]), vec_length_ * (size_t)sizeof(double));
+        std::string vec_label_i = get_vec_label(i);
+        psio_->read_entry(diis_file_, vec_label_i.data(), (char *)&(vec_i[0]), vec_length_ * (size_t)sizeof(double));
         C_DAXPY(vec_length_, Cvec[i], vec_i, 1, vec_j, 1);
-        free(vec_label_i);
     }
 
     psio_->write_entry(filenum_, vec_label_, (char *)&(vec_j[0]), vec_length_ * (size_t)sizeof(double));
@@ -2110,16 +2106,12 @@ void SAPTDIIS::get_new_vector() {
     free_block(Bmat);
 }
 
-char *SAPTDIIS::get_err_label(int num) {
-    char *label = (char *)malloc(16 * sizeof(char));
-    sprintf(label, "Error vector %2d", num);
-    return (label);
+std::string SAPTDIIS::get_err_label(const int64_t num) {
+    return ("Error vector "+to_str_width(num, 2));
 }
 
-char *SAPTDIIS::get_vec_label(int num) {
-    char *label = (char *)malloc(10 * sizeof(char));
-    sprintf(label, "Vector %2d", num);
-    return (label);
+std::string SAPTDIIS::get_vec_label(const int64_t num) {
+    return ("Vector "+to_str_width(num, 2));
 }
 
 std::shared_ptr<Matrix> SAPT2p::mo2no(int ampfile, const char *VV_opdm, int nvir, double cutoff) {

--- a/psi4/src/psi4/libsapt_solver/disp2ccd.cc
+++ b/psi4/src/psi4/libsapt_solver/disp2ccd.cc
@@ -2047,10 +2047,10 @@ void SAPTDIIS::store_vectors() {
     double *vec = init_array(vec_length_);
 
     psio_->read_entry(filenum_, vec_label_, (char *)&(vec[0]), vec_length_ * (size_t)sizeof(double));
-    psio_->write_entry(diis_file_, diis_vec_label.data(), (char *)&(vec[0]), vec_length_ * (size_t)sizeof(double));
+    psio_->write_entry(diis_file_, diis_vec_label.c_str(), (char *)&(vec[0]), vec_length_ * (size_t)sizeof(double));
 
     psio_->read_entry(filenum_, err_label_, (char *)&(vec[0]), vec_length_ * (size_t)sizeof(double));
-    psio_->write_entry(diis_file_, diis_err_label.data(), (char *)&(vec[0]), vec_length_ * (size_t)sizeof(double));
+    psio_->write_entry(diis_file_, diis_err_label.c_str(), (char *)&(vec[0]), vec_length_ * (size_t)sizeof(double));
 
     free(vec);
 }
@@ -2069,10 +2069,10 @@ void SAPTDIIS::get_new_vector() {
 
     for (int i = 0; i < num_vecs_; i++) {
         std::string err_label_i = get_err_label(i);
-        psio_->read_entry(diis_file_, err_label_i.data(), (char *)&(vec_i[0]), vec_length_ * (size_t)sizeof(double));
+        psio_->read_entry(diis_file_, err_label_i.c_str(), (char *)&(vec_i[0]), vec_length_ * (size_t)sizeof(double));
         for (int j = 0; j <= i; j++) {
             std::string err_label_j = get_err_label(j);
-            psio_->read_entry(diis_file_, err_label_j.data(), (char *)&(vec_j[0]), vec_length_ * (size_t)sizeof(double));
+            psio_->read_entry(diis_file_, err_label_j.c_str(), (char *)&(vec_j[0]), vec_length_ * (size_t)sizeof(double));
             Bmat[i][j] = Bmat[j][i] = C_DDOT(vec_length_, vec_i, 1, vec_j, 1);
         }
     }
@@ -2092,7 +2092,7 @@ void SAPTDIIS::get_new_vector() {
 
     for (int i = 0; i < num_vecs_; i++) {
         std::string vec_label_i = get_vec_label(i);
-        psio_->read_entry(diis_file_, vec_label_i.data(), (char *)&(vec_i[0]), vec_length_ * (size_t)sizeof(double));
+        psio_->read_entry(diis_file_, vec_label_i.c_str(), (char *)&(vec_i[0]), vec_length_ * (size_t)sizeof(double));
         C_DAXPY(vec_length_, Cvec[i], vec_i, 1, vec_j, 1);
     }
 

--- a/psi4/src/psi4/libsapt_solver/sapt2p.h
+++ b/psi4/src/psi4/libsapt_solver/sapt2p.h
@@ -168,8 +168,8 @@ class SAPTDIIS {
     int curr_vec_;
     int num_vecs_;
 
-    char *get_err_label(int);
-    char *get_vec_label(int);
+    std::string get_err_label(const int64_t);
+    std::string get_vec_label(const int64_t);
 
    protected:
     std::shared_ptr<PSIO> psio_;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
After seeing some GCC warnings related to sprintf usage I decided to modernize SAPTDIIS label generation with the use of `std::string` and a new utility function to retain the output format of `%2d`.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] No user-visible changes

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] New function: `to_str_width`: converts any type supported by `std::to_string` to an `std::string`, and prepends as many spaces as required to meet the specified minimum width.
- [x] `SAPTDIIS::get_vec_label` and `SAPTDIIS::get_err_label` are modernized to return an `std::string`, instead of a `char*` that the caller needs to deallocate.
- [x] Functions using these two functions have been adapted to the changes.

## Checklist
- [x] No new features
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
