### PR TITLE
Remove superfluous PsiOutStream includes

### DIFF
--- a/psi4/src/psi4/cc/ccenergy/d1diag.cc
+++ b/psi4/src/psi4/cc/ccenergy/d1diag.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "psi4/cc/ccwave.h"
-#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace ccenergy {

--- a/psi4/src/psi4/cc/ccenergy/d2diag.cc
+++ b/psi4/src/psi4/cc/ccenergy/d2diag.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "psi4/cc/ccwave.h"
-#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace ccenergy {

--- a/psi4/src/psi4/cc/ccenergy/new_d1diag.cc
+++ b/psi4/src/psi4/cc/ccenergy/new_d1diag.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "psi4/cc/ccwave.h"
-#include "psi4/libpsi4util/PsiOutStream.h"
 
 namespace psi {
 namespace ccenergy {

--- a/psi4/src/psi4/libqt/david.cc
+++ b/psi4/src/psi4/libqt/david.cc
@@ -38,7 +38,6 @@
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libqt/qt.h"
-#include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/exception.h"
 
 namespace psi {

--- a/psi4/src/psi4/mcscf/matrix_base.cc
+++ b/psi4/src/psi4/mcscf/matrix_base.cc
@@ -31,6 +31,7 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsi4util/libpsi4util.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/psi4-dec.h"
 
@@ -107,7 +108,6 @@ void MatrixBase::diagonalize(MatrixBase* eigenmatrix, VectorBase* eigenvalues) {
             throw PSIEXCEPTION("DSYEV failed in mcscf::MatrixBase::diagonalize()");
         }
     } else {
-        outfile->Printf("MatrixBase::diagonalize(...) cannot diagonalize non-square matrices!");
         throw PSIEXCEPTION("MatrixBase::diagonalize(...) cannot diagonalize non-square matrices!");
     }
 }

--- a/psi4/src/psi4/mcscf/matrix_base.cc
+++ b/psi4/src/psi4/mcscf/matrix_base.cc
@@ -31,7 +31,6 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsi4util/libpsi4util.h"
-#include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/psi4-dec.h"
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
PR #2686 has accidentally added some superfluous includes of `libpsi4util/PsiOutStream.h`, and I also missed removing a superfluous printf line. No real harm done, but they can be removed.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Remove some includes added by #2686 
- [x] Remove a printf added by #2686 

## Checklist
- [x] No new features
- [ ] CI tests are passing

## Status
- [x] Ready for review
- [ ] Ready for merge
