### PR TITLE
IncFock Standardization Part 2: DirectJK

### DIFF
--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -7,7 +7,7 @@ jobs:
       vmImage: 'windows-2022'
     timeoutInMinutes: 360
     variables:
-      llvm.version: '13.0.0'
+      llvm.version: '14.0.0'
       mkl.version: '2019.1'
       cmake.build_type: 'Release'
       conda.build: false

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -161,7 +161,7 @@ void DirectJK::incfock_postiter() {
 }
 
 void DirectJK::compute_JK() {
-
+   
 #ifdef USING_BrianQC
     if (brianEnable) {
         // zero out J, K, and wK matrices
@@ -396,6 +396,22 @@ void DirectJK::build_JK_matrices(std::vector<std::shared_ptr<TwoBodyAOInt>>& int
     if (!build_J && !build_K) return;
     
     timer_on("build_JK_matrices()");
+
+    // => Zeroing... <= //
+    
+    // Ideally, this wouldnt be here at all
+    // It would be better covered in incfock_setup()
+    // But removing this causes a couple of tests to fail for some reason
+    
+    if (!do_incfock_iter_) {
+        for (auto& Jmat : J) {
+            Jmat->zero();
+        }
+    
+        for (auto& Kmat : K) {
+            Kmat->zero();
+        }
+    }
 
     // => Sizing <= //
 

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -135,12 +135,12 @@ void DirectJK::incfock_setup() {
         size_t njk = D_ao_.size();
 
         // If there is no previous pseudo-density, this iteration is normal
-        if(initial_iteration_ || D_prev_.size() != njk) {
-            initial_iteration_ = true;
+        if (initial_iteration_ || D_prev_.size() != njk) {
+	        initial_iteration_ = true;
 
             D_ref_ = D_ao_;
             zero();
-        } else { // Otherwise, the iteraction is incremental
+        } else { // Otherwise, the iteration is incremental
             for (size_t jki = 0; jki < njk; jki++) {
                 D_ref_[jki] = D_ao_[jki]->clone();
                 D_ref_[jki]->subtract(D_prev_[jki]);

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -153,12 +153,10 @@ void DirectJK::incfock_setup() {
 }
 
 void DirectJK::incfock_postiter() {
-    if (do_incfock_iter_) {
-        // Save a copy of the density for the next iteration
-        D_prev_.clear();
-        for(auto const &Di : D_ao_) {
-            D_prev_.push_back(Di->clone());
-        }
+    // Save a copy of the density for the next iteration
+    D_prev_.clear();
+    for(auto const &Di : D_ao_) {
+        D_prev_.push_back(Di->clone());
     }
 }
 

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -731,7 +731,7 @@ void DirectJK::build_JK_matrices(std::vector<std::shared_ptr<TwoBodyAOInt>>& int
 	    }
         }
         
-        if (build_K) {
+        if (build_K && lr_symmetric_) {
 	    for (auto& KTmat : KT[thread]) {
                 KTmat->scale(2.0);
 	    }

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -167,7 +167,7 @@ void DirectJK::compute_JK() {
         // zero out J, K, and wK matrices
         zero();
         
-	brianBool computeCoulomb = (do_J_ ? BRIAN_TRUE : BRIAN_FALSE);
+        brianBool computeCoulomb = (do_J_ ? BRIAN_TRUE : BRIAN_FALSE);
         brianBool computeExchange = ((do_K_ || do_wK_) ? BRIAN_TRUE : BRIAN_FALSE);
 
         if (do_wK_ and not brianEnableDFT) {
@@ -337,7 +337,7 @@ void DirectJK::compute_JK() {
         
         incfock_setup();
 	
-	timer_off("DirectJK: INCFOCK Preprocessing");
+        timer_off("DirectJK: INCFOCK Preprocessing");
     } else {
         D_ref_ = D_ao_;
         zero();

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -749,17 +749,11 @@ class PSI_API DirectJK : public JK {
     int incfock_count_;
     bool do_incfock_iter_;
 
-    /// D, J, K, wK Matrices from previous iteration, used in Incremental Fock Builds
-    std::vector<SharedMatrix> prev_D_ao_;
-    std::vector<SharedMatrix> prev_J_ao_;
-    std::vector<SharedMatrix> prev_K_ao_;
-    std::vector<SharedMatrix> prev_wK_ao_;
+   /// Previous iteration pseudo-density matrix
+    std::vector<SharedMatrix> D_prev_;
 
-    // Delta D, J, K, wK Matrices for Incremental Fock Build
-    std::vector<SharedMatrix> delta_D_ao_;
-    std::vector<SharedMatrix> delta_J_ao_;
-    std::vector<SharedMatrix> delta_K_ao_;
-    std::vector<SharedMatrix> delta_wK_ao_;
+    /// Pseudo-density matrix to be used this iteration
+    std::vector<SharedMatrix> D_ref_;
 
     // Is the JK currently on a guess iteration
     bool initial_iteration_ = true;

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -749,7 +749,7 @@ class PSI_API DirectJK : public JK {
     int incfock_count_;
     bool do_incfock_iter_;
 
-   /// Previous iteration pseudo-density matrix
+    /// Previous iteration pseudo-density matrix
     std::vector<SharedMatrix> D_prev_;
 
     /// Pseudo-density matrix to be used this iteration

--- a/samples/scf5/input.dat
+++ b/samples/scf5/input.dat
@@ -31,7 +31,6 @@ set {
 
 set scf reference rhf
 set screening csam
-set incfock true
 
 set scf_type pk
 E = energy('scf')

--- a/samples/scf5/input.dat
+++ b/samples/scf5/input.dat
@@ -31,6 +31,7 @@ set {
 
 set scf reference rhf
 set screening csam
+set incfock true
 
 set scf_type pk
 E = energy('scf')


### PR DESCRIPTION
## Description
This PR is a continuation of the IncFock standardization effort initially started in https://github.com/psi4/psi4/pull/2682, and restarted in https://github.com/psi4/psi4/pull/2792. It is the second PR listed in the PR submission scheme discussed in the comments in https://github.com/psi4/psi4/pull/2682.

For all intents and purposes, the PR has basically the same changes as https://github.com/psi4/psi4/pull/2792, except applied to DirectJK instead of DFJLinK. The same benefits to DFJLinK seen in https://github.com/psi4/psi4/pull/2792 are applied to DirectJK here, and many of the same points of the benefits of that PR apply here, as well.

A couple of notes to be had for reviewers, some of which arise from discussions in https://github.com/psi4/psi4/pull/2792:
1. Unlike https://github.com/psi4/psi4/pull/2792, this PR is independent of the CompositeJK effort, since this PR is localized within DirectJK.
2. This PR makes slightly more expansive changes to the DirectJK infrastructure to support the new IncFock formalism, but it is still not a massive number of changes; and most of these changes are similar to those observed in DFJLinK in https://github.com/psi4/psi4/pull/2792.
3. As with https://github.com/psi4/psi4/pull/2792, this PR does not remove the bells and whistles related to IncFock seen in DirectJK (e.g., recomputing the full Fock matrix every so often, disabling IncFock past a given convergence threshold). This PR incorporates the DFJCOSK IncFock formalism as much as possible into DirectJK, while maintaining the IncFock bells and whistles seen in DirectJK.
4. It should be noted that there are no directJK-x tests akin to the linK-x tests, and thus, no IncFock efficiency tests were added in this PR, as was done for DFJLinK in https://github.com/psi4/psi4/pull/2792. Technically, IncFock efficiency tests could be added to scf5, but I feel that goes against the spirit of the scf5 test.
5. I looked at stability tests, as well. STABILITY_ANALYSIS=CHECK works for all of RHF, ROHF, and UHF references.

## User API & Changelog headlines
N/A

## Dev notes & details
- [X] Switches DirectJK to using the incremental Fock build implementation used in DFJCOSK. This change standardizes the incremental Fock implementation between DirectJK and DFJCOSK and improves the memory usage of DirectJK in the process.
- [X] Changes DirectJK machinery to support new incremental Fock formalism.

## Questions
- [x] Do we want to add extra tests for DirectJK to allow for Incremental Fock efficiency tests?

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [x] Ready for merge