### PR TITLE
bump libxc and revert qcng

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -99,7 +99,7 @@ jobs:
         pytest-xdist \
         msgpack-python \
         conda-forge::qcelemental \
-        conda-forge::qcengine \
+        conda-forge::qcengine=0.25.0 \
         scipy
       source activate p4env
       which python

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -137,7 +137,7 @@ jobs:
                         conda-forge::libxc ^
                         psi4/label/dev::libint2=*=h2e52968_4 ^
                         conda-forge::qcelemental ^
-                        conda-forge::qcengine ^
+                        conda-forge::qcengine=0.25.0 ^
                         scipy
           conda install --only-deps anaconda-client
           pip install git+https://github.com/loriab/anaconda-client.git@upload-catch-silent-110

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -116,7 +116,7 @@ jobs:
           - psi4/label/dev::gau2grid
           - psi4/label/dev::libint2
           - psi4/label/dev::qcelemental
-          - psi4/label/dev::qcengine
+          - psi4/label/dev::qcengine=0.25.0
           - psi4/label/dev::libxc
             # qc opt'l
           - psi4/label/dev::ambit
@@ -179,7 +179,7 @@ jobs:
           - psi4/label/dev::gau2grid
           - psi4/label/dev::libint2
           - psi4/label/dev::qcelemental
-          - psi4/label/dev::qcengine
+          - psi4/label/dev::qcengine=0.25.0
           - psi4/label/dev::libxc
             # qc req'd from buildtime
           - psi4/label/dev::ambit
@@ -222,7 +222,7 @@ jobs:
           - openfermion>=1.0
           - openfermionpsi4
           - pymdi
-          - qcengine
+          - qcengine=0.25.0
 
         # toml needed for psi4 to load parameters from dftd4-python
         EOF
@@ -251,7 +251,7 @@ jobs:
           - gau2grid
           - psi4/label/dev::libint2
           - qcelemental
-          - qcengine
+          - qcengine=0.25.0
           - libxc
             # qc req'd from buildtime
           #- psi4/label/dev::ambit

--- a/conda/win/meta.yaml
+++ b/conda/win/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - pytest>=7.0.1
     - python={{ PY_VER }}
     - qcelemental=0.25.1
-    - qcengine=0.24.1
+    - qcengine=0.25.0
     - msgpack-python
     - gau2grid
     - libint2 2.6.0 h2e52968_4

--- a/external/upstream/libxc/CMakeLists.txt
+++ b/external/upstream/libxc/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
         # Default: use a stable release tarball of libxc. To use the
         # development version of libxc, instead, comment the URL line,
         # and uncomment the GIT lines.
-        URL https://gitlab.com/libxc/libxc/-/archive/5.1.5/libxc-5.1.5.tar.gz
+        URL https://gitlab.com/libxc/libxc/-/archive/5.2.3/libxc-5.2.3.tar.gz
         #GIT_REPOSITORY https://gitlab.com/libxc/libxc.git
         #GIT_TAG 5.1.5
         #UPDATE_COMMAND ""

--- a/external/upstream/qcengine/CMakeLists.txt
+++ b/external/upstream/qcengine/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_qcengine}))
     include(FindPythonModule)
-    find_python_module(qcengine ATLEAST 0.24.2 QUIET)
+    find_python_module(qcengine ATLEAST 0.25.0 QUIET)
 endif()
 
 if(${qcengine_FOUND})
@@ -21,9 +21,7 @@ else()
     ExternalProject_Add(qcengine_external
         DEPENDS qcelemental_external
         BUILD_ALWAYS 1
-        # TODO-dfocc2: reset URL after qcng v0.24.2
-        # URL https://github.com/MolSSI/QCEngine/archive/v0.24.2.tar.gz
-        URL https://github.com/loriab/QCEngine/archive/stdsuite_refs_for_dfocc_5.tar.gz
+        URL https://github.com/MolSSI/QCEngine/archive/v0.25.0.tar.gz
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_COMMAND ${Python_EXECUTABLE} setup.py build


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Libxc 5.2.3 (latest in the 5 series) has had full tests run
- [x] fix qcng to 0.25.0 for the sake of fsaptd-terms before #2791 fixes it again.

## Status
- [x] Ready for review
- [x] Ready for merge
