### PR TITLE
Include <cerrno> where required for the sake of FreeBSD

### DIFF
--- a/psi4/src/psi4/libpsio/rw.cc
+++ b/psi4/src/psi4/libpsio/rw.cc
@@ -32,6 +32,7 @@
  */
 
 #include <cstdio>
+#include <cerrno>
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/psi4-dec.h"

--- a/psi4/src/psi4/libpsio/toclen.cc
+++ b/psi4/src/psi4/libpsio/toclen.cc
@@ -33,6 +33,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cerrno>
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"

--- a/psi4/src/psi4/libpsio/volseek.cc
+++ b/psi4/src/psi4/libpsio/volseek.cc
@@ -33,6 +33,7 @@
 
 #include "psi4/libpsio/psio.h"
 #include "psi4/psi4-dec.h"
+#include <cerrno>
 // This is strictly used to avoid overflow errors on lseek() calls
 #define PSIO_BIGNUM 10000
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Apparently `errno` is not defined on FreeBSD by default, so we have to explicitly include `<cerrno>` in files that use it. This PR adds that include.
Fixes and closes #2810

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] None? The offending code has not made it to any release yet.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `#include <cerrno>` is added to the few PSIO files that use `errno`

## Checklist
- [x] No new features
- [x] CI tests are passsing

## Status
- [x] Ready for review
- [x] Ready for merge
