### PR TITLE
Add deprecation message to schmidt_add in libqt

### DIFF
--- a/psi4/src/psi4/libqt/blas_intfc.cc
+++ b/psi4/src/psi4/libqt/blas_intfc.cc
@@ -211,7 +211,7 @@ void PSI_API C_DROT(size_t length, double *x, int inc_x, double *y, int inc_y, d
  * \ingroup QT
  */
 
-double PSI_API C_DDOT(size_t length, const double* const x, int inc_x, const double* const y, int inc_y) {
+double PSI_API C_DDOT(size_t length, const double *const x, int inc_x, const double *const y, int inc_y) {
     if (length == 0) return 0.0;
 
     double reg = 0.0;

--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -53,8 +53,8 @@ void fill_sym_matrix(double** A, int size);
 double combinations(int n, int k);
 double factorial(int n);
 void schmidt(double** A, int rows, int cols, std::string out_fname);
-PSI_API
-int schmidt_add(double** A, int rows, int cols, double* v);
+PSI_DEPRECATED("The libqt schmidt_add function is deprecated and 1.7 will be the last release to have it.")
+PSI_API int schmidt_add(double** A, int rows, int cols, double* v);
 void normalize(double** A, int rows, int cols);
 double invert_matrix(double** a, double** y, int N, std::string out_fname);
 void solve_2x2_pep(double** H, double S, double* evals, double** evecs);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
After the removal of `sem_test` in #2776, the only remaining internal user of `libqt/schmidt_add.cc` is `libqt/david.cc`. That too is destined for removal, if its only user in `dfocc` is removed by #2684. So it looks like `schmidt_add` could be removed in the future, when all of its callers are gone.

To keep the promise of not randomly breaking API without fair warning, this PR deprecates the function, setting up its eventual removal. Note that this `schmidt_add` is not the same function as the `schmidt_add` in `cceom` or `detci`, even though the name is the same.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] `PSI_API` function `int schmidt_add(double** A, int rows, int cols, double* v)` is deprecated and 1.7 will be the last release with it present.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Deprecation message is added to `schmidt_add` in `libqt`

## Questions
- [ ] This function was tagged as `PSI_API` in #1077 by @raimis, do we know why it was necessary back then?

## Checklist
- [x] No new features
- [x] CI tests are passing

## Status
- [x] Ready for review
- [x] Ready for merge
