### PR TITLE
IncFock Standardization Part 3: DFJCOSK

### DIFF
--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -792,7 +792,7 @@ a cutoff for the value of basis functions at grid points. This keyword is
 used to determine the radial extent of the each basis shell, and it is the
 COSX analogue to |scf__dft_basis_tolerance|.
 
-The |scf__cosx_incfock| keyword (defaults to ``false``) increases performance
+The |scf__incfock| keyword (defaults to ``false``) increases performance
 by constructing the Fock matrix from differences in the density matrix, which
 are more amenable to screening. This option is disabled by default because of
 potential SCF convergence issues, particularly when using diffuse basis functions.

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -300,7 +300,6 @@ def scf_iterate(self, e_conv=None, d_conv=None):
 
         # Check if special J/K construction algorithms were used
         incfock_performed = hasattr(self.jk(), "do_incfock_iter") and self.jk().do_incfock_iter()
-        
         upcm = 0.0
         if core.get_option('SCF', 'PCM'):
             calc_type = core.PCM.CalcType.Total

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -300,6 +300,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
 
         # Check if special J/K construction algorithms were used
         incfock_performed = hasattr(self.jk(), "do_incfock_iter") and self.jk().do_incfock_iter()
+        
         upcm = 0.0
         if core.get_option('SCF', 'PCM'):
             calc_type = core.PCM.CalcType.Total

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -197,7 +197,6 @@ void export_fock(py::module &m) {
         .def("do_incfock_iter", &DirectJK::do_incfock_iter, "Was the last Fock build incremental?");
 
     py::class_<DFJCOSK, std::shared_ptr<DFJCOSK>, JK>(m, "DFJCOSK", "docstring")
-
         .def("do_incfock_iter", &DFJCOSK::do_incfock_iter, "Was the last Fock build incremental?")
     	.def("clear_D_prev", &DFJCOSK::clear_D_prev, "Clear previous D matrices.");
 

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -197,7 +197,9 @@ void export_fock(py::module &m) {
         .def("do_incfock_iter", &DirectJK::do_incfock_iter, "Was the last Fock build incremental?");
 
     py::class_<DFJCOSK, std::shared_ptr<DFJCOSK>, JK>(m, "DFJCOSK", "docstring")
-        .def("clear_D_prev", &DFJCOSK::clear_D_prev, "Clear previous D matrices.");
+
+        .def("do_incfock_iter", &DFJCOSK::do_incfock_iter, "Was the last Fock build incremental?")
+    	.def("clear_D_prev", &DFJCOSK::clear_D_prev, "Clear previous D matrices.");
 
     py::class_<DFJLinK, std::shared_ptr<DFJLinK>, JK>(m, "DFJLinK", "docstring")
         .def("do_incfock_iter", &DFJLinK::do_incfock_iter, "Was the last Fock build incremental?");

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -165,6 +165,9 @@ void DFJCOSK::common_init() {
     // and a large grid for the final iterations
     early_screening_ = true;
 
+    // incremental Fock setup
+    incfock_ = options_.get_bool("COSX_INCFOCK");
+    
     // => Direct Density-Fitted Coulomb Setup <= //
 
     // pre-compute coulomb fitting metric
@@ -298,7 +301,7 @@ void DFJCOSK::print_header() const {
         if (do_wK_) outfile->Printf("    Omega:              %11.3E\n", omega_);
         outfile->Printf("    Integrals threads:  %11d\n", nthreads_);
         outfile->Printf("    Memory [MiB]:       %11ld\n", (memory_ *8L) / (1024L * 1024L));
-        outfile->Printf("    Incremental Fock :  %11s\n", (options_.get_bool("COSX_INCFOCK") ? "Yes" : "No"));
+        outfile->Printf("    Incremental Fock :  %11s\n", (incfock_ ? "Yes" : "No"));
         outfile->Printf("    J Screening Type:   %11s\n", screen_type.c_str());
         outfile->Printf("    J Screening Cutoff: %11.0E\n", cutoff_);
         outfile->Printf("    K Screening Cutoff: %11.0E\n", options_.get_double("COSX_INTS_TOLERANCE"));
@@ -310,55 +313,76 @@ void DFJCOSK::print_header() const {
 
 void DFJCOSK::preiterations() {}
 
-void DFJCOSK::compute_JK() {
-
-    int njk = D_ao_.size();
-
-    // range-separated semi-numerical exchange needs https://github.com/psi4/psi4/pull/2473
-    if (do_wK_) throw PSIEXCEPTION("COSK does not support wK integrals yet!");
-
-    // D_eff, the effective pseudo-density matrix is either:
-    //   (1) the regular density: D_eff == D_lr = C_lo x C*ro
-    //   (2) the difference density: D_eff == dD_lr = (C_lo x C_ro)_{iter} - (C_lo x C_ro)_{iter - 1}
-    //
-    std::vector<SharedMatrix> D_eff(njk);
-
-    if(options_.get_bool("COSX_INCFOCK")) {
+void DFJCOSK::incfock_setup() {
+    if (do_incfock_iter_) {
+	size_t njk = D_ao_.size();
 
         // If there is no previous pseudo-density, this iteration is normal
         if(D_prev_.size() != njk) {
-            D_eff = D_ao_;
+            D_ref_ = D_ao_;
             zero();
         } else { // Otherwise, the iteraction is incremental
             for (size_t jki = 0; jki < njk; jki++) {
-                D_eff[jki] = D_ao_[jki]->clone();
-                D_eff[jki]->subtract(D_prev_[jki]);
+                D_ref_[jki] = D_ao_[jki]->clone();
+                D_ref_[jki]->subtract(D_prev_[jki]);
             }
         }
+    } else {
+        D_ref_ = D_ao_;
+        zero();
+    }
+}
 
+void DFJCOSK::incfock_postiter() {
+    if (do_incfock_iter_) {
         // Save a copy of the density for the next iteration
         D_prev_.clear();
         for(auto const &Di : D_ao_) {
             D_prev_.push_back(Di->clone());
         }
+    }
+}
 
+void DFJCOSK::compute_JK() {
+    // range-separated semi-numerical exchange needs https://github.com/psi4/psi4/pull/2473
+    if (do_wK_) throw PSIEXCEPTION("COSK does not support wK integrals yet!");
+
+    // explicit setup of Incfock for this SCF iteration
+    if (incfock_) {
+        timer_on("DFJCOSK: INCFOCK Preprocessing");
+
+        // always do incfock on this iteration
+	// TODO: Adds bells and whistles from DFJLinK
+        do_incfock_iter_ = incfock_; 
+        
+	incfock_setup();
+        
+	timer_off("DFJCOSK: INCFOCK Preprocessing");
     } else {
-        D_eff = D_ao_;
+	D_ref_ = D_ao_;
         zero();
     }
-
+ 
+    // Direct DF-J
     if (do_J_) {
         timer_on("DFJ");
-        build_J(D_eff, J_ao_);
+        build_J(D_ref_, J_ao_);
         timer_off("DFJ");
     }
     
+    // COSX
     if (do_K_) {
         timer_on("COSK");
-        build_K(D_eff, K_ao_);
+        build_K(D_ref_, K_ao_);
         timer_off("COSK");
     }
 
+    // => Finalize Incremental Fock if required <= //
+    if (incfock_) {
+        timer_on("DFJCOSK: INCFOCK Postprocessing");
+        incfock_postiter();
+        timer_off("DFJCOSK: INCFOCK Postprocessing");
+    }
 }
 
 void DFJCOSK::postiterations() {}

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -315,7 +315,7 @@ void DFJCOSK::preiterations() {}
 
 void DFJCOSK::incfock_setup() {
     if (do_incfock_iter_) {
-	    size_t njk = D_ao_.size();
+	    auto njk = D_ao_.size();
 
         // If there is no previous pseudo-density, this iteration is normal
         if(initial_iteration_ || D_prev_.size() != njk) {

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -379,10 +379,8 @@ void DFJCOSK::compute_JK() {
     // COSX
     if (do_K_) {
         timer_on("COSK");
-   
-   	build_K(D_ref_, K_ao_);
-   
-   	timer_off("COSK");
+   	    build_K(D_ref_, K_ao_);
+   	    timer_off("COSK");
     }
 
     // => Finalize Incremental Fock if required <= //

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -166,7 +166,7 @@ void DFJCOSK::common_init() {
     early_screening_ = true;
 
     // incremental Fock setup
-    incfock_ = options_.get_bool("COSX_INCFOCK");
+    incfock_ = options_.get_bool("INCFOCK");
     
     // => Direct Density-Fitted Coulomb Setup <= //
 
@@ -334,12 +334,10 @@ void DFJCOSK::incfock_setup() {
 }
 
 void DFJCOSK::incfock_postiter() {
-    if (do_incfock_iter_) {
-        // Save a copy of the density for the next iteration
-        D_prev_.clear();
-        for(auto const &Di : D_ao_) {
-            D_prev_.push_back(Di->clone());
-        }
+    // Save a copy of the density for the next iteration
+    D_prev_.clear();
+    for(auto const &Di : D_ao_) {
+        D_prev_.push_back(Di->clone());
     }
 }
 

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -363,7 +363,7 @@ void DFJCOSK::compute_JK() {
         
 	timer_off("DFJCOSK: INCFOCK Preprocessing");
     } else {
-	D_ref_ = D_ao_;
+	    D_ref_ = D_ao_;
         zero();
     }
  

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -315,7 +315,7 @@ void DFJCOSK::preiterations() {}
 
 void DFJCOSK::incfock_setup() {
     if (do_incfock_iter_) {
-	size_t njk = D_ao_.size();
+	    size_t njk = D_ao_.size();
 
         // If there is no previous pseudo-density, this iteration is normal
         if(initial_iteration_ || D_prev_.size() != njk) {

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -351,9 +351,9 @@ void DFJCOSK::compute_JK() {
     if (incfock_) {
         timer_on("DFJCOSK: INCFOCK Preprocessing");
 
-        int reset = options_.get_int("INCFOCK_FULL_FOCK_EVERY");
-        double incfock_conv = options_.get_double("INCFOCK_CONVERGENCE");
-        double Dnorm = Process::environment.globals["SCF D NORM"];
+        auto reset = options_.get_int("INCFOCK_FULL_FOCK_EVERY");
+        auto incfock_conv = options_.get_double("INCFOCK_CONVERGENCE");
+        auto Dnorm = Process::environment.globals["SCF D NORM"];
         // Do IFB on this iteration?
         do_incfock_iter_ = (Dnorm >= incfock_conv) && !initial_iteration_ && (incfock_count_ % reset != reset - 1);
 

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -321,7 +321,7 @@ void DFJCOSK::incfock_setup() {
         if(initial_iteration_ || D_prev_.size() != njk) {
             initial_iteration_ = true;
 	    
-	    D_ref_ = D_ao_;
+	        D_ref_ = D_ao_;
             zero();
         } else { // Otherwise, the iteraction is incremental
             for (size_t jki = 0; jki < njk; jki++) {

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1199,6 +1199,8 @@ class PSI_API DFJCOSK : public JK {
 
     /// Perform Incremental Fock Build for J and K Matrices? (default false)
     bool incfock_;
+      /// The number of times INCFOCK has been performed (includes resets)
+    int incfock_count_;
     bool do_incfock_iter_;
 
     /// Previous iteration pseudo-density matrix
@@ -1209,6 +1211,9 @@ class PSI_API DFJCOSK : public JK {
     //   (2) the difference density: D_eff == dD_lr = (C_lo x C_ro)_{iter} - (C_lo x C_ro)_{iter - 1}
     std::vector<SharedMatrix> D_ref_;
 
+    // Is the JK currently on a guess iteration
+    bool initial_iteration_ = true;
+ 
     // => Density Fitting Stuff <= //
 
     /// Auxiliary basis set

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1196,8 +1196,18 @@ class PSI_API DFJCOSK : public JK {
     int nthreads_;
     /// Options object
     Options& options_;
+
+    /// Perform Incremental Fock Build for J and K Matrices? (default false)
+    bool incfock_;
+    bool do_incfock_iter_;
+
     /// Previous iteration pseudo-density matrix
     std::vector<SharedMatrix> D_prev_;
+    
+    // D_ref_, the effective pseudo-density matrix is either:
+    //   (1) the regular density: D_eff == D_lr = C_lo x C*ro
+    //   (2) the difference density: D_eff == dD_lr = (C_lo x C_ro)_{iter} - (C_lo x C_ro)_{iter - 1}
+    std::vector<SharedMatrix> D_ref_;
 
     // => Density Fitting Stuff <= //
 
@@ -1232,6 +1242,10 @@ class PSI_API DFJCOSK : public JK {
     void compute_JK() override;
     /// Delete integrals, files, etc
     void postiterations() override;
+    /// Set up Incfock variables per iteration
+    void incfock_setup();
+    /// Post-iteration Incfock processing
+    void incfock_postiter();
 
     /// Build the coulomb (J) matrix
     void build_J(std::vector<std::shared_ptr<Matrix> >& D,
@@ -1259,6 +1273,7 @@ class PSI_API DFJCOSK : public JK {
     ~DFJCOSK() override;
 
     // => Knobs <= //
+    bool do_incfock_iter() { return do_incfock_iter_; }
 
     /**
     * Print header information regarding JK

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -755,7 +755,7 @@ class PSI_API DirectJK : public JK {
     /// Pseudo-density matrix to be used this iteration
     std::vector<SharedMatrix> D_ref_;
 
-    // Is the JK currently on a guess iteration
+    // Is the JK currently on the first SCF iteration of this SCF cycle?
     bool initial_iteration_ = true;
 
     std::string name() override { return "DirectJK"; }
@@ -1211,7 +1211,7 @@ class PSI_API DFJCOSK : public JK {
     //   (2) the difference density: D_eff == dD_lr = (C_lo x C_ro)_{iter} - (C_lo x C_ro)_{iter - 1}
     std::vector<SharedMatrix> D_ref_;
 
-    // Is the JK currently on a guess iteration
+    // Is the JK currently on the first SCF iteration of this SCF cycle?
     bool initial_iteration_ = true;
  
     // => Density Fitting Stuff <= //
@@ -1323,7 +1323,7 @@ class PSI_API DFJLinK : public JK {
     /// Pseudo-density matrix to be used this iteration
     std::vector<SharedMatrix> D_ref_;
 
-    // Is the JK currently on a guess iteration
+    // Is the JK currently on the first SCF iteration of this SCF cycle?
     bool initial_iteration_ = true;
   
     // => Density Fitting Stuff <= //

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1592,8 +1592,6 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
                         "ROBUST TREUTLER NONE FLAT P_GAUSSIAN D_GAUSSIAN P_SLATER D_SLATER LOG_GAUSSIAN LOG_SLATER NONE");
         /*- Do reduce numerical COSX errors with overlap fitting? !expert -*/
         options.add_bool("COSX_OVERLAP_FITTING", true);
-        /*- Do allow for improved COSX screening performance by constructing the Fock matrix incrementally? !expert -*/
-        options.add_bool("COSX_INCFOCK", false);
 
         /*- SUBSECTION SAD Guess Algorithm -*/
 

--- a/tests/pytests/test_dfjcosk.py
+++ b/tests/pytests/test_dfjcosk.py
@@ -141,4 +141,4 @@ def test_dfjcosk_incfock(inp, mols):
     
     # how do SCF iteration counts compare?
     if hasattr(wfn_dfjcosk_noinc, "iteration_") and hasattr(wfn_dfjcosk_inc, "iteration_"):
-        assert compare_values(wfn_dfjcosk_noinc.iteration_, wfn_dfjcosk_inc.iteration_, 3)
+        assert compare(True, (niter_inc - niter_noinc) <= 3, "IncFock efficient?")

--- a/tests/pytests/test_dfjcosk.py
+++ b/tests/pytests/test_dfjcosk.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utils import compare_values
+from utils import compare_values, compare
 
 import psi4
 
@@ -140,5 +140,7 @@ def test_dfjcosk_incfock(inp, mols):
     assert compare_values(energy_dfjcosk_noinc, energy_dfjcosk_inc, atol=1e-6)
     
     # how do SCF iteration counts compare?
-    if hasattr(wfn_dfjcosk_noinc, "iteration_") and hasattr(wfn_dfjcosk_inc, "iteration_"):
-        assert compare(True, (niter_inc - niter_noinc) <= 3, "IncFock efficient?")
+    niter_noinc = int(wfn_dfjcosk_noinc.variable("SCF ITERATIONS")) if wfn_dfjcosk_noinc.has_scalar_variable("SCF ITERATIONS") else 0
+    niter_inc = int(wfn_dfjcosk_inc.variable("SCF ITERATIONS")) if wfn_dfjcosk_inc.has_scalar_variable("SCF ITERATIONS") else 0
+    
+    assert compare(True, abs(niter_inc - niter_noinc) <= 3, "IncFock efficient?")

--- a/tests/pytests/test_dfjcosk.py
+++ b/tests/pytests/test_dfjcosk.py
@@ -35,7 +35,6 @@ units au
 """)
         }
 
-
 @pytest.mark.parametrize(
     "inp",
     [
@@ -86,3 +85,60 @@ def test_dfjcosk(inp, mols):
     psi4.set_options({"scf_type" : "pk"})
     energy_pk = psi4.energy(inp["method"], molecule=molecule, bsse_type=inp["bsse_type"])
     assert compare_values(energy_pk, energy_dfjcosk, atol=1e-4)
+
+@pytest.mark.parametrize(
+    "inp",
+    [
+        pytest.param({"method" : "hf",
+                      "options": {"reference" : "rhf"},
+                      "molecule" : "h2o",
+                      "bsse_type" : None,
+                      "ref" : -76.026780223322},
+                      id="h2o (rhf)"),
+        pytest.param({"method" : "b3lyp",
+                      "options": {"reference" : "rhf"},
+                      "molecule" : "h2o",
+                      "bsse_type" : None,
+                      "ref" : -76.420402720419},
+                      id="h2o (rks)"),
+        pytest.param({"method" : "hf",
+                      "options": {"reference" : "uhf"},
+                      "molecule" : "nh2",
+                      "bsse_type" : None,
+                      "ref" : -55.566890252551},
+                      id="nh2 (uhf)"),
+        pytest.param({"method" : "hf",
+                      "options": {"reference" : "rohf"},
+                      "molecule" : "nh2",
+                      "bsse_type" : None,
+                      "ref" : -55.562689948780},
+                      id="nh2 (rohf)"),
+        pytest.param({"method" : "hf",
+                      "options": {"reference" : "rhf"},
+                      "molecule" : "h2o_nap1",
+                      "bsse_type" : "CP",
+                      "ref" :  -0.040121884077},
+                      id="h2o/na+ (rhf ie)"),
+    ],
+)
+def test_dfjcosk_incfock(inp, mols):
+    """Test the efficiency of IncFock in DFJCOSK JK object via SCF calculations"""
+
+    molecule = mols[inp["molecule"]]
+    psi4.set_options({"scf_type" : "cosx", "basis": "cc-pvdz", "incfock": False})
+    psi4.set_options(inp["options"])
+
+    # compute DFJCOSK energy+wfn without IncFock 
+    energy_dfjcosk_noinc, wfn_dfjcosk_noinc = psi4.energy(inp["method"], molecule=molecule, bsse_type=inp["bsse_type"], return_wfn=True)
+    #assert compare_values(inp["ref"], energy_dfjcosk, atol=1e-6)
+
+    # compute DFJCOSK energy+wfn with Incfock 
+    psi4.set_options({"incfock" : True})
+    energy_dfjcosk_inc, wfn_dfjcosk_inc = psi4.energy(inp["method"], molecule=molecule, bsse_type=inp["bsse_type"], return_wfn=True)
+
+    # how do energies compare?
+    assert compare_values(energy_dfjcosk_noinc, energy_dfjcosk_inc, atol=1e-6)
+    
+    # how do SCF iteration counts compare?
+    if hasattr(wfn_dfjcosk_noinc, "iteration_") and hasattr(wfn_dfjcosk_inc, "iteration_"):
+        assert compare_values(wfn_dfjcosk_noinc.iteration_, wfn_dfjcosk_inc.iteration_, 3)


### PR DESCRIPTION
## Description
... and another one!

This PR is a continuation of the IncFock standardization effort initially started in https://github.com/psi4/psi4/pull/2682, and continued in https://github.com/psi4/psi4/pull/2792 and https://github.com/psi4/psi4/pull/2808.

This PR continues to standardize the Incremental Fock process across the current integral-direct JK algorithms present in Psi4. However, this PR stands somewhat in contrast to https://github.com/psi4/psi4/pull/2682 and https://github.com/psi4/psi4/pull/2792. In those PRs, their IncFock schemes were adapted to use that of DFJCOSK, without removing the bells and whistles of their IncFock implementations (e.g., recomputing the full Fock matrix every so often, disabling IncFock after a given convergence threshold). In contrast, DFJCOSK is the template IncFock upon which the two previous PRs were based; however, DFJCOSK does not have the IncFock bells and whistles that DirectJK and DFJLinK had. Unmitigated, the incremental Fock procedure can actually significantly increase the number of SCF iterations needed to converged; and the IncFock bells and whistles in DirectJK and DFJLinK notably mitigate the effect of IncFock on SCF convergence counts. Without these bells and whistles, DFJCOSK runs the significant risk of excessive SCF iterations needed to converge when IncFock is enabled, an issue I have run into in my own calculations.

This PR seeks to rectify the aforementioned issue by implementing the IncFock bells and whistles of DirectJK and DFJLinK into DFJCOSK. With these extra features, DFJCOSK can now recompute the full Fock matrix every n iterations, or disable IncFock past a given convergence threshold, at the will of the end user. These features can notably reduce the amount of SCF iterations needed to converge.

This PR is also the continued effort to standardize IncFock among all integral-direct SCF algorithms in Psi4. With this PR, DirectJK, DFJLinK, and DFJCOSK will have effectively the exact same incremental Fock schemes, each featuring the lower memory usage of DFJCOSK's former IncFock scheme, and the bells and whistles of DirectJK and DFJLinK's former IncFock schemes. The final step to the IncFock standardization process, then, is the movement of the IncFock scheme of these algorithms into the base JK class itself - the final step of the PR scheme discussed in the comments in https://github.com/psi4/psi4/pull/2682.

It is worth noting for the reviewers that, since this PR more closely matches the IncFock of DFJCOSK to that of DFJLinK, it should be considered relevant to the CompositeJK PR chain as well, as it smooths the combination of DFJLinK and DFJCOSK into a single class as planned in the next CompositeJK step.

## User API & Changelog headlines
- [X] DFJCOSK now uses the "INCFOCK" keyword to control usage of the incremental Fock procedure, rather than "COSX_INCFOCK", standardizing the incremental Fock keywords among the integral-direct SCF algorithms.
- [X] DFJCOSK can now recompute the Fock matrix every n iterations during a calculation using incremental Fock. The "INCFOCK_FULL_FOCK_EVERY" keyword controls the number of SCF iterations between full Fock matrix recomputations for DFJCOSK.
- [X] DFJCOSK can now disable the incremental Fock process when a specific SCF convergence threshold. The "INCFOCK_CONVERGENCE" keyword controls the SCF convergence threshold point at which the incremental Fock build process is disabled.

## Dev notes & details
- [X] Improves the DFJCOSK incremental Fock procedure by allowing it to recompute the full Fock matrix every n iterations.
- [X] Improves the DFJCOSK incremental Fock procedure by allowing it to disable the incremental Fock procedure past a certain SCF convergence threshold.
- [X] Improves the DFJCOSK incremental Fock prodecure by computing the full Fock matrix during the first SCF iteration of the calculation, even with INCFOCK enabled.
- [X] Adds incremental Fock build efficiency tests to test_dfjcosk.py. 
- [X] Updates documentation to reflect new changes.

## Questions
N/A

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [x] Ready for merge