### PR TITLE
Remove set-but-unused labels (char arrays) from ccdensity::RHO_Params

### DIFF
--- a/psi4/src/psi4/cc/ccdensity/Params.h
+++ b/psi4/src/psi4/cc/ccdensity/Params.h
@@ -92,16 +92,9 @@ struct RHO_Params {
     int R_ground;
     double R0;
     double L0;
-    char L1A_lbl[32];
-    char L1B_lbl[32];
-    char L2AA_lbl[32];
-    char L2BB_lbl[32];
-    char L2AB_lbl[32];
+#ifdef EOM_DEBUG
     char R1A_lbl[32];
-    char R1B_lbl[32];
-    char R2AA_lbl[32];
-    char R2BB_lbl[32];
-    char R2AB_lbl[32];
+#endif
     double cceom_energy;
     double overlap1;   /* <L1|R1> */
     double overlap2;   /* <L2|R2> */

--- a/psi4/src/psi4/cc/ccdensity/get_rho_params.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_rho_params.cc
@@ -181,17 +181,9 @@ void get_rho_params(Options &options) {
         else
             rho_params[i].L0 = 0.0;
 
+#ifdef EOM_DEBUG
         sprintf(rho_params[i].R1A_lbl, "RIA %d %d", rho_params[i].R_irr, rho_params[i].R_root);
-        sprintf(rho_params[i].R1B_lbl, "Ria %d %d", rho_params[i].R_irr, rho_params[i].R_root);
-        sprintf(rho_params[i].R2AA_lbl, "RIJAB %d %d", rho_params[i].R_irr, rho_params[i].R_root);
-        sprintf(rho_params[i].R2BB_lbl, "Rijab %d %d", rho_params[i].R_irr, rho_params[i].R_root);
-        sprintf(rho_params[i].R2AB_lbl, "RIjAb %d %d", rho_params[i].R_irr, rho_params[i].R_root);
-        sprintf(rho_params[i].L1A_lbl, "LIA %d %d", rho_params[i].L_irr, rho_params[i].L_root);
-        sprintf(rho_params[i].L1B_lbl, "Lia %d %d", rho_params[i].L_irr, rho_params[i].L_root);
-        sprintf(rho_params[i].L2AA_lbl, "LIJAB %d %d", rho_params[i].L_irr, rho_params[i].L_root);
-        sprintf(rho_params[i].L2BB_lbl, "Lijab %d %d", rho_params[i].L_irr, rho_params[i].L_root);
-        sprintf(rho_params[i].L2AB_lbl, "LIjAb %d %d", rho_params[i].L_irr, rho_params[i].L_root);
-
+#endif
         sprintf(rho_params[i].DIJ_lbl, "DIJ %d", i - 1); /* change to a different label ? */
         sprintf(rho_params[i].Dij_lbl, "Dij %d", i - 1);
         sprintf(rho_params[i].DAB_lbl, "DAB %d", i - 1);

--- a/psi4/src/psi4/cc/ccdensity/get_rho_params.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_rho_params.cc
@@ -245,7 +245,6 @@ void get_rho_params(Options &options) {
     params.R0 = rho_params[0].R0;
     params.L0 = rho_params[0].L0;
     params.cceom_energy = rho_params[0].cceom_energy;
-
     return;
 }
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
There are some char arrays in `ccdensity::RHO_Params` that are set in `get_rho_params` but are otherwise never used. This PR removes them. This rectifies a few warnings with GCC 12, caused by the `sprintf `calls used to set them.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] No user-visible changes

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `R1B_lbl` and similar unused members of `RHO_Params` are removed, except `R1A_lbl` which becomes not unused if `EOM_DEBUG` is defined.

## Checklist
- [x] No new features
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
