### PR TITLE
Fixes orbital read for finite difference hessian

### DIFF
--- a/psi4/driver/driver_findif.py
+++ b/psi4/driver/driver_findif.py
@@ -1278,6 +1278,8 @@ class FiniteDifferenceComputer(BaseComputer):
                 "basis": data["basis"],
                 "keywords": data["keywords"] or {},
             }
+            # Displacements can run in lower symmetry. Don't overwrite orbitals from reference geom
+            packet['keywords']['function_kwargs'].update({"write_orbitals": False})
             if 'cbs_metadata' in data:
                 packet['cbs_metadata'] = data['cbs_metadata']
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,8 +77,8 @@ foreach(test_name aediis-1
                   omp2p5-1 omp2p5-2 omp2p5-grad1 omp2p5-grad2 omp3-1 omp3-2
                   omp3-3 omp3-4 omp3-5 omp3-grad1 omp3-grad2 opt-lindep-change
                   opt1 opt1-fd opt2 opt2-fd opt3 opt4 opt5 opt6 opt7 opt8 opt9
-                  opt11 opt12 opt13 opt14 opt-irc-1 opt-irc-2 opt-irc-3 opt-freeze-coords
-                  opt-full-hess-every
+                  opt11 opt12 opt13 opt14 opt15 opt16 opt-irc-1 opt-irc-2 opt-irc-3
+                  opt-freeze-coords opt-full-hess-every
                   oremp-grad1 oremp-grad2
                   phi-ao
                   props1 props2 props3 props4 psimrcc-ccsd_t-1 psimrcc-ccsd_t-2

--- a/tests/opt16/CMakeLists.txt
+++ b/tests/opt16/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(opt16 "psi;opt;noc1")

--- a/tests/opt16/input.dat
+++ b/tests/opt16/input.dat
@@ -1,0 +1,26 @@
+#! SCF 6-31G(d) optimization of TS for HCN to HNC
+#! Checks correct behavior for writing orbitals to disk in
+#! finite difference calculations for a symmetric molecule.
+#! The last two displacements break the plane of symmetry.
+
+SCF_E = -92.7236996864523064
+
+molecule {
+0 1
+C  -0.0399606537   1.7574844925   0.0000000000    
+N   1.2331003808   0.0000000000   0.0000000000    
+H  -1.1931397271  -1.7574844925   0.0000000000    
+units bohr
+}
+
+set {
+  scf_type pk
+  basis 6-31G
+  opt_type ts
+  full_hess_every 0
+}
+
+thisenergy = optimize('scf', dertype='gradient')
+
+compare_values(SCF_E, thisenergy, 5, "TS optimization of CNH - finite difference hessian with symmetry") #TEST 
+

--- a/tests/opt16/input.dat
+++ b/tests/opt16/input.dat
@@ -1,7 +1,9 @@
 #! SCF 6-31G(d) optimization of TS for HCN to HNC
-#! Checks correct behavior for writing orbitals to disk in
-#! finite difference calculations for a symmetric molecule.
-#! The last two displacements break the plane of symmetry.
+#! Performs finite difference hessian calculation. Then optimizes
+#! using previous orbitals for scf guess, in subsequent calculations.
+#! The last two displacements of the hessian break the plane of symemtry,
+#! This test confirms that only the reference geometry, with the correct
+#! symmetry, writes orbitals to disk. SCF will fail (ValidationError) otherwise.
 
 SCF_E = -92.7236996864523064
 

--- a/tests/opt16/input.dat
+++ b/tests/opt16/input.dat
@@ -20,7 +20,26 @@ set {
   full_hess_every 0
 }
 
-thisenergy = optimize('scf', dertype='gradient')
+fd_energy = optimize('scf', dertype='gradient')
 
-compare_values(SCF_E, thisenergy, 5, "TS optimization of CNH - finite difference hessian with symmetry") #TEST 
+molecule {
+0 1
+C  -0.0399606537   1.7574844925   0.0000000000    
+N   1.2331003808   0.0000000000   0.0000000000    
+H  -1.1931397271  -1.7574844925   0.0000000000    
+units bohr
+}
+
+set {
+  scf_type pk
+  basis 6-31G
+  opt_type ts
+  full_hess_every 0
+}
+
+analytic_energy = optimize('scf')
+
+compare_values(SCF_E, analytic_energy, 5, "TS optimization of CNH - analytic hessian with symmetry") #TEST 
+compare_values(analytic_energy, fd_energy, 5, "TS optimization of CNH - finite difference hessian with symmetry") #TEST 
+
 

--- a/tests/opt16/log.ref
+++ b/tests/opt16/log.ref
@@ -1,0 +1,1554 @@
+2022-12-06:14:18:29,524 INFO     [psi4.optking.optwrapper:214] Creating a UserComputer
+2022-12-06:14:18:29,524 INFO     [psi4.optking.optwrapper:222] 
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+2022-12-06:14:18:29,524 INFO     [psi4.optking.optwrapper:238] 
+		 -- Optimization Parameters --
+	accept_symmetry_breaking       =           False
+	alg_geom_maxiter               =              50
+	bt_dx_conv                     =           1e-07
+	bt_dx_rms_change_conv          =           1e-12
+	bt_max_iter                    =              25
+	cart_hess_read                 =           False
+	consecutive_backsteps_allowed  =               0
+	conv_max_DE                    =           1e-06
+	conv_max_disp                  =          0.0012
+	conv_max_force                 =          0.0003
+	conv_rms_disp                  =              -1
+	conv_rms_force                 =              -1
+	covalent_connect               =             1.3
+	dynamic_level                  =               0
+	dynamic_level_max              =               0
+	ensure_bt_convergence          =           False
+	ext_force_bend                 =              []
+	ext_force_cartesian            =              []
+	ext_force_dihedral             =              []
+	ext_force_distance             =              []
+	ext_force_oofp                 =              []
+	fix_val_near_pi                =            1.57
+	flexible_g_convergence         =           False
+	frag_mode                      =          SINGLE
+	frag_ref_atoms                 =            None
+	freeze_intrafrag               =           False
+	frozen_bend                    =              []
+	frozen_cartesian               =              []
+	frozen_dihedral                =              []
+	frozen_distance                =              []
+	frozen_oofp                    =              []
+	full_hess_every                =               0
+	g_convergence                  =           QCHEM
+	generate_intcos_exit           =           False
+	geom_maxiter                   =              50
+	h_bond_connect                 =             4.3
+	hess_update                    =          BOFILL
+	hess_update_den_tol            =           1e-07
+	hess_update_dq_tol             =             0.5
+	hess_update_limit              =            True
+	hess_update_limit_max          =             1.0
+	hess_update_limit_scale        =             0.5
+	hess_update_use_last           =               4
+	hessian_file                   =            None
+	i_max_DE                       =            True
+	i_max_disp                     =            True
+	i_max_force                    =            True
+	i_rms_disp                     =           False
+	i_rms_force                    =           False
+	i_untampered                   =            True
+	include_oofp                   =           False
+	interfrag_collinear_tol        =            0.01
+	interfrag_coords               =            None
+	interfrag_dist_inv             =           False
+	interfrag_mode                 =           FIXED
+	interfrag_trust                =             0.5
+	interfrag_trust_max            =             1.0
+	interfrag_trust_min            =           0.001
+	interfragment_connect          =             1.8
+	intrafrag_hess                 =        SCHLEGEL
+	intrafrag_trust                =             0.5
+	intrafrag_trust_max            =             1.0
+	intrafrag_trust_min            =           0.001
+	irc_direction                  =         FORWARD
+	irc_points                     =              20
+	irc_step_size                  =             0.2
+	keep_intcos                    =           False
+	linear_bend_threshold          =            3.05
+	linesearch                     =           False
+	linesearch_step                =             0.1
+	max_disp_g_convergence         =          0.0012
+	max_energy_g_convergence       =           1e-06
+	max_force_g_convergence        =          0.0003
+	opt_coordinates                =       REDUNDANT
+	opt_type                       =              TS
+	output_type                    =            FILE
+	print_lvl                      =               1
+	program                        =            psi4
+	ranged_bend                    =              []
+	ranged_cartesian               =              []
+	ranged_dihedral                =              []
+	ranged_distance                =              []
+	ranged_oofp                    =              []
+	redundant_eval_tol             =           1e-10
+	rfo_follow_root                =           False
+	rfo_normalization_max          =             100
+	rfo_root                       =               0
+	rms_disp_g_convergence         =          0.0012
+	rms_force_g_convergence        =          0.0003
+	rsrfo_alpha_max                =     100000000.0
+	sd_hessian                     =             1.0
+	simple_step_scaling            =           False
+	small_bend_fix_threshold       =            0.35
+	steepest_descent_type          =         OVERLAP
+	step_type                      =           P_RFO
+	test_B                         =           False
+	test_derivative_B              =           False
+	trajectory                     =           False
+	v3d_tors_angle_lim             =           0.017
+	v3d_tors_cos_tol               =           1e-10
+	working_consecutive_backsteps  =               0
+	working_steps_since_last_H     =               0
+
+
+2022-12-06:14:18:29,824 INFO     [psi4.optking.molsys:599] 	Increasing scaling to  1.500 to connect fragments.
+2022-12-06:14:18:29,824 INFO     [psi4.optking.molsys:599] 	Increasing scaling to  1.700 to connect fragments.
+2022-12-06:14:18:29,824 INFO     [psi4.optking.molsys:576] 	Connecting fragments with atoms 2 and 3
+2022-12-06:14:18:29,824 INFO     [psi4.optking.molsys:595] 	All fragments are connected in connectivity matrix.
+2022-12-06:14:18:29,824 INFO     [psi4.optking.molsys:470] 	Consolidating multiple fragments into one for optimization.
+2022-12-06:14:18:29,825 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000         -0.61695707  1.04227035  0.00000000   
+	       7.000000            14.003074          0.65610396 -0.71521414  0.00000000   
+	       1.000000             1.007825         -1.77013614 -2.47269864  0.00000000   
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.170124           1.148380
+	 R(2,3)           =         2.995896           1.585360
+	 B(1,2,3)         =         1.570796          90.000000
+
+2022-12-06:14:18:29,839 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:29,842 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.312194649889424
+2022-12-06:14:18:30,53 INFO     [psi4.driver.driver:640] Return gradient(): -92.67516810226587
+2022-12-06:14:18:30,53 INFO     [psi4.driver.driver:641] [[ 0.08837896 -0.10826844  0.00000000]
+ [-0.01310309  0.17000534  0.00000000]
+ [-0.07527588 -0.06173690  0.00000000]]
+2022-12-06:14:18:30,68 INFO     [psi4.driver.task_planner:287] PLANNING FD:  dermode=(2, 1) keywords={'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}, 'SCF__E_CONVERGENCE': 1e-08, 'SCF__D_CONVERGENCE': 1e-08} findif_kw={'findif_irrep': -1, 'findif_stencil_size': 3, 'findif_step_size': 0.005, 'findif_verbose': 1} kw={'ref_gradient': <psi4.core.Matrix object at 0x7f56eaf93060>, 'opt_iter': True}
+2022-12-06:14:18:30,69 INFO     [psi4.driver.driver_findif:1184] hessian() using ref_gradient to assess stationary point.
+2022-12-06:14:18:30,69 INFO     [psi4.driver.driver_findif:263] 
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ----------------------------------------------------------
+
+
+2022-12-06:14:18:30,69 INFO     [psi4.driver.driver_findif:272]   Using finite-differences of gradients to determine vibrational frequencies and 
+  normal modes. Resulting frequencies are only valid at stationary points.
+    Generating geometries for use with 3-point formula.
+    Displacement size will be 5.00e-03.
+
+2022-12-06:14:18:30,69 INFO     [psi4.driver.driver_findif:291]     Number of atoms is 3.
+    Number of irreps is 2.
+    Number of SALCs is 6.
+    Translations projected? 1. Rotations projected? 0.
+
+2022-12-06:14:18:30,69 INFO     [psi4.driver.driver_findif:342]     Index of SALCs per irrep:
+      1 :  0  1  2  3 
+      2 :  4  5 
+    Number of SALCs per irrep:
+      Irrep 1: 4
+      Irrep 2: 2
+
+2022-12-06:14:18:30,69 INFO     [psi4.driver.driver_findif:367]     Number of geometries (including reference) is 11.
+    Number of displacements per irrep:
+      Irrep 1: 8
+      Irrep 2: 2
+
+2022-12-06:14:18:30,94 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.312194649889427
+2022-12-06:14:18:30,873 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:30,874 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.312194649889427
+2022-12-06:14:18:31,70 INFO     [psi4.driver.driver:640] Return gradient(): -92.67516810226579
+2022-12-06:14:18:31,70 INFO     [psi4.driver.driver:641] [[ 0.08837896 -0.10826844  0.00000000]
+ [-0.01310309  0.17000534  0.00000000]
+ [-0.07527588 -0.06173690  0.00000000]]
+2022-12-06:14:18:31,80 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.302329811695742
+2022-12-06:14:18:31,99 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:31,100 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.302329811695742
+2022-12-06:14:18:31,333 INFO     [psi4.driver.driver:640] Return gradient(): -92.67533835385649
+2022-12-06:14:18:31,334 INFO     [psi4.driver.driver:641] [[ 0.08748453 -0.10682185  0.00000000]
+ [-0.01226103  0.16854669  0.00000000]
+ [-0.07522349 -0.06172484  0.00000000]]
+2022-12-06:14:18:31,343 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.32205967254632
+2022-12-06:14:18:31,363 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:31,364 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.32205967254632
+2022-12-06:14:18:31,560 INFO     [psi4.driver.driver:640] Return gradient(): -92.67499611865485
+2022-12-06:14:18:31,560 INFO     [psi4.driver.driver:641] [[ 0.08927364 -0.10972001  0.00000000]
+ [-0.01394531  0.17146888  0.00000000]
+ [-0.07532833 -0.06174888  0.00000000]]
+2022-12-06:14:18:31,570 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.326993136524873
+2022-12-06:14:18:31,589 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:31,591 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.326993136524873
+2022-12-06:14:18:31,788 INFO     [psi4.driver.driver:640] Return gradient(): -92.67495670203441
+2022-12-06:14:18:31,790 INFO     [psi4.driver.driver:641] [[ 0.08983229 -0.11010118  0.00000000]
+ [-0.01457886  0.17184122  0.00000000]
+ [-0.07525342 -0.06174004  0.00000000]]
+2022-12-06:14:18:31,800 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.297411828981428
+2022-12-06:14:18:31,819 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:31,821 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.297411828981428
+2022-12-06:14:18:32,17 INFO     [psi4.driver.driver:640] Return gradient(): -92.67537596060286
+2022-12-06:14:18:32,17 INFO     [psi4.driver.driver:641] [[ 0.08693412 -0.10644254  0.00000000]
+ [-0.01163596  0.16817642  0.00000000]
+ [-0.07529816 -0.06173388  0.00000000]]
+2022-12-06:14:18:32,26 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.317922835158754
+2022-12-06:14:18:32,46 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:32,47 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.317922835158754
+2022-12-06:14:18:32,246 INFO     [psi4.driver.driver:640] Return gradient(): -92.67552586456594
+2022-12-06:14:18:32,246 INFO     [psi4.driver.driver:641] [[ 0.08839912 -0.10858709  0.00000000]
+ [-0.01304903  0.17037196  0.00000000]
+ [-0.07535009 -0.06178487  0.00000000]]
+2022-12-06:14:18:32,256 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.306471235563706
+2022-12-06:14:18:32,274 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:32,276 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.306471235563706
+2022-12-06:14:18:32,470 INFO     [psi4.driver.driver:640] Return gradient(): -92.67481071602754
+2022-12-06:14:18:32,470 INFO     [psi4.driver.driver:641] [[ 0.08835841 -0.10794970  0.00000000]
+ [-0.01315691  0.16963857  0.00000000]
+ [-0.07520150 -0.06168886  0.00000000]]
+2022-12-06:14:18:32,480 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.31406007703851
+2022-12-06:14:18:32,499 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:32,501 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.31406007703851
+2022-12-06:14:18:32,701 INFO     [psi4.driver.driver:640] Return gradient(): -92.67552350732728
+2022-12-06:14:18:32,701 INFO     [psi4.driver.driver:641] [[ 0.08808784 -0.10793307  0.00000000]
+ [-0.01276263  0.16952327  0.00000000]
+ [-0.07532521 -0.06159020  0.00000000]]
+2022-12-06:14:18:32,711 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.310334609371353
+2022-12-06:14:18:32,730 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:32,732 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.310334609371353
+2022-12-06:14:18:32,952 INFO     [psi4.driver.driver:640] Return gradient(): -92.67481182717844
+2022-12-06:14:18:32,953 INFO     [psi4.driver.driver:641] [[ 0.08867008 -0.10860368  0.00000000]
+ [-0.01344457  0.17048629  0.00000000]
+ [-0.07522550 -0.06188261  0.00000000]]
+2022-12-06:14:18:32,962 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.312186724791463
+2022-12-06:14:18:32,984 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:32,986 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.312186724791463
+2022-12-06:14:18:33,212 INFO     [psi4.driver.driver:640] Return gradient(): -92.67516822277896
+2022-12-06:14:18:33,213 INFO     [psi4.driver.driver:641] [[ 0.08837817 -0.10826736  0.00012448]
+ [-0.01310230  0.17000425 -0.00012969]
+ [-0.07527587 -0.06173690  0.00000521]]
+2022-12-06:14:18:33,223 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.312189571102063
+2022-12-06:14:18:33,244 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:33,246 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.312189571102063
+2022-12-06:14:18:33,442 INFO     [psi4.driver.driver:640] Return gradient(): -92.675167679647
+2022-12-06:14:18:33,442 INFO     [psi4.driver.driver:641] [[ 0.08837905 -0.10826837 -0.00003613]
+ [-0.01310337  0.17000522 -0.00013020]
+ [-0.07527568 -0.06173686  0.00016634]]
+2022-12-06:14:18:33,454 INFO     [psi4.driver.driver_findif:272] 
+2022-12-06:14:18:33,454 INFO     [psi4.driver.driver_findif:272]   Computing second-derivative from gradients using projected, 
+  symmetry-adapted, cartesian coordinates.
+
+  11 gradients passed in, including the reference geometry.
+
+2022-12-06:14:18:33,481 INFO     [psi4.optking.molsys:771] Converting Hessian from cartesians to internals.
+2022-12-06:14:18:33,481 INFO     [psi4.optking.molsys:787] Neglecting force/B-matrix derivative term, only correct at stationary points.
+2022-12-06:14:18:33,481 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.487892  -0.006796  -0.038479
+	  -0.006796  -0.007985   0.077337
+	  -0.038479   0.077337  -0.183688
+
+2022-12-06:14:18:33,482 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.6169570705   1.0422703481   0.0000000000		   0.0883789637  -0.1082684399   0.0000000000
+   0.6561039640  -0.7152141444   0.0000000000		  -0.0131030853   0.1700053413   0.0000000000
+  -1.7701361439  -2.4726986369   0.0000000000		  -0.0752758784  -0.0617369014   0.0000000000
+
+2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+
+		  0.020543  0.095231 -0.140452
+
+2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+	  -0.213543  -0.020543
+	  -0.020543   0.000000
+
+2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+	   0.020936   0.000000  -0.095231
+	   0.000000   1.488826   0.140452
+	  -0.095231   0.140452   0.000000
+
+2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+
+	%s	 -0.092454  0.100203  1.502013
+
+2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+
+	%s	 -0.215501  0.001958
+
+2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+
+		 -0.095326  0.839848 -0.088822
+
+2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+
+		  0.075531 -0.753246 -0.386310
+
+2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:196] 	Step length exceeds trust radius of    0.50000.
+2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:197] 	Scaling displacements by    0.58831
+2022-12-06:14:18:33,483 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:14:18:33,485 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:14:18:33,485 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.606e-09 	Max(dx):  4.856e-09 	RMS(dq):  2.867e-16
+2022-12-06:14:18:33,486 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.14838        1.14953        0.02351       1.17189
+	               R(2,3)       1.58536       -0.80063       -0.23450       1.35086
+	             B(1,2,3)      90.00000       -0.00133      -13.02157      76.97843
+	-------------------------------------------------------------------------------
+
+2022-12-06:14:18:33,486 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.5000000000
+2022-12-06:14:18:33,486 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :   -0.1064792631
+2022-12-06:14:18:33,486 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :    0.0340186310
+2022-12-06:14:18:33,486 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.5000000000
+2022-12-06:14:18:33,486 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.5546623344
+2022-12-06:14:18:33,486 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.8044352287612170  0.7967015651354833  0.0000000000000000
+	       7.000000            14.003074        0.6598123770001038 -0.8646990434456613  0.0000000000000000
+	       1.000000             1.007825       -1.5863663986626961 -2.0776449549701117  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.214559           1.171894
+	 R(2,3)           =         2.552755           1.350860
+	 B(1,2,3)         =         1.343527          76.978432
+
+2022-12-06:14:18:33,487 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:14:18:33,487 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     1     -92.67516810   -9.27e+01      1.40e-01      9.87e-02 o    4.43e-01      2.89e-01 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:14:18:33,487 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
+2022-12-06:14:18:33,503 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:33,505 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.721764077245705
+2022-12-06:14:18:33,632 INFO     [psi4.driver.driver:640] Return gradient(): -92.72107309333414
+2022-12-06:14:18:33,632 INFO     [psi4.driver.driver:641] [[ 0.04552444 -0.05010744  0.00000000]
+ [ 0.01543105  0.08403187  0.00000000]
+ [-0.06095549 -0.03392443  0.00000000]]
+2022-12-06:14:18:33,634 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:14:18:33,635 INFO     [psi4.optking.history:268] 	Using 1 previous steps for update.
+2022-12-06:14:18:33,635 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  1
+
+2022-12-06:14:18:33,635 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.489354   0.002237  -0.029244
+	   0.002237   0.007739   0.106021
+	  -0.029244   0.106021  -0.145439
+
+2022-12-06:14:18:33,636 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.489354   0.002237  -0.029244
+	   0.002237   0.007739   0.106021
+	  -0.029244   0.106021  -0.145439
+
+2022-12-06:14:18:33,636 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.8044352288   0.7967015651   0.0000000000		   0.0455244362  -0.0501074424   0.0000000000
+   0.6598123770  -0.8646990434   0.0000000000		   0.0154310532   0.0840318705   0.0000000000
+  -1.5863663987  -2.0776449550   0.0000000000		  -0.0609554895  -0.0339244281   0.0000000000
+
+2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+ 
+	Current energy:       -92.7210730933
+	Energy change for the previous step:
+		Actual       :        -0.0459049911
+		Projected    :        -0.0391898421
+
+2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    1.17135
+2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+
+		  0.030773 -0.062626 -0.067705
+
+2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+	  -0.200074  -0.030773
+	  -0.030773   0.000000
+
+2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+	   0.061851   0.000000   0.062626
+	   0.000000   1.489877   0.067705
+	   0.062626   0.067705   0.000000
+
+2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+
+	%s	 -0.041093  0.099867  1.492953
+
+2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+
+	%s	 -0.204701  0.004626
+
+2022-12-06:14:18:33,637 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+
+		 -0.150330 -0.608352 -0.044224
+
+2022-12-06:14:18:33,637 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+
+		  0.036994 -0.473540 -0.411142
+
+2022-12-06:14:18:33,637 INFO     [psi4.optking.stepAlgorithms:196] 	Step length exceeds trust radius of    0.50000.
+2022-12-06:14:18:33,637 INFO     [psi4.optking.stepAlgorithms:197] 	Scaling displacements by    0.79591
+2022-12-06:14:18:33,637 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:14:18:33,639 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:14:18:33,639 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.594e-08 	Max(dx):  3.341e-08 	RMS(dq):  3.846e-16
+2022-12-06:14:18:33,639 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.17189        0.55769        0.01558       1.18748
+	               R(2,3)       1.35086       -0.57469       -0.19945       1.15141
+	             B(1,2,3)      76.97843       -0.00017      -18.74912      58.22931
+	-------------------------------------------------------------------------------
+
+2022-12-06:14:18:33,640 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.5000000000
+2022-12-06:14:18:33,640 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :   -0.0580486337
+2022-12-06:14:18:33,640 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :    0.0539287131
+2022-12-06:14:18:33,640 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.5000000000
+2022-12-06:14:18:33,640 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.6246787612
+2022-12-06:14:18:33,640 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -1.0067810985259733  0.4834377374016347  0.0000000000000000
+	       7.000000            14.003074        0.6787460223343709 -0.9979635231793742  0.0000000000000000
+	       1.000000             1.007825       -1.4029541742322071 -1.6311166475025503  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.244003           1.187475
+	 R(2,3)           =         2.175858           1.151415
+	 B(1,2,3)         =         1.016293          58.229315
+
+2022-12-06:14:18:33,641 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:14:18:33,641 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     2     -92.72107309   -4.59e-02      6.98e-02      5.61e-02 o    3.77e-01      2.89e-01 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:14:18:33,641 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
+2022-12-06:14:18:33,657 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:33,659 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=24.72262102796013
+2022-12-06:14:18:33,786 INFO     [psi4.driver.driver:640] Return gradient(): -92.71756640502304
+2022-12-06:14:18:33,786 INFO     [psi4.driver.driver:641] [[-0.01854126 -0.06848336  0.00000000]
+ [-0.01197632 -0.00944328  0.00000000]
+ [ 0.03051758  0.07792664  0.00000000]]
+2022-12-06:14:18:33,788 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:14:18:33,788 INFO     [psi4.optking.history:268] 	Using 2 previous steps for update.
+2022-12-06:14:18:33,789 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 8.20e-01 exceeds limit of 5.00e-01.
+2022-12-06:14:18:33,789 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 1.
+2022-12-06:14:18:33,789 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  2
+
+2022-12-06:14:18:33,789 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.491454   0.020706  -0.000912
+	   0.020706   0.092630   0.266857
+	  -0.000912   0.266857   0.136165
+
+2022-12-06:14:18:33,790 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.491454   0.020706  -0.000912
+	   0.020706   0.092630   0.266857
+	  -0.000912   0.266857   0.136165
+
+2022-12-06:14:18:33,790 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -1.0067810985   0.4834377374   0.0000000000		  -0.0185412551  -0.0684833630   0.0000000000
+   0.6787460223  -0.9979635232   0.0000000000		  -0.0119763201  -0.0094432784   0.0000000000
+  -1.4029541742  -1.6311166475   0.0000000000		   0.0305175752   0.0779266414   0.0000000000
+
+2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+ 
+	Current energy:       -92.7175664050
+	Energy change for the previous step:
+		Actual       :         0.0035066883
+		Projected    :        -0.0178265822
+
+2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =   -0.19671
+2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+
+		 -0.058973  0.139862 -0.032403
+
+2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+	  -0.153498   0.058973
+	   0.058973   0.000000
+
+2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+	   0.381980   0.000000  -0.139862
+	   0.000000   1.491767   0.032403
+	  -0.139862   0.032403   0.000000
+
+2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+
+	%s	 -0.046351  0.427620  1.492479
+
+2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+
+	%s	 -0.173539  0.020040
+
+2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+
+		  0.339825  0.326528 -0.021066
+
+2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+
+		  0.013859  0.471438  0.009955
+
+2022-12-06:14:18:33,791 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:14:18:33,793 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:14:18:33,793 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.850e-10 	Max(dx):  3.495e-10 	RMS(dq):  1.282e-16
+2022-12-06:14:18:33,793 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18748        0.25773        0.00733       1.19481
+	               R(2,3)       1.15141        0.42737        0.24947       1.40089
+	             B(1,2,3)      58.22931        0.01087        0.57041      58.79972
+	-------------------------------------------------------------------------------
+
+2022-12-06:14:18:33,794 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.4717471518
+2022-12-06:14:18:33,794 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :   -0.0557735830
+2022-12-06:14:18:33,794 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :    0.1063277335
+2022-12-06:14:18:33,794 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.4717471518
+2022-12-06:14:18:33,794 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.3655043012
+2022-12-06:14:18:33,794 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9268338816187616  0.5281196581923154  0.0000000000000000
+	       7.000000            14.003074        0.8395634847513129 -0.8782178223540624  0.0000000000000000
+	       1.000000             1.007825       -1.6437188535563609 -1.7955442691185426  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.257863           1.194810
+	 R(2,3)           =         2.647297           1.400889
+	 B(1,2,3)         =         1.026249          58.799721
+
+2022-12-06:14:18:33,795 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:14:18:33,795 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     3     -92.71756641    3.51e-03      1.43e-01      8.96e-02 o    4.71e-01      2.72e-01 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:14:18:33,795 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
+2022-12-06:14:18:33,810 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:33,812 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.71324156381199
+2022-12-06:14:18:33,938 INFO     [psi4.driver.driver:640] Return gradient(): -92.72283626825208
+2022-12-06:14:18:33,939 INFO     [psi4.driver.driver:641] [[-0.00141297  0.01251726  0.00000000]
+ [ 0.01942042  0.00223823  0.00000000]
+ [-0.01800745 -0.01475549  0.00000000]]
+2022-12-06:14:18:33,941 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:14:18:33,941 INFO     [psi4.optking.history:268] 	Using 3 previous steps for update.
+2022-12-06:14:18:33,942 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 5.45e-01 exceeds limit of 5.00e-01.
+2022-12-06:14:18:33,942 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 1.
+2022-12-06:14:18:33,942 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  3 2
+
+2022-12-06:14:18:33,942 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.500871   0.056391  -0.019760
+	   0.056391   0.178791   0.211469
+	  -0.019760   0.211469   0.004029
+
+2022-12-06:14:18:33,943 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.500871   0.056391  -0.019760
+	   0.056391   0.178791   0.211469
+	  -0.019760   0.211469   0.004029
+
+2022-12-06:14:18:33,943 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9268338816   0.5281196582   0.0000000000		  -0.0014129750   0.0125172559   0.0000000000
+   0.8395634848  -0.8782178224   0.0000000000		   0.0194204236   0.0022382299   0.0000000000
+  -1.6437188536  -1.7955442691   0.0000000000		  -0.0180074486  -0.0147554858   0.0000000000
+
+2022-12-06:14:18:33,943 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+ 
+	Current energy:       -92.7228362683
+	Energy change for the previous step:
+		Actual       :        -0.0052698632
+		Projected    :        -0.0118438600
+
+2022-12-06:14:18:33,943 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    0.44494
+2022-12-06:14:18:33,943 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+
+		 -0.004685 -0.029210  0.009657
+
+2022-12-06:14:18:33,943 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+	  -0.138796   0.004685
+	   0.004685   0.000000
+
+2022-12-06:14:18:33,943 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+	   0.319136   0.000000   0.029210
+	   0.000000   1.503350  -0.009657
+	   0.029210  -0.009657   0.000000
+
+2022-12-06:14:18:33,944 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+
+	%s	 -0.002713  0.321787  1.503412
+
+2022-12-06:14:18:33,944 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+
+	%s	 -0.138954  0.000158
+
+2022-12-06:14:18:33,944 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+
+		  0.033714 -0.090756  0.006412
+
+2022-12-06:14:18:33,944 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+
+		 -0.002679 -0.094308 -0.022653
+
+2022-12-06:14:18:33,944 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:14:18:33,946 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:14:18:33,946 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.711e-15 	Max(dx):  5.339e-15 	RMS(dq):  3.626e-16
+2022-12-06:14:18:33,947 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.19481       -0.07334       -0.00142       1.19339
+	               R(2,3)       1.40089       -0.18129       -0.04991       1.35098
+	             B(1,2,3)      58.79972       -0.00153       -1.29791      57.50182
+	-------------------------------------------------------------------------------
+
+2022-12-06:14:18:33,947 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.0970274732
+2022-12-06:14:18:33,947 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :   -0.0263319928
+2022-12-06:14:18:33,947 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :    0.2690207130
+2022-12-06:14:18:33,947 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.0970274732
+2022-12-06:14:18:33,947 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.0904171685
+2022-12-06:14:18:33,947 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9527005117516689  0.4966474325368037  0.0000000000000000
+	       7.000000            14.003074        0.8165135954770494 -0.9018282917313836  0.0000000000000000
+	       1.000000             1.007825       -1.5948023341491901 -1.7404615740857095  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.255184           1.193392
+	 R(2,3)           =         2.552989           1.350983
+	 B(1,2,3)         =         1.003596          57.501816
+
+2022-12-06:14:18:33,948 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:14:18:33,948 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     4     -92.72283627   -5.27e-03      2.20e-02      1.80e-02 o    9.43e-02      5.60e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:14:18:33,948 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
+2022-12-06:14:18:33,963 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:33,965 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.943591559989084
+2022-12-06:14:18:34,89 INFO     [psi4.driver.driver:640] Return gradient(): -92.72424403137798
+2022-12-06:14:18:34,89 INFO     [psi4.driver.driver:641] [[-0.00800510 -0.00185367  0.00000000]
+ [ 0.01471132 -0.00181669  0.00000000]
+ [-0.00670622  0.00367037  0.00000000]]
+2022-12-06:14:18:34,91 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:14:18:34,91 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:14:18:34,92 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 5.67e-01 exceeds limit of 5.00e-01.
+2022-12-06:14:18:34,92 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 1.
+2022-12-06:14:18:34,92 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  4 3 2
+
+2022-12-06:14:18:34,93 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.521467   0.067226  -0.032354
+	   0.067226   0.145579   0.198249
+	  -0.032354   0.198249   0.045512
+
+2022-12-06:14:18:34,94 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.521467   0.067226  -0.032354
+	   0.067226   0.145579   0.198249
+	  -0.032354   0.198249   0.045512
+
+2022-12-06:14:18:34,94 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9527005118   0.4966474325   0.0000000000		  -0.0080050967  -0.0018536725   0.0000000000
+   0.8165135955  -0.9018282917   0.0000000000		   0.0147113205  -0.0018166933   0.0000000000
+  -1.5948023341  -1.7404615741   0.0000000000		  -0.0067062238   0.0036703658   0.0000000000
+
+2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+ 
+	Current energy:       -92.7242440314
+	Energy change for the previous step:
+		Actual       :        -0.0014077631
+		Projected    :        -0.0012765836
+
+2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    1.10276
+2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+
+		  0.014332  0.005049  0.005589
+
+2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+	  -0.111659  -0.014332
+	  -0.014332   0.000000
+
+2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+	   0.299119   0.000000  -0.005049
+	   0.000000   1.525098  -0.005589
+	  -0.005049  -0.005589   0.000000
+
+2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+
+	%s	 -0.000106  0.299205  1.525118
+
+2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+
+	%s	 -0.113469  0.001810
+
+2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+
+		 -0.126307  0.016875  0.003664
+
+2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+
+		 -0.009286  0.090974 -0.088820
+
+2022-12-06:14:18:34,95 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:14:18:34,97 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:14:18:34,97 INFO     [psi4.optking.displace:379] 	RMS(dx):  4.512e-13 	Max(dx):  9.741e-13 	RMS(dq):  2.643e-16
+2022-12-06:14:18:34,98 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.19339       -0.04227       -0.00491       1.18848
+	               R(2,3)       1.35098       -0.04225        0.04814       1.39912
+	             B(1,2,3)      57.50182        0.00110       -5.08902      52.41280
+	-------------------------------------------------------------------------------
+
+2022-12-06:14:18:34,98 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.1274818086
+2022-12-06:14:18:34,98 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :    0.0133707932
+2022-12-06:14:18:34,98 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :   -0.1031088644
+2022-12-06:14:18:34,98 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.1274818086
+2022-12-06:14:18:34,98 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.1386617565
+2022-12-06:14:18:34,99 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9696013652817181  0.4048738820734400  0.0000000000000000
+	       7.000000            14.003074        0.8781933411965031 -0.8717264268825471  0.0000000000000000
+	       1.000000             1.007825       -1.6395812263385943 -1.6787898884711820  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.245897           1.188478
+	 R(2,3)           =         2.643963           1.399125
+	 B(1,2,3)         =         0.914776          52.412796
+
+2022-12-06:14:18:34,99 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:14:18:34,99 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     5     -92.72424403   -1.41e-03      1.45e-02      9.35e-03 o    9.10e-02      7.36e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:14:18:34,99 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
+2022-12-06:14:18:34,115 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:34,117 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=24.08962784561235
+2022-12-06:14:18:34,245 INFO     [psi4.driver.driver:640] Return gradient(): -92.72311094415689
+2022-12-06:14:18:34,245 INFO     [psi4.driver.driver:641] [[-0.01240689 -0.00637875  0.00000000]
+ [-0.00190229 -0.00918011  0.00000000]
+ [ 0.01430918  0.01555886  0.00000000]]
+2022-12-06:14:18:34,248 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:14:18:34,249 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:14:18:34,249 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  5 4 3 2
+
+2022-12-06:14:18:34,250 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.507020   0.064736  -0.049312
+	   0.064736   0.134566   0.238908
+	  -0.049312   0.238908   0.116932
+
+2022-12-06:14:18:34,251 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.507020   0.064736  -0.049312
+	   0.064736   0.134566   0.238908
+	  -0.049312   0.238908   0.116932
+
+2022-12-06:14:18:34,251 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9696013653   0.4048738821   0.0000000000		  -0.0124068938  -0.0063787517   0.0000000000
+   0.8781933412  -0.8717264269   0.0000000000		  -0.0019022895  -0.0091801050   0.0000000000
+  -1.6395812263  -1.6787898885   0.0000000000		   0.0143091833   0.0155588567   0.0000000000
+
+2022-12-06:14:18:34,251 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+ 
+	Current energy:       -92.7231109442
+	Energy change for the previous step:
+		Actual       :         0.0011330872
+		Projected    :         0.0008528304
+
+2022-12-06:14:18:34,251 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    1.32862
+2022-12-06:14:18:34,251 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+
+		  0.006764  0.032483  0.006577
+
+2022-12-06:14:18:34,251 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+	  -0.117304  -0.006764
+	  -0.006764   0.000000
+
+2022-12-06:14:18:34,251 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+	   0.364687   0.000000  -0.032483
+	   0.000000   1.511137  -0.006577
+	  -0.032483  -0.006577   0.000000
+
+2022-12-06:14:18:34,252 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+
+	%s	 -0.002899  0.367557  1.511165
+
+2022-12-06:14:18:34,252 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+
+	%s	 -0.117693  0.000389
+
+2022-12-06:14:18:34,252 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+
+		 -0.057470  0.088368  0.004344
+
+2022-12-06:14:18:34,252 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+
+		 -0.008128  0.103215  0.020277
+
+2022-12-06:14:18:34,252 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:14:18:34,254 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:14:18:34,254 INFO     [psi4.optking.displace:379] 	RMS(dx):  3.617e-15 	Max(dx):  6.785e-15 	RMS(dq):  5.286e-16
+2022-12-06:14:18:34,255 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18848       -0.05423       -0.00430       1.18418
+	               R(2,3)       1.39912        0.15139        0.05462       1.45374
+	             B(1,2,3)      52.41280        0.00210        1.16180      53.57459
+	-------------------------------------------------------------------------------
+
+2022-12-06:14:18:34,255 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.1055015936
+2022-12-06:14:18:34,255 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :   -0.0237939197
+2022-12-06:14:18:34,255 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :    0.2236079401
+2022-12-06:14:18:34,255 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.1055015936
+2022-12-06:14:18:34,255 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.0960764907
+2022-12-06:14:18:34,256 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9369865917421235  0.4303097307112949  0.0000000000000000
+	       7.000000            14.003074        0.9027421057032951 -0.8436633317811943  0.0000000000000000
+	       1.000000             1.007825       -1.6967447643849807 -1.7322888322103898  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.237769           1.184176
+	 R(2,3)           =         2.747178           1.453744
+	 B(1,2,3)         =         0.935053          53.574593
+
+2022-12-06:14:18:34,256 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:14:18:34,256 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     6     -92.72311094    1.13e-03      2.76e-02      1.95e-02 o    1.03e-01      6.09e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:14:18:34,256 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
+2022-12-06:14:18:34,271 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:34,273 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.934366020514354
+2022-12-06:14:18:34,399 INFO     [psi4.driver.driver:640] Return gradient(): -92.72388646390472
+2022-12-06:14:18:34,399 INFO     [psi4.driver.driver:641] [[ 0.00705936  0.01013773  0.00000000]
+ [-0.00763413  0.00030023  0.00000000]
+ [ 0.00057477 -0.01043796  0.00000000]]
+2022-12-06:14:18:34,401 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:14:18:34,401 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:14:18:34,402 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 5.71e-01 exceeds limit of 5.00e-01.
+2022-12-06:14:18:34,402 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 3.
+2022-12-06:14:18:34,403 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  6 5 4 2
+
+2022-12-06:14:18:34,404 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.464903   0.104993  -0.032430
+	   0.104993   0.214346   0.271822
+	  -0.032430   0.271822   0.065405
+
+2022-12-06:14:18:34,404 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.464903   0.104993  -0.032430
+	   0.104993   0.214346   0.271822
+	  -0.032430   0.271822   0.065405
+
+2022-12-06:14:18:34,404 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9369865917   0.4303097307   0.0000000000		   0.0070593593   0.0101377315   0.0000000000
+   0.9027421057  -0.8436633318   0.0000000000		  -0.0076341327   0.0003002327   0.0000000000
+  -1.6967447644  -1.7322888322   0.0000000000		   0.0005747733  -0.0104379643   0.0000000000
+
+2022-12-06:14:18:34,404 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+ 
+	Current energy:       -92.7238864639
+	Energy change for the previous step:
+		Actual       :        -0.0007755197
+		Projected    :        -0.0012519181
+
+2022-12-06:14:18:34,404 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    0.61947
+2022-12-06:14:18:34,404 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+
+		 -0.020108 -0.019180 -0.000001
+
+2022-12-06:14:18:34,405 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+	  -0.146951   0.020108
+	   0.020108   0.000000
+
+2022-12-06:14:18:34,405 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+	   0.417878   0.000000   0.019180
+	   0.000000   1.473727   0.000001
+	   0.019180   0.000001   0.000000
+
+2022-12-06:14:18:34,405 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+
+	%s	 -0.000879  0.418757  1.473727
+
+2022-12-06:14:18:34,405 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+
+	%s	 -0.149653  0.002702
+
+2022-12-06:14:18:34,405 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+
+		  0.134366 -0.045803 -0.000000
+
+2022-12-06:14:18:34,405 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+
+		  0.010228 -0.118119  0.078073
+
+2022-12-06:14:18:34,405 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:14:18:34,407 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:14:18:34,407 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.653e-13 	Max(dx):  5.887e-13 	RMS(dq):  3.846e-16
+2022-12-06:14:18:34,408 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18418        0.00027        0.00541       1.18959
+	               R(2,3)       1.45374       -0.02334       -0.06251       1.39124
+	             B(1,2,3)      53.57459       -0.00210        4.47323      58.04782
+	-------------------------------------------------------------------------------
+
+2022-12-06:14:18:34,408 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.1419576889
+2022-12-06:14:18:34,408 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :    0.0128443179
+2022-12-06:14:18:34,408 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :   -0.0881507757
+2022-12-06:14:18:34,408 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.1419576889
+2022-12-06:14:18:34,408 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.1318772281
+2022-12-06:14:18:34,408 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9289060824152746  0.5095557362515007  0.0000000000000000
+	       7.000000            14.003074        0.8359589077879728 -0.8828316900225756  0.0000000000000000
+	       1.000000             1.007825       -1.6380420757965073 -1.7723664795092144  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.247997           1.189589
+	 R(2,3)           =         2.629059           1.391238
+	 B(1,2,3)         =         1.013126          58.047825
+
+2022-12-06:14:18:34,409 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:14:18:34,409 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     7     -92.72388646   -7.76e-04      2.76e-02      1.60e-02 o    1.18e-01      8.20e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:14:18:34,409 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
+2022-12-06:14:18:34,424 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:34,426 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.856759412603612
+2022-12-06:14:18:34,550 INFO     [psi4.driver.driver:640] Return gradient(): -92.7234445503816
+2022-12-06:14:18:34,550 INFO     [psi4.driver.driver:641] [[ 0.00421211  0.00403919  0.00000000]
+ [ 0.00937494  0.00609811  0.00000000]
+ [-0.01358706 -0.01013729  0.00000000]]
+2022-12-06:14:18:34,552 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:14:18:34,552 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:14:18:34,553 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  7 6 5 4
+
+2022-12-06:14:18:34,554 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.292485  -0.001620  -0.229733
+	  -0.001620   0.136094   0.253229
+	  -0.229733   0.253229   0.364100
+
+2022-12-06:14:18:34,555 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.292485  -0.001620  -0.229733
+	  -0.001620   0.136094   0.253229
+	  -0.229733   0.253229   0.364100
+
+2022-12-06:14:18:34,555 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9289060824   0.5095557363   0.0000000000		   0.0042121116   0.0040391853   0.0000000000
+   0.8359589078  -0.8828316900   0.0000000000		   0.0093749448   0.0060981079   0.0000000000
+  -1.6380420758  -1.7723664795   0.0000000000		  -0.0135870564  -0.0101372932   0.0000000000
+
+2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+ 
+	Current energy:       -92.7234445504
+	Energy change for the previous step:
+		Actual       :         0.0004419135
+		Projected    :         0.0009166704
+
+2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    0.48209
+2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+
+		 -0.005954 -0.019357 -0.004720
+
+2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+	  -0.039633   0.005954
+	   0.005954   0.000000
+
+2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+	   0.483048   0.000000   0.019357
+	   0.000000   1.349263   0.004720
+	   0.019357   0.004720   0.000000
+
+2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+
+	%s	 -0.000791  0.483823  1.349280
+
+2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+
+	%s	 -0.040508  0.000875
+
+2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+
+		  0.146993 -0.040007 -0.003496
+
+2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+
+		 -0.019847  0.097018 -0.115815
+
+2022-12-06:14:18:34,556 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:14:18:34,558 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:14:18:34,558 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.364e-12 	Max(dx):  5.296e-12 	RMS(dq):  6.410e-17
+2022-12-06:14:18:34,558 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18959        0.00663       -0.01050       1.17909
+	               R(2,3)       1.39124       -0.13360        0.05134       1.44258
+	             B(1,2,3)      58.04782       -0.00099       -6.63573      51.41209
+	-------------------------------------------------------------------------------
+
+2022-12-06:14:18:34,558 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.1523797081
+2022-12-06:14:18:34,559 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :    0.0005534442
+2022-12-06:14:18:34,559 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :   -0.0028724876
+2022-12-06:14:18:34,559 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.1523797081
+2022-12-06:14:18:34,559 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.1811516665
+2022-12-06:14:18:34,559 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9527414848751103  0.3835427949900482  0.0000000000000000
+	       7.000000            14.003074        0.9071933279755539 -0.8433613439764761  0.0000000000000000
+	       1.000000             1.007825       -1.6854410935242525 -1.6858238842938613  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.228150           1.179086
+	 R(2,3)           =         2.726077           1.442578
+	 B(1,2,3)         =         0.897310          51.412091
+
+2022-12-06:14:18:34,559 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:14:18:34,560 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     8     -92.72344455    4.42e-04      1.62e-02      1.20e-02 o    1.16e-01      8.80e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:14:18:34,560 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
+2022-12-06:14:18:34,575 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:34,577 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=24.15068552247633
+2022-12-06:14:18:34,706 INFO     [psi4.driver.driver:640] Return gradient(): -92.72426965300876
+2022-12-06:14:18:34,706 INFO     [psi4.driver.driver:641] [[ 0.00527157 -0.00391752  0.00000000]
+ [-0.02025468 -0.00126691  0.00000000]
+ [ 0.01498311  0.00518443  0.00000000]]
+2022-12-06:14:18:34,708 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:14:18:34,708 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:14:18:34,709 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  8 7 6 5
+
+2022-12-06:14:18:34,710 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.280824   0.042347  -0.146845
+	   0.042347   0.134095   0.405001
+	  -0.146845   0.405001   0.568420
+
+2022-12-06:14:18:34,711 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.280824   0.042347  -0.146845
+	   0.042347   0.134095   0.405001
+	  -0.146845   0.405001   0.568420
+
+2022-12-06:14:18:34,711 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9527414849   0.3835427950   0.0000000000		   0.0052715732  -0.0039175224   0.0000000000
+   0.9071933280  -0.8433613440   0.0000000000		  -0.0202546794  -0.0012669063   0.0000000000
+  -1.6854410935  -1.6858238843   0.0000000000		   0.0149831062   0.0051844287   0.0000000000
+
+2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+ 
+	Current energy:       -92.7242696530
+	Energy change for the previous step:
+		Actual       :        -0.0008251026
+		Projected    :         0.0000498277
+
+2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =  -16.55911
+2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+
+		  0.012532  0.010314 -0.005616
+
+2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+	  -0.117298  -0.012532
+	  -0.012532   0.000000
+
+2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+	   0.789302   0.000000  -0.010314
+	   0.000000   1.311336   0.005616
+	  -0.010314   0.005616   0.000000
+
+2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+
+	%s	 -0.000159  0.789437  1.311360
+
+2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+
+	%s	 -0.118622  0.001324
+
+2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+
+		 -0.105645  0.013064 -0.004282
+
+2022-12-06:14:18:34,712 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+
+		  0.015305 -0.083178  0.064784
+
+2022-12-06:14:18:34,712 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:14:18:34,714 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:14:18:34,714 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.925e-14 	Max(dx):  6.668e-14 	RMS(dq):  6.410e-17
+2022-12-06:14:18:34,715 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.17909        0.05403        0.00810       1.18719
+	               R(2,3)       1.44258        0.13060       -0.04402       1.39856
+	             B(1,2,3)      51.41209        0.00006        3.71184      55.12393
+	-------------------------------------------------------------------------------
+
+2022-12-06:14:18:34,715 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.1065353175
+2022-12-06:14:18:34,715 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :    0.0109365514
+2022-12-06:14:18:34,715 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :   -0.1013573573
+2022-12-06:14:18:34,715 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.1065353175
+2022-12-06:14:18:34,715 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.1084980699
+2022-12-06:14:18:34,716 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9475816259267723  0.4547750885420321  0.0000000000000000
+	       7.000000            14.003074        0.8594108029495456 -0.8748370675052539  0.0000000000000000
+	       1.000000             1.007825       -1.6428184274465825 -1.7255804543170672  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.243455           1.187185
+	 R(2,3)           =         2.642899           1.398562
+	 B(1,2,3)         =         0.962094          55.123927
+
+2022-12-06:14:18:34,716 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:14:18:34,716 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     9     -92.72426965   -8.25e-04      1.59e-02      9.92e-03 o    8.32e-02      6.15e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:14:18:34,716 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
+2022-12-06:14:18:34,731 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:34,733 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.991517966838867
+2022-12-06:14:18:34,855 INFO     [psi4.driver.driver:640] Return gradient(): -92.72370022442102
+2022-12-06:14:18:34,855 INFO     [psi4.driver.driver:641] [[ 0.00047306 -0.00016801  0.00000000]
+ [ 0.00018062  0.00052030  0.00000000]
+ [-0.00065368 -0.00035229  0.00000000]]
+2022-12-06:14:18:34,858 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:14:18:34,858 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:14:18:34,859 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  9 8 7 6
+
+2022-12-06:14:18:34,860 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.277087   0.051577  -0.082185
+	   0.051577   0.126776   0.409329
+	  -0.082185   0.409329   0.595658
+
+2022-12-06:14:18:34,860 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.277087   0.051577  -0.082185
+	   0.051577   0.126776   0.409329
+	  -0.082185   0.409329   0.595658
+
+2022-12-06:14:18:34,860 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9475816259   0.4547750885   0.0000000000		   0.0004730577  -0.0001680072   0.0000000000
+   0.8594108029  -0.8748370675   0.0000000000		   0.0001806206   0.0005202987   0.0000000000
+  -1.6428184274  -1.7255804543   0.0000000000		  -0.0006536783  -0.0003522914   0.0000000000
+
+2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+ 
+	Current energy:       -92.7237002244
+	Energy change for the previous step:
+		Actual       :         0.0005694286
+		Projected    :         0.0005833169
+
+2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    0.97619
+2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+
+		 -0.000497 -0.000602 -0.000513
+
+2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+	  -0.115793   0.000497
+	   0.000497   0.000000
+
+2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+	   0.828446   0.000000   0.000602
+	   0.000000   1.286868   0.000513
+	   0.000602   0.000513   0.000000
+
+2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+
+	%s	 -0.000001  0.828447  1.286868
+
+2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+
+	%s	 -0.115796  0.000002
+
+2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+
+		  0.004293 -0.000727 -0.000399
+
+2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+
+		  0.000060  0.003334 -0.002829
+
+2022-12-06:14:18:34,861 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:14:18:34,863 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:14:18:34,863 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.252e-12 	Max(dx):  2.379e-12 	RMS(dq):  1.282e-16
+2022-12-06:14:18:34,863 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18719        0.00396        0.00003       1.18722
+	               R(2,3)       1.39856       -0.00603        0.00176       1.40033
+	             B(1,2,3)      55.12393       -0.00002       -0.16209      54.96184
+	-------------------------------------------------------------------------------
+
+2022-12-06:14:18:34,864 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.0043728182
+2022-12-06:14:18:34,864 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :    0.0003412259
+2022-12-06:14:18:34,864 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :   -0.0780313660
+2022-12-06:14:18:34,864 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.0043728182
+2022-12-06:14:18:34,864 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.0044085361
+2022-12-06:14:18:34,864 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9481945734882358  0.4520216831837158  0.0000000000000000
+	       7.000000            14.003074        0.8616125660921277 -0.8738575600665194  0.0000000000000000
+	       1.000000             1.007825       -1.6444072430277010 -1.7238065563974854  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.243515           1.187217
+	 R(2,3)           =         2.646233           1.400326
+	 B(1,2,3)         =         0.959265          54.961835
+
+2022-12-06:14:18:34,865 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:14:18:34,865 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	    10     -92.72370022    5.69e-04      7.32e-04      5.39e-04 o    3.33e-03      2.52e-03 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:14:18:34,865 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
+2022-12-06:14:18:34,882 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:14:18:34,883 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.992292195213906
+2022-12-06:14:18:34,999 INFO     [psi4.driver.driver:640] Return gradient(): -92.72369968645235
+2022-12-06:14:18:34,999 INFO     [psi4.driver.driver:641] [[ 0.00007992  0.00007887  0.00000000]
+ [-0.00002727  0.00003823  0.00000000]
+ [-0.00005265 -0.00011710  0.00000000]]
+2022-12-06:14:18:35,2 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:14:18:35,2 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:14:18:35,3 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  10 9 8 7
+
+2022-12-06:14:18:35,4 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.253539   0.051504  -0.082157
+	   0.051504   0.113902   0.349289
+	  -0.082157   0.349289   0.344279
+
+2022-12-06:14:18:35,4 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.253539   0.051504  -0.082157
+	   0.051504   0.113902   0.349289
+	  -0.082157   0.349289   0.344279
+
+2022-12-06:14:18:35,4 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9481945735   0.4520216832   0.0000000000		   0.0000799193   0.0000788722   0.0000000000
+   0.8616125661  -0.8738575601   0.0000000000		  -0.0000272663   0.0000382290   0.0000000000
+  -1.6444072430  -1.7238065564   0.0000000000		  -0.0000526529  -0.0001171012   0.0000000000
+
+2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+ 
+	Current energy:       -92.7236996865
+	Energy change for the previous step:
+		Actual       :         0.0000005380
+		Projected    :         0.0000007461
+
+2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    0.72108
+2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+
+		  0.000074 -0.000251 -0.000036
+
+2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+	  -0.144487  -0.000074
+	  -0.000074   0.000000
+
+2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+	   0.594905   0.000000   0.000251
+	   0.000000   1.261302   0.000036
+	   0.000251   0.000036   0.000000
+
+2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+
+	%s	 -0.000000  0.594905  1.261302
+
+2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+
+	%s	 -0.144487  0.000000
+
+2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+
+		 -0.000515 -0.000422 -0.000029
+
+2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+
+		  0.000039 -0.000664 -0.000040
+
+2022-12-06:14:18:35,5 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:14:18:35,6 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:14:18:35,6 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.173e-08 	Max(dx):  2.315e-08 	RMS(dq):  2.867e-16
+2022-12-06:14:18:35,7 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18722        0.00015        0.00002       1.18724
+	               R(2,3)       1.40033       -0.00072       -0.00035       1.39997
+	             B(1,2,3)      54.96184       -0.00002       -0.00228      54.95956
+	-------------------------------------------------------------------------------
+
+2022-12-06:14:18:35,7 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.0006660417
+2022-12-06:14:18:35,7 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :   -0.0001030514
+2022-12-06:14:18:35,7 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :    0.1547221383
+2022-12-06:14:18:35,7 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.0006660417
+2022-12-06:14:18:35,7 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.0005428280
+2022-12-06:14:18:35,8 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9483540554417276  0.4519517645947314  0.0000000000000000
+	       7.000000            14.003074        0.8614166452592497 -0.8740430533459389  0.0000000000000000
+	       1.000000             1.007825       -1.6440518402413311 -1.7235511445290814  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.243553           1.187237
+	 R(2,3)           =         2.645569           1.399975
+	 B(1,2,3)         =         0.959225          54.959559
+
+2022-12-06:14:18:35,8 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:14:18:35,8 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	    11     -92.72369969    5.38e-07 *    2.49e-04 *    1.53e-04 o    6.64e-04 *    3.85e-04 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:14:18:35,8 INFO     [psi4.optking.convcheck:193] 
+	                      ===> Final Convergence Report <===                     
+
+	----------------------------------------------------------------------------
+	|   Required Criteria    |  One or More Criteria  |   Alternate Criteria   |
+	----------------------------------------------------------------------------
+	| [x]     max_force      | [x]       max_DE       |                        |
+	|                        | [x]      max_disp      |                        |
+	----------------------------------------------------------------------------
+
+
+2022-12-06:14:18:35,8 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned True
+2022-12-06:14:18:35,8 INFO     [psi4.optking.optimize:286] 	Converged in 11 steps!
+2022-12-06:14:18:35,8 INFO     [psi4.optking.optimize:287] 	Final energy is    -92.7236996864523
+2022-12-06:14:18:35,8 INFO     [psi4.optking.optimize:288] 	Final structure (Angstroms): 
+	Fragment 1 (Ang)
+
+	    C  -0.5018473538   0.2391625741   0.0000000000
+	    N   0.4558420576  -0.4625236650   0.0000000000
+	    H  -0.8699947670  -0.9120639871   0.0000000000
+
+
+2022-12-06:14:18:35,9 INFO     [psi4.optking.optimize:432] 	Optimization Finished
+
+	==> Optimization Summary <==
+
+        
+	Measures of convergence in internal coordinates in au. (Any backward steps not shown.)
+        
+	---------------------------------------------------------------------------------------------------------------  ~
+        
+	 Step         Total Energy             Delta E       MAX Force       RMS Force        MAX Disp        RMS Disp   ~
+        
+	---------------------------------------------------------------------------------------------------------------  ~
+        
+	     1     -92.675168102266    -92.675168102266      0.13952751      0.09868759      0.44314123      0.28867513  ~
+	     2     -92.721073093334     -0.045904991068      0.06975422      0.05613366      0.37689664      0.28867513  ~
+	     3     -92.717566405023      0.003506688311      0.14289761      0.08960869      0.47143842      0.27236335  ~
+	     4     -92.722836268252     -0.005269863229      0.02200478      0.01796667      0.09430804      0.05601884  ~
+	     5     -92.724244031378     -0.001407763126      0.01447448      0.00934762      0.09097447      0.07360166  ~
+	     6     -92.723110944157      0.001133087221      0.02762527      0.01952894      0.10321508      0.06091137  ~
+	     7     -92.723886463905     -0.000775519748      0.02764411      0.01604391      0.11811872      0.08195931  ~
+	     8     -92.723444550382      0.000441913523      0.01621564      0.01200592      0.11581541      0.08797647  ~
+	     9     -92.724269653009     -0.000825102627      0.01585186      0.00991553      0.08317805      0.06150819  ~
+	    10     -92.723700224421      0.000569428588      0.00073229      0.00053948      0.00333385      0.00252465  ~
+	    11     -92.723699686452      0.000000537969      0.00024871      0.00015256      0.00066372      0.00038454  ~
+	----------------------------------------------------------------------------------------------------------------
+
+
+2022-12-06:14:18:35,9 INFO     [psi4.optking.optimize:640] Preparing OptimizationResult

--- a/tests/opt16/log.ref
+++ b/tests/opt16/log.ref
@@ -1,5 +1,5 @@
-2022-12-06:14:18:29,524 INFO     [psi4.optking.optwrapper:214] Creating a UserComputer
-2022-12-06:14:18:29,524 INFO     [psi4.optking.optwrapper:222] 
+2022-12-06:15:29:58,891 INFO     [psi4.optking.optwrapper:214] Creating a UserComputer
+2022-12-06:15:29:58,891 INFO     [psi4.optking.optwrapper:222] 
     			-----------------------------------------
 
     			 OPTKING 3.0: for geometry optimizations 
@@ -13,7 +13,7 @@
     			-----------------------------------------
 
     
-2022-12-06:14:18:29,524 INFO     [psi4.optking.optwrapper:238] 
+2022-12-06:15:29:58,891 INFO     [psi4.optking.optwrapper:238] 
 		 -- Optimization Parameters --
 	accept_symmetry_breaking       =           False
 	alg_geom_maxiter               =              50
@@ -119,12 +119,12 @@
 	working_steps_since_last_H     =               0
 
 
-2022-12-06:14:18:29,824 INFO     [psi4.optking.molsys:599] 	Increasing scaling to  1.500 to connect fragments.
-2022-12-06:14:18:29,824 INFO     [psi4.optking.molsys:599] 	Increasing scaling to  1.700 to connect fragments.
-2022-12-06:14:18:29,824 INFO     [psi4.optking.molsys:576] 	Connecting fragments with atoms 2 and 3
-2022-12-06:14:18:29,824 INFO     [psi4.optking.molsys:595] 	All fragments are connected in connectivity matrix.
-2022-12-06:14:18:29,824 INFO     [psi4.optking.molsys:470] 	Consolidating multiple fragments into one for optimization.
-2022-12-06:14:18:29,825 INFO     [psi4.optking.opt_helper:151] Molsys:
+2022-12-06:15:29:59,175 INFO     [psi4.optking.molsys:599] 	Increasing scaling to  1.500 to connect fragments.
+2022-12-06:15:29:59,176 INFO     [psi4.optking.molsys:599] 	Increasing scaling to  1.700 to connect fragments.
+2022-12-06:15:29:59,176 INFO     [psi4.optking.molsys:576] 	Connecting fragments with atoms 2 and 3
+2022-12-06:15:29:59,176 INFO     [psi4.optking.molsys:595] 	All fragments are connected in connectivity matrix.
+2022-12-06:15:29:59,176 INFO     [psi4.optking.molsys:470] 	Consolidating multiple fragments into one for optimization.
+2022-12-06:15:29:59,177 INFO     [psi4.optking.opt_helper:151] Molsys:
 
 	                            ===> Fragment 1 <== 
 
@@ -138,174 +138,174 @@
 	 R(2,3)           =         2.995896           1.585360
 	 B(1,2,3)         =         1.570796          90.000000
 
-2022-12-06:14:18:29,839 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:29,842 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.312194649889424
-2022-12-06:14:18:30,53 INFO     [psi4.driver.driver:640] Return gradient(): -92.67516810226587
-2022-12-06:14:18:30,53 INFO     [psi4.driver.driver:641] [[ 0.08837896 -0.10826844  0.00000000]
+2022-12-06:15:29:59,191 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:29:59,193 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.312194649889424
+2022-12-06:15:29:59,386 INFO     [psi4.driver.driver:640] Return gradient(): -92.67516810226593
+2022-12-06:15:29:59,386 INFO     [psi4.driver.driver:641] [[ 0.08837896 -0.10826844  0.00000000]
  [-0.01310309  0.17000534  0.00000000]
  [-0.07527588 -0.06173690  0.00000000]]
-2022-12-06:14:18:30,68 INFO     [psi4.driver.task_planner:287] PLANNING FD:  dermode=(2, 1) keywords={'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}, 'SCF__E_CONVERGENCE': 1e-08, 'SCF__D_CONVERGENCE': 1e-08} findif_kw={'findif_irrep': -1, 'findif_stencil_size': 3, 'findif_step_size': 0.005, 'findif_verbose': 1} kw={'ref_gradient': <psi4.core.Matrix object at 0x7f56eaf93060>, 'opt_iter': True}
-2022-12-06:14:18:30,69 INFO     [psi4.driver.driver_findif:1184] hessian() using ref_gradient to assess stationary point.
-2022-12-06:14:18:30,69 INFO     [psi4.driver.driver_findif:263] 
+2022-12-06:15:29:59,401 INFO     [psi4.driver.task_planner:287] PLANNING FD:  dermode=(2, 1) keywords={'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}, 'SCF__E_CONVERGENCE': 1e-08, 'SCF__D_CONVERGENCE': 1e-08} findif_kw={'findif_irrep': -1, 'findif_stencil_size': 3, 'findif_step_size': 0.005, 'findif_verbose': 1} kw={'ref_gradient': <psi4.core.Matrix object at 0x7fab69ebbd80>, 'opt_iter': True}
+2022-12-06:15:29:59,401 INFO     [psi4.driver.driver_findif:1184] hessian() using ref_gradient to assess stationary point.
+2022-12-06:15:29:59,401 INFO     [psi4.driver.driver_findif:263] 
          ----------------------------------------------------------
                                    FINDIF
                      R. A. King and Jonathon Misiewicz
          ----------------------------------------------------------
 
 
-2022-12-06:14:18:30,69 INFO     [psi4.driver.driver_findif:272]   Using finite-differences of gradients to determine vibrational frequencies and 
+2022-12-06:15:29:59,401 INFO     [psi4.driver.driver_findif:272]   Using finite-differences of gradients to determine vibrational frequencies and 
   normal modes. Resulting frequencies are only valid at stationary points.
     Generating geometries for use with 3-point formula.
     Displacement size will be 5.00e-03.
 
-2022-12-06:14:18:30,69 INFO     [psi4.driver.driver_findif:291]     Number of atoms is 3.
+2022-12-06:15:29:59,401 INFO     [psi4.driver.driver_findif:291]     Number of atoms is 3.
     Number of irreps is 2.
     Number of SALCs is 6.
     Translations projected? 1. Rotations projected? 0.
 
-2022-12-06:14:18:30,69 INFO     [psi4.driver.driver_findif:342]     Index of SALCs per irrep:
+2022-12-06:15:29:59,401 INFO     [psi4.driver.driver_findif:342]     Index of SALCs per irrep:
       1 :  0  1  2  3 
       2 :  4  5 
     Number of SALCs per irrep:
       Irrep 1: 4
       Irrep 2: 2
 
-2022-12-06:14:18:30,69 INFO     [psi4.driver.driver_findif:367]     Number of geometries (including reference) is 11.
+2022-12-06:15:29:59,401 INFO     [psi4.driver.driver_findif:367]     Number of geometries (including reference) is 11.
     Number of displacements per irrep:
       Irrep 1: 8
       Irrep 2: 2
 
-2022-12-06:14:18:30,94 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.312194649889427
-2022-12-06:14:18:30,873 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:30,874 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.312194649889427
-2022-12-06:14:18:31,70 INFO     [psi4.driver.driver:640] Return gradient(): -92.67516810226579
-2022-12-06:14:18:31,70 INFO     [psi4.driver.driver:641] [[ 0.08837896 -0.10826844  0.00000000]
+2022-12-06:15:29:59,425 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.312194649889427
+2022-12-06:15:30:00,150 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:00,152 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.312194649889427
+2022-12-06:15:30:00,333 INFO     [psi4.driver.driver:640] Return gradient(): -92.67516810226593
+2022-12-06:15:30:00,333 INFO     [psi4.driver.driver:641] [[ 0.08837896 -0.10826844  0.00000000]
  [-0.01310309  0.17000534  0.00000000]
  [-0.07527588 -0.06173690  0.00000000]]
-2022-12-06:14:18:31,80 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.302329811695742
-2022-12-06:14:18:31,99 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:31,100 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.302329811695742
-2022-12-06:14:18:31,333 INFO     [psi4.driver.driver:640] Return gradient(): -92.67533835385649
-2022-12-06:14:18:31,334 INFO     [psi4.driver.driver:641] [[ 0.08748453 -0.10682185  0.00000000]
+2022-12-06:15:30:00,343 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.302329811695742
+2022-12-06:15:30:00,385 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:00,387 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.302329811695742
+2022-12-06:15:30:00,567 INFO     [psi4.driver.driver:640] Return gradient(): -92.67533835385646
+2022-12-06:15:30:00,567 INFO     [psi4.driver.driver:641] [[ 0.08748453 -0.10682185  0.00000000]
  [-0.01226103  0.16854669  0.00000000]
  [-0.07522349 -0.06172484  0.00000000]]
-2022-12-06:14:18:31,343 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.32205967254632
-2022-12-06:14:18:31,363 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:31,364 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.32205967254632
-2022-12-06:14:18:31,560 INFO     [psi4.driver.driver:640] Return gradient(): -92.67499611865485
-2022-12-06:14:18:31,560 INFO     [psi4.driver.driver:641] [[ 0.08927364 -0.10972001  0.00000000]
+2022-12-06:15:30:00,577 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.32205967254632
+2022-12-06:15:30:00,595 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:00,597 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.32205967254632
+2022-12-06:15:30:00,778 INFO     [psi4.driver.driver:640] Return gradient(): -92.67499611865482
+2022-12-06:15:30:00,778 INFO     [psi4.driver.driver:641] [[ 0.08927364 -0.10972001  0.00000000]
  [-0.01394531  0.17146888  0.00000000]
  [-0.07532833 -0.06174888  0.00000000]]
-2022-12-06:14:18:31,570 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.326993136524873
-2022-12-06:14:18:31,589 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:31,591 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.326993136524873
-2022-12-06:14:18:31,788 INFO     [psi4.driver.driver:640] Return gradient(): -92.67495670203441
-2022-12-06:14:18:31,790 INFO     [psi4.driver.driver:641] [[ 0.08983229 -0.11010118  0.00000000]
+2022-12-06:15:30:00,787 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.326993136524873
+2022-12-06:15:30:00,806 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:00,807 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.326993136524873
+2022-12-06:15:30:00,987 INFO     [psi4.driver.driver:640] Return gradient(): -92.67495670203436
+2022-12-06:15:30:00,988 INFO     [psi4.driver.driver:641] [[ 0.08983229 -0.11010118  0.00000000]
  [-0.01457886  0.17184122  0.00000000]
  [-0.07525342 -0.06174004  0.00000000]]
-2022-12-06:14:18:31,800 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.297411828981428
-2022-12-06:14:18:31,819 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:31,821 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.297411828981428
-2022-12-06:14:18:32,17 INFO     [psi4.driver.driver:640] Return gradient(): -92.67537596060286
-2022-12-06:14:18:32,17 INFO     [psi4.driver.driver:641] [[ 0.08693412 -0.10644254  0.00000000]
+2022-12-06:15:30:00,997 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.297411828981428
+2022-12-06:15:30:01,15 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:01,17 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.297411828981428
+2022-12-06:15:30:01,204 INFO     [psi4.driver.driver:640] Return gradient(): -92.67537596060286
+2022-12-06:15:30:01,204 INFO     [psi4.driver.driver:641] [[ 0.08693412 -0.10644254  0.00000000]
  [-0.01163596  0.16817642  0.00000000]
  [-0.07529816 -0.06173388  0.00000000]]
-2022-12-06:14:18:32,26 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.317922835158754
-2022-12-06:14:18:32,46 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:32,47 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.317922835158754
-2022-12-06:14:18:32,246 INFO     [psi4.driver.driver:640] Return gradient(): -92.67552586456594
-2022-12-06:14:18:32,246 INFO     [psi4.driver.driver:641] [[ 0.08839912 -0.10858709  0.00000000]
+2022-12-06:15:30:01,214 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.317922835158754
+2022-12-06:15:30:01,233 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:01,235 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.317922835158754
+2022-12-06:15:30:01,421 INFO     [psi4.driver.driver:640] Return gradient(): -92.6755258645661
+2022-12-06:15:30:01,421 INFO     [psi4.driver.driver:641] [[ 0.08839912 -0.10858709  0.00000000]
  [-0.01304903  0.17037196  0.00000000]
  [-0.07535009 -0.06178487  0.00000000]]
-2022-12-06:14:18:32,256 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.306471235563706
-2022-12-06:14:18:32,274 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:32,276 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.306471235563706
-2022-12-06:14:18:32,470 INFO     [psi4.driver.driver:640] Return gradient(): -92.67481071602754
-2022-12-06:14:18:32,470 INFO     [psi4.driver.driver:641] [[ 0.08835841 -0.10794970  0.00000000]
+2022-12-06:15:30:01,430 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.306471235563706
+2022-12-06:15:30:01,448 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:01,450 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.306471235563706
+2022-12-06:15:30:01,627 INFO     [psi4.driver.driver:640] Return gradient(): -92.67481071602771
+2022-12-06:15:30:01,627 INFO     [psi4.driver.driver:641] [[ 0.08835841 -0.10794970  0.00000000]
  [-0.01315691  0.16963857  0.00000000]
  [-0.07520150 -0.06168886  0.00000000]]
-2022-12-06:14:18:32,480 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.31406007703851
-2022-12-06:14:18:32,499 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:32,501 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.31406007703851
-2022-12-06:14:18:32,701 INFO     [psi4.driver.driver:640] Return gradient(): -92.67552350732728
-2022-12-06:14:18:32,701 INFO     [psi4.driver.driver:641] [[ 0.08808784 -0.10793307  0.00000000]
+2022-12-06:15:30:01,637 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.31406007703851
+2022-12-06:15:30:01,656 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:01,658 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.31406007703851
+2022-12-06:15:30:01,839 INFO     [psi4.driver.driver:640] Return gradient(): -92.67552350732723
+2022-12-06:15:30:01,839 INFO     [psi4.driver.driver:641] [[ 0.08808784 -0.10793307  0.00000000]
  [-0.01276263  0.16952327  0.00000000]
  [-0.07532521 -0.06159020  0.00000000]]
-2022-12-06:14:18:32,711 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.310334609371353
-2022-12-06:14:18:32,730 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:32,732 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.310334609371353
-2022-12-06:14:18:32,952 INFO     [psi4.driver.driver:640] Return gradient(): -92.67481182717844
-2022-12-06:14:18:32,953 INFO     [psi4.driver.driver:641] [[ 0.08867008 -0.10860368  0.00000000]
+2022-12-06:15:30:01,848 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.310334609371353
+2022-12-06:15:30:01,866 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:01,867 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.310334609371353
+2022-12-06:15:30:02,44 INFO     [psi4.driver.driver:640] Return gradient(): -92.6748118271785
+2022-12-06:15:30:02,45 INFO     [psi4.driver.driver:641] [[ 0.08867008 -0.10860368  0.00000000]
  [-0.01344457  0.17048629  0.00000000]
  [-0.07522550 -0.06188261  0.00000000]]
-2022-12-06:14:18:32,962 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.312186724791463
-2022-12-06:14:18:32,984 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:32,986 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.312186724791463
-2022-12-06:14:18:33,212 INFO     [psi4.driver.driver:640] Return gradient(): -92.67516822277896
-2022-12-06:14:18:33,213 INFO     [psi4.driver.driver:641] [[ 0.08837817 -0.10826736  0.00012448]
+2022-12-06:15:30:02,54 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.312186724791463
+2022-12-06:15:30:02,73 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:02,75 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.312186724791463
+2022-12-06:15:30:02,250 INFO     [psi4.driver.driver:640] Return gradient(): -92.67516822277894
+2022-12-06:15:30:02,251 INFO     [psi4.driver.driver:641] [[ 0.08837817 -0.10826736  0.00012448]
  [-0.01310230  0.17000425 -0.00012969]
  [-0.07527587 -0.06173690  0.00000521]]
-2022-12-06:14:18:33,223 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.312189571102063
-2022-12-06:14:18:33,244 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:33,246 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.312189571102063
-2022-12-06:14:18:33,442 INFO     [psi4.driver.driver:640] Return gradient(): -92.675167679647
-2022-12-06:14:18:33,442 INFO     [psi4.driver.driver:641] [[ 0.08837905 -0.10826837 -0.00003613]
+2022-12-06:15:30:02,262 INFO     [psi4.driver.task_base:192] <<< JSON launch ... cs 23.312189571102063
+2022-12-06:15:30:02,281 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'SCF__D_CONVERGENCE': 1e-08, 'SCF__E_CONVERGENCE': 1e-08, 'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'PARENT_SYMMETRY': 'CS(Z)', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:02,283 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=CHN, nre=23.312189571102063
+2022-12-06:15:30:02,464 INFO     [psi4.driver.driver:640] Return gradient(): -92.67516767964709
+2022-12-06:15:30:02,465 INFO     [psi4.driver.driver:641] [[ 0.08837905 -0.10826837 -0.00003613]
  [-0.01310337  0.17000522 -0.00013020]
  [-0.07527568 -0.06173686  0.00016634]]
-2022-12-06:14:18:33,454 INFO     [psi4.driver.driver_findif:272] 
-2022-12-06:14:18:33,454 INFO     [psi4.driver.driver_findif:272]   Computing second-derivative from gradients using projected, 
+2022-12-06:15:30:02,475 INFO     [psi4.driver.driver_findif:272] 
+2022-12-06:15:30:02,476 INFO     [psi4.driver.driver_findif:272]   Computing second-derivative from gradients using projected, 
   symmetry-adapted, cartesian coordinates.
 
   11 gradients passed in, including the reference geometry.
 
-2022-12-06:14:18:33,481 INFO     [psi4.optking.molsys:771] Converting Hessian from cartesians to internals.
-2022-12-06:14:18:33,481 INFO     [psi4.optking.molsys:787] Neglecting force/B-matrix derivative term, only correct at stationary points.
-2022-12-06:14:18:33,481 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+2022-12-06:15:30:02,501 INFO     [psi4.optking.molsys:771] Converting Hessian from cartesians to internals.
+2022-12-06:15:30:02,501 INFO     [psi4.optking.molsys:787] Neglecting force/B-matrix derivative term, only correct at stationary points.
+2022-12-06:15:30:02,501 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
 	   1.487892  -0.006796  -0.038479
 	  -0.006796  -0.007985   0.077337
 	  -0.038479   0.077337  -0.183688
 
-2022-12-06:14:18:33,482 INFO     [psi4.optking.opt_helper:168] 
+2022-12-06:15:30:02,502 INFO     [psi4.optking.opt_helper:168] 
 	         Geometry (au)                                       Gradient (au)
   -0.6169570705   1.0422703481   0.0000000000		   0.0883789637  -0.1082684399   0.0000000000
    0.6561039640  -0.7152141444   0.0000000000		  -0.0131030853   0.1700053413   0.0000000000
   -1.7701361439  -2.4726986369   0.0000000000		  -0.0752758784  -0.0617369014   0.0000000000
 
-2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+2022-12-06:15:30:02,502 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
 
 		  0.020543  0.095231 -0.140452
 
-2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+2022-12-06:15:30:02,502 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
 	  -0.213543  -0.020543
 	  -0.020543   0.000000
 
-2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+2022-12-06:15:30:02,502 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
 	   0.020936   0.000000  -0.095231
 	   0.000000   1.488826   0.140452
 	  -0.095231   0.140452   0.000000
 
-2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+2022-12-06:15:30:02,502 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
 
 	%s	 -0.092454  0.100203  1.502013
 
-2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+2022-12-06:15:30:02,502 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
 
 	%s	 -0.215501  0.001958
 
-2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+2022-12-06:15:30:02,502 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
 
 		 -0.095326  0.839848 -0.088822
 
-2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+2022-12-06:15:30:02,502 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
 
 		  0.075531 -0.753246 -0.386310
 
-2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:196] 	Step length exceeds trust radius of    0.50000.
-2022-12-06:14:18:33,482 INFO     [psi4.optking.stepAlgorithms:197] 	Scaling displacements by    0.58831
-2022-12-06:14:18:33,483 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
-2022-12-06:14:18:33,485 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
-2022-12-06:14:18:33,485 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.606e-09 	Max(dx):  4.856e-09 	RMS(dq):  2.867e-16
-2022-12-06:14:18:33,486 INFO     [psi4.optking.displace:132] 
+2022-12-06:15:30:02,502 INFO     [psi4.optking.stepAlgorithms:195] 	Step length exceeds trust radius of    0.50000.
+2022-12-06:15:30:02,502 INFO     [psi4.optking.stepAlgorithms:196] 	Scaling displacements by    0.58831
+2022-12-06:15:30:02,503 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:02,505 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:02,505 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.606e-09 	Max(dx):  4.856e-09 	RMS(dq):  2.564e-16
+2022-12-06:15:30:02,505 INFO     [psi4.optking.displace:132] 
 
 	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
 	-------------------------------------------------------------------------------
@@ -316,27 +316,27 @@
 	             B(1,2,3)      90.00000       -0.00133      -13.02157      76.97843
 	-------------------------------------------------------------------------------
 
-2022-12-06:14:18:33,486 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.5000000000
-2022-12-06:14:18:33,486 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :   -0.1064792631
-2022-12-06:14:18:33,486 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :    0.0340186310
-2022-12-06:14:18:33,486 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.5000000000
-2022-12-06:14:18:33,486 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.5546623344
-2022-12-06:14:18:33,486 INFO     [psi4.optking.opt_helper:151] Molsys:
+2022-12-06:15:30:02,505 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.5000000000
+2022-12-06:15:30:02,505 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :   -0.1064792631
+2022-12-06:15:30:02,505 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :    0.0340186310
+2022-12-06:15:30:02,506 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.5000000000
+2022-12-06:15:30:02,506 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.5546623344
+2022-12-06:15:30:02,506 INFO     [psi4.optking.opt_helper:151] Molsys:
 
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.8044352287612170  0.7967015651354833  0.0000000000000000
-	       7.000000            14.003074        0.6598123770001038 -0.8646990434456613  0.0000000000000000
-	       1.000000             1.007825       -1.5863663986626961 -2.0776449549701117  0.0000000000000000
+	       6.000000            12.000000       -0.8044352287483525  0.7967015651574336  0.0000000000000000
+	       7.000000            14.003074        0.6598123769823561 -0.8646990434502408  0.0000000000000000
+	       1.000000             1.007825       -1.5863663986578127 -2.0776449549874823  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.214559           1.171894
 	 R(2,3)           =         2.552755           1.350860
 	 B(1,2,3)         =         1.343527          76.978432
 
-2022-12-06:14:18:33,487 INFO     [psi4.optking.convcheck:71] Performing convergence check.
-2022-12-06:14:18:33,487 INFO     [psi4.optking.convcheck:263] 
+2022-12-06:15:30:02,506 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:02,507 INFO     [psi4.optking.convcheck:263] 
 	                                 ==> Convergence Check <==                                  
     
 	Measures of convergence in internal coordinates in au.
@@ -352,76 +352,76 @@
 	----------------------------------------------------------------------------------------------
 
 
-2022-12-06:14:18:33,487 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
-2022-12-06:14:18:33,503 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:33,505 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.721764077245705
-2022-12-06:14:18:33,632 INFO     [psi4.driver.driver:640] Return gradient(): -92.72107309333414
-2022-12-06:14:18:33,632 INFO     [psi4.driver.driver:641] [[ 0.04552444 -0.05010744  0.00000000]
+2022-12-06:15:30:02,507 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:02,522 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:02,524 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.721764077236383
+2022-12-06:15:30:02,646 INFO     [psi4.driver.driver:640] Return gradient(): -92.721073093335
+2022-12-06:15:30:02,646 INFO     [psi4.driver.driver:641] [[ 0.04552444 -0.05010744  0.00000000]
  [ 0.01543105  0.08403187  0.00000000]
  [-0.06095549 -0.03392443  0.00000000]]
-2022-12-06:14:18:33,634 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
-2022-12-06:14:18:33,635 INFO     [psi4.optking.history:268] 	Using 1 previous steps for update.
-2022-12-06:14:18:33,635 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  1
+2022-12-06:15:30:02,648 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:02,649 INFO     [psi4.optking.history:268] 	Using 1 previous steps for update.
+2022-12-06:15:30:02,649 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  1
 
-2022-12-06:14:18:33,635 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+2022-12-06:15:30:02,649 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
  	   1.489354   0.002237  -0.029244
 	   0.002237   0.007739   0.106021
 	  -0.029244   0.106021  -0.145439
 
-2022-12-06:14:18:33,636 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+2022-12-06:15:30:02,650 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
 	   1.489354   0.002237  -0.029244
 	   0.002237   0.007739   0.106021
 	  -0.029244   0.106021  -0.145439
 
-2022-12-06:14:18:33,636 INFO     [psi4.optking.opt_helper:168] 
+2022-12-06:15:30:02,650 INFO     [psi4.optking.opt_helper:168] 
 	         Geometry (au)                                       Gradient (au)
-  -0.8044352288   0.7967015651   0.0000000000		   0.0455244362  -0.0501074424   0.0000000000
-   0.6598123770  -0.8646990434   0.0000000000		   0.0154310532   0.0840318705   0.0000000000
+  -0.8044352287   0.7967015652   0.0000000000		   0.0455244362  -0.0501074424   0.0000000000
+   0.6598123770  -0.8646990435   0.0000000000		   0.0154310532   0.0840318705   0.0000000000
   -1.5863663987  -2.0776449550   0.0000000000		  -0.0609554895  -0.0339244281   0.0000000000
 
-2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+2022-12-06:15:30:02,650 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
  
 	Current energy:       -92.7210730933
 	Energy change for the previous step:
 		Actual       :        -0.0459049911
 		Projected    :        -0.0391898421
 
-2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    1.17135
-2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+2022-12-06:15:30:02,650 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    1.17135
+2022-12-06:15:30:02,650 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
 
 		  0.030773 -0.062626 -0.067705
 
-2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+2022-12-06:15:30:02,650 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
 	  -0.200074  -0.030773
 	  -0.030773   0.000000
 
-2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+2022-12-06:15:30:02,650 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
 	   0.061851   0.000000   0.062626
 	   0.000000   1.489877   0.067705
 	   0.062626   0.067705   0.000000
 
-2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+2022-12-06:15:30:02,650 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
 
 	%s	 -0.041093  0.099867  1.492953
 
-2022-12-06:14:18:33,636 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+2022-12-06:15:30:02,650 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
 
 	%s	 -0.204701  0.004626
 
-2022-12-06:14:18:33,637 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+2022-12-06:15:30:02,650 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
 
 		 -0.150330 -0.608352 -0.044224
 
-2022-12-06:14:18:33,637 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+2022-12-06:15:30:02,650 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
 
 		  0.036994 -0.473540 -0.411142
 
-2022-12-06:14:18:33,637 INFO     [psi4.optking.stepAlgorithms:196] 	Step length exceeds trust radius of    0.50000.
-2022-12-06:14:18:33,637 INFO     [psi4.optking.stepAlgorithms:197] 	Scaling displacements by    0.79591
-2022-12-06:14:18:33,637 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
-2022-12-06:14:18:33,639 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
-2022-12-06:14:18:33,639 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.594e-08 	Max(dx):  3.341e-08 	RMS(dq):  3.846e-16
-2022-12-06:14:18:33,639 INFO     [psi4.optking.displace:132] 
+2022-12-06:15:30:02,650 INFO     [psi4.optking.stepAlgorithms:195] 	Step length exceeds trust radius of    0.50000.
+2022-12-06:15:30:02,651 INFO     [psi4.optking.stepAlgorithms:196] 	Scaling displacements by    0.79591
+2022-12-06:15:30:02,651 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:02,653 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:02,653 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.594e-08 	Max(dx):  3.341e-08 	RMS(dq):  9.333e-16
+2022-12-06:15:30:02,653 INFO     [psi4.optking.displace:132] 
 
 	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
 	-------------------------------------------------------------------------------
@@ -432,27 +432,27 @@
 	             B(1,2,3)      76.97843       -0.00017      -18.74912      58.22931
 	-------------------------------------------------------------------------------
 
-2022-12-06:14:18:33,640 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.5000000000
-2022-12-06:14:18:33,640 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :   -0.0580486337
-2022-12-06:14:18:33,640 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :    0.0539287131
-2022-12-06:14:18:33,640 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.5000000000
-2022-12-06:14:18:33,640 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.6246787612
-2022-12-06:14:18:33,640 INFO     [psi4.optking.opt_helper:151] Molsys:
+2022-12-06:15:30:02,654 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.5000000000
+2022-12-06:15:30:02,654 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :   -0.0580486337
+2022-12-06:15:30:02,654 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :    0.0539287131
+2022-12-06:15:30:02,654 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.5000000000
+2022-12-06:15:30:02,654 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.6246787612
+2022-12-06:15:30:02,654 INFO     [psi4.optking.opt_helper:151] Molsys:
 
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -1.0067810985259733  0.4834377374016347  0.0000000000000000
-	       7.000000            14.003074        0.6787460223343709 -0.9979635231793742  0.0000000000000000
-	       1.000000             1.007825       -1.4029541742322071 -1.6311166475025503  0.0000000000000000
+	       6.000000            12.000000       -1.0067810985103425  0.4834377374340838  0.0000000000000000
+	       7.000000            14.003074        0.6787460223142163 -0.9979635231888864  0.0000000000000000
+	       1.000000             1.007825       -1.4029541742276828 -1.6311166475254870  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.244003           1.187475
 	 R(2,3)           =         2.175858           1.151415
 	 B(1,2,3)         =         1.016293          58.229315
 
-2022-12-06:14:18:33,641 INFO     [psi4.optking.convcheck:71] Performing convergence check.
-2022-12-06:14:18:33,641 INFO     [psi4.optking.convcheck:263] 
+2022-12-06:15:30:02,655 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:02,655 INFO     [psi4.optking.convcheck:263] 
 	                                 ==> Convergence Check <==                                  
     
 	Measures of convergence in internal coordinates in au.
@@ -468,76 +468,76 @@
 	----------------------------------------------------------------------------------------------
 
 
-2022-12-06:14:18:33,641 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
-2022-12-06:14:18:33,657 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:33,659 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=24.72262102796013
-2022-12-06:14:18:33,786 INFO     [psi4.driver.driver:640] Return gradient(): -92.71756640502304
-2022-12-06:14:18:33,786 INFO     [psi4.driver.driver:641] [[-0.01854126 -0.06848336  0.00000000]
+2022-12-06:15:30:02,655 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:02,671 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:02,672 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=24.72262102790919
+2022-12-06:15:30:02,796 INFO     [psi4.driver.driver:640] Return gradient(): -92.7175664050268
+2022-12-06:15:30:02,796 INFO     [psi4.driver.driver:641] [[-0.01854126 -0.06848336  0.00000000]
  [-0.01197632 -0.00944328  0.00000000]
  [ 0.03051758  0.07792664  0.00000000]]
-2022-12-06:14:18:33,788 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
-2022-12-06:14:18:33,788 INFO     [psi4.optking.history:268] 	Using 2 previous steps for update.
-2022-12-06:14:18:33,789 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 8.20e-01 exceeds limit of 5.00e-01.
-2022-12-06:14:18:33,789 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 1.
-2022-12-06:14:18:33,789 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  2
+2022-12-06:15:30:02,798 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:02,798 INFO     [psi4.optking.history:268] 	Using 2 previous steps for update.
+2022-12-06:15:30:02,799 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 8.20e-01 exceeds limit of 5.00e-01.
+2022-12-06:15:30:02,799 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 1.
+2022-12-06:15:30:02,799 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  2
 
-2022-12-06:14:18:33,789 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+2022-12-06:15:30:02,799 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
  	   1.491454   0.020706  -0.000912
 	   0.020706   0.092630   0.266857
 	  -0.000912   0.266857   0.136165
 
-2022-12-06:14:18:33,790 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+2022-12-06:15:30:02,800 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
 	   1.491454   0.020706  -0.000912
 	   0.020706   0.092630   0.266857
 	  -0.000912   0.266857   0.136165
 
-2022-12-06:14:18:33,790 INFO     [psi4.optking.opt_helper:168] 
+2022-12-06:15:30:02,800 INFO     [psi4.optking.opt_helper:168] 
 	         Geometry (au)                                       Gradient (au)
   -1.0067810985   0.4834377374   0.0000000000		  -0.0185412551  -0.0684833630   0.0000000000
    0.6787460223  -0.9979635232   0.0000000000		  -0.0119763201  -0.0094432784   0.0000000000
   -1.4029541742  -1.6311166475   0.0000000000		   0.0305175752   0.0779266414   0.0000000000
 
-2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+2022-12-06:15:30:02,800 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
  
 	Current energy:       -92.7175664050
 	Energy change for the previous step:
 		Actual       :         0.0035066883
 		Projected    :        -0.0178265822
 
-2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =   -0.19671
-2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+2022-12-06:15:30:02,800 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =   -0.19671
+2022-12-06:15:30:02,800 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
 
 		 -0.058973  0.139862 -0.032403
 
-2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+2022-12-06:15:30:02,800 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
 	  -0.153498   0.058973
 	   0.058973   0.000000
 
-2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+2022-12-06:15:30:02,800 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
 	   0.381980   0.000000  -0.139862
 	   0.000000   1.491767   0.032403
 	  -0.139862   0.032403   0.000000
 
-2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+2022-12-06:15:30:02,800 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
 
 	%s	 -0.046351  0.427620  1.492479
 
-2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+2022-12-06:15:30:02,800 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
 
 	%s	 -0.173539  0.020040
 
-2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+2022-12-06:15:30:02,801 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
 
 		  0.339825  0.326528 -0.021066
 
-2022-12-06:14:18:33,790 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+2022-12-06:15:30:02,801 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
 
 		  0.013859  0.471438  0.009955
 
-2022-12-06:14:18:33,791 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
-2022-12-06:14:18:33,793 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
-2022-12-06:14:18:33,793 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.850e-10 	Max(dx):  3.495e-10 	RMS(dq):  1.282e-16
-2022-12-06:14:18:33,793 INFO     [psi4.optking.displace:132] 
+2022-12-06:15:30:02,801 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:02,803 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:02,803 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.850e-10 	Max(dx):  3.495e-10 	RMS(dq):  0.000e+00
+2022-12-06:15:30:02,803 INFO     [psi4.optking.displace:132] 
 
 	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
 	-------------------------------------------------------------------------------
@@ -548,27 +548,27 @@
 	             B(1,2,3)      58.22931        0.01087        0.57041      58.79972
 	-------------------------------------------------------------------------------
 
-2022-12-06:14:18:33,794 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.4717471518
-2022-12-06:14:18:33,794 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :   -0.0557735830
-2022-12-06:14:18:33,794 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :    0.1063277335
-2022-12-06:14:18:33,794 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.4717471518
-2022-12-06:14:18:33,794 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.3655043012
-2022-12-06:14:18:33,794 INFO     [psi4.optking.opt_helper:151] Molsys:
+2022-12-06:15:30:02,804 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.4717471517
+2022-12-06:15:30:02,804 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :   -0.0557735830
+2022-12-06:15:30:02,804 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :    0.1063277335
+2022-12-06:15:30:02,804 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.4717471517
+2022-12-06:15:30:02,804 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.3655043011
+2022-12-06:15:30:02,804 INFO     [psi4.optking.opt_helper:151] Molsys:
 
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9268338816187616  0.5281196581923154  0.0000000000000000
-	       7.000000            14.003074        0.8395634847513129 -0.8782178223540624  0.0000000000000000
-	       1.000000             1.007825       -1.6437188535563609 -1.7955442691185426  0.0000000000000000
+	       6.000000            12.000000       -0.9268338816157256  0.5281196582183108  0.0000000000000000
+	       7.000000            14.003074        0.8395634847185516 -0.8782178223740758  0.0000000000000000
+	       1.000000             1.007825       -1.6437188535266349 -1.7955442691245245  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.257863           1.194810
 	 R(2,3)           =         2.647297           1.400889
 	 B(1,2,3)         =         1.026249          58.799721
 
-2022-12-06:14:18:33,795 INFO     [psi4.optking.convcheck:71] Performing convergence check.
-2022-12-06:14:18:33,795 INFO     [psi4.optking.convcheck:263] 
+2022-12-06:15:30:02,805 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:02,805 INFO     [psi4.optking.convcheck:263] 
 	                                 ==> Convergence Check <==                                  
     
 	Measures of convergence in internal coordinates in au.
@@ -584,76 +584,76 @@
 	----------------------------------------------------------------------------------------------
 
 
-2022-12-06:14:18:33,795 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
-2022-12-06:14:18:33,810 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:33,812 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.71324156381199
-2022-12-06:14:18:33,938 INFO     [psi4.driver.driver:640] Return gradient(): -92.72283626825208
-2022-12-06:14:18:33,939 INFO     [psi4.driver.driver:641] [[-0.00141297  0.01251726  0.00000000]
+2022-12-06:15:30:02,805 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:02,820 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:02,821 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.713241563847
+2022-12-06:15:30:02,941 INFO     [psi4.driver.driver:640] Return gradient(): -92.72283626825303
+2022-12-06:15:30:02,941 INFO     [psi4.driver.driver:641] [[-0.00141297  0.01251726  0.00000000]
  [ 0.01942042  0.00223823  0.00000000]
  [-0.01800745 -0.01475549  0.00000000]]
-2022-12-06:14:18:33,941 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
-2022-12-06:14:18:33,941 INFO     [psi4.optking.history:268] 	Using 3 previous steps for update.
-2022-12-06:14:18:33,942 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 5.45e-01 exceeds limit of 5.00e-01.
-2022-12-06:14:18:33,942 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 1.
-2022-12-06:14:18:33,942 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  3 2
+2022-12-06:15:30:02,944 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:02,944 INFO     [psi4.optking.history:268] 	Using 3 previous steps for update.
+2022-12-06:15:30:02,944 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 5.45e-01 exceeds limit of 5.00e-01.
+2022-12-06:15:30:02,944 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 1.
+2022-12-06:15:30:02,944 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  3 2
 
-2022-12-06:14:18:33,942 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+2022-12-06:15:30:02,945 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
  	   1.500871   0.056391  -0.019760
 	   0.056391   0.178791   0.211469
 	  -0.019760   0.211469   0.004029
 
-2022-12-06:14:18:33,943 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+2022-12-06:15:30:02,945 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
 	   1.500871   0.056391  -0.019760
 	   0.056391   0.178791   0.211469
 	  -0.019760   0.211469   0.004029
 
-2022-12-06:14:18:33,943 INFO     [psi4.optking.opt_helper:168] 
+2022-12-06:15:30:02,945 INFO     [psi4.optking.opt_helper:168] 
 	         Geometry (au)                                       Gradient (au)
   -0.9268338816   0.5281196582   0.0000000000		  -0.0014129750   0.0125172559   0.0000000000
-   0.8395634848  -0.8782178224   0.0000000000		   0.0194204236   0.0022382299   0.0000000000
-  -1.6437188536  -1.7955442691   0.0000000000		  -0.0180074486  -0.0147554858   0.0000000000
+   0.8395634847  -0.8782178224   0.0000000000		   0.0194204236   0.0022382299   0.0000000000
+  -1.6437188535  -1.7955442691   0.0000000000		  -0.0180074486  -0.0147554858   0.0000000000
 
-2022-12-06:14:18:33,943 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+2022-12-06:15:30:02,946 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
  
 	Current energy:       -92.7228362683
 	Energy change for the previous step:
 		Actual       :        -0.0052698632
 		Projected    :        -0.0118438600
 
-2022-12-06:14:18:33,943 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    0.44494
-2022-12-06:14:18:33,943 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+2022-12-06:15:30:02,946 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    0.44494
+2022-12-06:15:30:02,946 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
 
 		 -0.004685 -0.029210  0.009657
 
-2022-12-06:14:18:33,943 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+2022-12-06:15:30:02,946 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
 	  -0.138796   0.004685
 	   0.004685   0.000000
 
-2022-12-06:14:18:33,943 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+2022-12-06:15:30:02,946 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
 	   0.319136   0.000000   0.029210
 	   0.000000   1.503350  -0.009657
 	   0.029210  -0.009657   0.000000
 
-2022-12-06:14:18:33,944 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+2022-12-06:15:30:02,946 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
 
 	%s	 -0.002713  0.321787  1.503412
 
-2022-12-06:14:18:33,944 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+2022-12-06:15:30:02,946 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
 
 	%s	 -0.138954  0.000158
 
-2022-12-06:14:18:33,944 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+2022-12-06:15:30:02,946 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
 
 		  0.033714 -0.090756  0.006412
 
-2022-12-06:14:18:33,944 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+2022-12-06:15:30:02,946 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
 
 		 -0.002679 -0.094308 -0.022653
 
-2022-12-06:14:18:33,944 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
-2022-12-06:14:18:33,946 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
-2022-12-06:14:18:33,946 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.711e-15 	Max(dx):  5.339e-15 	RMS(dq):  3.626e-16
-2022-12-06:14:18:33,947 INFO     [psi4.optking.displace:132] 
+2022-12-06:15:30:02,946 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:02,948 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:02,948 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.556e-15 	Max(dx):  4.966e-15 	RMS(dq):  1.282e-16
+2022-12-06:15:30:02,949 INFO     [psi4.optking.displace:132] 
 
 	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
 	-------------------------------------------------------------------------------
@@ -664,27 +664,27 @@
 	             B(1,2,3)      58.79972       -0.00153       -1.29791      57.50182
 	-------------------------------------------------------------------------------
 
-2022-12-06:14:18:33,947 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.0970274732
-2022-12-06:14:18:33,947 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :   -0.0263319928
-2022-12-06:14:18:33,947 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :    0.2690207130
-2022-12-06:14:18:33,947 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.0970274732
-2022-12-06:14:18:33,947 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.0904171685
-2022-12-06:14:18:33,947 INFO     [psi4.optking.opt_helper:151] Molsys:
+2022-12-06:15:30:02,949 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.0970274732
+2022-12-06:15:30:02,949 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :   -0.0263319928
+2022-12-06:15:30:02,949 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :    0.2690207131
+2022-12-06:15:30:02,949 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.0970274732
+2022-12-06:15:30:02,949 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.0904171686
+2022-12-06:15:30:02,950 INFO     [psi4.optking.opt_helper:151] Molsys:
 
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9527005117516689  0.4966474325368037  0.0000000000000000
-	       7.000000            14.003074        0.8165135954770494 -0.9018282917313836  0.0000000000000000
-	       1.000000             1.007825       -1.5948023341491901 -1.7404615740857095  0.0000000000000000
+	       6.000000            12.000000       -0.9527005117692455  0.4966474324997321  0.0000000000000000
+	       7.000000            14.003074        0.8165135954819379 -0.9018282917396838  0.0000000000000000
+	       1.000000             1.007825       -1.5948023341365012 -1.7404615740403377  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.255184           1.193392
 	 R(2,3)           =         2.552989           1.350983
 	 B(1,2,3)         =         1.003596          57.501816
 
-2022-12-06:14:18:33,948 INFO     [psi4.optking.convcheck:71] Performing convergence check.
-2022-12-06:14:18:33,948 INFO     [psi4.optking.convcheck:263] 
+2022-12-06:15:30:02,950 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:02,950 INFO     [psi4.optking.convcheck:263] 
 	                                 ==> Convergence Check <==                                  
     
 	Measures of convergence in internal coordinates in au.
@@ -700,76 +700,76 @@
 	----------------------------------------------------------------------------------------------
 
 
-2022-12-06:14:18:33,948 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
-2022-12-06:14:18:33,963 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:33,965 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.943591559989084
-2022-12-06:14:18:34,89 INFO     [psi4.driver.driver:640] Return gradient(): -92.72424403137798
-2022-12-06:14:18:34,89 INFO     [psi4.driver.driver:641] [[-0.00800510 -0.00185367  0.00000000]
+2022-12-06:15:30:02,950 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:02,965 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:02,966 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.943591560114747
+2022-12-06:15:30:03,83 INFO     [psi4.driver.driver:640] Return gradient(): -92.72424403137775
+2022-12-06:15:30:03,83 INFO     [psi4.driver.driver:641] [[-0.00800510 -0.00185367  0.00000000]
  [ 0.01471132 -0.00181669  0.00000000]
  [-0.00670622  0.00367037  0.00000000]]
-2022-12-06:14:18:34,91 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
-2022-12-06:14:18:34,91 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
-2022-12-06:14:18:34,92 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 5.67e-01 exceeds limit of 5.00e-01.
-2022-12-06:14:18:34,92 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 1.
-2022-12-06:14:18:34,92 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  4 3 2
+2022-12-06:15:30:03,86 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:03,86 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:03,87 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 5.67e-01 exceeds limit of 5.00e-01.
+2022-12-06:15:30:03,87 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 1.
+2022-12-06:15:30:03,87 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  4 3 2
 
-2022-12-06:14:18:34,93 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+2022-12-06:15:30:03,87 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
  	   1.521467   0.067226  -0.032354
 	   0.067226   0.145579   0.198249
 	  -0.032354   0.198249   0.045512
 
-2022-12-06:14:18:34,94 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+2022-12-06:15:30:03,88 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
 	   1.521467   0.067226  -0.032354
 	   0.067226   0.145579   0.198249
 	  -0.032354   0.198249   0.045512
 
-2022-12-06:14:18:34,94 INFO     [psi4.optking.opt_helper:168] 
+2022-12-06:15:30:03,88 INFO     [psi4.optking.opt_helper:168] 
 	         Geometry (au)                                       Gradient (au)
   -0.9527005118   0.4966474325   0.0000000000		  -0.0080050967  -0.0018536725   0.0000000000
    0.8165135955  -0.9018282917   0.0000000000		   0.0147113205  -0.0018166933   0.0000000000
-  -1.5948023341  -1.7404615741   0.0000000000		  -0.0067062238   0.0036703658   0.0000000000
+  -1.5948023341  -1.7404615740   0.0000000000		  -0.0067062238   0.0036703658   0.0000000000
 
-2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+2022-12-06:15:30:03,88 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
  
 	Current energy:       -92.7242440314
 	Energy change for the previous step:
 		Actual       :        -0.0014077631
 		Projected    :        -0.0012765836
 
-2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    1.10276
-2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+2022-12-06:15:30:03,88 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    1.10276
+2022-12-06:15:30:03,88 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
 
 		  0.014332  0.005049  0.005589
 
-2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+2022-12-06:15:30:03,88 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
 	  -0.111659  -0.014332
 	  -0.014332   0.000000
 
-2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+2022-12-06:15:30:03,88 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
 	   0.299119   0.000000  -0.005049
 	   0.000000   1.525098  -0.005589
 	  -0.005049  -0.005589   0.000000
 
-2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+2022-12-06:15:30:03,89 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
 
 	%s	 -0.000106  0.299205  1.525118
 
-2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+2022-12-06:15:30:03,89 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
 
 	%s	 -0.113469  0.001810
 
-2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+2022-12-06:15:30:03,89 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
 
 		 -0.126307  0.016875  0.003664
 
-2022-12-06:14:18:34,94 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+2022-12-06:15:30:03,89 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
 
 		 -0.009286  0.090974 -0.088820
 
-2022-12-06:14:18:34,95 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
-2022-12-06:14:18:34,97 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
-2022-12-06:14:18:34,97 INFO     [psi4.optking.displace:379] 	RMS(dx):  4.512e-13 	Max(dx):  9.741e-13 	RMS(dq):  2.643e-16
-2022-12-06:14:18:34,98 INFO     [psi4.optking.displace:132] 
+2022-12-06:15:30:03,89 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:03,91 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:03,91 INFO     [psi4.optking.displace:379] 	RMS(dx):  4.513e-13 	Max(dx):  9.745e-13 	RMS(dq):  2.867e-16
+2022-12-06:15:30:03,92 INFO     [psi4.optking.displace:132] 
 
 	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
 	-------------------------------------------------------------------------------
@@ -780,27 +780,27 @@
 	             B(1,2,3)      57.50182        0.00110       -5.08902      52.41280
 	-------------------------------------------------------------------------------
 
-2022-12-06:14:18:34,98 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.1274818086
-2022-12-06:14:18:34,98 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :    0.0133707932
-2022-12-06:14:18:34,98 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :   -0.1031088644
-2022-12-06:14:18:34,98 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.1274818086
-2022-12-06:14:18:34,98 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.1386617565
-2022-12-06:14:18:34,99 INFO     [psi4.optking.opt_helper:151] Molsys:
+2022-12-06:15:30:03,92 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.1274818084
+2022-12-06:15:30:03,92 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :    0.0133707932
+2022-12-06:15:30:03,92 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :   -0.1031088644
+2022-12-06:15:30:03,92 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.1274818084
+2022-12-06:15:30:03,92 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.1386617561
+2022-12-06:15:30:03,93 INFO     [psi4.optking.opt_helper:151] Molsys:
 
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9696013652817181  0.4048738820734400  0.0000000000000000
-	       7.000000            14.003074        0.8781933411965031 -0.8717264268825471  0.0000000000000000
-	       1.000000             1.007825       -1.6395812263385943 -1.6787898884711820  0.0000000000000000
+	       6.000000            12.000000       -0.9696013651679604  0.4048738823610264  0.0000000000000000
+	       7.000000            14.003074        0.8781933411135368 -0.8717264268869306  0.0000000000000000
+	       1.000000             1.007825       -1.6395812263693850 -1.6787898887543851  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.245897           1.188478
 	 R(2,3)           =         2.643963           1.399125
-	 B(1,2,3)         =         0.914776          52.412796
+	 B(1,2,3)         =         0.914776          52.412797
 
-2022-12-06:14:18:34,99 INFO     [psi4.optking.convcheck:71] Performing convergence check.
-2022-12-06:14:18:34,99 INFO     [psi4.optking.convcheck:263] 
+2022-12-06:15:30:03,93 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:03,93 INFO     [psi4.optking.convcheck:263] 
 	                                 ==> Convergence Check <==                                  
     
 	Measures of convergence in internal coordinates in au.
@@ -816,74 +816,74 @@
 	----------------------------------------------------------------------------------------------
 
 
-2022-12-06:14:18:34,99 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
-2022-12-06:14:18:34,115 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:34,117 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=24.08962784561235
-2022-12-06:14:18:34,245 INFO     [psi4.driver.driver:640] Return gradient(): -92.72311094415689
-2022-12-06:14:18:34,245 INFO     [psi4.driver.driver:641] [[-0.01240689 -0.00637875  0.00000000]
- [-0.00190229 -0.00918011  0.00000000]
+2022-12-06:15:30:03,93 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:03,108 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:03,110 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=24.08962784480668
+2022-12-06:15:30:03,235 INFO     [psi4.driver.driver:640] Return gradient(): -92.7231109441648
+2022-12-06:15:30:03,235 INFO     [psi4.driver.driver:641] [[-0.01240689 -0.00637875  0.00000000]
+ [-0.00190229 -0.00918010  0.00000000]
  [ 0.01430918  0.01555886  0.00000000]]
-2022-12-06:14:18:34,248 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
-2022-12-06:14:18:34,249 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
-2022-12-06:14:18:34,249 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  5 4 3 2
+2022-12-06:15:30:03,237 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:03,237 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:03,238 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  5 4 3 2
 
-2022-12-06:14:18:34,250 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+2022-12-06:15:30:03,239 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
  	   1.507020   0.064736  -0.049312
 	   0.064736   0.134566   0.238908
 	  -0.049312   0.238908   0.116932
 
-2022-12-06:14:18:34,251 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+2022-12-06:15:30:03,240 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
 	   1.507020   0.064736  -0.049312
 	   0.064736   0.134566   0.238908
 	  -0.049312   0.238908   0.116932
 
-2022-12-06:14:18:34,251 INFO     [psi4.optking.opt_helper:168] 
+2022-12-06:15:30:03,240 INFO     [psi4.optking.opt_helper:168] 
 	         Geometry (au)                                       Gradient (au)
-  -0.9696013653   0.4048738821   0.0000000000		  -0.0124068938  -0.0063787517   0.0000000000
-   0.8781933412  -0.8717264269   0.0000000000		  -0.0019022895  -0.0091801050   0.0000000000
-  -1.6395812263  -1.6787898885   0.0000000000		   0.0143091833   0.0155588567   0.0000000000
+  -0.9696013652   0.4048738824   0.0000000000		  -0.0124068937  -0.0063787516   0.0000000000
+   0.8781933411  -0.8717264269   0.0000000000		  -0.0019022895  -0.0091801050   0.0000000000
+  -1.6395812264  -1.6787898888   0.0000000000		   0.0143091832   0.0155588566   0.0000000000
 
-2022-12-06:14:18:34,251 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+2022-12-06:15:30:03,240 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
  
 	Current energy:       -92.7231109442
 	Energy change for the previous step:
 		Actual       :         0.0011330872
 		Projected    :         0.0008528304
 
-2022-12-06:14:18:34,251 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    1.32862
-2022-12-06:14:18:34,251 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+2022-12-06:15:30:03,240 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    1.32862
+2022-12-06:15:30:03,240 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
 
 		  0.006764  0.032483  0.006577
 
-2022-12-06:14:18:34,251 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+2022-12-06:15:30:03,240 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
 	  -0.117304  -0.006764
 	  -0.006764   0.000000
 
-2022-12-06:14:18:34,251 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+2022-12-06:15:30:03,241 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
 	   0.364687   0.000000  -0.032483
 	   0.000000   1.511137  -0.006577
 	  -0.032483  -0.006577   0.000000
 
-2022-12-06:14:18:34,252 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+2022-12-06:15:30:03,241 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
 
 	%s	 -0.002899  0.367557  1.511165
 
-2022-12-06:14:18:34,252 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+2022-12-06:15:30:03,241 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
 
 	%s	 -0.117693  0.000389
 
-2022-12-06:14:18:34,252 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+2022-12-06:15:30:03,241 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
 
 		 -0.057470  0.088368  0.004344
 
-2022-12-06:14:18:34,252 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+2022-12-06:15:30:03,241 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
 
 		 -0.008128  0.103215  0.020277
 
-2022-12-06:14:18:34,252 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
-2022-12-06:14:18:34,254 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
-2022-12-06:14:18:34,254 INFO     [psi4.optking.displace:379] 	RMS(dx):  3.617e-15 	Max(dx):  6.785e-15 	RMS(dq):  5.286e-16
-2022-12-06:14:18:34,255 INFO     [psi4.optking.displace:132] 
+2022-12-06:15:30:03,241 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:03,243 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:03,243 INFO     [psi4.optking.displace:379] 	RMS(dx):  3.732e-15 	Max(dx):  6.987e-15 	RMS(dq):  3.205e-16
+2022-12-06:15:30:03,244 INFO     [psi4.optking.displace:132] 
 
 	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
 	-------------------------------------------------------------------------------
@@ -894,27 +894,27 @@
 	             B(1,2,3)      52.41280        0.00210        1.16180      53.57459
 	-------------------------------------------------------------------------------
 
-2022-12-06:14:18:34,255 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.1055015936
-2022-12-06:14:18:34,255 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :   -0.0237939197
-2022-12-06:14:18:34,255 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :    0.2236079401
-2022-12-06:14:18:34,255 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.1055015936
-2022-12-06:14:18:34,255 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.0960764907
-2022-12-06:14:18:34,256 INFO     [psi4.optking.opt_helper:151] Molsys:
+2022-12-06:15:30:03,244 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.1055015928
+2022-12-06:15:30:03,244 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :   -0.0237939195
+2022-12-06:15:30:03,244 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :    0.2236079402
+2022-12-06:15:30:03,244 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.1055015928
+2022-12-06:15:30:03,244 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.0960764900
+2022-12-06:15:30:03,245 INFO     [psi4.optking.opt_helper:151] Molsys:
 
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9369865917421235  0.4303097307112949  0.0000000000000000
-	       7.000000            14.003074        0.9027421057032951 -0.8436633317811943  0.0000000000000000
-	       1.000000             1.007825       -1.6967447643849807 -1.7322888322103898  0.0000000000000000
+	       6.000000            12.000000       -0.9369865918502277  0.4303097308116196  0.0000000000000000
+	       7.000000            14.003074        0.9027421054453458 -0.8436633319656345  0.0000000000000000
+	       1.000000             1.007825       -1.6967447640189266 -1.7322888321262744  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.237769           1.184176
 	 R(2,3)           =         2.747178           1.453744
 	 B(1,2,3)         =         0.935053          53.574593
 
-2022-12-06:14:18:34,256 INFO     [psi4.optking.convcheck:71] Performing convergence check.
-2022-12-06:14:18:34,256 INFO     [psi4.optking.convcheck:263] 
+2022-12-06:15:30:03,245 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:03,245 INFO     [psi4.optking.convcheck:263] 
 	                                 ==> Convergence Check <==                                  
     
 	Measures of convergence in internal coordinates in au.
@@ -930,76 +930,76 @@
 	----------------------------------------------------------------------------------------------
 
 
-2022-12-06:14:18:34,256 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
-2022-12-06:14:18:34,271 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:34,273 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.934366020514354
-2022-12-06:14:18:34,399 INFO     [psi4.driver.driver:640] Return gradient(): -92.72388646390472
-2022-12-06:14:18:34,399 INFO     [psi4.driver.driver:641] [[ 0.00705936  0.01013773  0.00000000]
+2022-12-06:15:30:03,245 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:03,260 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:03,262 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.934366020978118
+2022-12-06:15:30:03,381 INFO     [psi4.driver.driver:640] Return gradient(): -92.72388646390334
+2022-12-06:15:30:03,381 INFO     [psi4.driver.driver:641] [[ 0.00705936  0.01013773  0.00000000]
  [-0.00763413  0.00030023  0.00000000]
  [ 0.00057477 -0.01043796  0.00000000]]
-2022-12-06:14:18:34,401 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
-2022-12-06:14:18:34,401 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
-2022-12-06:14:18:34,402 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 5.71e-01 exceeds limit of 5.00e-01.
-2022-12-06:14:18:34,402 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 3.
-2022-12-06:14:18:34,403 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  6 5 4 2
+2022-12-06:15:30:03,384 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:03,384 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:03,385 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 5.71e-01 exceeds limit of 5.00e-01.
+2022-12-06:15:30:03,385 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 3.
+2022-12-06:15:30:03,385 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  6 5 4 2
 
-2022-12-06:14:18:34,404 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+2022-12-06:15:30:03,386 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
  	   1.464903   0.104993  -0.032430
 	   0.104993   0.214346   0.271822
 	  -0.032430   0.271822   0.065405
 
-2022-12-06:14:18:34,404 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+2022-12-06:15:30:03,387 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
 	   1.464903   0.104993  -0.032430
 	   0.104993   0.214346   0.271822
 	  -0.032430   0.271822   0.065405
 
-2022-12-06:14:18:34,404 INFO     [psi4.optking.opt_helper:168] 
+2022-12-06:15:30:03,387 INFO     [psi4.optking.opt_helper:168] 
 	         Geometry (au)                                       Gradient (au)
-  -0.9369865917   0.4303097307   0.0000000000		   0.0070593593   0.0101377315   0.0000000000
-   0.9027421057  -0.8436633318   0.0000000000		  -0.0076341327   0.0003002327   0.0000000000
-  -1.6967447644  -1.7322888322   0.0000000000		   0.0005747733  -0.0104379643   0.0000000000
+  -0.9369865919   0.4303097308   0.0000000000		   0.0070593593   0.0101377315   0.0000000000
+   0.9027421054  -0.8436633320   0.0000000000		  -0.0076341326   0.0003002327   0.0000000000
+  -1.6967447640  -1.7322888321   0.0000000000		   0.0005747733  -0.0104379642   0.0000000000
 
-2022-12-06:14:18:34,404 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+2022-12-06:15:30:03,387 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
  
 	Current energy:       -92.7238864639
 	Energy change for the previous step:
 		Actual       :        -0.0007755197
 		Projected    :        -0.0012519181
 
-2022-12-06:14:18:34,404 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    0.61947
-2022-12-06:14:18:34,404 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+2022-12-06:15:30:03,387 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    0.61947
+2022-12-06:15:30:03,387 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
 
 		 -0.020108 -0.019180 -0.000001
 
-2022-12-06:14:18:34,405 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+2022-12-06:15:30:03,387 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
 	  -0.146951   0.020108
 	   0.020108   0.000000
 
-2022-12-06:14:18:34,405 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+2022-12-06:15:30:03,387 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
 	   0.417878   0.000000   0.019180
 	   0.000000   1.473727   0.000001
 	   0.019180   0.000001   0.000000
 
-2022-12-06:14:18:34,405 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+2022-12-06:15:30:03,387 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
 
 	%s	 -0.000879  0.418757  1.473727
 
-2022-12-06:14:18:34,405 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+2022-12-06:15:30:03,387 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
 
 	%s	 -0.149653  0.002702
 
-2022-12-06:14:18:34,405 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+2022-12-06:15:30:03,387 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
 
 		  0.134366 -0.045803 -0.000000
 
-2022-12-06:14:18:34,405 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+2022-12-06:15:30:03,387 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
 
 		  0.010228 -0.118119  0.078073
 
-2022-12-06:14:18:34,405 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
-2022-12-06:14:18:34,407 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
-2022-12-06:14:18:34,407 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.653e-13 	Max(dx):  5.887e-13 	RMS(dq):  3.846e-16
-2022-12-06:14:18:34,408 INFO     [psi4.optking.displace:132] 
+2022-12-06:15:30:03,388 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:03,390 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:03,390 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.650e-13 	Max(dx):  5.877e-13 	RMS(dq):  2.564e-16
+2022-12-06:15:30:03,390 INFO     [psi4.optking.displace:132] 
 
 	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
 	-------------------------------------------------------------------------------
@@ -1010,27 +1010,27 @@
 	             B(1,2,3)      53.57459       -0.00210        4.47323      58.04782
 	-------------------------------------------------------------------------------
 
-2022-12-06:14:18:34,408 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.1419576889
-2022-12-06:14:18:34,408 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :    0.0128443179
-2022-12-06:14:18:34,408 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :   -0.0881507757
-2022-12-06:14:18:34,408 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.1419576889
-2022-12-06:14:18:34,408 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.1318772281
-2022-12-06:14:18:34,408 INFO     [psi4.optking.opt_helper:151] Molsys:
+2022-12-06:15:30:03,391 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.1419576880
+2022-12-06:15:30:03,391 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :    0.0128443178
+2022-12-06:15:30:03,391 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :   -0.0881507756
+2022-12-06:15:30:03,391 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.1419576880
+2022-12-06:15:30:03,391 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.1318772273
+2022-12-06:15:30:03,391 INFO     [psi4.optking.opt_helper:151] Molsys:
 
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9289060824152746  0.5095557362515007  0.0000000000000000
-	       7.000000            14.003074        0.8359589077879728 -0.8828316900225756  0.0000000000000000
-	       1.000000             1.007825       -1.6380420757965073 -1.7723664795092144  0.0000000000000000
+	       6.000000            12.000000       -0.9289060826197840  0.5095557358076035  0.0000000000000000
+	       7.000000            14.003074        0.8359589079573475 -0.8828316899721258  0.0000000000000000
+	       1.000000             1.007825       -1.6380420757613721 -1.7723664791157669  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.247997           1.189589
 	 R(2,3)           =         2.629059           1.391238
 	 B(1,2,3)         =         1.013126          58.047825
 
-2022-12-06:14:18:34,409 INFO     [psi4.optking.convcheck:71] Performing convergence check.
-2022-12-06:14:18:34,409 INFO     [psi4.optking.convcheck:263] 
+2022-12-06:15:30:03,392 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:03,392 INFO     [psi4.optking.convcheck:263] 
 	                                 ==> Convergence Check <==                                  
     
 	Measures of convergence in internal coordinates in au.
@@ -1046,74 +1046,74 @@
 	----------------------------------------------------------------------------------------------
 
 
-2022-12-06:14:18:34,409 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
-2022-12-06:14:18:34,424 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:34,426 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.856759412603612
-2022-12-06:14:18:34,550 INFO     [psi4.driver.driver:640] Return gradient(): -92.7234445503816
-2022-12-06:14:18:34,550 INFO     [psi4.driver.driver:641] [[ 0.00421211  0.00403919  0.00000000]
+2022-12-06:15:30:03,392 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:03,406 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:03,408 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.856759413613418
+2022-12-06:15:30:03,532 INFO     [psi4.driver.driver:640] Return gradient(): -92.72344455038682
+2022-12-06:15:30:03,532 INFO     [psi4.driver.driver:641] [[ 0.00421211  0.00403919  0.00000000]
  [ 0.00937494  0.00609811  0.00000000]
  [-0.01358706 -0.01013729  0.00000000]]
-2022-12-06:14:18:34,552 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
-2022-12-06:14:18:34,552 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
-2022-12-06:14:18:34,553 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  7 6 5 4
+2022-12-06:15:30:03,534 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:03,534 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:03,535 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  7 6 5 4
 
-2022-12-06:14:18:34,554 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+2022-12-06:15:30:03,536 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
  	   1.292485  -0.001620  -0.229733
 	  -0.001620   0.136094   0.253229
 	  -0.229733   0.253229   0.364100
 
-2022-12-06:14:18:34,555 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+2022-12-06:15:30:03,537 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
 	   1.292485  -0.001620  -0.229733
 	  -0.001620   0.136094   0.253229
 	  -0.229733   0.253229   0.364100
 
-2022-12-06:14:18:34,555 INFO     [psi4.optking.opt_helper:168] 
+2022-12-06:15:30:03,537 INFO     [psi4.optking.opt_helper:168] 
 	         Geometry (au)                                       Gradient (au)
-  -0.9289060824   0.5095557363   0.0000000000		   0.0042121116   0.0040391853   0.0000000000
-   0.8359589078  -0.8828316900   0.0000000000		   0.0093749448   0.0060981079   0.0000000000
-  -1.6380420758  -1.7723664795   0.0000000000		  -0.0135870564  -0.0101372932   0.0000000000
+  -0.9289060826   0.5095557358   0.0000000000		   0.0042121116   0.0040391853   0.0000000000
+   0.8359589080  -0.8828316900   0.0000000000		   0.0093749448   0.0060981078   0.0000000000
+  -1.6380420758  -1.7723664791   0.0000000000		  -0.0135870563  -0.0101372931   0.0000000000
 
-2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+2022-12-06:15:30:03,537 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
  
 	Current energy:       -92.7234445504
 	Energy change for the previous step:
 		Actual       :         0.0004419135
 		Projected    :         0.0009166704
 
-2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    0.48209
-2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+2022-12-06:15:30:03,537 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    0.48209
+2022-12-06:15:30:03,537 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
 
 		 -0.005954 -0.019357 -0.004720
 
-2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+2022-12-06:15:30:03,537 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
 	  -0.039633   0.005954
 	   0.005954   0.000000
 
-2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+2022-12-06:15:30:03,537 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
 	   0.483048   0.000000   0.019357
-	   0.000000   1.349263   0.004720
+	   0.000000   1.349264   0.004720
 	   0.019357   0.004720   0.000000
 
-2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+2022-12-06:15:30:03,537 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
 
 	%s	 -0.000791  0.483823  1.349280
 
-2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+2022-12-06:15:30:03,537 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
 
 	%s	 -0.040508  0.000875
 
-2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+2022-12-06:15:30:03,537 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
 
 		  0.146993 -0.040007 -0.003496
 
-2022-12-06:14:18:34,555 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+2022-12-06:15:30:03,537 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
 
 		 -0.019847  0.097018 -0.115815
 
-2022-12-06:14:18:34,556 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
-2022-12-06:14:18:34,558 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
-2022-12-06:14:18:34,558 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.364e-12 	Max(dx):  5.296e-12 	RMS(dq):  6.410e-17
-2022-12-06:14:18:34,558 INFO     [psi4.optking.displace:132] 
+2022-12-06:15:30:03,538 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:03,540 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:03,540 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.364e-12 	Max(dx):  5.295e-12 	RMS(dq):  2.643e-16
+2022-12-06:15:30:03,540 INFO     [psi4.optking.displace:132] 
 
 	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
 	-------------------------------------------------------------------------------
@@ -1124,27 +1124,27 @@
 	             B(1,2,3)      58.04782       -0.00099       -6.63573      51.41209
 	-------------------------------------------------------------------------------
 
-2022-12-06:14:18:34,558 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.1523797081
-2022-12-06:14:18:34,559 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :    0.0005534442
-2022-12-06:14:18:34,559 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :   -0.0028724876
-2022-12-06:14:18:34,559 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.1523797081
-2022-12-06:14:18:34,559 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.1811516665
-2022-12-06:14:18:34,559 INFO     [psi4.optking.opt_helper:151] Molsys:
+2022-12-06:15:30:03,540 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.1523796941
+2022-12-06:15:30:03,541 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :    0.0005534436
+2022-12-06:15:30:03,541 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :   -0.0028724842
+2022-12-06:15:30:03,541 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.1523796941
+2022-12-06:15:30:03,541 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.1811516533
+2022-12-06:15:30:03,541 INFO     [psi4.optking.opt_helper:151] Molsys:
 
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9527414848751103  0.3835427949900482  0.0000000000000000
-	       7.000000            14.003074        0.9071933279755539 -0.8433613439764761  0.0000000000000000
-	       1.000000             1.007825       -1.6854410935242525 -1.6858238842938613  0.0000000000000000
+	       6.000000            12.000000       -0.9527414845765747  0.3835428030388749  0.0000000000000000
+	       7.000000            14.003074        0.9071933214206969 -0.8433613482671416  0.0000000000000000
+	       1.000000             1.007825       -1.6854410872679308 -1.6858238880520227  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.228150           1.179086
 	 R(2,3)           =         2.726077           1.442578
 	 B(1,2,3)         =         0.897310          51.412091
 
-2022-12-06:14:18:34,559 INFO     [psi4.optking.convcheck:71] Performing convergence check.
-2022-12-06:14:18:34,560 INFO     [psi4.optking.convcheck:263] 
+2022-12-06:15:30:03,541 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:03,542 INFO     [psi4.optking.convcheck:263] 
 	                                 ==> Convergence Check <==                                  
     
 	Measures of convergence in internal coordinates in au.
@@ -1160,74 +1160,74 @@
 	----------------------------------------------------------------------------------------------
 
 
-2022-12-06:14:18:34,560 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
-2022-12-06:14:18:34,575 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:34,577 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=24.15068552247633
-2022-12-06:14:18:34,706 INFO     [psi4.driver.driver:640] Return gradient(): -92.72426965300876
-2022-12-06:14:18:34,706 INFO     [psi4.driver.driver:641] [[ 0.00527157 -0.00391752  0.00000000]
+2022-12-06:15:30:03,542 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:03,556 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:03,558 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=24.150685513642678
+2022-12-06:15:30:03,681 INFO     [psi4.driver.driver:640] Return gradient(): -92.72426965282602
+2022-12-06:15:30:03,681 INFO     [psi4.driver.driver:641] [[ 0.00527157 -0.00391752  0.00000000]
  [-0.02025468 -0.00126691  0.00000000]
- [ 0.01498311  0.00518443  0.00000000]]
-2022-12-06:14:18:34,708 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
-2022-12-06:14:18:34,708 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
-2022-12-06:14:18:34,709 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  8 7 6 5
+ [ 0.01498310  0.00518443  0.00000000]]
+2022-12-06:15:30:03,683 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:03,683 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:03,684 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  8 7 6 5
 
-2022-12-06:14:18:34,710 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+2022-12-06:15:30:03,685 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
  	   1.280824   0.042347  -0.146845
 	   0.042347   0.134095   0.405001
 	  -0.146845   0.405001   0.568420
 
-2022-12-06:14:18:34,711 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+2022-12-06:15:30:03,686 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
 	   1.280824   0.042347  -0.146845
 	   0.042347   0.134095   0.405001
 	  -0.146845   0.405001   0.568420
 
-2022-12-06:14:18:34,711 INFO     [psi4.optking.opt_helper:168] 
+2022-12-06:15:30:03,686 INFO     [psi4.optking.opt_helper:168] 
 	         Geometry (au)                                       Gradient (au)
-  -0.9527414849   0.3835427950   0.0000000000		   0.0052715732  -0.0039175224   0.0000000000
-   0.9071933280  -0.8433613440   0.0000000000		  -0.0202546794  -0.0012669063   0.0000000000
-  -1.6854410935  -1.6858238843   0.0000000000		   0.0149831062   0.0051844287   0.0000000000
+  -0.9527414846   0.3835428030   0.0000000000		   0.0052715733  -0.0039175228   0.0000000000
+   0.9071933214  -0.8433613483   0.0000000000		  -0.0202546778  -0.0012669055   0.0000000000
+  -1.6854410873  -1.6858238881   0.0000000000		   0.0149831045   0.0051844284   0.0000000000
 
-2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+2022-12-06:15:30:03,686 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
  
-	Current energy:       -92.7242696530
+	Current energy:       -92.7242696528
 	Energy change for the previous step:
-		Actual       :        -0.0008251026
+		Actual       :        -0.0008251024
 		Projected    :         0.0000498277
 
-2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =  -16.55911
-2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+2022-12-06:15:30:03,686 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =  -16.55912
+2022-12-06:15:30:03,686 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
 
 		  0.012532  0.010314 -0.005616
 
-2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+2022-12-06:15:30:03,686 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
 	  -0.117298  -0.012532
 	  -0.012532   0.000000
 
-2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+2022-12-06:15:30:03,686 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
 	   0.789302   0.000000  -0.010314
 	   0.000000   1.311336   0.005616
 	  -0.010314   0.005616   0.000000
 
-2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+2022-12-06:15:30:03,687 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
 
 	%s	 -0.000159  0.789437  1.311360
 
-2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+2022-12-06:15:30:03,687 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
 
 	%s	 -0.118622  0.001324
 
-2022-12-06:14:18:34,711 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+2022-12-06:15:30:03,687 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
 
 		 -0.105645  0.013064 -0.004282
 
-2022-12-06:14:18:34,712 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+2022-12-06:15:30:03,687 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
 
 		  0.015305 -0.083178  0.064784
 
-2022-12-06:14:18:34,712 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
-2022-12-06:14:18:34,714 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
-2022-12-06:14:18:34,714 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.925e-14 	Max(dx):  6.668e-14 	RMS(dq):  6.410e-17
-2022-12-06:14:18:34,715 INFO     [psi4.optking.displace:132] 
+2022-12-06:15:30:03,687 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:03,689 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:03,689 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.921e-14 	Max(dx):  6.660e-14 	RMS(dq):  2.564e-16
+2022-12-06:15:30:03,690 INFO     [psi4.optking.displace:132] 
 
 	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
 	-------------------------------------------------------------------------------
@@ -1238,27 +1238,27 @@
 	             B(1,2,3)      51.41209        0.00006        3.71184      55.12393
 	-------------------------------------------------------------------------------
 
-2022-12-06:14:18:34,715 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.1065353175
-2022-12-06:14:18:34,715 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :    0.0109365514
-2022-12-06:14:18:34,715 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :   -0.1013573573
-2022-12-06:14:18:34,715 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.1065353175
-2022-12-06:14:18:34,715 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.1084980699
-2022-12-06:14:18:34,716 INFO     [psi4.optking.opt_helper:151] Molsys:
+2022-12-06:15:30:03,690 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.1065353029
+2022-12-06:15:30:03,690 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :    0.0109365494
+2022-12-06:15:30:03,690 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :   -0.1013573535
+2022-12-06:15:30:03,690 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.1065353029
+2022-12-06:15:30:03,690 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.1084980563
+2022-12-06:15:30:03,691 INFO     [psi4.optking.opt_helper:151] Molsys:
 
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9475816259267723  0.4547750885420321  0.0000000000000000
-	       7.000000            14.003074        0.8594108029495456 -0.8748370675052539  0.0000000000000000
-	       1.000000             1.007825       -1.6428184274465825 -1.7255804543170672  0.0000000000000000
+	       6.000000            12.000000       -0.9475816259017645  0.4547750882251752  0.0000000000000000
+	       7.000000            14.003074        0.8594108030209895 -0.8748370674792090  0.0000000000000000
+	       1.000000             1.007825       -1.6428184275430335 -1.7255804540262554  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.243455           1.187185
 	 R(2,3)           =         2.642899           1.398562
 	 B(1,2,3)         =         0.962094          55.123927
 
-2022-12-06:14:18:34,716 INFO     [psi4.optking.convcheck:71] Performing convergence check.
-2022-12-06:14:18:34,716 INFO     [psi4.optking.convcheck:263] 
+2022-12-06:15:30:03,691 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:03,691 INFO     [psi4.optking.convcheck:263] 
 	                                 ==> Convergence Check <==                                  
     
 	Measures of convergence in internal coordinates in au.
@@ -1274,74 +1274,74 @@
 	----------------------------------------------------------------------------------------------
 
 
-2022-12-06:14:18:34,716 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
-2022-12-06:14:18:34,731 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:34,733 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.991517966838867
-2022-12-06:14:18:34,855 INFO     [psi4.driver.driver:640] Return gradient(): -92.72370022442102
-2022-12-06:14:18:34,855 INFO     [psi4.driver.driver:641] [[ 0.00047306 -0.00016801  0.00000000]
+2022-12-06:15:30:03,691 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:03,706 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:03,708 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.99151796876972
+2022-12-06:15:30:03,824 INFO     [psi4.driver.driver:640] Return gradient(): -92.72370022442095
+2022-12-06:15:30:03,824 INFO     [psi4.driver.driver:641] [[ 0.00047306 -0.00016801  0.00000000]
  [ 0.00018062  0.00052030  0.00000000]
  [-0.00065368 -0.00035229  0.00000000]]
-2022-12-06:14:18:34,858 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
-2022-12-06:14:18:34,858 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
-2022-12-06:14:18:34,859 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  9 8 7 6
+2022-12-06:15:30:03,826 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:03,827 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:03,828 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  9 8 7 6
 
-2022-12-06:14:18:34,860 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+2022-12-06:15:30:03,829 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
  	   1.277087   0.051577  -0.082185
 	   0.051577   0.126776   0.409329
 	  -0.082185   0.409329   0.595658
 
-2022-12-06:14:18:34,860 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+2022-12-06:15:30:03,829 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
 	   1.277087   0.051577  -0.082185
 	   0.051577   0.126776   0.409329
 	  -0.082185   0.409329   0.595658
 
-2022-12-06:14:18:34,860 INFO     [psi4.optking.opt_helper:168] 
+2022-12-06:15:30:03,829 INFO     [psi4.optking.opt_helper:168] 
 	         Geometry (au)                                       Gradient (au)
-  -0.9475816259   0.4547750885   0.0000000000		   0.0004730577  -0.0001680072   0.0000000000
-   0.8594108029  -0.8748370675   0.0000000000		   0.0001806206   0.0005202987   0.0000000000
-  -1.6428184274  -1.7255804543   0.0000000000		  -0.0006536783  -0.0003522914   0.0000000000
+  -0.9475816259   0.4547750882   0.0000000000		   0.0004730578  -0.0001680073   0.0000000000
+   0.8594108030  -0.8748370675   0.0000000000		   0.0001806204   0.0005202987   0.0000000000
+  -1.6428184275  -1.7255804540   0.0000000000		  -0.0006536782  -0.0003522914   0.0000000000
 
-2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+2022-12-06:15:30:03,829 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
  
 	Current energy:       -92.7237002244
 	Energy change for the previous step:
-		Actual       :         0.0005694286
-		Projected    :         0.0005833169
+		Actual       :         0.0005694284
+		Projected    :         0.0005833167
 
-2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    0.97619
-2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+2022-12-06:15:30:03,829 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    0.97619
+2022-12-06:15:30:03,829 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
 
 		 -0.000497 -0.000602 -0.000513
 
-2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+2022-12-06:15:30:03,830 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
 	  -0.115793   0.000497
 	   0.000497   0.000000
 
-2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+2022-12-06:15:30:03,830 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
 	   0.828446   0.000000   0.000602
 	   0.000000   1.286868   0.000513
 	   0.000602   0.000513   0.000000
 
-2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+2022-12-06:15:30:03,830 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
 
 	%s	 -0.000001  0.828447  1.286868
 
-2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+2022-12-06:15:30:03,830 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
 
 	%s	 -0.115796  0.000002
 
-2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+2022-12-06:15:30:03,830 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
 
 		  0.004293 -0.000727 -0.000399
 
-2022-12-06:14:18:34,861 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+2022-12-06:15:30:03,830 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
 
 		  0.000060  0.003334 -0.002829
 
-2022-12-06:14:18:34,861 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
-2022-12-06:14:18:34,863 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
-2022-12-06:14:18:34,863 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.252e-12 	Max(dx):  2.379e-12 	RMS(dq):  1.282e-16
-2022-12-06:14:18:34,863 INFO     [psi4.optking.displace:132] 
+2022-12-06:15:30:03,830 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:03,832 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:03,832 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.253e-12 	Max(dx):  2.380e-12 	RMS(dq):  3.205e-16
+2022-12-06:15:30:03,832 INFO     [psi4.optking.displace:132] 
 
 	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
 	-------------------------------------------------------------------------------
@@ -1352,27 +1352,27 @@
 	             B(1,2,3)      55.12393       -0.00002       -0.16209      54.96184
 	-------------------------------------------------------------------------------
 
-2022-12-06:14:18:34,864 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.0043728182
-2022-12-06:14:18:34,864 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :    0.0003412259
-2022-12-06:14:18:34,864 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :   -0.0780313660
-2022-12-06:14:18:34,864 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.0043728182
-2022-12-06:14:18:34,864 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.0044085361
-2022-12-06:14:18:34,864 INFO     [psi4.optking.opt_helper:151] Molsys:
+2022-12-06:15:30:03,832 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.0043728179
+2022-12-06:15:30:03,832 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :    0.0003412258
+2022-12-06:15:30:03,832 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :   -0.0780313650
+2022-12-06:15:30:03,833 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.0043728179
+2022-12-06:15:30:03,833 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.0044085357
+2022-12-06:15:30:03,833 INFO     [psi4.optking.opt_helper:151] Molsys:
 
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9481945734882358  0.4520216831837158  0.0000000000000000
-	       7.000000            14.003074        0.8616125660921277 -0.8738575600665194  0.0000000000000000
-	       1.000000             1.007825       -1.6444072430277010 -1.7238065563974854  0.0000000000000000
+	       6.000000            12.000000       -0.9481945734416852  0.4520216831848538  0.0000000000000000
+	       7.000000            14.003074        0.8616125660497205 -0.8738575601487806  0.0000000000000000
+	       1.000000             1.007825       -1.6444072430318437 -1.7238065563163623  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.243515           1.187217
 	 R(2,3)           =         2.646233           1.400326
 	 B(1,2,3)         =         0.959265          54.961835
 
-2022-12-06:14:18:34,865 INFO     [psi4.optking.convcheck:71] Performing convergence check.
-2022-12-06:14:18:34,865 INFO     [psi4.optking.convcheck:263] 
+2022-12-06:15:30:03,833 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:03,833 INFO     [psi4.optking.convcheck:263] 
 	                                 ==> Convergence Check <==                                  
     
 	Measures of convergence in internal coordinates in au.
@@ -1388,74 +1388,74 @@
 	----------------------------------------------------------------------------------------------
 
 
-2022-12-06:14:18:34,865 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned False
-2022-12-06:14:18:34,882 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
-2022-12-06:14:18:34,883 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.992292195213906
-2022-12-06:14:18:34,999 INFO     [psi4.driver.driver:640] Return gradient(): -92.72369968645235
-2022-12-06:14:18:34,999 INFO     [psi4.driver.driver:641] [[ 0.00007992  0.00007887  0.00000000]
+2022-12-06:15:30:03,834 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:03,848 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:03,850 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.99229219555993
+2022-12-06:15:30:03,959 INFO     [psi4.driver.driver:640] Return gradient(): -92.72369968645228
+2022-12-06:15:30:03,959 INFO     [psi4.driver.driver:641] [[ 0.00007992  0.00007887  0.00000000]
  [-0.00002727  0.00003823  0.00000000]
  [-0.00005265 -0.00011710  0.00000000]]
-2022-12-06:14:18:35,2 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
-2022-12-06:14:18:35,2 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
-2022-12-06:14:18:35,3 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  10 9 8 7
+2022-12-06:15:30:03,961 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:03,962 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:03,962 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  10 9 8 7
 
-2022-12-06:14:18:35,4 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+2022-12-06:15:30:03,963 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
  	   1.253539   0.051504  -0.082157
 	   0.051504   0.113902   0.349289
 	  -0.082157   0.349289   0.344279
 
-2022-12-06:14:18:35,4 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+2022-12-06:15:30:03,964 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
 	   1.253539   0.051504  -0.082157
 	   0.051504   0.113902   0.349289
 	  -0.082157   0.349289   0.344279
 
-2022-12-06:14:18:35,4 INFO     [psi4.optking.opt_helper:168] 
+2022-12-06:15:30:03,964 INFO     [psi4.optking.opt_helper:168] 
 	         Geometry (au)                                       Gradient (au)
-  -0.9481945735   0.4520216832   0.0000000000		   0.0000799193   0.0000788722   0.0000000000
-   0.8616125661  -0.8738575601   0.0000000000		  -0.0000272663   0.0000382290   0.0000000000
-  -1.6444072430  -1.7238065564   0.0000000000		  -0.0000526529  -0.0001171012   0.0000000000
+  -0.9481945734   0.4520216832   0.0000000000		   0.0000799193   0.0000788722   0.0000000000
+   0.8616125660  -0.8738575601   0.0000000000		  -0.0000272663   0.0000382290   0.0000000000
+  -1.6444072430  -1.7238065563   0.0000000000		  -0.0000526529  -0.0001171012   0.0000000000
 
-2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:315] 	Current Step Report 
+2022-12-06:15:30:03,964 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
  
 	Current energy:       -92.7236996865
 	Energy change for the previous step:
 		Actual       :         0.0000005380
 		Projected    :         0.0000007461
 
-2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:318] 	Energy ratio =    0.72108
-2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:823] 	Internal forces in au, in Hevect basis:
+2022-12-06:15:30:03,964 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    0.72108
+2022-12-06:15:30:03,964 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
 
 		  0.000074 -0.000251 -0.000036
 
-2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:829] 	RFO max
+2022-12-06:15:30:03,964 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
 	  -0.144487  -0.000074
 	  -0.000074   0.000000
 
-2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:830] 	RFO min
+2022-12-06:15:30:03,964 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
 	   0.594905   0.000000   0.000251
 	   0.000000   1.261302   0.000036
 	   0.000251   0.000036   0.000000
 
-2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:836] 	RFO min eigenvalues:
+2022-12-06:15:30:03,965 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
 
 	%s	 -0.000000  0.594905  1.261302
 
-2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:837] 	RFO max eigenvalues:
+2022-12-06:15:30:03,965 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
 
 	%s	 -0.144487  0.000000
 
-2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:851] 	RFO step in Hessian Eigenvector Basis
+2022-12-06:15:30:03,965 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
 
 		 -0.000515 -0.000422 -0.000029
 
-2022-12-06:14:18:35,5 INFO     [psi4.optking.stepAlgorithms:852] 	RFO step in original Basis
+2022-12-06:15:30:03,965 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
 
 		  0.000039 -0.000664 -0.000040
 
-2022-12-06:14:18:35,5 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
-2022-12-06:14:18:35,6 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
-2022-12-06:14:18:35,6 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.173e-08 	Max(dx):  2.315e-08 	RMS(dq):  2.867e-16
-2022-12-06:14:18:35,7 INFO     [psi4.optking.displace:132] 
+2022-12-06:15:30:03,965 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:03,966 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:03,966 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.173e-08 	Max(dx):  2.315e-08 	RMS(dq):  3.846e-16
+2022-12-06:15:30:03,967 INFO     [psi4.optking.displace:132] 
 
 	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
 	-------------------------------------------------------------------------------
@@ -1466,27 +1466,27 @@
 	             B(1,2,3)      54.96184       -0.00002       -0.00228      54.95956
 	-------------------------------------------------------------------------------
 
-2022-12-06:14:18:35,7 INFO     [psi4.optking.stepAlgorithms:96] 	|target step| :    0.0006660417
-2022-12-06:14:18:35,7 INFO     [psi4.optking.stepAlgorithms:97] 	gradient     :   -0.0001030514
-2022-12-06:14:18:35,7 INFO     [psi4.optking.stepAlgorithms:98] 	hessian      :    0.1547221383
-2022-12-06:14:18:35,7 INFO     [psi4.optking.stepAlgorithms:177] 	Norm of achieved step-size    0.0006660417
-2022-12-06:14:18:35,7 INFO     [psi4.optking.stepAlgorithms:179] 	Norm of achieved step-size (cart):    0.0005428280
-2022-12-06:14:18:35,8 INFO     [psi4.optking.opt_helper:151] Molsys:
+2022-12-06:15:30:03,967 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.0006660416
+2022-12-06:15:30:03,967 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :   -0.0001030514
+2022-12-06:15:30:03,967 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :    0.1547221457
+2022-12-06:15:30:03,967 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.0006660416
+2022-12-06:15:30:03,967 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.0005428279
+2022-12-06:15:30:03,968 INFO     [psi4.optking.opt_helper:151] Molsys:
 
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9483540554417276  0.4519517645947314  0.0000000000000000
-	       7.000000            14.003074        0.8614166452592497 -0.8740430533459389  0.0000000000000000
-	       1.000000             1.007825       -1.6440518402413311 -1.7235511445290814  0.0000000000000000
+	       6.000000            12.000000       -0.9483540553842027  0.4519517646105619  0.0000000000000000
+	       7.000000            14.003074        0.8614166452526349 -0.8740430534105976  0.0000000000000000
+	       1.000000             1.007825       -1.6440518402922408 -1.7235511444802534  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.243553           1.187237
 	 R(2,3)           =         2.645569           1.399975
 	 B(1,2,3)         =         0.959225          54.959559
 
-2022-12-06:14:18:35,8 INFO     [psi4.optking.convcheck:71] Performing convergence check.
-2022-12-06:14:18:35,8 INFO     [psi4.optking.convcheck:263] 
+2022-12-06:15:30:03,968 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:03,968 INFO     [psi4.optking.convcheck:263] 
 	                                 ==> Convergence Check <==                                  
     
 	Measures of convergence in internal coordinates in au.
@@ -1502,7 +1502,7 @@
 	----------------------------------------------------------------------------------------------
 
 
-2022-12-06:14:18:35,8 INFO     [psi4.optking.convcheck:193] 
+2022-12-06:15:30:03,968 INFO     [psi4.optking.convcheck:193] 
 	                      ===> Final Convergence Report <===                     
 
 	----------------------------------------------------------------------------
@@ -1513,18 +1513,18 @@
 	----------------------------------------------------------------------------
 
 
-2022-12-06:14:18:35,8 INFO     [psi4.optking.stepAlgorithms:266] 	Convergence check returned True
-2022-12-06:14:18:35,8 INFO     [psi4.optking.optimize:286] 	Converged in 11 steps!
-2022-12-06:14:18:35,8 INFO     [psi4.optking.optimize:287] 	Final energy is    -92.7236996864523
-2022-12-06:14:18:35,8 INFO     [psi4.optking.optimize:288] 	Final structure (Angstroms): 
+2022-12-06:15:30:03,968 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned True
+2022-12-06:15:30:03,968 INFO     [psi4.optking.optimize:286] 	Converged in 11 steps!
+2022-12-06:15:30:03,968 INFO     [psi4.optking.optimize:287] 	Final energy is    -92.7236996864523
+2022-12-06:15:30:03,968 INFO     [psi4.optking.optimize:288] 	Final structure (Angstroms): 
 	Fragment 1 (Ang)
 
-	    C  -0.5018473538   0.2391625741   0.0000000000
+	    C  -0.5018473538   0.2391625742   0.0000000000
 	    N   0.4558420576  -0.4625236650   0.0000000000
 	    H  -0.8699947670  -0.9120639871   0.0000000000
 
 
-2022-12-06:14:18:35,9 INFO     [psi4.optking.optimize:432] 	Optimization Finished
+2022-12-06:15:30:03,969 INFO     [psi4.optking.optimize:455] 	Optimization Finished
 
 	==> Optimization Summary <==
 
@@ -1538,17 +1538,1469 @@
 	---------------------------------------------------------------------------------------------------------------  ~
         
 	     1     -92.675168102266    -92.675168102266      0.13952751      0.09868759      0.44314123      0.28867513  ~
-	     2     -92.721073093334     -0.045904991068      0.06975422      0.05613366      0.37689664      0.28867513  ~
-	     3     -92.717566405023      0.003506688311      0.14289761      0.08960869      0.47143842      0.27236335  ~
-	     4     -92.722836268252     -0.005269863229      0.02200478      0.01796667      0.09430804      0.05601884  ~
-	     5     -92.724244031378     -0.001407763126      0.01447448      0.00934762      0.09097447      0.07360166  ~
-	     6     -92.723110944157      0.001133087221      0.02762527      0.01952894      0.10321508      0.06091137  ~
-	     7     -92.723886463905     -0.000775519748      0.02764411      0.01604391      0.11811872      0.08195931  ~
-	     8     -92.723444550382      0.000441913523      0.01621564      0.01200592      0.11581541      0.08797647  ~
-	     9     -92.724269653009     -0.000825102627      0.01585186      0.00991553      0.08317805      0.06150819  ~
-	    10     -92.723700224421      0.000569428588      0.00073229      0.00053948      0.00333385      0.00252465  ~
+	     2     -92.721073093335     -0.045904991069      0.06975422      0.05613366      0.37689664      0.28867513  ~
+	     3     -92.717566405027      0.003506688308      0.14289761      0.08960869      0.47143842      0.27236335  ~
+	     4     -92.722836268253     -0.005269863226      0.02200478      0.01796667      0.09430804      0.05601884  ~
+	     5     -92.724244031378     -0.001407763125      0.01447448      0.00934762      0.09097447      0.07360166  ~
+	     6     -92.723110944165      0.001133087213      0.02762527      0.01952894      0.10321508      0.06091137  ~
+	     7     -92.723886463903     -0.000775519739      0.02764411      0.01604391      0.11811872      0.08195931  ~
+	     8     -92.723444550387      0.000441913517      0.01621564      0.01200592      0.11581540      0.08797646  ~
+	     9     -92.724269652826     -0.000825102439      0.01585186      0.00991553      0.08317803      0.06150819  ~
+	    10     -92.723700224421      0.000569428405      0.00073229      0.00053948      0.00333385      0.00252465  ~
 	    11     -92.723699686452      0.000000537969      0.00024871      0.00015256      0.00066372      0.00038454  ~
 	----------------------------------------------------------------------------------------------------------------
 
 
-2022-12-06:14:18:35,9 INFO     [psi4.optking.optimize:640] Preparing OptimizationResult
+2022-12-06:15:30:03,969 INFO     [psi4.optking.optimize:663] Preparing OptimizationResult
+2022-12-06:15:30:04,192 INFO     [psi4.optking.optwrapper:214] Creating a UserComputer
+2022-12-06:15:30:04,192 INFO     [psi4.optking.optwrapper:222] 
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+2022-12-06:15:30:04,192 INFO     [psi4.optking.optwrapper:238] 
+		 -- Optimization Parameters --
+	accept_symmetry_breaking       =           False
+	alg_geom_maxiter               =              50
+	bt_dx_conv                     =           1e-07
+	bt_dx_rms_change_conv          =           1e-12
+	bt_max_iter                    =              25
+	cart_hess_read                 =           False
+	consecutive_backsteps_allowed  =               0
+	conv_max_DE                    =           1e-06
+	conv_max_disp                  =          0.0012
+	conv_max_force                 =          0.0003
+	conv_rms_disp                  =              -1
+	conv_rms_force                 =              -1
+	covalent_connect               =             1.3
+	dynamic_level                  =               0
+	dynamic_level_max              =               0
+	ensure_bt_convergence          =           False
+	ext_force_bend                 =              []
+	ext_force_cartesian            =              []
+	ext_force_dihedral             =              []
+	ext_force_distance             =              []
+	ext_force_oofp                 =              []
+	fix_val_near_pi                =            1.57
+	flexible_g_convergence         =           False
+	frag_mode                      =          SINGLE
+	frag_ref_atoms                 =            None
+	freeze_intrafrag               =           False
+	frozen_bend                    =              []
+	frozen_cartesian               =              []
+	frozen_dihedral                =              []
+	frozen_distance                =              []
+	frozen_oofp                    =              []
+	full_hess_every                =               0
+	g_convergence                  =           QCHEM
+	generate_intcos_exit           =           False
+	geom_maxiter                   =              50
+	h_bond_connect                 =             4.3
+	hess_update                    =          BOFILL
+	hess_update_den_tol            =           1e-07
+	hess_update_dq_tol             =             0.5
+	hess_update_limit              =            True
+	hess_update_limit_max          =             1.0
+	hess_update_limit_scale        =             0.5
+	hess_update_use_last           =               4
+	hessian_file                   =            None
+	i_max_DE                       =            True
+	i_max_disp                     =            True
+	i_max_force                    =            True
+	i_rms_disp                     =           False
+	i_rms_force                    =           False
+	i_untampered                   =            True
+	include_oofp                   =           False
+	interfrag_collinear_tol        =            0.01
+	interfrag_coords               =            None
+	interfrag_dist_inv             =           False
+	interfrag_mode                 =           FIXED
+	interfrag_trust                =             0.5
+	interfrag_trust_max            =             1.0
+	interfrag_trust_min            =           0.001
+	interfragment_connect          =             1.8
+	intrafrag_hess                 =        SCHLEGEL
+	intrafrag_trust                =             0.5
+	intrafrag_trust_max            =             1.0
+	intrafrag_trust_min            =           0.001
+	irc_direction                  =         FORWARD
+	irc_points                     =              20
+	irc_step_size                  =             0.2
+	keep_intcos                    =           False
+	linear_bend_threshold          =            3.05
+	linesearch                     =           False
+	linesearch_step                =             0.1
+	max_disp_g_convergence         =          0.0012
+	max_energy_g_convergence       =           1e-06
+	max_force_g_convergence        =          0.0003
+	opt_coordinates                =       REDUNDANT
+	opt_type                       =              TS
+	output_type                    =            FILE
+	print_lvl                      =               1
+	program                        =            psi4
+	ranged_bend                    =              []
+	ranged_cartesian               =              []
+	ranged_dihedral                =              []
+	ranged_distance                =              []
+	ranged_oofp                    =              []
+	redundant_eval_tol             =           1e-10
+	rfo_follow_root                =           False
+	rfo_normalization_max          =             100
+	rfo_root                       =               0
+	rms_disp_g_convergence         =          0.0012
+	rms_force_g_convergence        =          0.0003
+	rsrfo_alpha_max                =     100000000.0
+	sd_hessian                     =             1.0
+	simple_step_scaling            =           False
+	small_bend_fix_threshold       =            0.35
+	steepest_descent_type          =         OVERLAP
+	step_type                      =           P_RFO
+	test_B                         =           False
+	test_derivative_B              =           False
+	trajectory                     =           False
+	v3d_tors_angle_lim             =           0.017
+	v3d_tors_cos_tol               =           1e-10
+	working_consecutive_backsteps  =               0
+	working_steps_since_last_H     =               0
+
+
+2022-12-06:15:30:04,193 INFO     [psi4.optking.molsys:599] 	Increasing scaling to  1.500 to connect fragments.
+2022-12-06:15:30:04,193 INFO     [psi4.optking.molsys:599] 	Increasing scaling to  1.700 to connect fragments.
+2022-12-06:15:30:04,193 INFO     [psi4.optking.molsys:576] 	Connecting fragments with atoms 2 and 3
+2022-12-06:15:30:04,193 INFO     [psi4.optking.molsys:595] 	All fragments are connected in connectivity matrix.
+2022-12-06:15:30:04,193 INFO     [psi4.optking.molsys:470] 	Consolidating multiple fragments into one for optimization.
+2022-12-06:15:30:04,194 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.6169570705079367  1.0422703480732367  0.0000000000000000
+	       7.000000            14.003074        0.6561039639920634 -0.7152141444267632  0.0000000000000000
+	       1.000000             1.007825       -1.7701361439079366 -2.4726986369267632  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.170124           1.148380
+	 R(2,3)           =         2.995896           1.585360
+	 B(1,2,3)         =         1.570796          90.000000
+
+2022-12-06:15:30:04,209 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:04,211 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.312194649889424
+2022-12-06:15:30:04,395 INFO     [psi4.driver.driver:640] Return gradient(): -92.67516810226593
+2022-12-06:15:30:04,395 INFO     [psi4.driver.driver:641] [[ 0.08837896 -0.10826844  0.00000000]
+ [-0.01310309  0.17000534  0.00000000]
+ [-0.07527588 -0.06173690  0.00000000]]
+2022-12-06:15:30:04,410 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:04,413 INFO     [psi4.driver.driver:1470] Compute hessian(): method=scf, basis=6-31g, molecule=default, nre=23.312194649889427
+2022-12-06:15:30:04,707 INFO     [psi4.driver.driver:1474] Return hessian(): -92.67516810226593
+2022-12-06:15:30:04,707 INFO     [psi4.driver.driver:1475] [[ 0.46202180 -0.74842172  0.00000000 -0.43494902  0.75462806  0.00000000 -0.02707278 -0.00620633  0.00000000]
+ [-0.74842172  0.94480964  0.00000000  0.75997514 -0.94639865  0.00000000 -0.01155342  0.00158901  0.00000000]
+ [ 0.00000000  0.00000000 -0.06429474  0.00000000  0.00000000  0.06698527  0.00000000  0.00000000 -0.00269053]
+ [-0.43494902  0.75997514  0.00000000  0.39528642 -0.77507388  0.00000000  0.03966260  0.01509873  0.00000000]
+ [ 0.75462806 -0.94639865  0.00000000 -0.77507388  0.97623393  0.00000000  0.02044582 -0.02983528  0.00000000]
+ [ 0.00000000  0.00000000  0.06698527  0.00000000  0.00000000 -0.03723833  0.00000000  0.00000000 -0.02974694]
+ [-0.02707278 -0.01155342  0.00000000  0.03966260  0.02044582  0.00000000 -0.01258982 -0.00889240  0.00000000]
+ [-0.00620633  0.00158901  0.00000000  0.01509873 -0.02983528  0.00000000 -0.00889240  0.02824627  0.00000000]
+ [ 0.00000000  0.00000000 -0.00269053  0.00000000  0.00000000 -0.02974694  0.00000000  0.00000000  0.03243747]]
+2022-12-06:15:30:04,716 INFO     [psi4.optking.molsys:771] Converting Hessian from cartesians to internals.
+2022-12-06:15:30:04,717 INFO     [psi4.optking.molsys:787] Neglecting force/B-matrix derivative term, only correct at stationary points.
+2022-12-06:15:30:04,717 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.487890  -0.006796  -0.038479
+	  -0.006796  -0.007985   0.077337
+	  -0.038479   0.077337  -0.183683
+
+2022-12-06:15:30:04,717 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.6169570705   1.0422703481   0.0000000000		   0.0883789637  -0.1082684399   0.0000000000
+   0.6561039640  -0.7152141444   0.0000000000		  -0.0131030853   0.1700053413   0.0000000000
+  -1.7701361439  -2.4726986369   0.0000000000		  -0.0752758784  -0.0617369014   0.0000000000
+
+2022-12-06:15:30:04,718 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
+
+		  0.020543  0.095230 -0.140452
+
+2022-12-06:15:30:04,718 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
+	  -0.213539  -0.020543
+	  -0.020543   0.000000
+
+2022-12-06:15:30:04,718 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
+	   0.020936   0.000000  -0.095230
+	   0.000000   1.488824   0.140452
+	  -0.095230   0.140452   0.000000
+
+2022-12-06:15:30:04,718 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
+
+	%s	 -0.092454  0.100203  1.502012
+
+2022-12-06:15:30:04,718 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
+
+	%s	 -0.215498  0.001958
+
+2022-12-06:15:30:04,718 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
+
+		 -0.095330  0.839846 -0.088822
+
+2022-12-06:15:30:04,718 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
+
+		  0.075531 -0.753241 -0.386318
+
+2022-12-06:15:30:04,718 INFO     [psi4.optking.stepAlgorithms:195] 	Step length exceeds trust radius of    0.50000.
+2022-12-06:15:30:04,718 INFO     [psi4.optking.stepAlgorithms:196] 	Scaling displacements by    0.58831
+2022-12-06:15:30:04,718 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:04,720 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:04,720 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.606e-09 	Max(dx):  4.856e-09 	RMS(dq):  3.846e-16
+2022-12-06:15:30:04,721 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.14838        1.14953        0.02351       1.17189
+	               R(2,3)       1.58536       -0.80063       -0.23450       1.35086
+	             B(1,2,3)      90.00000       -0.00133      -13.02187      76.97813
+	-------------------------------------------------------------------------------
+
+2022-12-06:15:30:04,721 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.5000000000
+2022-12-06:15:30:04,721 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :   -0.1064789164
+2022-12-06:15:30:04,721 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :    0.0340186812
+2022-12-06:15:30:04,721 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.5000000000
+2022-12-06:15:30:04,721 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.5546669394
+2022-12-06:15:30:04,722 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.8044376962475241  0.7966972614486511  0.0000000000000000
+	       7.000000            14.003074        0.6598157878567307 -0.8646981165358915  0.0000000000000000
+	       1.000000             1.007825       -1.5863673420330158 -2.0776415781930488  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.214559           1.171894
+	 R(2,3)           =         2.552757           1.350861
+	 B(1,2,3)         =         1.343522          76.978133
+
+2022-12-06:15:30:04,722 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:04,722 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     1     -92.67516810   -9.27e+01      1.40e-01      9.87e-02 o    4.43e-01      2.89e-01 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:15:30:04,722 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:04,737 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:04,739 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.721766813928177
+2022-12-06:15:30:04,860 INFO     [psi4.driver.driver:640] Return gradient(): -92.7210729165499
+2022-12-06:15:30:04,860 INFO     [psi4.driver.driver:641] [[ 0.04552471 -0.05010690  0.00000000]
+ [ 0.01543032  0.08403126  0.00000000]
+ [-0.06095503 -0.03392437  0.00000000]]
+2022-12-06:15:30:04,863 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:04,863 INFO     [psi4.optking.history:268] 	Using 1 previous steps for update.
+2022-12-06:15:30:04,863 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  1
+
+2022-12-06:15:30:04,863 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.489352   0.002237  -0.029244
+	   0.002237   0.007739   0.106020
+	  -0.029244   0.106020  -0.145436
+
+2022-12-06:15:30:04,864 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.489352   0.002237  -0.029244
+	   0.002237   0.007739   0.106020
+	  -0.029244   0.106020  -0.145436
+
+2022-12-06:15:30:04,864 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.7299276341   0.9685524731   0.0000000000		   0.0455247077  -0.0501068952   0.0000000000
+   0.7343258500  -0.6928429049   0.0000000000		   0.0154303250   0.0840312647   0.0000000000
+  -1.5118572799  -1.9057863666   0.0000000000		  -0.0609550326  -0.0339243695   0.0000000000
+
+2022-12-06:15:30:04,864 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
+ 
+	Current energy:       -92.7210729165
+	Energy change for the previous step:
+		Actual       :        -0.0459048143
+		Projected    :        -0.0391896985
+
+2022-12-06:15:30:04,864 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    1.17135
+2022-12-06:15:30:04,864 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
+
+		  0.030772 -0.062626 -0.067705
+
+2022-12-06:15:30:04,864 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
+	  -0.200071  -0.030772
+	  -0.030772   0.000000
+
+2022-12-06:15:30:04,864 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
+	   0.061851   0.000000   0.062626
+	   0.000000   1.489875   0.067705
+	   0.062626   0.067705   0.000000
+
+2022-12-06:15:30:04,864 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
+
+	%s	 -0.041093  0.099867  1.492951
+
+2022-12-06:15:30:04,865 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
+
+	%s	 -0.204697  0.004626
+
+2022-12-06:15:30:04,865 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
+
+		 -0.150329 -0.608351 -0.044224
+
+2022-12-06:15:30:04,865 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
+
+		  0.036994 -0.473538 -0.411143
+
+2022-12-06:15:30:04,865 INFO     [psi4.optking.stepAlgorithms:195] 	Step length exceeds trust radius of    0.50000.
+2022-12-06:15:30:04,865 INFO     [psi4.optking.stepAlgorithms:196] 	Scaling displacements by    0.79591
+2022-12-06:15:30:04,865 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:04,867 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:04,867 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.594e-08 	Max(dx):  3.341e-08 	RMS(dq):  2.564e-16
+2022-12-06:15:30:04,867 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.17189        0.55769        0.01558       1.18748
+	               R(2,3)       1.35086       -0.57468       -0.19944       1.15142
+	             B(1,2,3)      76.97813       -0.00017      -18.74915      58.22898
+	-------------------------------------------------------------------------------
+
+2022-12-06:15:30:04,868 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.5000000000
+2022-12-06:15:30:04,868 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :   -0.0580486713
+2022-12-06:15:30:04,868 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :    0.0539290621
+2022-12-06:15:30:04,868 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.5000000000
+2022-12-06:15:30:04,868 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.6246799238
+2022-12-06:15:30:04,868 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9322738291707102  0.6552872670887475  0.0000000000000000
+	       7.000000            14.003074        0.7532595082139633 -0.8261066183323337  0.0000000000000000
+	       1.000000             1.007825       -1.3284447430186905 -1.4592574471242077  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.244003           1.187475
+	 R(2,3)           =         2.175861           1.151416
+	 B(1,2,3)         =         1.016287          58.228980
+
+2022-12-06:15:30:04,869 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:04,869 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     2     -92.72107292   -4.59e-02      6.98e-02      5.61e-02 o    3.77e-01      2.89e-01 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:15:30:04,869 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:04,884 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:04,886 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=24.722630781527492
+2022-12-06:15:30:05,10 INFO     [psi4.driver.driver:640] Return gradient(): -92.71756572953294
+2022-12-06:15:30:05,10 INFO     [psi4.driver.driver:641] [[-0.01854181 -0.06848496  0.00000000]
+ [-0.01197683 -0.00944364  0.00000000]
+ [ 0.03051863  0.07792860  0.00000000]]
+2022-12-06:15:30:05,12 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:05,12 INFO     [psi4.optking.history:268] 	Using 2 previous steps for update.
+2022-12-06:15:30:05,13 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 8.20e-01 exceeds limit of 5.00e-01.
+2022-12-06:15:30:05,13 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 1.
+2022-12-06:15:30:05,13 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  2
+
+2022-12-06:15:30:05,13 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.491452   0.020707  -0.000911
+	   0.020707   0.092631   0.266859
+	  -0.000911   0.266859   0.136177
+
+2022-12-06:15:30:05,14 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.491452   0.020707  -0.000911
+	   0.020707   0.092631   0.266859
+	  -0.000911   0.266859   0.136177
+
+2022-12-06:15:30:05,14 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.8590375709   0.8468862614   0.0000000000		  -0.0185418058  -0.0684849593   0.0000000000
+   0.8264957665  -0.6345076240   0.0000000000		  -0.0119768267  -0.0094436414   0.0000000000
+  -1.2552084847  -1.2676584528   0.0000000000		   0.0305186325   0.0779286007   0.0000000000
+
+2022-12-06:15:30:05,14 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
+ 
+	Current energy:       -92.7175657295
+	Energy change for the previous step:
+		Actual       :         0.0035071870
+		Projected    :        -0.0178265623
+
+2022-12-06:15:30:05,14 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =   -0.19674
+2022-12-06:15:30:05,14 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
+
+		 -0.058973  0.139867 -0.032403
+
+2022-12-06:15:30:05,14 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
+	  -0.153495   0.058973
+	   0.058973   0.000000
+
+2022-12-06:15:30:05,14 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
+	   0.381989   0.000000  -0.139867
+	   0.000000   1.491765   0.032403
+	  -0.139867   0.032403   0.000000
+
+2022-12-06:15:30:05,14 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
+
+	%s	 -0.046353  0.427630  1.492477
+
+2022-12-06:15:30:05,14 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
+
+	%s	 -0.173535  0.020041
+
+2022-12-06:15:30:05,14 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
+
+		  0.339832  0.326530 -0.021067
+
+2022-12-06:15:30:05,14 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
+
+		  0.013860  0.471445  0.009957
+
+2022-12-06:15:30:05,15 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:05,17 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:05,17 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.850e-10 	Max(dx):  3.495e-10 	RMS(dq):  2.867e-16
+2022-12-06:15:30:05,17 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18748        0.25774        0.00733       1.19481
+	               R(2,3)       1.15142        0.42738        0.24948       1.40089
+	             B(1,2,3)      58.22898        0.01087        0.57051      58.79949
+	-------------------------------------------------------------------------------
+
+2022-12-06:15:30:05,17 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.4717535378
+2022-12-06:15:30:05,17 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :   -0.0557756389
+2022-12-06:15:30:05,17 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :    0.1063302971
+2022-12-06:15:30:05,18 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.4717535378
+2022-12-06:15:30:05,18 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.3655101977
+2022-12-06:15:30:05,18 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.7790880789532152  0.8915702010699978  0.0000000000000000
+	       7.000000            14.003074        0.9873146475576901 -0.5147603970040507  0.0000000000000000
+	       1.000000             1.007825       -1.4959768577718331 -1.4320896195216311  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.257863           1.194810
+	 R(2,3)           =         2.647306           1.400894
+	 B(1,2,3)         =         1.026245          58.799487
+
+2022-12-06:15:30:05,18 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:05,18 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     3     -92.71756573    3.51e-03      1.43e-01      8.96e-02 o    4.71e-01      2.72e-01 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:15:30:05,19 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:05,33 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:05,35 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.713235626627544
+2022-12-06:15:30:05,157 INFO     [psi4.driver.driver:640] Return gradient(): -92.7228361408007
+2022-12-06:15:30:05,158 INFO     [psi4.driver.driver:641] [[-0.00141289  0.01251821  0.00000000]
+ [ 0.01941991  0.00223784  0.00000000]
+ [-0.01800702 -0.01475605  0.00000000]]
+2022-12-06:15:30:05,160 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:05,160 INFO     [psi4.optking.history:268] 	Using 3 previous steps for update.
+2022-12-06:15:30:05,161 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 5.45e-01 exceeds limit of 5.00e-01.
+2022-12-06:15:30:05,161 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 1.
+2022-12-06:15:30:05,161 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  3 2
+
+2022-12-06:15:30:05,162 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.500869   0.056394  -0.019759
+	   0.056394   0.178797   0.211475
+	  -0.019759   0.211475   0.004032
+
+2022-12-06:15:30:05,162 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.500869   0.056394  -0.019759
+	   0.056394   0.178797   0.211475
+	  -0.019759   0.211475   0.004032
+
+2022-12-06:15:30:05,162 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.8889955722   0.8157741785   0.0000000000		  -0.0014128940   0.0125182082   0.0000000000
+   0.8774071543  -0.5905564195   0.0000000000		   0.0194199145   0.0022378393   0.0000000000
+  -1.6058843510  -1.5078856421   0.0000000000		  -0.0180070205  -0.0147560475   0.0000000000
+
+2022-12-06:15:30:05,162 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
+ 
+	Current energy:       -92.7228361408
+	Energy change for the previous step:
+		Actual       :        -0.0052704113
+		Projected    :        -0.0118443909
+
+2022-12-06:15:30:05,163 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    0.44497
+2022-12-06:15:30:05,163 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
+
+		 -0.004686 -0.029211  0.009657
+
+2022-12-06:15:30:05,163 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
+	  -0.138798   0.004686
+	   0.004686   0.000000
+
+2022-12-06:15:30:05,163 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
+	   0.319147   0.000000   0.029211
+	   0.000000   1.503349  -0.009657
+	   0.029211  -0.009657   0.000000
+
+2022-12-06:15:30:05,163 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
+
+	%s	 -0.002713  0.321798  1.503411
+
+2022-12-06:15:30:05,163 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
+
+	%s	 -0.138956  0.000158
+
+2022-12-06:15:30:05,163 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
+
+		  0.033725 -0.090755  0.006412
+
+2022-12-06:15:30:05,163 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
+
+		 -0.002679 -0.094314 -0.022643
+
+2022-12-06:15:30:05,163 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:05,165 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:05,165 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.556e-15 	Max(dx):  4.966e-15 	RMS(dq):  0.000e+00
+2022-12-06:15:30:05,166 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.19481       -0.07334       -0.00142       1.19339
+	               R(2,3)       1.40089       -0.18129       -0.04991       1.35099
+	             B(1,2,3)      58.79949       -0.00153       -1.29737      57.50212
+	-------------------------------------------------------------------------------
+
+2022-12-06:15:30:05,166 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.0970311051
+2022-12-06:15:30:05,166 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :   -0.0263306551
+2022-12-06:15:30:05,166 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :    0.2689969232
+2022-12-06:15:30:05,166 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.0970311051
+2022-12-06:15:30:05,166 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.0904119736
+2022-12-06:15:30:05,167 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9148592542054622  0.7843111656073425  0.0000000000000000
+	       7.000000            14.003074        0.8543516469049374 -0.6141687157929820  0.0000000000000000
+	       1.000000             1.007825       -1.5569651615637548 -1.4528103328771054  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.255184           1.193392
+	 R(2,3)           =         2.552992           1.350985
+	 B(1,2,3)         =         1.003601          57.502119
+
+2022-12-06:15:30:05,167 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:05,167 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     4     -92.72283614   -5.27e-03      2.20e-02      1.80e-02 o    9.43e-02      5.60e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:15:30:05,167 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:05,182 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:05,184 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.943572662790583
+2022-12-06:15:30:05,302 INFO     [psi4.driver.driver:640] Return gradient(): -92.72424408943418
+2022-12-06:15:30:05,302 INFO     [psi4.driver.driver:641] [[-0.00800408 -0.00185263  0.00000000]
+ [ 0.01471195 -0.00181580  0.00000000]
+ [-0.00670786  0.00366843  0.00000000]]
+2022-12-06:15:30:05,304 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:05,305 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:05,305 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 5.67e-01 exceeds limit of 5.00e-01.
+2022-12-06:15:30:05,305 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 1.
+2022-12-06:15:30:05,305 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  4 3 2
+
+2022-12-06:15:30:05,306 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.521468   0.067231  -0.032353
+	   0.067231   0.145667   0.198248
+	  -0.032353   0.198248   0.045507
+
+2022-12-06:15:30:05,307 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.521468   0.067231  -0.032353
+	   0.067231   0.145667   0.198248
+	  -0.032353   0.198248   0.045507
+
+2022-12-06:15:30:05,307 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.8932416777   0.8084752858   0.0000000000		  -0.0080040848  -0.0018526296   0.0000000000
+   0.8759692234  -0.5900045956   0.0000000000		   0.0147119474  -0.0018158011   0.0000000000
+  -1.5353475850  -1.4286462127   0.0000000000		  -0.0067078626   0.0036684307   0.0000000000
+
+2022-12-06:15:30:05,307 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
+ 
+	Current energy:       -92.7242440894
+	Energy change for the previous step:
+		Actual       :        -0.0014079486
+		Projected    :        -0.0012765659
+
+2022-12-06:15:30:05,307 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    1.10292
+2022-12-06:15:30:05,307 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
+
+		  0.014331  0.005044  0.005589
+
+2022-12-06:15:30:05,307 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
+	  -0.111629  -0.014331
+	  -0.014331   0.000000
+
+2022-12-06:15:30:05,307 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
+	   0.299171   0.000000  -0.005044
+	   0.000000   1.525100  -0.005589
+	  -0.005044  -0.005589   0.000000
+
+2022-12-06:15:30:05,307 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
+
+	%s	 -0.000105  0.299256  1.525121
+
+2022-12-06:15:30:05,307 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
+
+	%s	 -0.113439  0.001811
+
+2022-12-06:15:30:05,308 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
+
+		 -0.126334  0.016855  0.003664
+
+2022-12-06:15:30:05,308 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
+
+		 -0.009287  0.090966 -0.088864
+
+2022-12-06:15:30:05,308 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:05,310 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:05,310 INFO     [psi4.optking.displace:379] 	RMS(dx):  4.529e-13 	Max(dx):  9.778e-13 	RMS(dq):  6.410e-17
+2022-12-06:15:30:05,310 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.19339       -0.04227       -0.00491       1.18848
+	               R(2,3)       1.35099       -0.04227        0.04814       1.39912
+	             B(1,2,3)      57.50212        0.00110       -5.09155      52.41057
+	-------------------------------------------------------------------------------
+
+2022-12-06:15:30:05,310 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.1275062920
+2022-12-06:15:30:05,311 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :    0.0133721563
+2022-12-06:15:30:05,311 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :   -0.1030990141
+2022-12-06:15:30:05,311 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.1275062920
+2022-12-06:15:30:05,311 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.1387211591
+2022-12-06:15:30:05,311 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9101619218229949  0.7166536780708004  0.0000000000000000
+	       7.000000            14.003074        0.9376619843910825 -0.5599032640847524  0.0000000000000000
+	       1.000000             1.007825       -1.5801201018297129 -1.3669259363720700  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.245896           1.188477
+	 R(2,3)           =         2.643958           1.399122
+	 B(1,2,3)         =         0.914737          52.410571
+
+2022-12-06:15:30:05,311 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:05,312 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     5     -92.72424409   -1.41e-03      1.45e-02      9.35e-03 o    9.10e-02      7.36e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:15:30:05,312 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:05,326 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:05,328 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=24.0897470147513
+2022-12-06:15:30:05,447 INFO     [psi4.driver.driver:640] Return gradient(): -92.72310977754353
+2022-12-06:15:30:05,448 INFO     [psi4.driver.driver:641] [[-0.01241692 -0.00638911  0.00000000]
+ [-0.00190640 -0.00918654  0.00000000]
+ [ 0.01432332  0.01557566  0.00000000]]
+2022-12-06:15:30:05,450 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:05,450 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:05,451 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  5 4 3 2
+
+2022-12-06:15:30:05,452 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.507033   0.064732  -0.049317
+	   0.064732   0.134555   0.238926
+	  -0.049317   0.238926   0.116998
+
+2022-12-06:15:30:05,453 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.507033   0.064732  -0.049317
+	   0.064732   0.134555   0.238926
+	  -0.049317   0.238926   0.116998
+
+2022-12-06:15:30:05,453 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9329572573   0.7395386950   0.0000000000		  -0.0124169151  -0.0063891149   0.0000000000
+   0.9148666489  -0.5370182472   0.0000000000		  -0.0019064013  -0.0091865406   0.0000000000
+  -1.6029154373  -1.3440409195   0.0000000000		   0.0143233165   0.0155756554   0.0000000000
+
+2022-12-06:15:30:05,453 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
+ 
+	Current energy:       -92.7231097775
+	Energy change for the previous step:
+		Actual       :         0.0011343119
+		Projected    :         0.0008530804
+
+2022-12-06:15:30:05,453 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    1.32967
+2022-12-06:15:30:05,453 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
+
+		  0.006771  0.032519  0.006580
+
+2022-12-06:15:30:05,453 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
+	  -0.117294  -0.006771
+	  -0.006771   0.000000
+
+2022-12-06:15:30:05,453 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
+	   0.364730   0.000000  -0.032519
+	   0.000000   1.511149  -0.006580
+	  -0.032519  -0.006580   0.000000
+
+2022-12-06:15:30:05,453 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
+
+	%s	 -0.002905  0.367607  1.511177
+
+2022-12-06:15:30:05,453 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
+
+	%s	 -0.117684  0.000390
+
+2022-12-06:15:30:05,453 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
+
+		 -0.057535  0.088453  0.004346
+
+2022-12-06:15:30:05,453 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
+
+		 -0.008133  0.103320  0.020298
+
+2022-12-06:15:30:05,454 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:05,456 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:05,456 INFO     [psi4.optking.displace:379] 	RMS(dx):  4.043e-15 	Max(dx):  7.494e-15 	RMS(dq):  3.846e-16
+2022-12-06:15:30:05,457 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18848       -0.05425       -0.00430       1.18417
+	               R(2,3)       1.39912        0.15154        0.05467       1.45380
+	             B(1,2,3)      52.41057        0.00210        1.16298      53.57356
+	-------------------------------------------------------------------------------
+
+2022-12-06:15:30:05,457 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.1056087518
+2022-12-06:15:30:05,457 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :   -0.0238180991
+2022-12-06:15:30:05,457 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :    0.2236043547
+2022-12-06:15:30:05,457 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.1056087518
+2022-12-06:15:30:05,457 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.0961743512
+2022-12-06:15:30:05,457 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9003097051643261  0.7650023319001547  0.0000000000000000
+	       7.000000            14.003074        0.9394411309937878 -0.5089286153762722  0.0000000000000000
+	       1.000000             1.007825       -1.6601374714180441 -1.3975941881662395  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.237763           1.184173
+	 R(2,3)           =         2.747278           1.453797
+	 B(1,2,3)         =         0.935035          53.573556
+
+2022-12-06:15:30:05,458 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:05,458 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     6     -92.72310978    1.13e-03      2.77e-02      1.95e-02 o    1.03e-01      6.10e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:15:30:05,458 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:05,473 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:05,475 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.93429778662292
+2022-12-06:15:30:05,593 INFO     [psi4.driver.driver:640] Return gradient(): -92.72388668162617
+2022-12-06:15:30:05,593 INFO     [psi4.driver.driver:641] [[ 0.00706762  0.01014844  0.00000000]
+ [-0.00764125  0.00030113  0.00000000]
+ [ 0.00057363 -0.01044958  0.00000000]]
+2022-12-06:15:30:05,596 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:05,596 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:05,597 WARNING  [psi4.optking.history:286] 	Change in internal coordinate of 5.71e-01 exceeds limit of 5.00e-01.
+2022-12-06:15:30:05,597 WARNING  [psi4.optking.history:291] 	Skipping Hessian update for step 3.
+2022-12-06:15:30:05,597 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  6 5 4 2
+
+2022-12-06:15:30:05,598 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.464959   0.104974  -0.032428
+	   0.104974   0.214444   0.271896
+	  -0.032428   0.271896   0.065432
+
+2022-12-06:15:30:05,598 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.464959   0.104974  -0.032428
+	   0.104974   0.214444   0.271896
+	  -0.032428   0.271896   0.065432
+
+2022-12-06:15:30:05,598 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9254187960   0.7411255809   0.0000000000		   0.0070676188   0.0101484439   0.0000000000
+   0.9143320402  -0.5328053664   0.0000000000		  -0.0076412532   0.0003011333   0.0000000000
+  -1.6852465623  -1.4214709392   0.0000000000		   0.0005736344  -0.0104495772   0.0000000000
+
+2022-12-06:15:30:05,599 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
+ 
+	Current energy:       -92.7238866816
+	Energy change for the previous step:
+		Actual       :        -0.0007769041
+		Projected    :        -0.0012544555
+
+2022-12-06:15:30:05,599 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    0.61932
+2022-12-06:15:30:05,599 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
+
+		 -0.020130 -0.019202 -0.000001
+
+2022-12-06:15:30:05,599 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
+	  -0.146968   0.020130
+	   0.020130   0.000000
+
+2022-12-06:15:30:05,599 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
+	   0.418023   0.000000   0.019202
+	   0.000000   1.473780   0.000001
+	   0.019202   0.000001   0.000000
+
+2022-12-06:15:30:05,599 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
+
+	%s	 -0.000880  0.418903  1.473780
+
+2022-12-06:15:30:05,599 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
+
+	%s	 -0.149675  0.002707
+
+2022-12-06:15:30:05,599 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
+
+		  0.134489 -0.045839 -0.000001
+
+2022-12-06:15:30:05,599 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
+
+		  0.010236 -0.118220  0.078152
+
+2022-12-06:15:30:05,599 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:05,601 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:05,601 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.671e-13 	Max(dx):  5.925e-13 	RMS(dq):  1.282e-16
+2022-12-06:15:30:05,602 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18417        0.00027        0.00542       1.18959
+	               R(2,3)       1.45380       -0.02338       -0.06256       1.39124
+	             B(1,2,3)      53.57356       -0.00211        4.47779      58.05134
+	-------------------------------------------------------------------------------
+
+2022-12-06:15:30:05,602 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.1420862671
+2022-12-06:15:30:05,602 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :    0.0128586126
+2022-12-06:15:30:05,602 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :   -0.0881647793
+2022-12-06:15:30:05,602 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.1420862671
+2022-12-06:15:30:05,602 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.1320040359
+2022-12-06:15:30:05,603 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9173240915403221  0.8204518060098537  0.0000000000000000
+	       7.000000            14.003074        0.8474858793066242 -0.5720083595048392  0.0000000000000000
+	       1.000000             1.007825       -1.6264951058659802 -1.4615941711916041  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.247999           1.189590
+	 R(2,3)           =         2.629058           1.391237
+	 B(1,2,3)         =         1.013187          58.051343
+
+2022-12-06:15:30:05,603 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:05,603 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     7     -92.72388668   -7.77e-04      2.77e-02      1.61e-02 o    1.18e-01      8.20e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:15:30:05,603 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:05,618 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:05,620 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.856610419205197
+2022-12-06:15:30:05,740 INFO     [psi4.driver.driver:640] Return gradient(): -92.72344377887617
+2022-12-06:15:30:05,741 INFO     [psi4.driver.driver:641] [[ 0.00421924  0.00404187  0.00000000]
+ [ 0.00938275  0.00610712  0.00000000]
+ [-0.01360200 -0.01014899  0.00000000]]
+2022-12-06:15:30:05,743 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:05,743 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:05,744 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  7 6 5 4
+
+2022-12-06:15:30:05,745 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.292006  -0.002003  -0.229470
+	  -0.002003   0.136220   0.253093
+	  -0.229470   0.253093   0.364682
+
+2022-12-06:15:30:05,745 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.292006  -0.002003  -0.229470
+	  -0.002003   0.136220   0.253093
+	  -0.229470   0.253093   0.364682
+
+2022-12-06:15:30:05,745 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.8884578145   0.8070307388   0.0000000000		   0.0042192441   0.0040418691   0.0000000000
+   0.8763521564  -0.5854294267   0.0000000000		   0.0093827536   0.0061071217   0.0000000000
+  -1.5976288288  -1.4750152384   0.0000000000		  -0.0136019977  -0.0101489909   0.0000000000
+
+2022-12-06:15:30:05,746 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
+ 
+	Current energy:       -92.7234437789
+	Energy change for the previous step:
+		Actual       :         0.0004429027
+		Projected    :         0.0009185308
+
+2022-12-06:15:30:05,746 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    0.48219
+2022-12-06:15:30:05,746 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
+
+		 -0.005973 -0.019373 -0.004735
+
+2022-12-06:15:30:05,746 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
+	  -0.039149   0.005973
+	   0.005973   0.000000
+
+2022-12-06:15:30:05,746 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
+	   0.483297   0.000000   0.019373
+	   0.000000   1.348759   0.004735
+	   0.019373   0.004735   0.000000
+
+2022-12-06:15:30:05,746 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
+
+	%s	 -0.000792  0.484073  1.348776
+
+2022-12-06:15:30:05,746 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
+
+	%s	 -0.040040  0.000891
+
+2022-12-06:15:30:05,746 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
+
+		  0.149167 -0.040020 -0.003508
+
+2022-12-06:15:30:05,746 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
+
+		 -0.020009  0.098861 -0.117007
+
+2022-12-06:15:30:05,746 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:05,748 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:05,748 INFO     [psi4.optking.displace:379] 	RMS(dx):  2.624e-12 	Max(dx):  5.878e-12 	RMS(dq):  1.923e-16
+2022-12-06:15:30:05,749 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18959        0.00666       -0.01059       1.17900
+	               R(2,3)       1.39124       -0.13375        0.05232       1.44355
+	             B(1,2,3)      58.05134       -0.00099       -6.70403      51.34731
+	-------------------------------------------------------------------------------
+
+2022-12-06:15:30:05,749 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.1544817540
+2022-12-06:15:30:05,749 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :    0.0006408827
+2022-12-06:15:30:05,749 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :   -0.0033714848
+2022-12-06:15:30:05,749 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.1544817540
+2022-12-06:15:30:05,749 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.1831166633
+2022-12-06:15:30:05,750 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9123677171428842  0.6797519639344178  0.0000000000000000
+	       7.000000            14.003074        0.9485890671191125 -0.5453116052676075  0.0000000000000000
+	       1.000000             1.007825       -1.6459558368844465 -1.3878542848453985  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.227990           1.179002
+	 R(2,3)           =         2.727919           1.443553
+	 B(1,2,3)         =         0.896180          51.347308
+
+2022-12-06:15:30:05,750 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:05,750 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     8     -92.72344378    4.43e-04      1.62e-02      1.20e-02 o    1.17e-01      8.92e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:15:30:05,750 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:05,764 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:05,766 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=24.15199793947908
+2022-12-06:15:30:05,887 INFO     [psi4.driver.driver:640] Return gradient(): -92.72429716819991
+2022-12-06:15:30:05,887 INFO     [psi4.driver.driver:641] [[ 0.00524965 -0.00385795  0.00000000]
+ [-0.02049652 -0.00138169  0.00000000]
+ [ 0.01524688  0.00523963  0.00000000]]
+2022-12-06:15:30:05,889 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:05,889 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:05,890 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  8 7 6 5
+
+2022-12-06:15:30:05,891 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.281025   0.041032  -0.149143
+	   0.041032   0.133923   0.405516
+	  -0.149143   0.405516   0.570353
+
+2022-12-06:15:30:05,892 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.281025   0.041032  -0.149143
+	   0.041032   0.133923   0.405516
+	  -0.149143   0.405516   0.570353
+
+2022-12-06:15:30:05,892 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9373914976   0.7122473461   0.0000000000		   0.0052496451  -0.0038579460   0.0000000000
+   0.9235652867  -0.5128162231   0.0000000000		  -0.0204965226  -0.0013816889   0.0000000000
+  -1.6709796173  -1.3553589027   0.0000000000		   0.0152468775   0.0052396349   0.0000000000
+
+2022-12-06:15:30:05,892 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
+ 
+	Current energy:       -92.7242971682
+	Energy change for the previous step:
+		Actual       :        -0.0008533893
+		Projected    :         0.0000574051
+
+2022-12-06:15:30:05,892 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =  -14.86608
+2022-12-06:15:30:05,892 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
+
+		  0.012805  0.010409 -0.005516
+
+2022-12-06:15:30:05,892 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
+	  -0.117367  -0.012805
+	  -0.012805   0.000000
+
+2022-12-06:15:30:05,892 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
+	   0.789971   0.000000  -0.010409
+	   0.000000   1.312698   0.005516
+	  -0.010409   0.005516   0.000000
+
+2022-12-06:15:30:05,892 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
+
+	%s	 -0.000160  0.790108  1.312721
+
+2022-12-06:15:30:05,892 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
+
+	%s	 -0.118748  0.001381
+
+2022-12-06:15:30:05,893 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
+
+		 -0.107834  0.013173 -0.004202
+
+2022-12-06:15:30:05,893 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
+
+		  0.015489 -0.085029  0.065950
+
+2022-12-06:15:30:05,893 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:05,895 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:05,895 INFO     [psi4.optking.displace:379] 	RMS(dx):  3.408e-14 	Max(dx):  7.774e-14 	RMS(dq):  3.626e-16
+2022-12-06:15:30:05,895 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.17900        0.05360        0.00820       1.18720
+	               R(2,3)       1.44355        0.13281       -0.04500       1.39856
+	             B(1,2,3)      51.34731        0.00006        3.77866      55.12597
+	-------------------------------------------------------------------------------
+
+2022-12-06:15:30:05,895 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.1087165959
+2022-12-06:15:30:05,896 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :    0.0112266551
+2022-12-06:15:30:05,896 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :   -0.1019094426
+2022-12-06:15:30:05,896 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.1087165959
+2022-12-06:15:30:05,896 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.1105319993
+2022-12-06:15:30:05,896 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9321914640274376  0.7847252431596277  0.0000000000000000
+	       7.000000            14.003074        0.8747957679877996 -0.5449352090291700  0.0000000000000000
+	       1.000000             1.007825       -1.6274101321452563 -1.3957178138848867  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.243479           1.187198
+	 R(2,3)           =         2.642890           1.398557
+	 B(1,2,3)         =         0.962130          55.125967
+
+2022-12-06:15:30:05,896 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:05,897 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     9     -92.72429717   -8.53e-04      1.61e-02      1.00e-02 o    8.50e-02      6.28e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:15:30:05,897 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:05,912 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:05,914 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.99123431807848
+2022-12-06:15:30:06,33 INFO     [psi4.driver.driver:640] Return gradient(): -92.72370023111081
+2022-12-06:15:30:06,33 INFO     [psi4.driver.driver:641] [[ 0.00045762 -0.00015090  0.00000000]
+ [ 0.00020699  0.00051108  0.00000000]
+ [-0.00066461 -0.00036018  0.00000000]]
+2022-12-06:15:30:06,35 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:06,35 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:06,36 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  9 8 7 6
+
+2022-12-06:15:30:06,37 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.277564   0.051582  -0.082282
+	   0.051582   0.126757   0.409330
+	  -0.082282   0.409330   0.595683
+
+2022-12-06:15:30:06,38 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.277564   0.051582  -0.082282
+	   0.051582   0.126757   0.409330
+	  -0.082282   0.409330   0.595683
+
+2022-12-06:15:30:06,38 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9108440680   0.7706829298   0.0000000000		   0.0004576185  -0.0001509017   0.0000000000
+   0.8961431640  -0.5589775224   0.0000000000		   0.0002069899   0.0005110811   0.0000000000
+  -1.6060627361  -1.4097601272   0.0000000000		  -0.0006646084  -0.0003601794   0.0000000000
+
+2022-12-06:15:30:06,38 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
+ 
+	Current energy:       -92.7237002311
+	Energy change for the previous step:
+		Actual       :         0.0005969371
+		Projected    :         0.0006110525
+
+2022-12-06:15:30:06,38 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    0.97690
+2022-12-06:15:30:06,38 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
+
+		 -0.000502 -0.000620 -0.000492
+
+2022-12-06:15:30:06,38 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
+	  -0.115807   0.000502
+	   0.000502   0.000000
+
+2022-12-06:15:30:06,38 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
+	   0.828450   0.000000   0.000620
+	   0.000000   1.287361   0.000492
+	   0.000620   0.000492   0.000000
+
+2022-12-06:15:30:06,38 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
+
+	%s	 -0.000001  0.828451  1.287361
+
+2022-12-06:15:30:06,38 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
+
+	%s	 -0.115809  0.000002
+
+2022-12-06:15:30:06,38 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
+
+		  0.004332 -0.000748 -0.000382
+
+2022-12-06:15:30:06,38 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
+
+		  0.000039  0.003356 -0.002865
+
+2022-12-06:15:30:06,39 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:06,40 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:06,40 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.297e-12 	Max(dx):  2.465e-12 	RMS(dq):  3.846e-16
+2022-12-06:15:30:06,41 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18720        0.00377        0.00002       1.18722
+	               R(2,3)       1.39856       -0.00614        0.00178       1.40033
+	             B(1,2,3)      55.12597       -0.00003       -0.16413      54.96184
+	-------------------------------------------------------------------------------
+
+2022-12-06:15:30:06,41 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.0044125843
+2022-12-06:15:30:06,41 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :    0.0003447689
+2022-12-06:15:30:06,41 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :   -0.0781310303
+2022-12-06:15:30:06,41 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.0044125843
+2022-12-06:15:30:06,41 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.0044654626
+2022-12-06:15:30:06,42 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9114599421415510  0.7678839554629108  0.0000000000000000
+	       7.000000            14.003074        0.8983606486396080 -0.5579825565860180  0.0000000000000000
+	       1.000000             1.007825       -1.6076643465426701 -1.4079561186102416  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.243518           1.187219
+	 R(2,3)           =         2.646246           1.400333
+	 B(1,2,3)         =         0.959265          54.961838
+
+2022-12-06:15:30:06,42 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:06,42 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	    10     -92.72370023    5.97e-04      7.45e-04      5.41e-04 o    3.36e-03      2.55e-03 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:15:30:06,42 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned False
+2022-12-06:15:30:06,57 INFO     [psi4.driver.task_planner:283] PLANNING Atomic:  keywords={'FULL_HESS_EVERY': 0, 'SCF__GUESS': 'READ', 'SCF__INTS_TOLERANCE': 1e-12, 'OPT_TYPE': 'TS', 'SCF_TYPE': 'PK', 'function_kwargs': {}}
+2022-12-06:15:30:06,58 INFO     [psi4.driver.driver:637] Compute gradient(): method=scf, basis=6-31g, molecule=default, nre=23.992241573980753
+2022-12-06:15:30:06,170 INFO     [psi4.driver.driver:640] Return gradient(): -92.72369968536393
+2022-12-06:15:30:06,171 INFO     [psi4.driver.driver:641] [[ 0.00007779  0.00008289  0.00000000]
+ [-0.00002410  0.00003634  0.00000000]
+ [-0.00005369 -0.00011923  0.00000000]]
+2022-12-06:15:30:06,173 INFO     [psi4.optking.history:257] 	Performing BOFILL update.
+2022-12-06:15:30:06,174 INFO     [psi4.optking.history:268] 	Using 4 previous steps for update.
+2022-12-06:15:30:06,174 INFO     [psi4.optking.history:302] 	Steps to be used in Hessian update:  10 9 8 7
+
+2022-12-06:15:30:06,175 INFO     [psi4.optking.history:400] 	Updated Hessian (in au) 
+ 	   1.255066   0.051558  -0.082309
+	   0.051558   0.113880   0.349177
+	  -0.082309   0.349177   0.343815
+
+2022-12-06:15:30:06,176 INFO     [psi4.optking.molsys:874] Projected (PHP) Hessian matrix
+	   1.255066   0.051558  -0.082309
+	   0.051558   0.113880   0.349177
+	  -0.082309   0.349177   0.343815
+
+2022-12-06:15:30:06,176 INFO     [psi4.optking.opt_helper:168] 
+	         Geometry (au)                                       Gradient (au)
+  -0.9122761670   0.7685443181   0.0000000000		   0.0000777932   0.0000828852   0.0000000000
+   0.8975444238  -0.5573221940   0.0000000000		  -0.0000241002   0.0000363429   0.0000000000
+  -1.6084805714  -1.4072957560   0.0000000000		  -0.0000536931  -0.0001192282   0.0000000000
+
+2022-12-06:15:30:06,176 INFO     [psi4.optking.stepAlgorithms:314] 	Current Step Report 
+ 
+	Current energy:       -92.7236996854
+	Energy change for the previous step:
+		Actual       :         0.0000005457
+		Projected    :         0.0000007607
+
+2022-12-06:15:30:06,176 INFO     [psi4.optking.stepAlgorithms:317] 	Energy ratio =    0.71746
+2022-12-06:15:30:06,176 INFO     [psi4.optking.stepAlgorithms:837] 	Internal forces in au, in Hevect basis:
+
+		  0.000076 -0.000256 -0.000033
+
+2022-12-06:15:30:06,177 INFO     [psi4.optking.stepAlgorithms:843] 	RFO max
+	  -0.144567  -0.000076
+	  -0.000076   0.000000
+
+2022-12-06:15:30:06,177 INFO     [psi4.optking.stepAlgorithms:844] 	RFO min
+	   0.594485   0.000000   0.000256
+	   0.000000   1.262842   0.000033
+	   0.000256   0.000033   0.000000
+
+2022-12-06:15:30:06,177 INFO     [psi4.optking.stepAlgorithms:850] 	RFO min eigenvalues:
+
+	%s	 -0.000000  0.594486  1.262842
+
+2022-12-06:15:30:06,177 INFO     [psi4.optking.stepAlgorithms:851] 	RFO max eigenvalues:
+
+	%s	 -0.144567  0.000000
+
+2022-12-06:15:30:06,177 INFO     [psi4.optking.stepAlgorithms:865] 	RFO step in Hessian Eigenvector Basis
+
+		 -0.000525 -0.000430 -0.000026
+
+2022-12-06:15:30:06,177 INFO     [psi4.optking.stepAlgorithms:866] 	RFO step in original Basis
+
+		  0.000036 -0.000677 -0.000040
+
+2022-12-06:15:30:06,177 INFO     [psi4.optking.displace:73] 	Determining Cartesian step for fragment 1.
+2022-12-06:15:30:06,178 INFO     [psi4.optking.displace:378] 	Successfully converged to displaced geometry.
+2022-12-06:15:30:06,178 INFO     [psi4.optking.displace:379] 	RMS(dx):  1.208e-08 	Max(dx):  2.383e-08 	RMS(dq):  4.104e-16
+2022-12-06:15:30:06,179 INFO     [psi4.optking.displace:132] 
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18722        0.00011        0.00002       1.18724
+	               R(2,3)       1.40033       -0.00073       -0.00036       1.39997
+	             B(1,2,3)      54.96184       -0.00002       -0.00228      54.95956
+	-------------------------------------------------------------------------------
+
+2022-12-06:15:30:06,179 INFO     [psi4.optking.stepAlgorithms:95] 	|target step| :    0.0006794634
+2022-12-06:15:30:06,179 INFO     [psi4.optking.stepAlgorithms:96] 	gradient     :   -0.0001044034
+2022-12-06:15:30:06,179 INFO     [psi4.optking.stepAlgorithms:97] 	hessian      :    0.1536556036
+2022-12-06:15:30:06,179 INFO     [psi4.optking.stepAlgorithms:176] 	Norm of achieved step-size    0.0006794634
+2022-12-06:15:30:06,179 INFO     [psi4.optking.stepAlgorithms:178] 	Norm of achieved step-size (cart):    0.0005528974
+2022-12-06:15:30:06,180 INFO     [psi4.optking.opt_helper:151] Molsys:
+
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9124371909388032  0.7684722816345814  0.0000000000000000
+	       7.000000            14.003074        0.8973432977980585 -0.5575102056218055  0.0000000000000000
+	       1.000000             1.007825       -1.6081184215633357 -1.4070357078794027  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.243554           1.187238
+	 R(2,3)           =         2.645568           1.399974
+	 B(1,2,3)         =         0.959225          54.959561
+
+2022-12-06:15:30:06,180 INFO     [psi4.optking.convcheck:71] Performing convergence check.
+2022-12-06:15:30:06,180 INFO     [psi4.optking.convcheck:263] 
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	    11     -92.72369969    5.46e-07 *    2.53e-04 *    1.55e-04 o    6.77e-04 *    3.92e-04 o  ~
+	----------------------------------------------------------------------------------------------
+
+
+2022-12-06:15:30:06,180 INFO     [psi4.optking.convcheck:193] 
+	                      ===> Final Convergence Report <===                     
+
+	----------------------------------------------------------------------------
+	|   Required Criteria    |  One or More Criteria  |   Alternate Criteria   |
+	----------------------------------------------------------------------------
+	| [x]     max_force      | [x]       max_DE       |                        |
+	|                        | [x]      max_disp      |                        |
+	----------------------------------------------------------------------------
+
+
+2022-12-06:15:30:06,180 INFO     [psi4.optking.stepAlgorithms:265] 	Convergence check returned True
+2022-12-06:15:30:06,180 INFO     [psi4.optking.optimize:286] 	Converged in 11 steps!
+2022-12-06:15:30:06,180 INFO     [psi4.optking.optimize:287] 	Final energy is    -92.7236996853639
+2022-12-06:15:30:06,180 INFO     [psi4.optking.optimize:288] 	Final structure (Angstroms): 
+	Fragment 1 (Ang)
+
+	    C  -0.4828409676   0.4066580185   0.0000000000
+	    N   0.4748536233  -0.2950216955   0.0000000000
+	    H  -0.8509796207  -0.7445712312   0.0000000000
+
+
+2022-12-06:15:30:06,182 INFO     [psi4.optking.optimize:455] 	Optimization Finished
+
+	==> Optimization Summary <==
+
+        
+	Measures of convergence in internal coordinates in au. (Any backward steps not shown.)
+        
+	---------------------------------------------------------------------------------------------------------------  ~
+        
+	 Step         Total Energy             Delta E       MAX Force       RMS Force        MAX Disp        RMS Disp   ~
+        
+	---------------------------------------------------------------------------------------------------------------  ~
+        
+	     1     -92.675168102266    -92.675168102266      0.13952751      0.09868759      0.44313856      0.28867513  ~
+	     2     -92.721072916550     -0.045904814284      0.06975379      0.05613340      0.37689609      0.28867513  ~
+	     3     -92.717565729533      0.003507187017      0.14290140      0.08961104      0.47144477      0.27236703  ~
+	     4     -92.722836140801     -0.005270411268      0.02200457      0.01796736      0.09431403      0.05602093  ~
+	     5     -92.724244089434     -0.001407948633      0.01447124      0.00934631      0.09096561      0.07361579  ~
+	     6     -92.723109777544      0.001134311891      0.02765686      0.01954991      0.10332014      0.06097324  ~
+	     7     -92.723886681626     -0.000776904083      0.02767427      0.01606151      0.11822003      0.08203354  ~
+	     8     -92.723443778876      0.000442902750      0.01623376      0.01201948      0.11700747      0.08919008  ~
+	     9     -92.724297168200     -0.000853389324      0.01611973      0.01004549      0.08502929      0.06276756  ~
+	    10     -92.723700231111      0.000596937089      0.00074518      0.00054094      0.00335611      0.00254761  ~
+	    11     -92.723699685364      0.000000545747      0.00025315      0.00015516      0.00067733      0.00039229  ~
+	----------------------------------------------------------------------------------------------------------------
+
+
+2022-12-06:15:30:06,182 INFO     [psi4.optking.optimize:663] Preparing OptimizationResult

--- a/tests/opt16/output.ref
+++ b/tests/opt16/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev138 
+                               Psi4 1.7a1.dev139 
 
-                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+                         Git: Rev {findif-scf-read} b703eab dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,20 +30,21 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+    Psi4 started on: Tuesday, 06 December 2022 03:29PM
 
-    Process ID: 330641
+    Process ID: 337007
     Host:       nidavellir
     PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
-    Threads:    4
+    Threads:    1
     
   ==> Input File <==
 
 --------------------------------------------------------------------------
-#! 6-31G(d) optimization of SF4 starting from linear bond angle
-#! that is not linear in the optimized structure but is in a 
-#! symmetry plane of the molecule.
+#! SCF 6-31G(d) optimization of TS for HCN to HNC
+#! Checks correct behavior for writing orbitals to disk in
+#! finite difference calculations for a symmetric molecule.
+#! The last two displacements break the plane of symmetry.
 
 SCF_E = -92.7236996864523064
 
@@ -62,9 +63,28 @@ set {
   full_hess_every 0
 }
 
-thisenergy = optimize('scf', dertype='gradient')
+fd_energy = optimize('scf', dertype='gradient')
 
-compare_values(SCF_E, thisenergy, 5, "6-31G(D) SCF optimization of SF4") #TEST 
+molecule {
+0 1
+C  -0.0399606537   1.7574844925   0.0000000000    
+N   1.2331003808   0.0000000000   0.0000000000    
+H  -1.1931397271  -1.7574844925   0.0000000000    
+units bohr
+}
+
+set {
+  scf_type pk
+  basis 6-31G
+  opt_type ts
+  full_hess_every 0
+}
+
+analytic_energy = optimize('scf')
+
+compare_values(SCF_E, analytic_energy, 5, "TS optimization of CNH - analytic hessian with symmetry") #TEST 
+compare_values(analytic_energy, fd_energy, 5, "TS optimization of CNH - finite difference hessian with symmetry") #TEST 
+
 
 --------------------------------------------------------------------------
 
@@ -72,7 +92,7 @@ Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:29 2022
+*** at Tue Dec  6 15:29:59 2022
 
    => Loading Basis Set <=
 
@@ -89,7 +109,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -149,13 +169,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -165,7 +184,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 9.6850361242E-03.
   Reciprocal condition number of the overlap matrix is 2.7456671621E-03.
@@ -188,19 +207,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter SAD:   -91.81613896682580   -9.18161e+01   0.00000e+00 
-   @RHF iter   1:   -92.61386260678688   -7.97724e-01   1.57396e-02 ADIIS/DIIS
-   @RHF iter   2:   -92.66021533756283   -4.63527e-02   1.07246e-02 ADIIS/DIIS
-   @RHF iter   3:   -92.67364182145670   -1.34265e-02   2.50489e-03 ADIIS/DIIS
-   @RHF iter   4:   -92.67491387466457   -1.27205e-03   8.26547e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.67514619775849   -2.32323e-04   1.92086e-04 ADIIS/DIIS
-   @RHF iter   6:   -92.67516667680232   -2.04790e-05   3.81285e-05 DIIS
-   @RHF iter   7:   -92.67516788606345   -1.20926e-06   1.45091e-05 DIIS
-   @RHF iter   8:   -92.67516808836463   -2.02301e-07   4.03440e-06 DIIS
-   @RHF iter   9:   -92.67516810204485   -1.36802e-08   6.27437e-07 DIIS
-   @RHF iter  10:   -92.67516810225041   -2.05560e-10   1.45473e-07 DIIS
-   @RHF iter  11:   -92.67516810226411   -1.36993e-11   4.77525e-08 DIIS
-   @RHF iter  12:   -92.67516810226587   -1.76215e-12   7.39513e-09 DIIS
+   @RHF iter SAD:   -91.81613896682578   -9.18161e+01   0.00000e+00 
+   @RHF iter   1:   -92.61386260678677   -7.97724e-01   1.57396e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66021533756289   -4.63527e-02   1.07246e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67364182145673   -1.34265e-02   2.50489e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67491387466453   -1.27205e-03   8.26547e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67514619775851   -2.32323e-04   1.92086e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67516667680229   -2.04790e-05   3.81285e-05 DIIS
+   @RHF iter   7:   -92.67516788606352   -1.20926e-06   1.45091e-05 DIIS
+   @RHF iter   8:   -92.67516808836476   -2.02301e-07   4.03440e-06 DIIS
+   @RHF iter   9:   -92.67516810204491   -1.36802e-08   6.27437e-07 DIIS
+   @RHF iter  10:   -92.67516810225044   -2.05532e-10   1.45473e-07 DIIS
+   @RHF iter  11:   -92.67516810226411   -1.36708e-11   4.77525e-08 DIIS
+   @RHF iter  12:   -92.67516810226593   -1.81899e-12   7.39513e-09 DIIS
   Energy and wave function converged.
 
 
@@ -229,14 +248,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.67516810226587
+  @RHF Final Energy:   -92.67516810226593
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             23.3121946498894275
-    One-Electron Energy =                -171.0147567493457075
-    Two-Electron Energy =                  55.0273939971904156
-    Total Energy =                        -92.6751681022658715
+    One-Electron Energy =                -171.0147567493459633
+    Two-Electron Energy =                  55.0273939971906145
+    Total Energy =                        -92.6751681022659284
 
 Computation Completed
 
@@ -260,18 +279,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:30 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:29:59 2022
 Module time:
-	user time   =       0.66 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.16 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.66 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.16 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:30 2022
+*** at Tue Dec  6 15:29:59 2022
 
 
          ------------------------------------------------------------
@@ -311,7 +330,7 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
@@ -323,15 +342,15 @@ Total time:
        3       -0.075275878378    -0.061736901383     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:30 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:29:59 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.73 seconds =       0.01 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.18 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 
          ----------------------------------------------------------
                                    FINDIF
@@ -365,9 +384,9 @@ Total time:
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev138 
+                               Psi4 1.7a1.dev139 
 
-                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+                         Git: Rev {findif-scf-read} b703eab dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -394,13 +413,13 @@ Total time:
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+    Psi4 started on: Tuesday, 06 December 2022 03:29PM
 
-    Process ID: 330641
+    Process ID: 337007
     Host:       nidavellir
     PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
-    Threads:    4
+    Threads:    1
     
   ==> Input QCSchema <==
 
@@ -449,7 +468,7 @@ Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:30 2022
+*** at Tue Dec  6 15:30:00 2022
 
    => Loading Basis Set <=
 
@@ -466,7 +485,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -526,13 +545,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -542,7 +560,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 9.6850361242E-03.
   Reciprocal condition number of the overlap matrix is 2.7456671621E-03.
@@ -565,19 +583,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter SAD:   -91.81613896682582   -9.18161e+01   0.00000e+00 
-   @RHF iter   1:   -92.61386260678680   -7.97724e-01   1.57396e-02 ADIIS/DIIS
-   @RHF iter   2:   -92.66021533756283   -4.63527e-02   1.07246e-02 ADIIS/DIIS
+   @RHF iter SAD:   -91.81613896682578   -9.18161e+01   0.00000e+00 
+   @RHF iter   1:   -92.61386260678677   -7.97724e-01   1.57396e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66021533756289   -4.63527e-02   1.07246e-02 ADIIS/DIIS
    @RHF iter   3:   -92.67364182145673   -1.34265e-02   2.50489e-03 ADIIS/DIIS
-   @RHF iter   4:   -92.67491387466454   -1.27205e-03   8.26547e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.67514619775852   -2.32323e-04   1.92086e-04 ADIIS/DIIS
-   @RHF iter   6:   -92.67516667680231   -2.04790e-05   3.81285e-05 DIIS
-   @RHF iter   7:   -92.67516788606348   -1.20926e-06   1.45091e-05 DIIS
-   @RHF iter   8:   -92.67516808836471   -2.02301e-07   4.03440e-06 DIIS
-   @RHF iter   9:   -92.67516810204486   -1.36802e-08   6.27437e-07 DIIS
-   @RHF iter  10:   -92.67516810225042   -2.05560e-10   1.45473e-07 DIIS
-   @RHF iter  11:   -92.67516810226410   -1.36708e-11   4.77525e-08 DIIS
-   @RHF iter  12:   -92.67516810226579   -1.69109e-12   7.39513e-09 DIIS
+   @RHF iter   4:   -92.67491387466453   -1.27205e-03   8.26547e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67514619775851   -2.32323e-04   1.92086e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67516667680229   -2.04790e-05   3.81285e-05 DIIS
+   @RHF iter   7:   -92.67516788606352   -1.20926e-06   1.45091e-05 DIIS
+   @RHF iter   8:   -92.67516808836476   -2.02301e-07   4.03440e-06 DIIS
+   @RHF iter   9:   -92.67516810204491   -1.36802e-08   6.27437e-07 DIIS
+   @RHF iter  10:   -92.67516810225044   -2.05532e-10   1.45473e-07 DIIS
+   @RHF iter  11:   -92.67516810226411   -1.36708e-11   4.77525e-08 DIIS
+   @RHF iter  12:   -92.67516810226593   -1.81899e-12   7.39513e-09 DIIS
   Energy and wave function converged.
 
 
@@ -606,14 +624,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.67516810226579
+  @RHF Final Energy:   -92.67516810226593
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             23.3121946498894275
-    One-Electron Energy =                -171.0147567493454801
-    Two-Electron Energy =                  55.0273939971902806
-    Total Energy =                        -92.6751681022657863
+    One-Electron Energy =                -171.0147567493459633
+    Two-Electron Energy =                  55.0273939971906145
+    Total Energy =                        -92.6751681022659284
 
 Computation Completed
 
@@ -637,18 +655,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:00 2022
 Module time:
-	user time   =       0.61 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.15 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.05 seconds =       0.03 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:31 2022
+*** at Tue Dec  6 15:30:00 2022
 
 
          ------------------------------------------------------------
@@ -688,7 +706,7 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
@@ -700,25 +718,25 @@ Total time:
        3       -0.075275878378    -0.061736901383     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:00 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       2.12 seconds =       0.04 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.42 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
-    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
-    Psi4 wall time for execution: 0:00:00.21
+    Psi4 stopped on: Tuesday, 06 December 2022 03:30PM
+    Psi4 wall time for execution: 0:00:00.20
 
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev138 
+                               Psi4 1.7a1.dev139 
 
-                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+                         Git: Rev {findif-scf-read} b703eab dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -745,13 +763,13 @@ Total time:
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+    Psi4 started on: Tuesday, 06 December 2022 03:29PM
 
-    Process ID: 330641
+    Process ID: 337007
     Host:       nidavellir
     PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
-    Threads:    4
+    Threads:    1
     
   ==> Input QCSchema <==
 
@@ -800,7 +818,7 @@ Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:31 2022
+*** at Tue Dec  6 15:30:00 2022
 
    => Loading Basis Set <=
 
@@ -817,7 +835,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -877,13 +895,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -893,7 +910,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 9.7049696899E-03.
   Reciprocal condition number of the overlap matrix is 2.7515202933E-03.
@@ -916,19 +933,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter SAD:   -91.81505307663748   -9.18151e+01   0.00000e+00 
+   @RHF iter SAD:   -91.81505307663747   -9.18151e+01   0.00000e+00 
    @RHF iter   1:   -92.61405130606653   -7.98998e-01   1.57376e-02 ADIIS/DIIS
-   @RHF iter   2:   -92.66036188095381   -4.63106e-02   1.07335e-02 ADIIS/DIIS
-   @RHF iter   3:   -92.67381037248433   -1.34485e-02   2.50666e-03 ADIIS/DIIS
-   @RHF iter   4:   -92.67508429492827   -1.27392e-03   8.26319e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.67531649409455   -2.32199e-04   1.92007e-04 ADIIS/DIIS
-   @RHF iter   6:   -92.67533693574730   -2.04417e-05   3.80508e-05 DIIS
-   @RHF iter   7:   -92.67533813889904   -1.20315e-06   1.44669e-05 DIIS
-   @RHF iter   8:   -92.67533833997150   -2.01072e-07   4.03068e-06 DIIS
-   @RHF iter   9:   -92.67533835363656   -1.36651e-08   6.26281e-07 DIIS
-   @RHF iter  10:   -92.67533835384124   -2.04679e-10   1.44841e-07 DIIS
-   @RHF iter  11:   -92.67533835385480   -1.35572e-11   4.76260e-08 DIIS
-   @RHF iter  12:   -92.67533835385649   -1.69109e-12   7.41751e-09 DIIS
+   @RHF iter   2:   -92.66036188095370   -4.63106e-02   1.07335e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67381037248431   -1.34485e-02   2.50666e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67508429492830   -1.27392e-03   8.26319e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67531649409447   -2.32199e-04   1.92007e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67533693574728   -2.04417e-05   3.80508e-05 DIIS
+   @RHF iter   7:   -92.67533813889906   -1.20315e-06   1.44669e-05 DIIS
+   @RHF iter   8:   -92.67533833997147   -2.01072e-07   4.03068e-06 DIIS
+   @RHF iter   9:   -92.67533835363655   -1.36651e-08   6.26281e-07 DIIS
+   @RHF iter  10:   -92.67533835384111   -2.04565e-10   1.44841e-07 DIIS
+   @RHF iter  11:   -92.67533835385467   -1.35572e-11   4.76260e-08 DIIS
+   @RHF iter  12:   -92.67533835385646   -1.79057e-12   7.41751e-09 DIIS
   Energy and wave function converged.
 
 
@@ -957,14 +974,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.67533835385649
+  @RHF Final Energy:   -92.67533835385646
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             23.3023298116957420
-    One-Electron Energy =                -170.9952458566346820
-    Two-Electron Energy =                  55.0175776910824723
-    Total Energy =                        -92.6753383538564890
+    One-Electron Energy =                -170.9952458566345967
+    Two-Electron Energy =                  55.0175776910823728
+    Total Energy =                        -92.6753383538564606
 
 Computation Completed
 
@@ -988,18 +1005,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:00 2022
 Module time:
-	user time   =       0.80 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.15 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.07 seconds =       0.05 minutes
-	system time =       0.09 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.63 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:31 2022
+*** at Tue Dec  6 15:30:00 2022
 
 
          ------------------------------------------------------------
@@ -1039,7 +1056,7 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
@@ -1051,25 +1068,25 @@ Total time:
        3       -0.075223491584    -0.061724842086     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:00 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.14 seconds =       0.05 minutes
-	system time =       0.10 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.65 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
-    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
-    Psi4 wall time for execution: 0:00:00.25
+    Psi4 stopped on: Tuesday, 06 December 2022 03:30PM
+    Psi4 wall time for execution: 0:00:00.22
 
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev138 
+                               Psi4 1.7a1.dev139 
 
-                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+                         Git: Rev {findif-scf-read} b703eab dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -1096,13 +1113,13 @@ Total time:
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+    Psi4 started on: Tuesday, 06 December 2022 03:29PM
 
-    Process ID: 330641
+    Process ID: 337007
     Host:       nidavellir
     PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
-    Threads:    4
+    Threads:    1
     
   ==> Input QCSchema <==
 
@@ -1151,7 +1168,7 @@ Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:31 2022
+*** at Tue Dec  6 15:30:00 2022
 
    => Loading Basis Set <=
 
@@ -1168,7 +1185,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1228,13 +1245,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -1244,7 +1260,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 9.6651599845E-03.
   Reciprocal condition number of the overlap matrix is 2.7398315673E-03.
@@ -1267,19 +1283,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter SAD:   -91.81722378948035   -9.18172e+01   0.00000e+00 
-   @RHF iter   1:   -92.61367205194610   -7.96448e-01   1.57417e-02 ADIIS/DIIS
+   @RHF iter SAD:   -91.81722378948037   -9.18172e+01   0.00000e+00 
+   @RHF iter   1:   -92.61367205194605   -7.96448e-01   1.57417e-02 ADIIS/DIIS
    @RHF iter   2:   -92.66006691234628   -4.63949e-02   1.07157e-02 ADIIS/DIIS
    @RHF iter   3:   -92.67347153580761   -1.34046e-02   2.50312e-03 ADIIS/DIIS
    @RHF iter   4:   -92.67474172387801   -1.27019e-03   8.26773e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.67497416942943   -2.32446e-04   1.92166e-04 ADIIS/DIIS
-   @RHF iter   6:   -92.67499468582993   -2.05164e-05   3.82062e-05 DIIS
-   @RHF iter   7:   -92.67499590120974   -1.21538e-06   1.45511e-05 DIIS
-   @RHF iter   8:   -92.67499610473793   -2.03528e-07   4.03807e-06 DIIS
-   @RHF iter   9:   -92.67499611843292   -1.36950e-08   6.28588e-07 DIIS
-   @RHF iter  10:   -92.67499611863930   -2.06384e-10   1.46102e-07 DIIS
-   @RHF iter  11:   -92.67499611865306   -1.37561e-11   4.78758e-08 DIIS
-   @RHF iter  12:   -92.67499611865485   -1.79057e-12   7.37205e-09 DIIS
+   @RHF iter   5:   -92.67497416942946   -2.32446e-04   1.92166e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67499468582983   -2.05164e-05   3.82062e-05 DIIS
+   @RHF iter   7:   -92.67499590120964   -1.21538e-06   1.45511e-05 DIIS
+   @RHF iter   8:   -92.67499610473780   -2.03528e-07   4.03807e-06 DIIS
+   @RHF iter   9:   -92.67499611843289   -1.36951e-08   6.28588e-07 DIIS
+   @RHF iter  10:   -92.67499611863930   -2.06413e-10   1.46102e-07 DIIS
+   @RHF iter  11:   -92.67499611865300   -1.36993e-11   4.78758e-08 DIIS
+   @RHF iter  12:   -92.67499611865482   -1.81899e-12   7.37205e-09 DIIS
   Energy and wave function converged.
 
 
@@ -1308,14 +1324,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.67499611865485
+  @RHF Final Energy:   -92.67499611865482
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             23.3220596725463203
-    One-Electron Energy =                -171.0342653946867699
-    Two-Electron Energy =                  55.0372096034856071
-    Total Energy =                        -92.6749961186548461
+    One-Electron Energy =                -171.0342653946868836
+    Two-Electron Energy =                  55.0372096034857421
+    Total Energy =                        -92.6749961186548319
 
 Computation Completed
 
@@ -1339,18 +1355,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:00 2022
 Module time:
-	user time   =       0.67 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.15 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       3.96 seconds =       0.07 minutes
-	system time =       0.11 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.84 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:31 2022
+*** at Tue Dec  6 15:30:00 2022
 
 
          ------------------------------------------------------------
@@ -1390,7 +1406,7 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
@@ -1398,29 +1414,29 @@ Total time:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
        1        0.089273635109    -0.109720008419     0.000000000000
-       2       -0.013945308034     0.171468883614     0.000000000000
+       2       -0.013945308034     0.171468883613     0.000000000000
        3       -0.075328327075    -0.061748875194     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:00 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       4.02 seconds =       0.07 minutes
-	system time =       0.12 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.86 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
-    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
-    Psi4 wall time for execution: 0:00:00.21
+    Psi4 stopped on: Tuesday, 06 December 2022 03:30PM
+    Psi4 wall time for execution: 0:00:00.20
 
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev138 
+                               Psi4 1.7a1.dev139 
 
-                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+                         Git: Rev {findif-scf-read} b703eab dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -1447,13 +1463,13 @@ Total time:
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+    Psi4 started on: Tuesday, 06 December 2022 03:29PM
 
-    Process ID: 330641
+    Process ID: 337007
     Host:       nidavellir
     PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
-    Threads:    4
+    Threads:    1
     
   ==> Input QCSchema <==
 
@@ -1502,7 +1518,7 @@ Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:31 2022
+*** at Tue Dec  6 15:30:00 2022
 
    => Loading Basis Set <=
 
@@ -1519,7 +1535,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1579,13 +1595,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -1595,7 +1610,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 9.6570482411E-03.
   Reciprocal condition number of the overlap matrix is 2.7370338356E-03.
@@ -1618,19 +1633,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter SAD:   -91.81785097141164   -9.18179e+01   0.00000e+00 
-   @RHF iter   1:   -92.61361603207096   -7.95765e-01   1.57443e-02 ADIIS/DIIS
-   @RHF iter   2:   -92.66003044370039   -4.64144e-02   1.07159e-02 ADIIS/DIIS
-   @RHF iter   3:   -92.67343357605608   -1.34031e-02   2.50182e-03 ADIIS/DIIS
-   @RHF iter   4:   -92.67470260896921   -1.26903e-03   8.26795e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.67493481031573   -2.32201e-04   1.92038e-04 ADIIS/DIIS
-   @RHF iter   6:   -92.67495527967959   -2.04694e-05   3.80781e-05 DIIS
-   @RHF iter   7:   -92.67495648628214   -1.20660e-06   1.44890e-05 DIIS
-   @RHF iter   8:   -92.67495668814226   -2.01860e-07   4.03301e-06 DIIS
-   @RHF iter   9:   -92.67495670181580   -1.36735e-08   6.25431e-07 DIIS
-   @RHF iter  10:   -92.67495670201937   -2.03570e-10   1.44186e-07 DIIS
-   @RHF iter  11:   -92.67495670203276   -1.33866e-11   4.73451e-08 DIIS
-   @RHF iter  12:   -92.67495670203441   -1.64846e-12   7.30193e-09 DIIS
+   @RHF iter SAD:   -91.81785097141169   -9.18179e+01   0.00000e+00 
+   @RHF iter   1:   -92.61361603207084   -7.95765e-01   1.57443e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66003044370031   -4.64144e-02   1.07159e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67343357605606   -1.34031e-02   2.50182e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67470260896923   -1.26903e-03   8.26795e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67493481031575   -2.32201e-04   1.92038e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67495527967961   -2.04694e-05   3.80781e-05 DIIS
+   @RHF iter   7:   -92.67495648628213   -1.20660e-06   1.44890e-05 DIIS
+   @RHF iter   8:   -92.67495668814229   -2.01860e-07   4.03301e-06 DIIS
+   @RHF iter   9:   -92.67495670181577   -1.36735e-08   6.25431e-07 DIIS
+   @RHF iter  10:   -92.67495670201929   -2.03514e-10   1.44186e-07 DIIS
+   @RHF iter  11:   -92.67495670203272   -1.34293e-11   4.73451e-08 DIIS
+   @RHF iter  12:   -92.67495670203436   -1.64846e-12   7.30193e-09 DIIS
   Energy and wave function converged.
 
 
@@ -1659,14 +1674,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.67495670203441
+  @RHF Final Energy:   -92.67495670203436
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             23.3269931365248731
-    One-Electron Energy =                -171.0433231044125080
-    Two-Electron Energy =                  55.0413732658532382
-    Total Energy =                        -92.6749567020344074
+    One-Electron Energy =                -171.0433231044123943
+    Two-Electron Energy =                  55.0413732658531600
+    Total Energy =                        -92.6749567020343648
 
 Computation Completed
 
@@ -1690,18 +1705,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:00 2022
 Module time:
-	user time   =       0.67 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.15 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       4.84 seconds =       0.08 minutes
-	system time =       0.14 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       1.05 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:31 2022
+*** at Tue Dec  6 15:30:00 2022
 
 
          ------------------------------------------------------------
@@ -1741,7 +1756,7 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
@@ -1753,25 +1768,25 @@ Total time:
        3       -0.075253423064    -0.061740036939     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:00 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       4.91 seconds =       0.08 minutes
-	system time =       0.15 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       1.07 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
-    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
-    Psi4 wall time for execution: 0:00:00.22
+    Psi4 stopped on: Tuesday, 06 December 2022 03:30PM
+    Psi4 wall time for execution: 0:00:00.20
 
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev138 
+                               Psi4 1.7a1.dev139 
 
-                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+                         Git: Rev {findif-scf-read} b703eab dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -1798,13 +1813,13 @@ Total time:
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+    Psi4 started on: Tuesday, 06 December 2022 03:29PM
 
-    Process ID: 330641
+    Process ID: 337007
     Host:       nidavellir
     PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
-    Threads:    4
+    Threads:    1
     
   ==> Input QCSchema <==
 
@@ -1853,7 +1868,7 @@ Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:31 2022
+*** at Tue Dec  6 15:30:01 2022
 
    => Loading Basis Set <=
 
@@ -1870,7 +1885,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -1930,13 +1945,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -1946,7 +1960,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 9.7131045745E-03.
   Reciprocal condition number of the overlap matrix is 2.7543280064E-03.
@@ -1969,19 +1983,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter SAD:   -91.81442686017978   -9.18144e+01   0.00000e+00 
-   @RHF iter   1:   -92.61410539783108   -7.99679e-01   1.57350e-02 ADIIS/DIIS
-   @RHF iter   2:   -92.66039642890759   -4.62910e-02   1.07334e-02 ADIIS/DIIS
-   @RHF iter   3:   -92.67384651646560   -1.34501e-02   2.50797e-03 ADIIS/DIIS
-   @RHF iter   4:   -92.67512159963691   -1.27508e-03   8.26297e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.67535404309200   -2.32443e-04   1.92135e-04 ADIIS/DIIS
-   @RHF iter   6:   -92.67537453197396   -2.04889e-05   3.81796e-05 DIIS
-   @RHF iter   7:   -92.67537574393906   -1.21197e-06   1.45295e-05 DIIS
-   @RHF iter   8:   -92.67537594669200   -2.02753e-07   4.03589e-06 DIIS
-   @RHF iter   9:   -92.67537596037963   -1.36876e-08   6.29481e-07 DIIS
-   @RHF iter  10:   -92.67537596058722   -2.07592e-10   1.46778e-07 DIIS
-   @RHF iter  11:   -92.67537596060109   -1.38698e-11   4.81650e-08 DIIS
-   @RHF iter  12:   -92.67537596060286   -1.77636e-12   7.49020e-09 DIIS
+   @RHF iter SAD:   -91.81442686017974   -9.18144e+01   0.00000e+00 
+   @RHF iter   1:   -92.61410539783105   -7.99679e-01   1.57350e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66039642890769   -4.62910e-02   1.07334e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67384651646552   -1.34501e-02   2.50797e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67512159963695   -1.27508e-03   8.26297e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67535404309199   -2.32443e-04   1.92135e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67537453197394   -2.04889e-05   3.81796e-05 DIIS
+   @RHF iter   7:   -92.67537574393913   -1.21197e-06   1.45295e-05 DIIS
+   @RHF iter   8:   -92.67537594669209   -2.02753e-07   4.03589e-06 DIIS
+   @RHF iter   9:   -92.67537596037964   -1.36876e-08   6.29481e-07 DIIS
+   @RHF iter  10:   -92.67537596058727   -2.07635e-10   1.46778e-07 DIIS
+   @RHF iter  11:   -92.67537596060113   -1.38556e-11   4.81650e-08 DIIS
+   @RHF iter  12:   -92.67537596060286   -1.73372e-12   7.49020e-09 DIIS
   Energy and wave function converged.
 
 
@@ -2015,8 +2029,8 @@ gradient() will perform analytic gradient computation.
    => Energetics <=
 
     Nuclear Repulsion Energy =             23.2974118289814278
-    One-Electron Energy =                -170.9862149971144163
-    Two-Electron Energy =                  55.0134272075301141
+    One-Electron Energy =                -170.9862149971145016
+    Two-Electron Energy =                  55.0134272075301993
     Total Energy =                        -92.6753759606028638
 
 Computation Completed
@@ -2041,18 +2055,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:01 2022
 Module time:
-	user time   =       0.66 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.16 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.72 seconds =       0.10 minutes
-	system time =       0.17 seconds =       0.00 minutes
+	user time   =       1.26 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:31 2022
+*** at Tue Dec  6 15:30:01 2022
 
 
          ------------------------------------------------------------
@@ -2092,7 +2106,7 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
@@ -2104,25 +2118,25 @@ Total time:
        3       -0.075298162606    -0.061733883632     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:01 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       5.79 seconds =       0.10 minutes
-	system time =       0.17 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       1.28 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
-    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
-    Psi4 wall time for execution: 0:00:00.21
+    Psi4 stopped on: Tuesday, 06 December 2022 03:30PM
+    Psi4 wall time for execution: 0:00:00.20
 
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev138 
+                               Psi4 1.7a1.dev139 
 
-                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+                         Git: Rev {findif-scf-read} b703eab dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -2149,13 +2163,13 @@ Total time:
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+    Psi4 started on: Tuesday, 06 December 2022 03:29PM
 
-    Process ID: 330641
+    Process ID: 337007
     Host:       nidavellir
     PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
-    Threads:    4
+    Threads:    1
     
   ==> Input QCSchema <==
 
@@ -2204,7 +2218,7 @@ Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:32 2022
+*** at Tue Dec  6 15:30:01 2022
 
    => Loading Basis Set <=
 
@@ -2221,7 +2235,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2281,13 +2295,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -2297,7 +2310,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 9.6802053135E-03.
   Reciprocal condition number of the overlap matrix is 2.7434815300E-03.
@@ -2320,19 +2333,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter SAD:   -91.81715549720876   -9.18172e+01   0.00000e+00 
-   @RHF iter   1:   -92.61439123410250   -7.97236e-01   1.57266e-02 ADIIS/DIIS
-   @RHF iter   2:   -92.66064044329177   -4.62492e-02   1.06997e-02 ADIIS/DIIS
-   @RHF iter   3:   -92.67400441141210   -1.33640e-02   2.50299e-03 ADIIS/DIIS
-   @RHF iter   4:   -92.67527287979414   -1.26847e-03   8.23907e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.67550401260425   -2.31133e-04   1.91797e-04 ADIIS/DIIS
+   @RHF iter SAD:   -91.81715549720886   -9.18172e+01   0.00000e+00 
+   @RHF iter   1:   -92.61439123410247   -7.97236e-01   1.57266e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66064044329167   -4.62492e-02   1.06997e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67400441141217   -1.33640e-02   2.50299e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67527287979421   -1.26847e-03   8.23907e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67550401260432   -2.31133e-04   1.91797e-04 ADIIS/DIIS
    @RHF iter   6:   -92.67552444224918   -2.04296e-05   3.81433e-05 DIIS
    @RHF iter   7:   -92.67552564975938   -1.20751e-06   1.44917e-05 DIIS
-   @RHF iter   8:   -92.67552585084535   -2.01086e-07   4.01401e-06 DIIS
-   @RHF iter   9:   -92.67552586434283   -1.34975e-08   6.28972e-07 DIIS
-   @RHF iter  10:   -92.67552586455034   -2.07507e-10   1.47572e-07 DIIS
-   @RHF iter  11:   -92.67552586456439   -1.40545e-11   4.83611e-08 DIIS
-   @RHF iter  12:   -92.67552586456594   -1.54898e-12   7.46102e-09 DIIS
+   @RHF iter   8:   -92.67552585084516   -2.01086e-07   4.01401e-06 DIIS
+   @RHF iter   9:   -92.67552586434289   -1.34977e-08   6.28972e-07 DIIS
+   @RHF iter  10:   -92.67552586455025   -2.07365e-10   1.47572e-07 DIIS
+   @RHF iter  11:   -92.67552586456434   -1.40830e-11   4.83611e-08 DIIS
+   @RHF iter  12:   -92.67552586456610   -1.76215e-12   7.46102e-09 DIIS
   Energy and wave function converged.
 
 
@@ -2361,14 +2374,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.67552586456594
+  @RHF Final Energy:   -92.67552586456610
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             23.3179228351587540
-    One-Electron Energy =                -171.0258553534937107
-    Two-Electron Energy =                  55.0324066537690086
-    Total Energy =                        -92.6755258645659410
+    One-Electron Energy =                -171.0258553534940233
+    Two-Electron Energy =                  55.0324066537691721
+    Total Energy =                        -92.6755258645660973
 
 Computation Completed
 
@@ -2392,18 +2405,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:01 2022
 Module time:
-	user time   =       0.67 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.15 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.61 seconds =       0.11 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       1.47 seconds =       0.02 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:32 2022
+*** at Tue Dec  6 15:30:01 2022
 
 
          ------------------------------------------------------------
@@ -2443,7 +2456,7 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
@@ -2455,25 +2468,25 @@ Total time:
        3       -0.075350085422    -0.061784868652     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:01 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.68 seconds =       0.11 minutes
-	system time =       0.20 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       1.50 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
-    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
-    Psi4 wall time for execution: 0:00:00.22
+    Psi4 stopped on: Tuesday, 06 December 2022 03:30PM
+    Psi4 wall time for execution: 0:00:00.20
 
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev138 
+                               Psi4 1.7a1.dev139 
 
-                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+                         Git: Rev {findif-scf-read} b703eab dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -2500,13 +2513,13 @@ Total time:
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+    Psi4 started on: Tuesday, 06 December 2022 03:29PM
 
-    Process ID: 330641
+    Process ID: 337007
     Host:       nidavellir
     PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
-    Threads:    4
+    Threads:    1
     
   ==> Input QCSchema <==
 
@@ -2555,7 +2568,7 @@ Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:32 2022
+*** at Tue Dec  6 15:30:01 2022
 
    => Loading Basis Set <=
 
@@ -2572,7 +2585,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2632,13 +2645,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -2648,7 +2660,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 9.6898583460E-03.
   Reciprocal condition number of the overlap matrix is 2.7478510709E-03.
@@ -2671,19 +2683,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter SAD:   -91.81512449151978   -9.18151e+01   0.00000e+00 
-   @RHF iter   1:   -92.61333410052731   -7.98210e-01   1.57527e-02 ADIIS/DIIS
-   @RHF iter   2:   -92.65979030855006   -4.64562e-02   1.07496e-02 ADIIS/DIIS
-   @RHF iter   3:   -92.67327958135601   -1.34893e-02   2.50681e-03 ADIIS/DIIS
-   @RHF iter   4:   -92.67455523463667   -1.27565e-03   8.29197e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.67478875647591   -2.33522e-04   1.92382e-04 ADIIS/DIIS
-   @RHF iter   6:   -92.67480928691360   -2.05304e-05   3.81203e-05 DIIS
-   @RHF iter   7:   -92.67481049833448   -1.21142e-06   1.45300e-05 DIIS
-   @RHF iter   8:   -92.67481070194199   -2.03608e-07   4.05540e-06 DIIS
-   @RHF iter   9:   -92.67481071580896   -1.38670e-08   6.26004e-07 DIIS
-   @RHF iter  10:   -92.67481071601262   -2.03656e-10   1.43390e-07 DIIS
+   @RHF iter SAD:   -91.81512449151985   -9.18151e+01   0.00000e+00 
+   @RHF iter   1:   -92.61333410052728   -7.98210e-01   1.57527e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.65979030855004   -4.64562e-02   1.07496e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67327958135607   -1.34893e-02   2.50681e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67455523463678   -1.27565e-03   8.29197e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67478875647586   -2.33522e-04   1.92382e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67480928691356   -2.05304e-05   3.81203e-05 DIIS
+   @RHF iter   7:   -92.67481049833447   -1.21142e-06   1.45300e-05 DIIS
+   @RHF iter   8:   -92.67481070194204   -2.03608e-07   4.05540e-06 DIIS
+   @RHF iter   9:   -92.67481071580889   -1.38669e-08   6.26004e-07 DIIS
+   @RHF iter  10:   -92.67481071601262   -2.03727e-10   1.43390e-07 DIIS
    @RHF iter  11:   -92.67481071602597   -1.33582e-11   4.71279e-08 DIIS
-   @RHF iter  12:   -92.67481071602754   -1.56319e-12   7.32596e-09 DIIS
+   @RHF iter  12:   -92.67481071602771   -1.73372e-12   7.32596e-09 DIIS
   Energy and wave function converged.
 
 
@@ -2712,14 +2724,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.67481071602754
+  @RHF Final Energy:   -92.67481071602771
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             23.3064712355637056
-    One-Electron Energy =                -171.0036689246194328
-    Two-Electron Energy =                  55.0223869730281763
-    Total Energy =                        -92.6748107160275367
+    One-Electron Energy =                -171.0036689246198023
+    Two-Electron Energy =                  55.0223869730284108
+    Total Energy =                        -92.6748107160277073
 
 Computation Completed
 
@@ -2743,18 +2755,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:01 2022
 Module time:
-	user time   =       0.66 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.15 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       7.48 seconds =       0.12 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       1.68 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:32 2022
+*** at Tue Dec  6 15:30:01 2022
 
 
          ------------------------------------------------------------
@@ -2794,7 +2806,7 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
@@ -2802,29 +2814,29 @@ Total time:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
        1        0.088358409552    -0.107949703797     0.000000000000
-       2       -0.013156910807     0.169638565521     0.000000000000
+       2       -0.013156910806     0.169638565521     0.000000000000
        3       -0.075201498746    -0.061688861724     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:01 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       7.54 seconds =       0.13 minutes
-	system time =       0.23 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       1.70 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
-    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
-    Psi4 wall time for execution: 0:00:00.21
+    Psi4 stopped on: Tuesday, 06 December 2022 03:30PM
+    Psi4 wall time for execution: 0:00:00.19
 
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev138 
+                               Psi4 1.7a1.dev139 
 
-                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+                         Git: Rev {findif-scf-read} b703eab dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -2851,13 +2863,13 @@ Total time:
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+    Psi4 started on: Tuesday, 06 December 2022 03:29PM
 
-    Process ID: 330641
+    Process ID: 337007
     Host:       nidavellir
     PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
-    Threads:    4
+    Threads:    1
     
   ==> Input QCSchema <==
 
@@ -2906,7 +2918,7 @@ Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:32 2022
+*** at Tue Dec  6 15:30:01 2022
 
    => Loading Basis Set <=
 
@@ -2923,7 +2935,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -2983,13 +2995,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -2999,7 +3010,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 9.6883619328E-03.
   Reciprocal condition number of the overlap matrix is 2.7455770523E-03.
@@ -3022,19 +3033,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter SAD:   -91.81672763988399   -9.18167e+01   0.00000e+00 
-   @RHF iter   1:   -92.61433705847890   -7.97609e-01   1.57317e-02 ADIIS/DIIS
-   @RHF iter   2:   -92.66060332869651   -4.62663e-02   1.07142e-02 ADIIS/DIIS
-   @RHF iter   3:   -92.67400107762772   -1.33977e-02   2.50341e-03 ADIIS/DIIS
-   @RHF iter   4:   -92.67527068953864   -1.26961e-03   8.24470e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.67550174903701   -2.31059e-04   1.91653e-04 ADIIS/DIIS
-   @RHF iter   6:   -92.67552210314325   -2.03541e-05   3.79158e-05 DIIS
-   @RHF iter   7:   -92.67552329525404   -1.19211e-06   1.43841e-05 DIIS
+   @RHF iter SAD:   -91.81672763988405   -9.18167e+01   0.00000e+00 
+   @RHF iter   1:   -92.61433705847892   -7.97609e-01   1.57317e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66060332869648   -4.62663e-02   1.07142e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67400107762771   -1.33977e-02   2.50341e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67527068953868   -1.26961e-03   8.24470e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67550174903700   -2.31059e-04   1.91653e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67552210314332   -2.03541e-05   3.79158e-05 DIIS
+   @RHF iter   7:   -92.67552329525405   -1.19211e-06   1.43841e-05 DIIS
    @RHF iter   8:   -92.67552349360167   -1.98348e-07   4.01007e-06 DIIS
-   @RHF iter   9:   -92.67552350710938   -1.35077e-08   6.23683e-07 DIIS
-   @RHF iter  10:   -92.67552350731223   -2.02860e-10   1.44117e-07 DIIS
-   @RHF iter  11:   -92.67552350732565   -1.34150e-11   4.74441e-08 DIIS
-   @RHF iter  12:   -92.67552350732728   -1.63425e-12   7.37602e-09 DIIS
+   @RHF iter   9:   -92.67552350710939   -1.35077e-08   6.23683e-07 DIIS
+   @RHF iter  10:   -92.67552350731226   -2.02874e-10   1.44117e-07 DIIS
+   @RHF iter  11:   -92.67552350732554   -1.32729e-11   4.74441e-08 DIIS
+   @RHF iter  12:   -92.67552350732723   -1.69109e-12   7.37602e-09 DIIS
   Energy and wave function converged.
 
 
@@ -3063,14 +3074,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.67552350732728
+  @RHF Final Energy:   -92.67552350732723
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             23.3140600770385085
-    One-Electron Energy =                -171.0174286700033122
-    Two-Electron Energy =                  55.0278450856375230
-    Total Energy =                        -92.6755235073272843
+    One-Electron Energy =                -171.0174286700032269
+    Two-Electron Energy =                  55.0278450856374945
+    Total Energy =                        -92.6755235073272274
 
 Computation Completed
 
@@ -3094,18 +3105,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:01 2022
 Module time:
-	user time   =       0.69 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.15 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.38 seconds =       0.14 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       1.89 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:32 2022
+*** at Tue Dec  6 15:30:01 2022
 
 
          ------------------------------------------------------------
@@ -3145,7 +3156,7 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
@@ -3157,25 +3168,25 @@ Total time:
        3       -0.075325211467    -0.061590200860     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:01 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.45 seconds =       0.14 minutes
-	system time =       0.25 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       1.91 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
 
-    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
-    Psi4 wall time for execution: 0:00:00.22
+    Psi4 stopped on: Tuesday, 06 December 2022 03:30PM
+    Psi4 wall time for execution: 0:00:00.20
 
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev138 
+                               Psi4 1.7a1.dev139 
 
-                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+                         Git: Rev {findif-scf-read} b703eab dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -3202,13 +3213,13 @@ Total time:
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+    Psi4 started on: Tuesday, 06 December 2022 03:29PM
 
-    Process ID: 330641
+    Process ID: 337007
     Host:       nidavellir
     PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
-    Threads:    4
+    Threads:    1
     
   ==> Input QCSchema <==
 
@@ -3257,7 +3268,7 @@ Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:32 2022
+*** at Tue Dec  6 15:30:01 2022
 
    => Loading Basis Set <=
 
@@ -3274,7 +3285,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3334,13 +3345,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -3350,7 +3360,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 9.6817090020E-03.
   Reciprocal condition number of the overlap matrix is 2.7457535395E-03.
@@ -3373,19 +3383,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter SAD:   -91.81555261778567   -9.18156e+01   0.00000e+00 
-   @RHF iter   1:   -92.61338687877875   -7.97834e-01   1.57476e-02 ADIIS/DIIS
+   @RHF iter SAD:   -91.81555261778568   -9.18156e+01   0.00000e+00 
+   @RHF iter   1:   -92.61338687877861   -7.97834e-01   1.57476e-02 ADIIS/DIIS
    @RHF iter   2:   -92.65982625781143   -4.64394e-02   1.07351e-02 ADIIS/DIIS
-   @RHF iter   3:   -92.67328168166154   -1.34554e-02   2.50638e-03 ADIIS/DIIS
-   @RHF iter   4:   -92.67455618303055   -1.27450e-03   8.28629e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.67478977534053   -2.33592e-04   1.92522e-04 ADIIS/DIIS
-   @RHF iter   6:   -92.67481038012903   -2.06048e-05   3.83427e-05 DIIS
-   @RHF iter   7:   -92.67481160678246   -1.22665e-06   1.46346e-05 DIIS
-   @RHF iter   8:   -92.67481181309991   -2.06317e-07   4.05880e-06 DIIS
+   @RHF iter   3:   -92.67328168166156   -1.34554e-02   2.50638e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67455618303056   -1.27450e-03   8.28629e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67478977534054   -2.33592e-04   1.92522e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67481038012912   -2.06048e-05   3.83427e-05 DIIS
+   @RHF iter   7:   -92.67481160678237   -1.22665e-06   1.46346e-05 DIIS
+   @RHF iter   8:   -92.67481181309989   -2.06318e-07   4.05880e-06 DIIS
    @RHF iter   9:   -92.67481182695431   -1.38544e-08   6.31217e-07 DIIS
-   @RHF iter  10:   -92.67481182716274   -2.08431e-10   1.46842e-07 DIIS
-   @RHF iter  11:   -92.67481182717677   -1.40261e-11   4.80637e-08 DIIS
-   @RHF iter  12:   -92.67481182717844   -1.67688e-12   7.41399e-09 DIIS
+   @RHF iter  10:   -92.67481182716284   -2.08530e-10   1.46842e-07 DIIS
+   @RHF iter  11:   -92.67481182717685   -1.40119e-11   4.80637e-08 DIIS
+   @RHF iter  12:   -92.67481182717850   -1.64846e-12   7.41399e-09 DIIS
   Energy and wave function converged.
 
 
@@ -3414,14 +3424,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.67481182717844
+  @RHF Final Energy:   -92.67481182717850
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             23.3103346093713526
-    One-Electron Energy =                -171.0120944196803521
-    Two-Electron Energy =                  55.0269479831305475
-    Total Energy =                        -92.6748118271784449
+    One-Electron Energy =                -171.0120944196804942
+    Two-Electron Energy =                  55.0269479831306398
+    Total Energy =                        -92.6748118271785017
 
 Computation Completed
 
@@ -3445,18 +3455,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:02 2022
 Module time:
-	user time   =       0.75 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.15 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       9.35 seconds =       0.16 minutes
-	system time =       0.27 seconds =       0.00 minutes
+	user time   =       2.09 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:32 2022
+*** at Tue Dec  6 15:30:02 2022
 
 
          ------------------------------------------------------------
@@ -3496,7 +3506,7 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
@@ -3508,25 +3518,25 @@ Total time:
        3       -0.075225503889    -0.061882613800     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:02 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       9.42 seconds =       0.16 minutes
-	system time =       0.27 seconds =       0.00 minutes
+	user time   =       2.11 seconds =       0.04 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 
-    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
-    Psi4 wall time for execution: 0:00:00.24
+    Psi4 stopped on: Tuesday, 06 December 2022 03:30PM
+    Psi4 wall time for execution: 0:00:00.19
 
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev138 
+                               Psi4 1.7a1.dev139 
 
-                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+                         Git: Rev {findif-scf-read} b703eab dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -3553,13 +3563,13 @@ Total time:
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+    Psi4 started on: Tuesday, 06 December 2022 03:29PM
 
-    Process ID: 330641
+    Process ID: 337007
     Host:       nidavellir
     PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
-    Threads:    4
+    Threads:    1
     
   ==> Input QCSchema <==
 
@@ -3609,7 +3619,7 @@ Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:32 2022
+*** at Tue Dec  6 15:30:02 2022
 
    => Loading Basis Set <=
 
@@ -3626,7 +3636,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -3686,13 +3696,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -3702,7 +3711,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 9.6850514591E-03.
   Reciprocal condition number of the overlap matrix is 2.7456718156E-03.
@@ -3724,19 +3733,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter SAD:   -91.81613806426915   -9.18161e+01   0.00000e+00 
-   @RHF iter   1:   -92.61386274480782   -7.97725e-01   1.29792e-02 ADIIS/DIIS
-   @RHF iter   2:   -92.66021544226815   -4.63527e-02   8.84375e-03 ADIIS/DIIS
-   @RHF iter   3:   -92.67368238807418   -1.34669e-02   2.00015e-03 ADIIS/DIIS
-   @RHF iter   4:   -92.67491490066924   -1.23251e-03   6.77634e-04 ADIIS/DIIS
+   @RHF iter SAD:   -91.81613806426918   -9.18161e+01   0.00000e+00 
+   @RHF iter   1:   -92.61386274480779   -7.97725e-01   1.29792e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66021544226828   -4.63527e-02   8.84375e-03 ADIIS/DIIS
+   @RHF iter   3:   -92.67368238807403   -1.34669e-02   2.00015e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67491490066917   -1.23251e-03   6.77634e-04 ADIIS/DIIS
    @RHF iter   5:   -92.67514643242184   -2.31532e-04   1.57974e-04 ADIIS/DIIS
-   @RHF iter   6:   -92.67516680732209   -2.03749e-05   3.13216e-05 DIIS
-   @RHF iter   7:   -92.67516800739651   -1.20007e-06   1.19403e-05 DIIS
-   @RHF iter   8:   -92.67516820887290   -2.01476e-07   3.32711e-06 DIIS
-   @RHF iter   9:   -92.67516822255816   -1.36853e-08   5.17251e-07 DIIS
-   @RHF iter  10:   -92.67516822276369   -2.05532e-10   1.19797e-07 DIIS
-   @RHF iter  11:   -92.67516822277729   -1.35998e-11   3.93164e-08 DIIS
-   @RHF iter  12:   -92.67516822277896   -1.67688e-12   6.08813e-09 DIIS
+   @RHF iter   6:   -92.67516680732206   -2.03749e-05   3.13216e-05 DIIS
+   @RHF iter   7:   -92.67516800739638   -1.20007e-06   1.19403e-05 DIIS
+   @RHF iter   8:   -92.67516820887276   -2.01476e-07   3.32711e-06 DIIS
+   @RHF iter   9:   -92.67516822255814   -1.36854e-08   5.17251e-07 DIIS
+   @RHF iter  10:   -92.67516822276369   -2.05546e-10   1.19797e-07 DIIS
+   @RHF iter  11:   -92.67516822277722   -1.35287e-11   3.93164e-08 DIIS
+   @RHF iter  12:   -92.67516822277894   -1.71951e-12   6.08813e-09 DIIS
   Energy and wave function converged.
 
 
@@ -3765,14 +3774,14 @@ gradient() will perform analytic gradient computation.
     NA   [     7 ]
     NB   [     7 ]
 
-  @RHF Final Energy:   -92.67516822277896
+  @RHF Final Energy:   -92.67516822277894
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             23.3121867247914629
     One-Electron Energy =                -171.0147413270739776
-    Two-Electron Energy =                  55.0273863795035396
-    Total Energy =                        -92.6751682227789644
+    Two-Electron Energy =                  55.0273863795035680
+    Total Energy =                        -92.6751682227789360
 
 Computation Completed
 
@@ -3796,18 +3805,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:02 2022
 Module time:
-	user time   =       0.78 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.14 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      10.36 seconds =       0.17 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       2.29 seconds =       0.04 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:33 2022
+*** at Tue Dec  6 15:30:02 2022
 
 
          ------------------------------------------------------------
@@ -3847,7 +3856,7 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
@@ -3859,25 +3868,25 @@ Total time:
        3       -0.075275874165    -0.061736895337     0.000005209338
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:02 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      10.43 seconds =       0.17 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       2.31 seconds =       0.04 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
-    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
-    Psi4 wall time for execution: 0:00:00.25
+    Psi4 stopped on: Tuesday, 06 December 2022 03:30PM
+    Psi4 wall time for execution: 0:00:00.19
 
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.7a1.dev138 
+                               Psi4 1.7a1.dev139 
 
-                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+                         Git: Rev {findif-scf-read} b703eab dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -3904,13 +3913,13 @@ Total time:
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+    Psi4 started on: Tuesday, 06 December 2022 03:29PM
 
-    Process ID: 330641
+    Process ID: 337007
     Host:       nidavellir
     PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
-    Threads:    4
+    Threads:    1
     
   ==> Input QCSchema <==
 
@@ -3959,7 +3968,7 @@ Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:33 2022
+*** at Tue Dec  6 15:30:02 2022
 
    => Loading Basis Set <=
 
@@ -3976,7 +3985,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4036,13 +4045,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -4052,7 +4060,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 9.6850382496E-03.
   Reciprocal condition number of the overlap matrix is 2.7456688260E-03.
@@ -4076,17 +4084,17 @@ gradient() will perform analytic gradient computation.
 
    @RHF iter SAD:   -91.81613795286238   -9.18161e+01   0.00000e+00 
    @RHF iter   1:   -92.61386200448652   -7.97724e-01   1.29792e-02 ADIIS/DIIS
-   @RHF iter   2:   -92.66021485034986   -4.63528e-02   8.84376e-03 ADIIS/DIIS
-   @RHF iter   3:   -92.67368184126222   -1.34670e-02   2.00015e-03 ADIIS/DIIS
-   @RHF iter   4:   -92.67491435599470   -1.23251e-03   6.77636e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.67514588917956   -2.31533e-04   1.57975e-04 ADIIS/DIIS
-   @RHF iter   6:   -92.67516626417752   -2.03750e-05   3.13217e-05 DIIS
-   @RHF iter   7:   -92.67516746426148   -1.20008e-06   1.19404e-05 DIIS
-   @RHF iter   8:   -92.67516766574062   -2.01479e-07   3.32713e-06 DIIS
-   @RHF iter   9:   -92.67516767942624   -1.36856e-08   5.17251e-07 DIIS
-   @RHF iter  10:   -92.67516767963181   -2.05574e-10   1.19796e-07 DIIS
-   @RHF iter  11:   -92.67516767964547   -1.36566e-11   3.93160e-08 DIIS
-   @RHF iter  12:   -92.67516767964700   -1.53477e-12   6.08806e-09 DIIS
+   @RHF iter   2:   -92.66021485035002   -4.63528e-02   8.84376e-03 ADIIS/DIIS
+   @RHF iter   3:   -92.67368184126219   -1.34670e-02   2.00015e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67491435599459   -1.23251e-03   6.77636e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67514588917966   -2.31533e-04   1.57975e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67516626417766   -2.03750e-05   3.13217e-05 DIIS
+   @RHF iter   7:   -92.67516746426142   -1.20008e-06   1.19404e-05 DIIS
+   @RHF iter   8:   -92.67516766574070   -2.01479e-07   3.32713e-06 DIIS
+   @RHF iter   9:   -92.67516767942635   -1.36856e-08   5.17251e-07 DIIS
+   @RHF iter  10:   -92.67516767963184   -2.05489e-10   1.19796e-07 DIIS
+   @RHF iter  11:   -92.67516767964543   -1.35856e-11   3.93160e-08 DIIS
+   @RHF iter  12:   -92.67516767964709   -1.66267e-12   6.08806e-09 DIIS
   Energy and wave function converged.
 
 
@@ -4115,14 +4123,14 @@ gradient() will perform analytic gradient computation.
     NA   [     7 ]
     NB   [     7 ]
 
-  @RHF Final Energy:   -92.67516767964700
+  @RHF Final Energy:   -92.67516767964709
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             23.3121895711020635
-    One-Electron Energy =                -171.0147473234867448
-    Two-Electron Energy =                  55.0273900727376741
-    Total Energy =                        -92.6751676796470036
+    One-Electron Energy =                -171.0147473234869722
+    Two-Electron Energy =                  55.0273900727378162
+    Total Energy =                        -92.6751676796470889
 
 Computation Completed
 
@@ -4146,18 +4154,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:02 2022
 Module time:
-	user time   =       0.66 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.16 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      11.25 seconds =       0.19 minutes
-	system time =       0.32 seconds =       0.01 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       2.51 seconds =       0.04 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:33 2022
+*** at Tue Dec  6 15:30:02 2022
 
 
          ------------------------------------------------------------
@@ -4197,7 +4205,7 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
@@ -4209,18 +4217,18 @@ Total time:
        3       -0.075275677512    -0.061736856908     0.000166337373
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:02 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      11.32 seconds =       0.19 minutes
-	system time =       0.33 seconds =       0.01 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       2.53 seconds =       0.04 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
-    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
-    Psi4 wall time for execution: 0:00:00.21
+    Psi4 stopped on: Tuesday, 06 December 2022 03:30PM
+    Psi4 wall time for execution: 0:00:00.20
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -4273,9 +4281,9 @@ Total time:
   IR activ [km/mol]            14.2343              0.0578             64.2327        
   Char temp [K]                 0.0000              0.0000              0.0000        
   ----------------------------------------------------------------------------------
-      1   C                0.15  0.12  0.00   -0.00 -0.00  0.72   -0.19 -0.13 -0.00   
-      2   N               -0.19 -0.11 -0.00   -0.00 -0.00 -0.59    0.10  0.09 -0.00   
-      3   H                0.94  0.15 -0.00   -0.00 -0.00 -0.37    0.92  0.28 -0.00   
+      1   C                0.15  0.12  0.00   -0.00 -0.00  0.72   -0.19 -0.13  0.00   
+      2   N               -0.19 -0.11 -0.00   -0.00 -0.00 -0.59    0.10  0.09  0.00   
+      3   H                0.94  0.15 -0.00   -0.00  0.00 -0.37    0.92  0.28  0.00   
 
   Vibration                       7                   8                   9           
   Freq [cm^-1]                 905.3863            947.7049           2473.8044       
@@ -4288,8 +4296,8 @@ Total time:
   Char temp [K]               1302.6493           1363.5363           3559.2538       
   ----------------------------------------------------------------------------------
       1   C                0.02 -0.03 -0.00    0.00 -0.00 -0.01   -0.44  0.61  0.00   
-      2   N               -0.01 -0.04  0.00   -0.00 -0.00 -0.06    0.37 -0.53  0.00   
-      3   H               -0.23  0.97 -0.00   -0.00  0.00  1.00    0.03  0.12 -0.00   
+      2   N               -0.01 -0.04  0.00    0.00 -0.00 -0.06    0.37 -0.53  0.00   
+      3   H               -0.23  0.97 -0.00    0.00  0.00  1.00    0.03  0.12 -0.00   
 
   ==> Thermochemistry Components <==
 
@@ -4417,16 +4425,16 @@ Next Geometry in Ang
 
     Geometry (in Bohr), charge = 0, multiplicity = 1:
 
-    C           -0.804435228761     0.796701565135     0.000000000000
-    N            0.659812377000    -0.864699043446     0.000000000000
-    H           -1.586366398663    -2.077644954970     0.000000000000
+    C           -0.804435228748     0.796701565157     0.000000000000
+    N            0.659812376982    -0.864699043450     0.000000000000
+    H           -1.586366398658    -2.077644954987     0.000000000000
 
 
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:33 2022
+*** at Tue Dec  6 15:30:02 2022
 
    => Loading Basis Set <=
 
@@ -4443,7 +4451,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4455,15 +4463,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.804435228761     0.796701565135     0.000000000000    12.000000000000
-         N            0.659812377000    -0.864699043446     0.000000000000    14.003074004430
-         H           -1.586366398663    -2.077644954970     0.000000000000     1.007825032230
+         C           -0.804435228748     0.796701565157     0.000000000000    12.000000000000
+         N            0.659812376982    -0.864699043450     0.000000000000    14.003074004430
+         H           -1.586366398658    -2.077644954987     0.000000000000     1.007825032230
 
   Running in cs symmetry.
 
   Rotational constants: A =      8.99079  B =      1.87307  C =      1.55013 [cm^-1]
   Rotational constants: A = 269537.02054  B =  56153.27523  C =  46471.71468 [MHz]
-  Nuclear repulsion =   23.721764077245705
+  Nuclear repulsion =   23.721764077236383
 
   Charge       = 0
   Multiplicity = 1
@@ -4501,7 +4509,7 @@ gradient() will perform analytic gradient computation.
     atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
     atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
 
-  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
 
   ==> Integral Setup <==
 
@@ -4514,13 +4522,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -4530,7 +4537,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 1.0205920108E-02.
   Reciprocal condition number of the overlap matrix is 2.6923050876E-03.
@@ -4553,19 +4560,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -92.76700450835595   -9.27670e+01   1.85558e-02 
-   @RHF iter   1:   -92.71864274902882    4.83618e-02   2.40606e-03 ADIIS/DIIS
-   @RHF iter   2:   -92.72055134704449   -1.90860e-03   9.48258e-04 ADIIS/DIIS
-   @RHF iter   3:   -92.72096495473735   -4.13608e-04   4.66783e-04 ADIIS/DIIS
-   @RHF iter   4:   -92.72105166123798   -8.67065e-05   2.41405e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.72107196980951   -2.03086e-05   5.08633e-05 DIIS
-   @RHF iter   6:   -92.72107298359424   -1.01378e-06   1.32500e-05 DIIS
-   @RHF iter   7:   -92.72107307752657   -9.39323e-08   4.61395e-06 DIIS
-   @RHF iter   8:   -92.72107309241659   -1.48900e-08   1.09728e-06 DIIS
-   @RHF iter   9:   -92.72107309327740   -8.60808e-10   2.81905e-07 DIIS
-   @RHF iter  10:   -92.72107309333234   -5.49392e-11   6.37484e-08 DIIS
-   @RHF iter  11:   -92.72107309333410   -1.76215e-12   1.24961e-08 DIIS
-   @RHF iter  12:   -92.72107309333414   -4.26326e-14   2.94974e-09 DIIS
+   @RHF iter   0:   -92.76700450836353   -9.27670e+01   1.85558e-02 
+   @RHF iter   1:   -92.71864274903012    4.83618e-02   2.40606e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72055134704533   -1.90860e-03   9.48258e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72096495473809   -4.13608e-04   4.66783e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72105166123876   -8.67065e-05   2.41405e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72107196981023   -2.03086e-05   5.08633e-05 DIIS
+   @RHF iter   6:   -92.72107298359504   -1.01378e-06   1.32500e-05 DIIS
+   @RHF iter   7:   -92.72107307752736   -9.39323e-08   4.61395e-06 DIIS
+   @RHF iter   8:   -92.72107309241734   -1.48900e-08   1.09728e-06 DIIS
+   @RHF iter   9:   -92.72107309327814   -8.60794e-10   2.81905e-07 DIIS
+   @RHF iter  10:   -92.72107309333313   -5.49960e-11   6.37484e-08 DIIS
+   @RHF iter  11:   -92.72107309333482   -1.69109e-12   1.24961e-08 DIIS
+   @RHF iter  12:   -92.72107309333499   -1.70530e-13   2.94974e-09 DIIS
   Energy and wave function converged.
 
 
@@ -4594,14 +4601,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.72107309333414
+  @RHF Final Energy:   -92.72107309333499
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             23.7217640772457052
-    One-Electron Energy =                -171.6427990003683135
-    Two-Electron Energy =                  55.1999618297884780
-    Total Energy =                        -92.7210730933341409
+    Nuclear Repulsion Energy =             23.7217640772363829
+    One-Electron Energy =                -171.6427990003607817
+    Two-Electron Energy =                  55.1999618297894159
+    Total Energy =                        -92.7210730933349936
 
 Computation Completed
 
@@ -4625,18 +4632,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:02 2022
 Module time:
-	user time   =       0.40 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.10 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      11.99 seconds =       0.20 minutes
-	system time =       0.34 seconds =       0.01 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       2.69 seconds =       0.04 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:33 2022
+*** at Tue Dec  6 15:30:02 2022
 
 
          ------------------------------------------------------------
@@ -4654,11 +4661,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.804435228761     0.796701565135     0.000000000000    12.000000000000
-         N            0.659812377000    -0.864699043446     0.000000000000    14.003074004430
-         H           -1.586366398663    -2.077644954970     0.000000000000     1.007825032230
+         C           -0.804435228748     0.796701565157     0.000000000000    12.000000000000
+         N            0.659812376982    -0.864699043450     0.000000000000    14.003074004430
+         H           -1.586366398658    -2.077644954987     0.000000000000     1.007825032230
 
-  Nuclear repulsion =   23.721764077245705
+  Nuclear repulsion =   23.721764077236383
 
   ==> Basis Set <==
 
@@ -4676,27 +4683,27 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.045524436210    -0.050107442403     0.000000000000
-       2        0.015431053242     0.084031870482     0.000000000000
-       3       -0.060955489452    -0.033924428079     0.000000000000
+       1        0.045524436210    -0.050107442406     0.000000000000
+       2        0.015431053245     0.084031870486     0.000000000000
+       3       -0.060955489455    -0.033924428079     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:02 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      12.06 seconds =       0.20 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       2.71 seconds =       0.05 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
     			-----------------------------------------
 
@@ -4714,9 +4721,9 @@ Total time:
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.8044352287612170  0.7967015651354833  0.0000000000000000
-	       7.000000            14.003074        0.6598123770001038 -0.8646990434456613  0.0000000000000000
-	       1.000000             1.007825       -1.5863663986626961 -2.0776449549701117  0.0000000000000000
+	       6.000000            12.000000       -0.8044352287483525  0.7967015651574336  0.0000000000000000
+	       7.000000            14.003074        0.6598123769823561 -0.8646990434502408  0.0000000000000000
+	       1.000000             1.007825       -1.5863663986578127 -2.0776449549874823  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.214559           1.171894
@@ -4751,7 +4758,7 @@ Next Geometry in Ang
 	Fragment 1 (Ang)
 
 	    C  -0.5327656135   0.2558242334   0.0000000000
-	    N   0.3591769269  -0.5280995535   0.0000000000
+	    N   0.3591769268  -0.5280995536   0.0000000000
 	    H  -0.7424113766  -0.8631497578   0.0000000000
 
 
@@ -4761,16 +4768,16 @@ Next Geometry in Ang
 
     Geometry (in Bohr), charge = 0, multiplicity = 1:
 
-    C           -1.006781098526     0.483437737402     0.000000000000
-    N            0.678746022334    -0.997963523179     0.000000000000
-    H           -1.402954174232    -1.631116647503     0.000000000000
+    C           -1.006781098510     0.483437737434     0.000000000000
+    N            0.678746022314    -0.997963523189     0.000000000000
+    H           -1.402954174228    -1.631116647525     0.000000000000
 
 
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:33 2022
+*** at Tue Dec  6 15:30:02 2022
 
    => Loading Basis Set <=
 
@@ -4787,7 +4794,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -4799,15 +4806,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -1.006781098526     0.483437737402     0.000000000000    12.000000000000
-         N            0.678746022334    -0.997963523179     0.000000000000    14.003074004430
-         H           -1.402954174232    -1.631116647503     0.000000000000     1.007825032230
+         C           -1.006781098510     0.483437737434     0.000000000000    12.000000000000
+         N            0.678746022314    -0.997963523189     0.000000000000    14.003074004430
+         H           -1.402954174228    -1.631116647525     0.000000000000     1.007825032230
 
   Running in cs symmetry.
 
   Rotational constants: A =      8.62145  B =      1.82161  C =      1.50386 [cm^-1]
   Rotational constants: A = 258464.66679  B =  54610.35468  C =  45084.55213 [MHz]
-  Nuclear repulsion =   24.722621027960130
+  Nuclear repulsion =   24.722621027909192
 
   Charge       = 0
   Multiplicity = 1
@@ -4845,7 +4852,7 @@ gradient() will perform analytic gradient computation.
     atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
     atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
 
-  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
 
   ==> Integral Setup <==
 
@@ -4858,13 +4865,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -4874,10 +4880,10 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 1.0122560536E-02.
-  Reciprocal condition number of the overlap matrix is 2.4318027632E-03.
+  Reciprocal condition number of the overlap matrix is 2.4318027633E-03.
     Using symmetric orthogonalization.
 
   ==> Pre-Iterations <==
@@ -4897,19 +4903,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -92.78004220967478   -9.27800e+01   2.88584e-02 
-   @RHF iter   1:   -92.71257113266431    6.74711e-02   3.85466e-03 ADIIS/DIIS
-   @RHF iter   2:   -92.71668081947855   -4.10969e-03   1.39181e-03 ADIIS/DIIS
-   @RHF iter   3:   -92.71736174893206   -6.80929e-04   7.76791e-04 ADIIS/DIIS
-   @RHF iter   4:   -92.71751717769342   -1.55429e-04   3.48192e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.71756019866150   -4.30210e-05   9.63037e-05 DIIS
-   @RHF iter   6:   -92.71756583478877   -5.63613e-06   2.98866e-05 DIIS
-   @RHF iter   7:   -92.71756637245811   -5.37669e-07   7.72349e-06 DIIS
-   @RHF iter   8:   -92.71756640375803   -3.12999e-08   1.32758e-06 DIIS
-   @RHF iter   9:   -92.71756640480085   -1.04282e-09   5.13311e-07 DIIS
-   @RHF iter  10:   -92.71756640501461   -2.13760e-10   1.15250e-07 DIIS
-   @RHF iter  11:   -92.71756640502305   -8.44125e-12   1.61333e-08 DIIS
-   @RHF iter  12:   -92.71756640502304    1.42109e-14   2.03167e-09 DIIS
+   @RHF iter   0:   -92.78004220967595   -9.27800e+01   2.88584e-02 
+   @RHF iter   1:   -92.71257113266840    6.74711e-02   3.85466e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.71668081948243   -4.10969e-03   1.39181e-03 ADIIS/DIIS
+   @RHF iter   3:   -92.71736174893591   -6.80929e-04   7.76791e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.71751717769720   -1.55429e-04   3.48192e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.71756019866521   -4.30210e-05   9.63037e-05 DIIS
+   @RHF iter   6:   -92.71756583479257   -5.63613e-06   2.98866e-05 DIIS
+   @RHF iter   7:   -92.71756637246182   -5.37669e-07   7.72349e-06 DIIS
+   @RHF iter   8:   -92.71756640376167   -3.12998e-08   1.32758e-06 DIIS
+   @RHF iter   9:   -92.71756640480470   -1.04303e-09   5.13311e-07 DIIS
+   @RHF iter  10:   -92.71756640501836   -2.13660e-10   1.15250e-07 DIIS
+   @RHF iter  11:   -92.71756640502670   -8.34177e-12   1.61333e-08 DIIS
+   @RHF iter  12:   -92.71756640502680   -9.94760e-14   2.03167e-09 DIIS
   Energy and wave function converged.
 
 
@@ -4938,14 +4944,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.71756640502304
+  @RHF Final Energy:   -92.71756640502680
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             24.7226210279601304
-    One-Electron Energy =                -173.2604916957059515
-    Two-Electron Energy =                  55.8203042627228001
-    Total Energy =                        -92.7175664050230353
+    Nuclear Repulsion Energy =             24.7226210279091916
+    One-Electron Energy =                -173.2604916956272518
+    Two-Electron Energy =                  55.8203042626912662
+    Total Energy =                        -92.7175664050268011
 
 Computation Completed
 
@@ -4969,18 +4975,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:02 2022
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.10 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      12.59 seconds =       0.21 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       2.84 seconds =       0.05 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:33 2022
+*** at Tue Dec  6 15:30:02 2022
 
 
          ------------------------------------------------------------
@@ -4998,11 +5004,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -1.006781098526     0.483437737402     0.000000000000    12.000000000000
-         N            0.678746022334    -0.997963523179     0.000000000000    14.003074004430
-         H           -1.402954174232    -1.631116647503     0.000000000000     1.007825032230
+         C           -1.006781098510     0.483437737434     0.000000000000    12.000000000000
+         N            0.678746022314    -0.997963523189     0.000000000000    14.003074004430
+         H           -1.402954174228    -1.631116647525     0.000000000000     1.007825032230
 
-  Nuclear repulsion =   24.722621027960130
+  Nuclear repulsion =   24.722621027909192
 
   ==> Basis Set <==
 
@@ -5020,27 +5026,27 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.018541255121    -0.068483363009     0.000000000000
-       2       -0.011976320057    -0.009443278357     0.000000000000
-       3        0.030517575177     0.077926641367     0.000000000000
+       1       -0.018541255117    -0.068483363000     0.000000000000
+       2       -0.011976320054    -0.009443278355     0.000000000000
+       3        0.030517575171     0.077926641356     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:02 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      12.66 seconds =       0.21 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       2.86 seconds =       0.05 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
     			-----------------------------------------
 
@@ -5058,9 +5064,9 @@ Total time:
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -1.0067810985259733  0.4834377374016347  0.0000000000000000
-	       7.000000            14.003074        0.6787460223343709 -0.9979635231793742  0.0000000000000000
-	       1.000000             1.007825       -1.4029541742322071 -1.6311166475025503  0.0000000000000000
+	       6.000000            12.000000       -1.0067810985103425  0.4834377374340838  0.0000000000000000
+	       7.000000            14.003074        0.6787460223142163 -0.9979635231888864  0.0000000000000000
+	       1.000000             1.007825       -1.4029541742276828 -1.6311166475254870  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.244003           1.187475
@@ -5096,7 +5102,7 @@ Next Geometry in Ang
 
 	    C  -0.4904593682   0.2794688876   0.0000000000
 	    N   0.4442778630  -0.4647328576   0.0000000000
-	    H  -0.8698185581  -0.9501611080   0.0000000000
+	    H  -0.8698185580  -0.9501611080   0.0000000000
 
 
     Structure for next step:
@@ -5105,16 +5111,16 @@ Next Geometry in Ang
 
     Geometry (in Bohr), charge = 0, multiplicity = 1:
 
-    C           -0.926833881619     0.528119658192     0.000000000000
-    N            0.839563484751    -0.878217822354     0.000000000000
-    H           -1.643718853556    -1.795544269119     0.000000000000
+    C           -0.926833881616     0.528119658218     0.000000000000
+    N            0.839563484719    -0.878217822374     0.000000000000
+    H           -1.643718853527    -1.795544269125     0.000000000000
 
 
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:33 2022
+*** at Tue Dec  6 15:30:02 2022
 
    => Loading Basis Set <=
 
@@ -5131,7 +5137,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5143,15 +5149,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.926833881619     0.528119658192     0.000000000000    12.000000000000
-         N            0.839563484751    -0.878217822354     0.000000000000    14.003074004430
-         H           -1.643718853556    -1.795544269119     0.000000000000     1.007825032230
+         C           -0.926833881616     0.528119658218     0.000000000000    12.000000000000
+         N            0.839563484719    -0.878217822374     0.000000000000    14.003074004430
+         H           -1.643718853527    -1.795544269125     0.000000000000     1.007825032230
 
   Running in cs symmetry.
 
   Rotational constants: A =      9.06431  B =      1.78866  C =      1.49387 [cm^-1]
   Rotational constants: A = 271741.26216  B =  53622.61110  C =  44785.16891 [MHz]
-  Nuclear repulsion =   23.713241563811991
+  Nuclear repulsion =   23.713241563846999
 
   Charge       = 0
   Multiplicity = 1
@@ -5189,7 +5195,7 @@ gradient() will perform analytic gradient computation.
     atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
     atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
 
-  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
 
   ==> Integral Setup <==
 
@@ -5202,13 +5208,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -5218,7 +5223,7 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 1.0524214905E-02.
   Reciprocal condition number of the overlap matrix is 2.6890182749E-03.
@@ -5241,19 +5246,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -92.61474224629335   -9.26147e+01   1.70861e-02 
-   @RHF iter   1:   -92.72062081898893   -1.05879e-01   2.55215e-03 ADIIS/DIIS
-   @RHF iter   2:   -92.72237178434141   -1.75097e-03   8.75226e-04 ADIIS/DIIS
-   @RHF iter   3:   -92.72270290736446   -3.31123e-04   5.34866e-04 ADIIS/DIIS
-   @RHF iter   4:   -92.72279581682389   -9.29095e-05   2.84850e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.72283387174733   -3.80549e-05   6.12861e-05 DIIS
-   @RHF iter   6:   -92.72283613886414   -2.26712e-06   1.75106e-05 DIIS
-   @RHF iter   7:   -92.72283625553818   -1.16674e-07   5.35149e-06 DIIS
-   @RHF iter   8:   -92.72283626796852   -1.24303e-08   8.38167e-07 DIIS
-   @RHF iter   9:   -92.72283626824139   -2.72877e-10   1.28098e-07 DIIS
-   @RHF iter  10:   -92.72283626825035   -8.95284e-12   4.56037e-08 DIIS
-   @RHF iter  11:   -92.72283626825194   -1.59162e-12   1.30223e-08 DIIS
-   @RHF iter  12:   -92.72283626825208   -1.42109e-13   2.67021e-09 DIIS
+   @RHF iter   0:   -92.61474224630059   -9.26147e+01   1.70861e-02 
+   @RHF iter   1:   -92.72062081899014   -1.05879e-01   2.55215e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72237178434241   -1.75097e-03   8.75226e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72270290736529   -3.31123e-04   5.34866e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72279581682479   -9.29095e-05   2.84850e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72283387174818   -3.80549e-05   6.12861e-05 DIIS
+   @RHF iter   6:   -92.72283613886512   -2.26712e-06   1.75106e-05 DIIS
+   @RHF iter   7:   -92.72283625553901   -1.16674e-07   5.35149e-06 DIIS
+   @RHF iter   8:   -92.72283626796937   -1.24304e-08   8.38167e-07 DIIS
+   @RHF iter   9:   -92.72283626824225   -2.72877e-10   1.28098e-07 DIIS
+   @RHF iter  10:   -92.72283626825107   -8.82494e-12   4.56037e-08 DIIS
+   @RHF iter  11:   -92.72283626825288   -1.80478e-12   1.30223e-08 DIIS
+   @RHF iter  12:   -92.72283626825303   -1.56319e-13   2.67022e-09 DIIS
   Energy and wave function converged.
 
 
@@ -5282,14 +5287,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.72283626825208
+  @RHF Final Energy:   -92.72283626825303
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             23.7132415638119909
-    One-Electron Energy =                -171.5018150268838042
-    Two-Electron Energy =                  55.0657371948197465
-    Total Energy =                        -92.7228362682520810
+    Nuclear Repulsion Energy =             23.7132415638469993
+    One-Electron Energy =                -171.5018150269443709
+    Two-Electron Energy =                  55.0657371948443455
+    Total Energy =                        -92.7228362682530332
 
 Computation Completed
 
@@ -5313,18 +5318,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:02 2022
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      13.17 seconds =       0.22 minutes
-	system time =       0.38 seconds =       0.01 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       2.98 seconds =       0.05 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:33 2022
+*** at Tue Dec  6 15:30:02 2022
 
 
          ------------------------------------------------------------
@@ -5342,11 +5347,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.926833881619     0.528119658192     0.000000000000    12.000000000000
-         N            0.839563484751    -0.878217822354     0.000000000000    14.003074004430
-         H           -1.643718853556    -1.795544269119     0.000000000000     1.007825032230
+         C           -0.926833881616     0.528119658218     0.000000000000    12.000000000000
+         N            0.839563484719    -0.878217822374     0.000000000000    14.003074004430
+         H           -1.643718853527    -1.795544269125     0.000000000000     1.007825032230
 
-  Nuclear repulsion =   23.713241563811991
+  Nuclear repulsion =   23.713241563846999
 
   ==> Basis Set <==
 
@@ -5364,27 +5369,27 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.001412974981     0.012517255912     0.000000000000
-       2        0.019420423588     0.002238229910     0.000000000000
-       3       -0.018007448606    -0.014755485823     0.000000000000
+       1       -0.001412974982     0.012517255906     0.000000000000
+       2        0.019420423591     0.002238229913     0.000000000000
+       3       -0.018007448610    -0.014755485819     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:02 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      13.24 seconds =       0.22 minutes
-	system time =       0.38 seconds =       0.01 minutes
-	total time  =          4 seconds =       0.07 minutes
+	user time   =       3.00 seconds =       0.05 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
 
     			-----------------------------------------
 
@@ -5402,9 +5407,9 @@ Total time:
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9268338816187616  0.5281196581923154  0.0000000000000000
-	       7.000000            14.003074        0.8395634847513129 -0.8782178223540624  0.0000000000000000
-	       1.000000             1.007825       -1.6437188535563609 -1.7955442691185426  0.0000000000000000
+	       6.000000            12.000000       -0.9268338816157256  0.5281196582183108  0.0000000000000000
+	       7.000000            14.003074        0.8395634847185516 -0.8782178223740758  0.0000000000000000
+	       1.000000             1.007825       -1.6437188535266349 -1.7955442691245245  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.257863           1.194810
@@ -5440,7 +5445,7 @@ Next Geometry in Ang
 
 	    C  -0.5041473994   0.2628145030   0.0000000000
 	    N   0.4320803869  -0.4772269799   0.0000000000
-	    H  -0.8439330508  -0.9210126011   0.0000000000
+	    H  -0.8439330507  -0.9210126010   0.0000000000
 
 
     Structure for next step:
@@ -5449,16 +5454,16 @@ Next Geometry in Ang
 
     Geometry (in Bohr), charge = 0, multiplicity = 1:
 
-    C           -0.952700511752     0.496647432537     0.000000000000
-    N            0.816513595477    -0.901828291731     0.000000000000
-    H           -1.594802334149    -1.740461574086     0.000000000000
+    C           -0.952700511769     0.496647432500     0.000000000000
+    N            0.816513595482    -0.901828291740     0.000000000000
+    H           -1.594802334137    -1.740461574040     0.000000000000
 
 
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:33 2022
+*** at Tue Dec  6 15:30:02 2022
 
    => Loading Basis Set <=
 
@@ -5475,7 +5480,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5487,15 +5492,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.952700511752     0.496647432537     0.000000000000    12.000000000000
-         N            0.816513595477    -0.901828291731     0.000000000000    14.003074004430
-         H           -1.594802334149    -1.740461574086     0.000000000000     1.007825032230
+         C           -0.952700511769     0.496647432500     0.000000000000    12.000000000000
+         N            0.816513595482    -0.901828291740     0.000000000000    14.003074004430
+         H           -1.594802334137    -1.740461574040     0.000000000000     1.007825032230
 
   Running in cs symmetry.
 
   Rotational constants: A =      9.07718  B =      1.79378  C =      1.49780 [cm^-1]
   Rotational constants: A = 272127.04918  B =  53776.26493  C =  44902.81521 [MHz]
-  Nuclear repulsion =   23.943591559989084
+  Nuclear repulsion =   23.943591560114747
 
   Charge       = 0
   Multiplicity = 1
@@ -5533,7 +5538,7 @@ gradient() will perform analytic gradient computation.
     atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
     atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
 
-  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
 
   ==> Integral Setup <==
 
@@ -5546,13 +5551,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -5562,10 +5566,10 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 1.0374810444E-02.
-  Reciprocal condition number of the overlap matrix is 2.6090285763E-03.
+  Reciprocal condition number of the overlap matrix is 2.6090285762E-03.
     Using symmetric orthogonalization.
 
   ==> Pre-Iterations <==
@@ -5585,18 +5589,18 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -92.74817822163004   -9.27482e+01   3.73007e-03 
-   @RHF iter   1:   -92.72417400607576    2.40042e-02   5.17699e-04 ADIIS/DIIS
-   @RHF iter   2:   -92.72423673161084   -6.27255e-05   1.37366e-04 ADIIS/DIIS
-   @RHF iter   3:   -92.72424231803510   -5.58642e-06   7.28872e-05 DIIS
-   @RHF iter   4:   -92.72424355413963   -1.23610e-06   3.91680e-05 DIIS
-   @RHF iter   5:   -92.72424399677284   -4.42633e-07   6.83826e-06 DIIS
-   @RHF iter   6:   -92.72424402683707   -3.00642e-08   2.40733e-06 DIIS
-   @RHF iter   7:   -92.72424403102683   -4.18976e-09   6.98860e-07 DIIS
-   @RHF iter   8:   -92.72424403135115   -3.24320e-10   1.93538e-07 DIIS
-   @RHF iter   9:   -92.72424403137448   -2.33342e-11   6.48373e-08 DIIS
-   @RHF iter  10:   -92.72424403137776   -3.28271e-12   1.86239e-08 DIIS
-   @RHF iter  11:   -92.72424403137798   -2.13163e-13   3.40647e-09 DIIS
+   @RHF iter   0:   -92.74817822164138   -9.27482e+01   3.73007e-03 
+   @RHF iter   1:   -92.72417400607543    2.40042e-02   5.17699e-04 ADIIS/DIIS
+   @RHF iter   2:   -92.72423673161055   -6.27255e-05   1.37366e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72424231803470   -5.58642e-06   7.28872e-05 DIIS
+   @RHF iter   4:   -92.72424355413936   -1.23610e-06   3.91680e-05 DIIS
+   @RHF iter   5:   -92.72424399677256   -4.42633e-07   6.83826e-06 DIIS
+   @RHF iter   6:   -92.72424402683674   -3.00642e-08   2.40733e-06 DIIS
+   @RHF iter   7:   -92.72424403102657   -4.18983e-09   6.98860e-07 DIIS
+   @RHF iter   8:   -92.72424403135079   -3.24221e-10   1.93538e-07 DIIS
+   @RHF iter   9:   -92.72424403137414   -2.33484e-11   6.48373e-08 DIIS
+   @RHF iter  10:   -92.72424403137747   -3.32534e-12   1.86239e-08 DIIS
+   @RHF iter  11:   -92.72424403137775   -2.84217e-13   3.40647e-09 DIIS
   Energy and wave function converged.
 
 
@@ -5625,14 +5629,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.72424403137798
+  @RHF Final Energy:   -92.72424403137775
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             23.9435915599890841
-    One-Electron Energy =                -171.9078719582187489
-    Two-Electron Energy =                  55.2400363668516974
-    Total Energy =                        -92.7242440313779781
+    Nuclear Repulsion Energy =             23.9435915601147471
+    One-Electron Energy =                -171.9078719584364592
+    Two-Electron Energy =                  55.2400363669439542
+    Total Energy =                        -92.7242440313777507
 
 Computation Completed
 
@@ -5656,18 +5660,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      13.75 seconds =       0.23 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.12 seconds =       0.05 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
 
          ------------------------------------------------------------
@@ -5685,11 +5689,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.952700511752     0.496647432537     0.000000000000    12.000000000000
-         N            0.816513595477    -0.901828291731     0.000000000000    14.003074004430
-         H           -1.594802334149    -1.740461574086     0.000000000000     1.007825032230
+         C           -0.952700511769     0.496647432500     0.000000000000    12.000000000000
+         N            0.816513595482    -0.901828291740     0.000000000000    14.003074004430
+         H           -1.594802334137    -1.740461574040     0.000000000000     1.007825032230
 
-  Nuclear repulsion =   23.943591559989084
+  Nuclear repulsion =   23.943591560114747
 
   ==> Basis Set <==
 
@@ -5707,27 +5711,27 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.008005096672    -0.001853672517     0.000000000000
-       2        0.014711320471    -0.001816693317     0.000000000000
-       3       -0.006706223799     0.003670365834     0.000000000000
+       1       -0.008005096679    -0.001853672524     0.000000000000
+       2        0.014711320467    -0.001816693323     0.000000000000
+       3       -0.006706223788     0.003670365847     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      13.82 seconds =       0.23 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.14 seconds =       0.05 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
     			-----------------------------------------
 
@@ -5745,9 +5749,9 @@ Total time:
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9527005117516689  0.4966474325368037  0.0000000000000000
-	       7.000000            14.003074        0.8165135954770494 -0.9018282917313836  0.0000000000000000
-	       1.000000             1.007825       -1.5948023341491901 -1.7404615740857095  0.0000000000000000
+	       6.000000            12.000000       -0.9527005117692455  0.4966474324997321  0.0000000000000000
+	       7.000000            14.003074        0.8165135954819379 -0.9018282917396838  0.0000000000000000
+	       1.000000             1.007825       -1.5948023341365012 -1.7404615740403377  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.255184           1.193392
@@ -5781,9 +5785,9 @@ Total time:
 Next Geometry in Ang 
 	Fragment 1 (Ang)
 
-	    C  -0.5130909459   0.2142500316   0.0000000000
+	    C  -0.5130909459   0.2142500317   0.0000000000
 	    N   0.4647199027  -0.4612977590   0.0000000000
-	    H  -0.8676290200  -0.8883773505   0.0000000000
+	    H  -0.8676290200  -0.8883773506   0.0000000000
 
 
     Structure for next step:
@@ -5792,16 +5796,16 @@ Next Geometry in Ang
 
     Geometry (in Bohr), charge = 0, multiplicity = 1:
 
-    C           -0.969601365282     0.404873882073     0.000000000000
-    N            0.878193341197    -0.871726426883     0.000000000000
-    H           -1.639581226339    -1.678789888471     0.000000000000
+    C           -0.969601365168     0.404873882361     0.000000000000
+    N            0.878193341114    -0.871726426887     0.000000000000
+    H           -1.639581226369    -1.678789888754     0.000000000000
 
 
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
    => Loading Basis Set <=
 
@@ -5818,7 +5822,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -5830,15 +5834,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.969601365282     0.404873882073     0.000000000000    12.000000000000
-         N            0.878193341197    -0.871726426883     0.000000000000    14.003074004430
-         H           -1.639581226339    -1.678789888471     0.000000000000     1.007825032230
+         C           -0.969601365168     0.404873882361     0.000000000000    12.000000000000
+         N            0.878193341114    -0.871726426887     0.000000000000    14.003074004430
+         H           -1.639581226369    -1.678789888754     0.000000000000     1.007825032230
 
   Running in cs symmetry.
 
   Rotational constants: A =      9.08223  B =      1.79110  C =      1.49606 [cm^-1]
-  Rotational constants: A = 272278.51734  B =  53695.77173  C =  44850.79224 [MHz]
-  Nuclear repulsion =   24.089627845612348
+  Rotational constants: A = 272278.51735  B =  53695.77173  C =  44850.79224 [MHz]
+  Nuclear repulsion =   24.089627844806682
 
   Charge       = 0
   Multiplicity = 1
@@ -5876,7 +5880,7 @@ gradient() will perform analytic gradient computation.
     atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
     atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
 
-  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
 
   ==> Integral Setup <==
 
@@ -5889,13 +5893,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -5905,10 +5908,10 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
-  Minimum eigenvalue in the overlap matrix is 9.8031301032E-03.
-  Reciprocal condition number of the overlap matrix is 2.4565850733E-03.
+  Minimum eigenvalue in the overlap matrix is 9.8031301046E-03.
+  Reciprocal condition number of the overlap matrix is 2.4565850737E-03.
     Using symmetric orthogonalization.
 
   ==> Pre-Iterations <==
@@ -5928,18 +5931,18 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -92.73498861283764   -9.27350e+01   9.24005e-03 
-   @RHF iter   1:   -92.72192305926815    1.30656e-02   1.54663e-03 ADIIS/DIIS
-   @RHF iter   2:   -92.72276501536169   -8.41956e-04   8.23903e-04 ADIIS/DIIS
-   @RHF iter   3:   -92.72298137606516   -2.16361e-04   5.62272e-04 ADIIS/DIIS
-   @RHF iter   4:   -92.72309314664290   -1.11771e-04   1.63440e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.72311029684539   -1.71502e-05   3.11390e-05 DIIS
-   @RHF iter   6:   -92.72311088445996   -5.87615e-07   9.99133e-06 DIIS
-   @RHF iter   7:   -92.72311093883670   -5.43767e-08   2.71100e-06 DIIS
-   @RHF iter   8:   -92.72311094321688   -4.38018e-09   1.01583e-06 DIIS
-   @RHF iter   9:   -92.72311094403129   -8.14410e-10   3.53126e-07 DIIS
-   @RHF iter  10:   -92.72311094415515   -1.23862e-10   5.01959e-08 DIIS
-   @RHF iter  11:   -92.72311094415689   -1.73372e-12   7.31511e-09 DIIS
+   @RHF iter   0:   -92.73498861276768   -9.27350e+01   9.24005e-03 
+   @RHF iter   1:   -92.72192305928220    1.30656e-02   1.54663e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72276501537125   -8.41956e-04   8.23903e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72298137607368   -2.16361e-04   5.62272e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72309314665098   -1.11771e-04   1.63440e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72311029685325   -1.71502e-05   3.11390e-05 DIIS
+   @RHF iter   6:   -92.72311088446779   -5.87615e-07   9.99133e-06 DIIS
+   @RHF iter   7:   -92.72311093884457   -5.43768e-08   2.71100e-06 DIIS
+   @RHF iter   8:   -92.72311094322465   -4.38008e-09   1.01583e-06 DIIS
+   @RHF iter   9:   -92.72311094403906   -8.14410e-10   3.53126e-07 DIIS
+   @RHF iter  10:   -92.72311094416294   -1.23876e-10   5.01959e-08 DIIS
+   @RHF iter  11:   -92.72311094416480   -1.86162e-12   7.31511e-09 DIIS
   Energy and wave function converged.
 
 
@@ -5968,14 +5971,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.72311094415689
+  @RHF Final Energy:   -92.72311094416480
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             24.0896278456123483
-    One-Electron Energy =                -172.1865713138318199
-    Two-Electron Energy =                  55.3738325240625926
-    Total Energy =                        -92.7231109441568861
+    Nuclear Repulsion Energy =             24.0896278448066816
+    One-Electron Energy =                -172.1865713124024637
+    Two-Electron Energy =                  55.3738325234309912
+    Total Energy =                        -92.7231109441648016
 
 Computation Completed
 
@@ -5999,18 +6002,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.40 seconds =       0.01 minutes
+	user time   =       0.10 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.36 seconds =       0.24 minutes
-	system time =       0.42 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.27 seconds =       0.05 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
 
          ------------------------------------------------------------
@@ -6028,11 +6031,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.969601365282     0.404873882073     0.000000000000    12.000000000000
-         N            0.878193341197    -0.871726426883     0.000000000000    14.003074004430
-         H           -1.639581226339    -1.678789888471     0.000000000000     1.007825032230
+         C           -0.969601365168     0.404873882361     0.000000000000    12.000000000000
+         N            0.878193341114    -0.871726426887     0.000000000000    14.003074004430
+         H           -1.639581226369    -1.678789888754     0.000000000000     1.007825032230
 
-  Nuclear repulsion =   24.089627845612348
+  Nuclear repulsion =   24.089627844806682
 
   ==> Basis Set <==
 
@@ -6050,27 +6053,27 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1       -0.012406893783    -0.006378751708     0.000000000000
-       2       -0.001902289533    -0.009180105035     0.000000000000
-       3        0.014309183315     0.015558856743     0.000000000000
+       1       -0.012406893715    -0.006378751638     0.000000000000
+       2       -0.001902289505    -0.009180104991     0.000000000000
+       3        0.014309183220     0.015558856629     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.43 seconds =       0.24 minutes
-	system time =       0.42 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.29 seconds =       0.05 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
     			-----------------------------------------
 
@@ -6088,14 +6091,14 @@ Total time:
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9696013652817181  0.4048738820734400  0.0000000000000000
-	       7.000000            14.003074        0.8781933411965031 -0.8717264268825471  0.0000000000000000
-	       1.000000             1.007825       -1.6395812263385943 -1.6787898884711820  0.0000000000000000
+	       6.000000            12.000000       -0.9696013651679604  0.4048738823610264  0.0000000000000000
+	       7.000000            14.003074        0.8781933411135368 -0.8717264268869306  0.0000000000000000
+	       1.000000             1.007825       -1.6395812263693850 -1.6787898887543851  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.245897           1.188478
 	 R(2,3)           =         2.643963           1.399125
-	 B(1,2,3)         =         0.914776          52.412796
+	 B(1,2,3)         =         0.914776          52.412797
 
 
 	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
@@ -6124,9 +6127,9 @@ Total time:
 Next Geometry in Ang 
 	Fragment 1 (Ang)
 
-	    C  -0.4958319511   0.2277101030   0.0000000000
-	    N   0.4777105495  -0.4464474087   0.0000000000
-	    H  -0.8978786616  -0.9166877723   0.0000000000
+	    C  -0.4958319511   0.2277101031   0.0000000000
+	    N   0.4777105493  -0.4464474088   0.0000000000
+	    H  -0.8978786614  -0.9166877723   0.0000000000
 
 
     Structure for next step:
@@ -6135,16 +6138,16 @@ Next Geometry in Ang
 
     Geometry (in Bohr), charge = 0, multiplicity = 1:
 
-    C           -0.936986591742     0.430309730711     0.000000000000
-    N            0.902742105703    -0.843663331781     0.000000000000
-    H           -1.696744764385    -1.732288832210     0.000000000000
+    C           -0.936986591850     0.430309730812     0.000000000000
+    N            0.902742105445    -0.843663331966     0.000000000000
+    H           -1.696744764019    -1.732288832126     0.000000000000
 
 
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
    => Loading Basis Set <=
 
@@ -6161,7 +6164,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -6173,15 +6176,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.936986591742     0.430309730711     0.000000000000    12.000000000000
-         N            0.902742105703    -0.843663331781     0.000000000000    14.003074004430
-         H           -1.696744764385    -1.732288832210     0.000000000000     1.007825032230
+         C           -0.936986591850     0.430309730812     0.000000000000    12.000000000000
+         N            0.902742105445    -0.843663331966     0.000000000000    14.003074004430
+         H           -1.696744764019    -1.732288832126     0.000000000000     1.007825032230
 
   Running in cs symmetry.
 
   Rotational constants: A =      9.12616  B =      1.79887  C =      1.50267 [cm^-1]
-  Rotational constants: A = 273595.44694  B =  53928.62977  C =  45048.98606 [MHz]
-  Nuclear repulsion =   23.934366020514354
+  Rotational constants: A = 273595.44693  B =  53928.62977  C =  45048.98606 [MHz]
+  Nuclear repulsion =   23.934366020978118
 
   Charge       = 0
   Multiplicity = 1
@@ -6219,7 +6222,7 @@ gradient() will perform analytic gradient computation.
     atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
     atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
 
-  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
 
   ==> Integral Setup <==
 
@@ -6232,13 +6235,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -6248,10 +6250,10 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
-  Minimum eigenvalue in the overlap matrix is 9.7676622416E-03.
-  Reciprocal condition number of the overlap matrix is 2.4867611876E-03.
+  Minimum eigenvalue in the overlap matrix is 9.7676622428E-03.
+  Reciprocal condition number of the overlap matrix is 2.4867611878E-03.
     Using symmetric orthogonalization.
 
   ==> Pre-Iterations <==
@@ -6271,18 +6273,18 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -92.70498545355733   -9.27050e+01   4.33046e-03 
-   @RHF iter   1:   -92.72379998739139   -1.88145e-02   5.25708e-04 ADIIS/DIIS
-   @RHF iter   2:   -92.72387259735798   -7.26100e-05   1.51917e-04 ADIIS/DIIS
-   @RHF iter   3:   -92.72388300222855   -1.04049e-05   6.85489e-05 DIIS
-   @RHF iter   4:   -92.72388571230405   -2.71008e-06   4.11070e-05 DIIS
-   @RHF iter   5:   -92.72388626475909   -5.52455e-07   1.59485e-05 DIIS
-   @RHF iter   6:   -92.72388644921094   -1.84452e-07   4.28267e-06 DIIS
-   @RHF iter   7:   -92.72388646296814   -1.37572e-08   1.11202e-06 DIIS
-   @RHF iter   8:   -92.72388646375174   -7.83601e-10   4.34369e-07 DIIS
-   @RHF iter   9:   -92.72388646388501   -1.33269e-10   1.56801e-07 DIIS
-   @RHF iter  10:   -92.72388646390444   -1.94262e-11   3.12313e-08 DIIS
-   @RHF iter  11:   -92.72388646390472   -2.84217e-13   4.20329e-09 DIIS
+   @RHF iter   0:   -92.70498545370232   -9.27050e+01   4.33046e-03 
+   @RHF iter   1:   -92.72379998739115   -1.88145e-02   5.25708e-04 ADIIS/DIIS
+   @RHF iter   2:   -92.72387259735672   -7.26100e-05   1.51917e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72388300222720   -1.04049e-05   6.85489e-05 DIIS
+   @RHF iter   4:   -92.72388571230267   -2.71008e-06   4.11070e-05 DIIS
+   @RHF iter   5:   -92.72388626475771   -5.52455e-07   1.59485e-05 DIIS
+   @RHF iter   6:   -92.72388644920949   -1.84452e-07   4.28267e-06 DIIS
+   @RHF iter   7:   -92.72388646296679   -1.37573e-08   1.11202e-06 DIIS
+   @RHF iter   8:   -92.72388646375038   -7.83587e-10   4.34369e-07 DIIS
+   @RHF iter   9:   -92.72388646388345   -1.33070e-10   1.56801e-07 DIIS
+   @RHF iter  10:   -92.72388646390304   -1.95968e-11   3.12313e-08 DIIS
+   @RHF iter  11:   -92.72388646390334   -2.98428e-13   4.20329e-09 DIIS
   Energy and wave function converged.
 
 
@@ -6311,14 +6313,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.72388646390472
+  @RHF Final Energy:   -92.72388646390334
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             23.9343660205143536
-    One-Electron Energy =                -171.9354225860151928
-    Two-Electron Energy =                  55.2771701015961270
-    Total Energy =                        -92.7238864639047193
+    Nuclear Repulsion Energy =             23.9343660209781177
+    One-Electron Energy =                -171.9354225867003834
+    Two-Electron Energy =                  55.2771701018189177
+    Total Energy =                        -92.7238864639033409
 
 Computation Completed
 
@@ -6342,18 +6344,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.95 seconds =       0.25 minutes
-	system time =       0.44 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.41 seconds =       0.06 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
 
          ------------------------------------------------------------
@@ -6371,11 +6373,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.936986591742     0.430309730711     0.000000000000    12.000000000000
-         N            0.902742105703    -0.843663331781     0.000000000000    14.003074004430
-         H           -1.696744764385    -1.732288832210     0.000000000000     1.007825032230
+         C           -0.936986591850     0.430309730812     0.000000000000    12.000000000000
+         N            0.902742105445    -0.843663331966     0.000000000000    14.003074004430
+         H           -1.696744764019    -1.732288832126     0.000000000000     1.007825032230
 
-  Nuclear repulsion =   23.934366020514354
+  Nuclear repulsion =   23.934366020978118
 
   ==> Basis Set <==
 
@@ -6393,27 +6395,27 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.007059359329     0.010137731543     0.000000000000
-       2       -0.007634132653     0.000300232738     0.000000000000
-       3        0.000574773324    -0.010437964281     0.000000000000
+       1        0.007059359273     0.010137731470     0.000000000000
+       2       -0.007634132605     0.000300232732     0.000000000000
+       3        0.000574773332    -0.010437964202     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      15.02 seconds =       0.25 minutes
-	system time =       0.45 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.43 seconds =       0.06 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
     			-----------------------------------------
 
@@ -6431,9 +6433,9 @@ Total time:
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9369865917421235  0.4303097307112949  0.0000000000000000
-	       7.000000            14.003074        0.9027421057032951 -0.8436633317811943  0.0000000000000000
-	       1.000000             1.007825       -1.6967447643849807 -1.7322888322103898  0.0000000000000000
+	       6.000000            12.000000       -0.9369865918502277  0.4303097308116196  0.0000000000000000
+	       7.000000            14.003074        0.9027421054453458 -0.8436633319656345  0.0000000000000000
+	       1.000000             1.007825       -1.6967447640189266 -1.7322888321262744  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.237769           1.184176
@@ -6467,9 +6469,9 @@ Total time:
 Next Geometry in Ang 
 	Fragment 1 (Ang)
 
-	    C  -0.4915559297   0.2696452832   0.0000000000
+	    C  -0.4915559298   0.2696452830   0.0000000000
 	    N   0.4423704031  -0.4671744112   0.0000000000
-	    H  -0.8668145366  -0.9378959499   0.0000000000
+	    H  -0.8668145366  -0.9378959497   0.0000000000
 
 
     Structure for next step:
@@ -6478,16 +6480,16 @@ Next Geometry in Ang
 
     Geometry (in Bohr), charge = 0, multiplicity = 1:
 
-    C           -0.928906082415     0.509555736252     0.000000000000
-    N            0.835958907788    -0.882831690023     0.000000000000
-    H           -1.638042075797    -1.772366479509     0.000000000000
+    C           -0.928906082620     0.509555735808     0.000000000000
+    N            0.835958907957    -0.882831689972     0.000000000000
+    H           -1.638042075761    -1.772366479116     0.000000000000
 
 
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
    => Loading Basis Set <=
 
@@ -6504,7 +6506,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -6516,15 +6518,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.928906082415     0.509555736252     0.000000000000    12.000000000000
-         N            0.835958907788    -0.882831690023     0.000000000000    14.003074004430
-         H           -1.638042075797    -1.772366479509     0.000000000000     1.007825032230
+         C           -0.928906082620     0.509555735808     0.000000000000    12.000000000000
+         N            0.835958907957    -0.882831689972     0.000000000000    14.003074004430
+         H           -1.638042075761    -1.772366479116     0.000000000000     1.007825032230
 
   Running in cs symmetry.
 
   Rotational constants: A =      9.07964  B =      1.80187  C =      1.50350 [cm^-1]
   Rotational constants: A = 272200.74258  B =  54018.59187  C =  45073.66446 [MHz]
-  Nuclear repulsion =   23.856759412603612
+  Nuclear repulsion =   23.856759413613418
 
   Charge       = 0
   Multiplicity = 1
@@ -6562,7 +6564,7 @@ gradient() will perform analytic gradient computation.
     atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
     atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
 
-  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
 
   ==> Integral Setup <==
 
@@ -6575,13 +6577,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -6591,10 +6592,10 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
-  Minimum eigenvalue in the overlap matrix is 1.0281880624E-02.
-  Reciprocal condition number of the overlap matrix is 2.6130674925E-03.
+  Minimum eigenvalue in the overlap matrix is 1.0281880622E-02.
+  Reciprocal condition number of the overlap matrix is 2.6130674919E-03.
     Using symmetric orthogonalization.
 
   ==> Pre-Iterations <==
@@ -6614,18 +6615,18 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -92.70123570088862   -9.27012e+01   8.24953e-03 
-   @RHF iter   1:   -92.72233657760313   -2.11009e-02   1.48638e-03 ADIIS/DIIS
-   @RHF iter   2:   -92.72312277411734   -7.86197e-04   7.76480e-04 ADIIS/DIIS
-   @RHF iter   3:   -92.72333057168944   -2.07798e-04   5.30679e-04 ADIIS/DIIS
-   @RHF iter   4:   -92.72343003292261   -9.94612e-05   1.51769e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.72344386205926   -1.38291e-05   3.44035e-05 DIIS
-   @RHF iter   6:   -92.72344448751080   -6.25452e-07   1.05684e-05 DIIS
-   @RHF iter   7:   -92.72344454627381   -5.87630e-08   2.41138e-06 DIIS
-   @RHF iter   8:   -92.72344454984730   -3.57349e-09   7.87215e-07 DIIS
-   @RHF iter   9:   -92.72344455030732   -4.60020e-10   2.84334e-07 DIIS
-   @RHF iter  10:   -92.72344455038009   -7.27738e-11   4.51723e-08 DIIS
-   @RHF iter  11:   -92.72344455038160   -1.50635e-12   6.12486e-09 DIIS
+   @RHF iter   0:   -92.70123570110427   -9.27012e+01   8.24953e-03 
+   @RHF iter   1:   -92.72233657762287   -2.11009e-02   1.48638e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72312277412661   -7.86197e-04   7.76480e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72333057169610   -2.07798e-04   5.30679e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72343003292791   -9.94612e-05   1.51769e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72344386206443   -1.38291e-05   3.44035e-05 DIIS
+   @RHF iter   6:   -92.72344448751599   -6.25452e-07   1.05684e-05 DIIS
+   @RHF iter   7:   -92.72344454627887   -5.87629e-08   2.41138e-06 DIIS
+   @RHF iter   8:   -92.72344454985245   -3.57358e-09   7.87215e-07 DIIS
+   @RHF iter   9:   -92.72344455031254   -4.60091e-10   2.84334e-07 DIIS
+   @RHF iter  10:   -92.72344455038532   -7.27880e-11   4.51723e-08 DIIS
+   @RHF iter  11:   -92.72344455038682   -1.49214e-12   6.12486e-09 DIIS
   Energy and wave function converged.
 
 
@@ -6654,14 +6655,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.72344455038160
+  @RHF Final Energy:   -92.72344455038682
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             23.8567594126036120
-    One-Electron Energy =                -171.7708893217541117
-    Two-Electron Energy =                  55.1906853587688815
-    Total Energy =                        -92.7234445503816005
+    Nuclear Repulsion Energy =             23.8567594136134176
+    One-Electron Energy =                -171.7708893235457026
+    Two-Electron Energy =                  55.1906853595454692
+    Total Energy =                        -92.7234445503868159
 
 Computation Completed
 
@@ -6685,18 +6686,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.39 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      15.54 seconds =       0.26 minutes
-	system time =       0.46 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.56 seconds =       0.06 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
 
          ------------------------------------------------------------
@@ -6714,11 +6715,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.928906082415     0.509555736252     0.000000000000    12.000000000000
-         N            0.835958907788    -0.882831690023     0.000000000000    14.003074004430
-         H           -1.638042075797    -1.772366479509     0.000000000000     1.007825032230
+         C           -0.928906082620     0.509555735808     0.000000000000    12.000000000000
+         N            0.835958907957    -0.882831689972     0.000000000000    14.003074004430
+         H           -1.638042075761    -1.772366479116     0.000000000000     1.007825032230
 
-  Nuclear repulsion =   23.856759412603612
+  Nuclear repulsion =   23.856759413613418
 
   ==> Basis Set <==
 
@@ -6736,27 +6737,27 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.004212111616     0.004039185304     0.000000000000
-       2        0.009374944806     0.006098107885     0.000000000000
-       3       -0.013587056422    -0.010137293189     0.000000000000
+       1        0.004212111568     0.004039185286     0.000000000000
+       2        0.009374944753     0.006098107824     0.000000000000
+       3       -0.013587056321    -0.010137293110     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      15.60 seconds =       0.26 minutes
-	system time =       0.46 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.58 seconds =       0.06 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
     			-----------------------------------------
 
@@ -6774,9 +6775,9 @@ Total time:
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9289060824152746  0.5095557362515007  0.0000000000000000
-	       7.000000            14.003074        0.8359589077879728 -0.8828316900225756  0.0000000000000000
-	       1.000000             1.007825       -1.6380420757965073 -1.7723664795092144  0.0000000000000000
+	       6.000000            12.000000       -0.9289060826197840  0.5095557358076035  0.0000000000000000
+	       7.000000            14.003074        0.8359589079573475 -0.8828316899721258  0.0000000000000000
+	       1.000000             1.007825       -1.6380420757613721 -1.7723664791157669  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.247997           1.189589
@@ -6810,9 +6811,9 @@ Total time:
 Next Geometry in Ang 
 	Fragment 1 (Ang)
 
-	    C  -0.5041690815   0.2029621064   0.0000000000
-	    N   0.4800660348  -0.4462876036   0.0000000000
-	    H  -0.8918970166  -0.8920995808   0.0000000000
+	    C  -0.5041690813   0.2029621107   0.0000000000
+	    N   0.4800660314  -0.4462876059   0.0000000000
+	    H  -0.8918970133  -0.8920995828   0.0000000000
 
 
     Structure for next step:
@@ -6821,16 +6822,16 @@ Next Geometry in Ang
 
     Geometry (in Bohr), charge = 0, multiplicity = 1:
 
-    C           -0.952741484875     0.383542794990     0.000000000000
-    N            0.907193327976    -0.843361343976     0.000000000000
-    H           -1.685441093524    -1.685823884294     0.000000000000
+    C           -0.952741484577     0.383542803039     0.000000000000
+    N            0.907193321421    -0.843361348267     0.000000000000
+    H           -1.685441087268    -1.685823888052     0.000000000000
 
 
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
    => Loading Basis Set <=
 
@@ -6847,7 +6848,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -6859,15 +6860,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.952741484875     0.383542794990     0.000000000000    12.000000000000
-         N            0.907193327976    -0.843361343976     0.000000000000    14.003074004430
-         H           -1.685441093524    -1.685823884294     0.000000000000     1.007825032230
+         C           -0.952741484577     0.383542803039     0.000000000000    12.000000000000
+         N            0.907193321421    -0.843361348267     0.000000000000    14.003074004430
+         H           -1.685441087268    -1.685823888052     0.000000000000     1.007825032230
 
   Running in cs symmetry.
 
   Rotational constants: A =      9.14483  B =      1.80853  C =      1.50992 [cm^-1]
-  Rotational constants: A = 274155.06845  B =  54218.49991  C =  45266.36120 [MHz]
-  Nuclear repulsion =   24.150685522476330
+  Rotational constants: A = 274155.06814  B =  54218.49993  C =  45266.36121 [MHz]
+  Nuclear repulsion =   24.150685513642678
 
   Charge       = 0
   Multiplicity = 1
@@ -6905,7 +6906,7 @@ gradient() will perform analytic gradient computation.
     atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
     atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
 
-  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
 
   ==> Integral Setup <==
 
@@ -6918,13 +6919,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -6934,10 +6934,10 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
-  Minimum eigenvalue in the overlap matrix is 9.4115252645E-03.
-  Reciprocal condition number of the overlap matrix is 2.3734103857E-03.
+  Minimum eigenvalue in the overlap matrix is 9.4115253192E-03.
+  Reciprocal condition number of the overlap matrix is 2.3734103988E-03.
     Using symmetric orthogonalization.
 
   ==> Pre-Iterations <==
@@ -6957,19 +6957,19 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -92.74646331702283   -9.27465e+01   1.21446e-02 
-   @RHF iter   1:   -92.72223763173527    2.42257e-02   1.99625e-03 ADIIS/DIIS
-   @RHF iter   2:   -92.72368391394855   -1.44628e-03   1.05289e-03 ADIIS/DIIS
-   @RHF iter   3:   -92.72405609303168   -3.72179e-04   7.15346e-04 ADIIS/DIIS
-   @RHF iter   4:   -92.72423676482268   -1.80672e-04   2.22626e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.72426803372949   -3.12689e-05   4.69123e-05 DIIS
-   @RHF iter   6:   -92.72426949465478   -1.46093e-06   1.48877e-05 DIIS
-   @RHF iter   7:   -92.72426963199607   -1.37341e-07   4.92012e-06 DIIS
-   @RHF iter   8:   -92.72426964923724   -1.72412e-08   2.00663e-06 DIIS
-   @RHF iter   9:   -92.72426965269624   -3.45899e-09   5.71743e-07 DIIS
-   @RHF iter  10:   -92.72426965300502   -3.08788e-10   7.74665e-08 DIIS
-   @RHF iter  11:   -92.72426965300880   -3.78009e-12   1.19140e-08 DIIS
-   @RHF iter  12:   -92.72426965300876    4.26326e-14   2.15947e-09 DIIS
+   @RHF iter   0:   -92.74646331720106   -9.27465e+01   1.21446e-02 
+   @RHF iter   1:   -92.72223763187608    2.42257e-02   1.99625e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72368391386216   -1.44628e-03   1.05289e-03 ADIIS/DIIS
+   @RHF iter   3:   -92.72405609288253   -3.72179e-04   7.15346e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72423676464595   -1.80672e-04   2.22626e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72426803354715   -3.12689e-05   4.69123e-05 DIIS
+   @RHF iter   6:   -92.72426949447213   -1.46092e-06   1.48877e-05 DIIS
+   @RHF iter   7:   -92.72426963181343   -1.37341e-07   4.92011e-06 DIIS
+   @RHF iter   8:   -92.72426964905465   -1.72412e-08   2.00663e-06 DIIS
+   @RHF iter   9:   -92.72426965251375   -3.45911e-09   5.71743e-07 DIIS
+   @RHF iter  10:   -92.72426965282234   -3.08589e-10   7.74665e-08 DIIS
+   @RHF iter  11:   -92.72426965282608   -3.73745e-12   1.19140e-08 DIIS
+   @RHF iter  12:   -92.72426965282602    5.68434e-14   2.15947e-09 DIIS
   Energy and wave function converged.
 
 
@@ -6998,14 +6998,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.72426965300876
+  @RHF Final Energy:   -92.72426965282602
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             24.1506855224763299
-    One-Electron Energy =                -172.3363651366070144
-    Two-Electron Energy =                  55.4614099611219231
-    Total Energy =                        -92.7242696530087755
+    Nuclear Repulsion Energy =             24.1506855136426779
+    One-Electron Energy =                -172.3363651168191382
+    Two-Electron Energy =                  55.4614099503504292
+    Total Energy =                        -92.7242696528260240
 
 Computation Completed
 
@@ -7029,18 +7029,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.40 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      16.14 seconds =       0.27 minutes
-	system time =       0.48 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.71 seconds =       0.06 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
 
          ------------------------------------------------------------
@@ -7058,11 +7058,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.952741484875     0.383542794990     0.000000000000    12.000000000000
-         N            0.907193327976    -0.843361343976     0.000000000000    14.003074004430
-         H           -1.685441093524    -1.685823884294     0.000000000000     1.007825032230
+         C           -0.952741484577     0.383542803039     0.000000000000    12.000000000000
+         N            0.907193321421    -0.843361348267     0.000000000000    14.003074004430
+         H           -1.685441087268    -1.685823888052     0.000000000000     1.007825032230
 
-  Nuclear repulsion =   24.150685522476330
+  Nuclear repulsion =   24.150685513642678
 
   ==> Basis Set <==
 
@@ -7080,27 +7080,27 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.005271573177    -0.003917522440     0.000000000000
-       2       -0.020254679398    -0.001266906300     0.000000000000
-       3        0.014983106222     0.005184428740     0.000000000000
+       1        0.005271573315    -0.003917522837     0.000000000000
+       2       -0.020254677770    -0.001266905535     0.000000000000
+       3        0.014983104454     0.005184428372     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      16.21 seconds =       0.27 minutes
-	system time =       0.48 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.73 seconds =       0.06 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
     			-----------------------------------------
 
@@ -7118,9 +7118,9 @@ Total time:
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9527414848751103  0.3835427949900482  0.0000000000000000
-	       7.000000            14.003074        0.9071933279755539 -0.8433613439764761  0.0000000000000000
-	       1.000000             1.007825       -1.6854410935242525 -1.6858238842938613  0.0000000000000000
+	       6.000000            12.000000       -0.9527414845765747  0.3835428030388749  0.0000000000000000
+	       7.000000            14.003074        0.9071933214206969 -0.8433613482671416  0.0000000000000000
+	       1.000000             1.007825       -1.6854410872679308 -1.6858238880520227  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.228150           1.179086
@@ -7154,9 +7154,9 @@ Total time:
 Next Geometry in Ang 
 	Fragment 1 (Ang)
 
-	    C  -0.5014386017   0.2406566128   0.0000000000
-	    N   0.4547806115  -0.4629438392   0.0000000000
-	    H  -0.8693420731  -0.9131378516   0.0000000000
+	    C  -0.5014386017   0.2406566127   0.0000000000
+	    N   0.4547806116  -0.4629438392   0.0000000000
+	    H  -0.8693420731  -0.9131378514   0.0000000000
 
 
     Structure for next step:
@@ -7165,16 +7165,16 @@ Next Geometry in Ang
 
     Geometry (in Bohr), charge = 0, multiplicity = 1:
 
-    C           -0.947581625927     0.454775088542     0.000000000000
-    N            0.859410802950    -0.874837067505     0.000000000000
-    H           -1.642818427447    -1.725580454317     0.000000000000
+    C           -0.947581625902     0.454775088225     0.000000000000
+    N            0.859410803021    -0.874837067479     0.000000000000
+    H           -1.642818427543    -1.725580454026     0.000000000000
 
 
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
    => Loading Basis Set <=
 
@@ -7191,7 +7191,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -7203,15 +7203,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.947581625927     0.454775088542     0.000000000000    12.000000000000
-         N            0.859410802950    -0.874837067505     0.000000000000    14.003074004430
-         H           -1.642818427447    -1.725580454317     0.000000000000     1.007825032230
+         C           -0.947581625902     0.454775088225     0.000000000000    12.000000000000
+         N            0.859410803021    -0.874837067479     0.000000000000    14.003074004430
+         H           -1.642818427543    -1.725580454026     0.000000000000     1.007825032230
 
   Running in cs symmetry.
 
   Rotational constants: A =      9.09289  B =      1.80148  C =      1.50359 [cm^-1]
-  Rotational constants: A = 272597.95124  B =  54007.08399  C =  45076.52626 [MHz]
-  Nuclear repulsion =   23.991517966838867
+  Rotational constants: A = 272597.95124  B =  54007.08399  C =  45076.52627 [MHz]
+  Nuclear repulsion =   23.991517968769720
 
   Charge       = 0
   Multiplicity = 1
@@ -7249,7 +7249,7 @@ gradient() will perform analytic gradient computation.
     atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
     atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
 
-  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
 
   ==> Integral Setup <==
 
@@ -7262,13 +7262,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -7278,10 +7277,10 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
-  Minimum eigenvalue in the overlap matrix is 9.9862181741E-03.
-  Reciprocal condition number of the overlap matrix is 2.5206727049E-03.
+  Minimum eigenvalue in the overlap matrix is 9.9862181699E-03.
+  Reciprocal condition number of the overlap matrix is 2.5206727038E-03.
     Using symmetric orthogonalization.
 
   ==> Pre-Iterations <==
@@ -7301,18 +7300,18 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -92.69609992466528   -9.26961e+01   7.20062e-03 
-   @RHF iter   1:   -92.72289930795834   -2.67994e-02   1.24280e-03 ADIIS/DIIS
-   @RHF iter   2:   -92.72346759728606   -5.68289e-04   6.32461e-04 ADIIS/DIIS
-   @RHF iter   3:   -92.72362132823386   -1.53731e-04   4.32161e-04 ADIIS/DIIS
-   @RHF iter   4:   -92.72368713581099   -6.58076e-05   1.44221e-04 ADIIS/DIIS
-   @RHF iter   5:   -92.72369931289812   -1.21771e-05   3.78513e-05 DIIS
-   @RHF iter   6:   -92.72370014964179   -8.36744e-07   1.06469e-05 DIIS
-   @RHF iter   7:   -92.72370021605124   -6.64095e-08   3.22665e-06 DIIS
-   @RHF iter   8:   -92.72370022343762   -7.38638e-09   1.04899e-06 DIIS
-   @RHF iter   9:   -92.72370022432031   -8.82693e-10   3.32858e-07 DIIS
-   @RHF iter  10:   -92.72370022442003   -9.97176e-11   3.90713e-08 DIIS
-   @RHF iter  11:   -92.72370022442102   -9.94760e-13   4.77764e-09 DIIS
+   @RHF iter   0:   -92.69609992838890   -9.26961e+01   7.20062e-03 
+   @RHF iter   1:   -92.72289930816314   -2.67994e-02   1.24280e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72346759734559   -5.68289e-04   6.32461e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72362132825232   -1.53731e-04   4.32161e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72368713581457   -6.58076e-05   1.44221e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72369931289843   -1.21771e-05   3.78513e-05 DIIS
+   @RHF iter   6:   -92.72370014964199   -8.36744e-07   1.06469e-05 DIIS
+   @RHF iter   7:   -92.72370021605127   -6.64093e-08   3.22665e-06 DIIS
+   @RHF iter   8:   -92.72370022343779   -7.38652e-09   1.04899e-06 DIIS
+   @RHF iter   9:   -92.72370022432042   -8.82636e-10   3.32858e-07 DIIS
+   @RHF iter  10:   -92.72370022442003   -9.96039e-11   3.90713e-08 DIIS
+   @RHF iter  11:   -92.72370022442095   -9.23706e-13   4.77764e-09 DIIS
   Energy and wave function converged.
 
 
@@ -7341,14 +7340,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.72370022442102
+  @RHF Final Energy:   -92.72370022442095
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             23.9915179668388667
-    One-Electron Energy =                -172.0167717574415747
-    Two-Electron Energy =                  55.3015535661816884
-    Total Energy =                        -92.7237002244210089
+    Nuclear Repulsion Energy =             23.9915179687697204
+    One-Electron Energy =                -172.0167717611411433
+    Two-Electron Energy =                  55.3015535679504637
+    Total Energy =                        -92.7237002244209521
 
 Computation Completed
 
@@ -7372,18 +7371,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      16.72 seconds =       0.28 minutes
-	system time =       0.49 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.85 seconds =       0.06 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
 
          ------------------------------------------------------------
@@ -7401,11 +7400,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.947581625927     0.454775088542     0.000000000000    12.000000000000
-         N            0.859410802950    -0.874837067505     0.000000000000    14.003074004430
-         H           -1.642818427447    -1.725580454317     0.000000000000     1.007825032230
+         C           -0.947581625902     0.454775088225     0.000000000000    12.000000000000
+         N            0.859410803021    -0.874837067479     0.000000000000    14.003074004430
+         H           -1.642818427543    -1.725580454026     0.000000000000     1.007825032230
 
-  Nuclear repulsion =   23.991517966838867
+  Nuclear repulsion =   23.991517968769720
 
   ==> Basis Set <==
 
@@ -7423,27 +7422,27 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000473057712    -0.000168007209     0.000000000000
-       2        0.000180620602     0.000520298652     0.000000000000
-       3       -0.000653678314    -0.000352291443     0.000000000000
+       1        0.000473057816    -0.000168007325     0.000000000000
+       2        0.000180620423     0.000520298714     0.000000000000
+       3       -0.000653678238    -0.000352291389     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      16.79 seconds =       0.28 minutes
-	system time =       0.50 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.87 seconds =       0.06 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
     			-----------------------------------------
 
@@ -7461,9 +7460,9 @@ Total time:
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9475816259267723  0.4547750885420321  0.0000000000000000
-	       7.000000            14.003074        0.8594108029495456 -0.8748370675052539  0.0000000000000000
-	       1.000000             1.007825       -1.6428184274465825 -1.7255804543170672  0.0000000000000000
+	       6.000000            12.000000       -0.9475816259017645  0.4547750882251752  0.0000000000000000
+	       7.000000            14.003074        0.8594108030209895 -0.8748370674792090  0.0000000000000000
+	       1.000000             1.007825       -1.6428184275430335 -1.7255804540262554  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.243455           1.187185
@@ -7497,7 +7496,7 @@ Total time:
 Next Geometry in Ang 
 	Fragment 1 (Ang)
 
-	    C  -0.5017629596   0.2391995735   0.0000000000
+	    C  -0.5017629595   0.2391995735   0.0000000000
 	    N   0.4559457344  -0.4624255062   0.0000000000
 	    H  -0.8701828381  -0.9121991452   0.0000000000
 
@@ -7508,16 +7507,16 @@ Next Geometry in Ang
 
     Geometry (in Bohr), charge = 0, multiplicity = 1:
 
-    C           -0.948194573488     0.452021683184     0.000000000000
-    N            0.861612566092    -0.873857560067     0.000000000000
-    H           -1.644407243028    -1.723806556397     0.000000000000
+    C           -0.948194573442     0.452021683185     0.000000000000
+    N            0.861612566050    -0.873857560149     0.000000000000
+    H           -1.644407243032    -1.723806556316     0.000000000000
 
 
 Scratch directory: /tmp/
 gradient() will perform analytic gradient computation.
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
    => Loading Basis Set <=
 
@@ -7534,7 +7533,7 @@ gradient() will perform analytic gradient computation.
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
                               RHF Reference
-                        4 Threads,    500 MiB Core
+                        1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
   ==> Geometry <==
@@ -7546,15 +7545,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.948194573488     0.452021683184     0.000000000000    12.000000000000
-         N            0.861612566092    -0.873857560067     0.000000000000    14.003074004430
-         H           -1.644407243028    -1.723806556397     0.000000000000     1.007825032230
+         C           -0.948194573442     0.452021683185     0.000000000000    12.000000000000
+         N            0.861612566050    -0.873857560149     0.000000000000    14.003074004430
+         H           -1.644407243032    -1.723806556316     0.000000000000     1.007825032230
 
   Running in cs symmetry.
 
   Rotational constants: A =      9.09403  B =      1.80078  C =      1.50313 [cm^-1]
   Rotational constants: A = 272632.03292  B =  53986.10831  C =  45062.84434 [MHz]
-  Nuclear repulsion =   23.992292195213906
+  Nuclear repulsion =   23.992292195559930
 
   Charge       = 0
   Multiplicity = 1
@@ -7592,7 +7591,7 @@ gradient() will perform analytic gradient computation.
     atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
     atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
 
-  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
 
   ==> Integral Setup <==
 
@@ -7605,13 +7604,12 @@ gradient() will perform analytic gradient computation.
       Number of basis functions:        20
 
       Integral cutoff                 1.00e-12
-      Number of threads:                 4
+      Number of threads:                 1
 
   Performing in-core PK
   Using 44310 doubles for integral storage.
-  We computed 3972 shell quartets total.
+  We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
-    28.92 percent of shell quartets recomputed by reordering.
 
   ==> DiskJK: Disk-Based J/K Matrices <==
 
@@ -7621,10 +7619,10 @@ gradient() will perform analytic gradient computation.
     Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
-    OpenMP threads:              4
+    OpenMP threads:              1
 
-  Minimum eigenvalue in the overlap matrix is 9.9749474481E-03.
-  Reciprocal condition number of the overlap matrix is 2.5177734004E-03.
+  Minimum eigenvalue in the overlap matrix is 9.9749474477E-03.
+  Reciprocal condition number of the overlap matrix is 2.5177734002E-03.
     Using symmetric orthogonalization.
 
   ==> Pre-Iterations <==
@@ -7644,16 +7642,16 @@ gradient() will perform analytic gradient computation.
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -92.72406815609587   -9.27241e+01   2.85793e-04 
-   @RHF iter   1:   -92.72369847261261    3.69683e-04   4.86558e-05 DIIS
-   @RHF iter   2:   -92.72369933905993   -8.66447e-07   2.47652e-05 DIIS
-   @RHF iter   3:   -92.72369957389226   -2.34832e-07   1.73266e-05 DIIS
-   @RHF iter   4:   -92.72369967024072   -9.63485e-08   5.06370e-06 DIIS
-   @RHF iter   5:   -92.72369968604514   -1.58044e-08   7.90387e-07 DIIS
-   @RHF iter   6:   -92.72369968641760   -3.72467e-10   2.45745e-07 DIIS
-   @RHF iter   7:   -92.72369968645076   -3.31539e-11   4.46432e-08 DIIS
-   @RHF iter   8:   -92.72369968645202   -1.26477e-12   2.01497e-08 DIIS
-   @RHF iter   9:   -92.72369968645235   -3.26850e-13   6.30537e-09 DIIS
+   @RHF iter   0:   -92.72406815594445   -9.27241e+01   2.85793e-04 
+   @RHF iter   1:   -92.72369847261287    3.69683e-04   4.86558e-05 DIIS
+   @RHF iter   2:   -92.72369933906015   -8.66447e-07   2.47652e-05 DIIS
+   @RHF iter   3:   -92.72369957389245   -2.34832e-07   1.73266e-05 DIIS
+   @RHF iter   4:   -92.72369967024086   -9.63484e-08   5.06370e-06 DIIS
+   @RHF iter   5:   -92.72369968604522   -1.58044e-08   7.90387e-07 DIIS
+   @RHF iter   6:   -92.72369968641773   -3.72509e-10   2.45745e-07 DIIS
+   @RHF iter   7:   -92.72369968645077   -3.30402e-11   4.46432e-08 DIIS
+   @RHF iter   8:   -92.72369968645202   -1.25056e-12   2.01497e-08 DIIS
+   @RHF iter   9:   -92.72369968645228   -2.55795e-13   6.30539e-09 DIIS
   Energy and wave function converged.
 
 
@@ -7682,14 +7680,14 @@ gradient() will perform analytic gradient computation.
     NA   [     6,    1 ]
     NB   [     6,    1 ]
 
-  @RHF Final Energy:   -92.72369968645235
+  @RHF Final Energy:   -92.72369968645228
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             23.9922921952139063
-    One-Electron Energy =                -172.0183300537175626
-    Two-Electron Energy =                  55.3023381720513143
-    Total Energy =                        -92.7236996864523348
+    Nuclear Repulsion Energy =             23.9922921955599300
+    One-Electron Energy =                -172.0183300543591258
+    Two-Electron Energy =                  55.3023381723469001
+    Total Energy =                        -92.7236996864522780
 
 Computation Completed
 
@@ -7713,18 +7711,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.36 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.08 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      17.28 seconds =       0.29 minutes
-	system time =       0.51 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       3.98 seconds =       0.07 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
 *** tstart() called on nidavellir
-*** at Tue Dec  6 14:18:34 2022
+*** at Tue Dec  6 15:30:03 2022
 
 
          ------------------------------------------------------------
@@ -7742,11 +7740,11 @@ Total time:
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-         C           -0.948194573488     0.452021683184     0.000000000000    12.000000000000
-         N            0.861612566092    -0.873857560067     0.000000000000    14.003074004430
-         H           -1.644407243028    -1.723806556397     0.000000000000     1.007825032230
+         C           -0.948194573442     0.452021683185     0.000000000000    12.000000000000
+         N            0.861612566050    -0.873857560149     0.000000000000    14.003074004430
+         H           -1.644407243032    -1.723806556316     0.000000000000     1.007825032230
 
-  Nuclear repulsion =   23.992292195213906
+  Nuclear repulsion =   23.992292195559930
 
   ==> Basis Set <==
 
@@ -7764,27 +7762,27 @@ Total time:
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Integrals threads:           4
+    Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
 
   -Total Gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000079919257     0.000078872197     0.000000000000
-       2       -0.000027266308     0.000038229016     0.000000000000
-       3       -0.000052652950    -0.000117101213     0.000000000000
+       1        0.000079919272     0.000078872170     0.000000000000
+       2       -0.000027266329     0.000038229028     0.000000000000
+       3       -0.000052652942    -0.000117101198     0.000000000000
 
 
-*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+*** tstop() called on nidavellir at Tue Dec  6 15:30:03 2022
 Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      17.34 seconds =       0.29 minutes
-	system time =       0.52 seconds =       0.01 minutes
-	total time  =          5 seconds =       0.08 minutes
+	user time   =       4.00 seconds =       0.07 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
 
     			-----------------------------------------
 
@@ -7802,9 +7800,9 @@ Total time:
 	                            ===> Fragment 1 <== 
 
 	 Z (Atomic Numbers)          Masses                          Geom                  
-	       6.000000            12.000000       -0.9481945734882358  0.4520216831837158  0.0000000000000000
-	       7.000000            14.003074        0.8616125660921277 -0.8738575600665194  0.0000000000000000
-	       1.000000             1.007825       -1.6444072430277010 -1.7238065563974854  0.0000000000000000
+	       6.000000            12.000000       -0.9481945734416852  0.4520216831848538  0.0000000000000000
+	       7.000000            14.003074        0.8616125660497205 -0.8738575601487806  0.0000000000000000
+	       1.000000             1.007825       -1.6444072430318437 -1.7238065563163623  0.0000000000000000
 
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
 	 R(1,2)           =         2.243515           1.187217
@@ -7838,7 +7836,7 @@ Total time:
 Next Geometry in Ang 
 	Fragment 1 (Ang)
 
-	    C  -0.5018473538   0.2391625741   0.0000000000
+	    C  -0.5018473538   0.2391625742   0.0000000000
 	    N   0.4558420576  -0.4625236650   0.0000000000
 	    H  -0.8699947670  -0.9120639871   0.0000000000
 
@@ -7849,13 +7847,4276 @@ Next Geometry in Ang
 
     Geometry (in Bohr), charge = 0, multiplicity = 1:
 
-    C           -0.948194573488     0.452021683184     0.000000000000
-    N            0.861612566092    -0.873857560067     0.000000000000
-    H           -1.644407243028    -1.723806556397     0.000000000000
+    C           -0.948194573442     0.452021683185     0.000000000000
+    N            0.861612566050    -0.873857560149     0.000000000000
+    H           -1.644407243032    -1.723806556316     0.000000000000
 
-    6-31G(D) SCF optimization of SF4......................................................PASSED
 
-    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
-    Psi4 wall time for execution: 0:00:05.70
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:04 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.472698636927     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      7.21755  B =      1.89464  C =      1.50070 [cm^-1]
+  Rotational constants: A = 216376.62079  B =  56799.75018  C =  44989.75501 [MHz]
+  Nuclear repulsion =   23.312194649889427
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 9.6850361242E-03.
+  Reciprocal condition number of the overlap matrix is 2.7456671621E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        16      16 
+     A"         4       4 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81613896682578   -9.18161e+01   0.00000e+00 
+   @RHF iter   1:   -92.61386260678677   -7.97724e-01   1.57396e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66021533756289   -4.63527e-02   1.07246e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67364182145673   -1.34265e-02   2.50489e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67491387466453   -1.27205e-03   8.26547e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67514619775851   -2.32323e-04   1.92086e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67516667680229   -2.04790e-05   3.81285e-05 DIIS
+   @RHF iter   7:   -92.67516788606352   -1.20926e-06   1.45091e-05 DIIS
+   @RHF iter   8:   -92.67516808836476   -2.02301e-07   4.03440e-06 DIIS
+   @RHF iter   9:   -92.67516810204491   -1.36802e-08   6.27437e-07 DIIS
+   @RHF iter  10:   -92.67516810225044   -2.05532e-10   1.45473e-07 DIIS
+   @RHF iter  11:   -92.67516810226411   -1.36708e-11   4.77525e-08 DIIS
+   @RHF iter  12:   -92.67516810226593   -1.81899e-12   7.39513e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.636708     2Ap   -11.316726     3Ap    -1.313328  
+       4Ap    -0.649977     5Ap    -0.560432     1App   -0.521926  
+       6Ap    -0.480887  
+
+    Virtual:                                                              
+
+       7Ap     0.000802     8Ap     0.200208     2App    0.201502  
+       9Ap     0.492584    10Ap     0.752596     3App    0.759105  
+      11Ap     0.814506    12Ap     0.847100    13Ap     0.918069  
+       4App    1.015285    14Ap     1.105823    15Ap     1.261470  
+      16Ap     1.611281  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.67516810226593
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3121946498894275
+    One-Electron Energy =                -171.0147567493459633
+    Two-Electron Energy =                  55.0273939971906145
+    Total Energy =                        -92.6751681022659284
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1110436           -0.8791508           -0.7681073
+ Dipole Y            :          0.4540718           -1.2255756           -0.7715037
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    1.0886720
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:04 2022
+Module time:
+	user time   =       0.16 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.42 seconds =       0.07 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:04 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.472698636927     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.312194649889427
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.088378963710    -0.108268439938     0.000000000000
+       2       -0.013103085332     0.170005341321     0.000000000000
+       3       -0.075275878378    -0.061736901383     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:04 2022
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.44 seconds =       0.07 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+hessian() using ref_gradient to assess stationary point.
+
+  Based on options and gradient (rms=8.03E-02), recommend projecting translations and not projecting rotations.
+hessian() will perform analytic frequency computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:04 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.472698636927     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      7.21755  B =      1.89464  C =      1.50070 [cm^-1]
+  Rotational constants: A = 216376.62079  B =  56799.75018  C =  44989.75501 [MHz]
+  Nuclear repulsion =   23.312194649889427
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 9.6850361242E-03.
+  Reciprocal condition number of the overlap matrix is 2.7456671621E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        16      16 
+     A"         4       4 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81613896682578   -9.18161e+01   0.00000e+00 
+   @RHF iter   1:   -92.61386260678677   -7.97724e-01   1.57396e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66021533756289   -4.63527e-02   1.07246e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67364182145673   -1.34265e-02   2.50489e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67491387466453   -1.27205e-03   8.26547e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67514619775851   -2.32323e-04   1.92086e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67516667680229   -2.04790e-05   3.81285e-05 DIIS
+   @RHF iter   7:   -92.67516788606352   -1.20926e-06   1.45091e-05 DIIS
+   @RHF iter   8:   -92.67516808836476   -2.02301e-07   4.03440e-06 DIIS
+   @RHF iter   9:   -92.67516810204491   -1.36802e-08   6.27437e-07 DIIS
+   @RHF iter  10:   -92.67516810225044   -2.05532e-10   1.45473e-07 DIIS
+   @RHF iter  11:   -92.67516810226411   -1.36708e-11   4.77525e-08 DIIS
+   @RHF iter  12:   -92.67516810226593   -1.81899e-12   7.39513e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.636708     2Ap   -11.316726     3Ap    -1.313328  
+       4Ap    -0.649977     5Ap    -0.560432     1App   -0.521926  
+       6Ap    -0.480887  
+
+    Virtual:                                                              
+
+       7Ap     0.000802     8Ap     0.200208     2App    0.201502  
+       9Ap     0.492584    10Ap     0.752596     3App    0.759105  
+      11Ap     0.814506    12Ap     0.847100    13Ap     0.918069  
+       4App    1.015285    14Ap     1.105823    15Ap     1.261470  
+      16Ap     1.611281  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.67516810226593
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3121946498894275
+    One-Electron Energy =                -171.0147567493459633
+    Two-Electron Energy =                  55.0273939971906145
+    Total Energy =                        -92.6751681022659284
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1110436           -0.8791508           -0.7681073
+ Dipole Y            :          0.4540718           -1.2255756           -0.7715037
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    1.0886720
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:04 2022
+Module time:
+	user time   =       0.16 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.62 seconds =       0.08 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:04 2022
+
+
+         ------------------------------------------------------------
+                                   SCF HESS                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.472698636927     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.312194649889427
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    2
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-12
+
+  ## JHess (Symmetry 0) ##
+  Irrep: 1 Size: 9 x 9
+
+                 1                   2                   3                   4                   5
+
+    1    -5.48158576341957    -5.97193430039926     0.00000000000000     5.22659206103125     5.89693140350111
+    2    -5.97193430039926    -1.33032450193157     0.00000000000000     6.06525274841784     1.71763764826863
+    3     0.00000000000000     0.00000000000000   -10.88902166450372     0.00000000000000     0.00000000000000
+    4     5.22659206103125     6.06525274841784     0.00000000000000    -4.87128976293072    -5.35622632418426
+    5     5.89693140350111     1.71763764826863     0.00000000000000    -5.35622632418426    -2.14786209571001
+    6     0.00000000000000     0.00000000000000    10.72596262852194     0.00000000000000     0.00000000000000
+    7     0.25499370238830    -0.09331844801859     0.00000000000000    -0.35530229810055    -0.54070507931684
+    8     0.07500289689814    -0.38731314633709     0.00000000000000    -0.70902642423357     0.43022444744134
+    9     0.00000000000000     0.00000000000000     0.16305903598174     0.00000000000000     0.00000000000000
+
+                 6                   7                   8                   9
+
+    1     0.00000000000000     0.25499370238830     0.07500289689814     0.00000000000000
+    2     0.00000000000000    -0.09331844801859    -0.38731314633709     0.00000000000000
+    3    10.72596262852194     0.00000000000000     0.00000000000000     0.16305903598174
+    4     0.00000000000000    -0.35530229810055    -0.70902642423357     0.00000000000000
+    5     0.00000000000000    -0.54070507931684     0.43022444744134     0.00000000000000
+    6   -11.43833419612739     0.00000000000000     0.00000000000000     0.71237156760544
+    7     0.00000000000000     0.10030859571225     0.63402352733543     0.00000000000000
+    8     0.00000000000000     0.63402352733543    -0.04291130110425     0.00000000000000
+    9     0.71237156760544     0.00000000000000     0.00000000000000    -0.87543060358718
+
+
+
+  ## KHess (Symmetry 0) ##
+  Irrep: 1 Size: 9 x 9
+
+                 1                   2                   3                   4                   5
+
+    1    -0.44122782523112    -0.54623685960977     0.00000000000000     0.41510491149225     0.54332187834117
+    2    -0.54623685960977    -0.03091545595256     0.00000000000000     0.53064949316493     0.07173824734457
+    3     0.00000000000000     0.00000000000000    -0.94243912560791     0.00000000000000     0.00000000000000
+    4     0.41510491149225     0.53064949316493     0.00000000000000    -0.34197353865158    -0.44513503430692
+    5     0.54332187834117     0.07173824734457     0.00000000000000    -0.44513503430692    -0.10248342255903
+    6     0.00000000000000     0.00000000000000     0.93330822929481     0.00000000000000     0.00000000000000
+    7     0.02612291373885     0.01558736644484     0.00000000000000    -0.07313137284070    -0.09818684403426
+    8     0.00291498126860    -0.04082279139203     0.00000000000000    -0.08551445885802     0.03074517521445
+    9     0.00000000000000     0.00000000000000     0.00913089631309     0.00000000000000     0.00000000000000
+
+                 6                   7                   8                   9
+
+    1     0.00000000000000     0.02612291373885     0.00291498126860     0.00000000000000
+    2     0.00000000000000     0.01558736644484    -0.04082279139203     0.00000000000000
+    3     0.93330822929481     0.00000000000000     0.00000000000000     0.00913089631309
+    4     0.00000000000000    -0.07313137284070    -0.08551445885802     0.00000000000000
+    5     0.00000000000000    -0.09818684403426     0.03074517521445     0.00000000000000
+    6    -1.01099519429449     0.00000000000000     0.00000000000000     0.07768696499966
+    7     0.00000000000000     0.04700845910185     0.08259947758941     0.00000000000000
+    8     0.00000000000000     0.08259947758941     0.01007761617758     0.00000000000000
+    9     0.07768696499966     0.00000000000000     0.00000000000000    -0.08681786131274
+
+
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              450
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+
+   ==> Coupled-Perturbed RHF Solver <==
+
+    Maxiter             =         100
+    Convergence         =   1.000E-06
+    Number of equations =           9
+   -----------------------------------------------------
+     Iter   Residual RMS      Max RMS  Remain  Time [s]
+   -----------------------------------------------------
+        1      5.978e-01    9.617e-01       9         0
+        2      1.962e-01    2.812e-01       9         0
+        3      6.261e-02    1.039e-01       9         0
+        4      1.679e-02    2.447e-02       9         0
+        5      5.045e-03    8.201e-03       9         0
+        6      1.188e-03    2.028e-03       9         0
+        7      2.469e-04    4.321e-04       9         0
+        8      7.111e-05    1.186e-04       9         0
+        9      1.389e-05    2.362e-05       9         0
+       10      2.663e-06    4.919e-06       6         0
+       11      8.330e-07    1.500e-06       4         0
+       12      3.717e-07    3.869e-07       0         0
+  ## Total Hessian (Symmetry 0) ##
+  Irrep: 1 Size: 9 x 9
+
+                 1                   2                   3                   4                   5
+
+    1     0.46202179915919    -0.74842172489523     0.00000000000000    -0.43494901593600     0.75462805773277
+    2    -0.74842172489523     0.94480963779601     0.00000000000000     0.75997514431555    -0.94639864788880
+    3     0.00000000000000     0.00000000000000    -0.06429473776065     0.00000000000000     0.00000000000000
+    4    -0.43494901593600     0.75997514431555     0.00000000000000     0.39528641562228    -0.77507387923955
+    5     0.75462805773277    -0.94639864788880     0.00000000000000    -0.77507387923955     0.97623393278407
+    6     0.00000000000000     0.00000000000000     0.06698526505901     0.00000000000000     0.00000000000000
+    7    -0.02707278322302    -0.01155341942033     0.00000000000000     0.03966260031332     0.02044582150681
+    8    -0.00620633283754     0.00158901009292     0.00000000000000     0.01509873492402    -0.02983528489499
+    9     0.00000000000000     0.00000000000000    -0.00269052729855     0.00000000000000     0.00000000000000
+
+                 6                   7                   8                   9
+
+    1     0.00000000000000    -0.02707278322302    -0.00620633283754     0.00000000000000
+    2     0.00000000000000    -0.01155341942033     0.00158901009292     0.00000000000000
+    3     0.06698526505901     0.00000000000000     0.00000000000000    -0.00269052729855
+    4     0.00000000000000     0.03966260031332     0.01509873492402     0.00000000000000
+    5     0.00000000000000     0.02044582150681    -0.02983528489499     0.00000000000000
+    6    -0.03723832615855     0.00000000000000     0.00000000000000    -0.02974693890128
+    7     0.00000000000000    -0.01258981709030    -0.00889240208649     0.00000000000000
+    8     0.00000000000000    -0.00889240208649     0.02824627480207     0.00000000000000
+    9    -0.02974693890128     0.00000000000000     0.00000000000000     0.03243746619983
+
+
+
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:04 2022
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.74 seconds =       0.08 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+
+  ==> Harmonic Vibrational Analysis <==
+
+  non-mass-weighted Hessian:       Symmetric? True   Hermitian? True   Lin Dep Dim?  0 (0)
+  projection of translations (True) and rotations (False) removed 3 degrees of freedom (6)
+  total projector:                 Symmetric? True   Hermitian? True   Lin Dep Dim?  3 (3)
+  mass-weighted Hessian:           Symmetric? True   Hermitian? True   Lin Dep Dim?  0 (0)
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0006  [cm^-1]
+  pre-proj  all modes:['889.6505i' '509.4167i' '226.7050i' '0.0010i' '0.0005i' '0.0006'
+ '905.3880' '947.7059' '2473.8030']
+  projected mass-weighted Hessian: Symmetric? True   Hermitian? True   Lin Dep Dim?  3 (3)
+  post-proj low-frequency mode:  889.6505i [cm^-1] (V)
+  post-proj low-frequency mode:  509.4167i [cm^-1] (V)
+  post-proj low-frequency mode:  226.7050i [cm^-1] (V)
+  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj  all modes:['889.6505i' '509.4167i' '226.7050i' '0.0000i' '0.0000i' '0.0000'
+ '905.3880' '947.7059' '2473.8030']
+
+  Note that "Vibration"s include 3 un-projected rotation-like modes.
+  Vibration                       1                   2                   3           
+  Freq [cm^-1]                889.6505i           509.4167i           226.7050i       
+  Irrep                           Ap                 App                  Ap          
+  Reduced mass [u]              2.0532             11.2032              1.8088        
+  Force const [mDyne/A]        -0.9575             -1.7129             -0.0548        
+  Turning point v=0 [a0]        0.0000              0.0000              0.0000        
+  RMS dev v=0 [a0 u^1/2]        0.0000              0.0000              0.0000        
+  IR activ [km/mol]            14.2348              0.0578             64.2319        
+  Char temp [K]                 0.0000              0.0000              0.0000        
+  ----------------------------------------------------------------------------------
+      1   C                0.15  0.12  0.00   -0.00 -0.00  0.72   -0.19 -0.13 -0.00   
+      2   N               -0.19 -0.11 -0.00   -0.00 -0.00 -0.59    0.10  0.09 -0.00   
+      3   H                0.94  0.15 -0.00   -0.00 -0.00 -0.37    0.92  0.28 -0.00   
+
+  Vibration                       7                   8                   9           
+  Freq [cm^-1]                 905.3880            947.7059           2473.8030       
+  Irrep                           Ap                 App                  Ap          
+  Reduced mass [u]              1.0493              1.0564             12.6706        
+  Force const [mDyne/A]         0.5068              0.5590             45.6855        
+  Turning point v=0 [a0]        0.3560              0.3468              0.0620        
+  RMS dev v=0 [a0 u^1/2]        0.2579              0.2520              0.1560        
+  IR activ [km/mol]            169.2821            130.3260            223.8659       
+  Char temp [K]               1302.6518           1363.5378           3559.2518       
+  ----------------------------------------------------------------------------------
+      1   C                0.02 -0.03 -0.00    0.00 -0.00 -0.01   -0.44  0.61  0.00   
+      2   N               -0.01 -0.04 -0.00   -0.00 -0.00 -0.06    0.37 -0.53 -0.00   
+      3   H               -0.23  0.97 -0.00   -0.00  0.00  1.00    0.03  0.12  0.00   
+
+  ==> Thermochemistry Components <==
+
+  Entropy, S
+    Electronic S            0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K] (multiplicity = 1)
+    Translational S        35.816 [cal/(mol K)]      149.856 [J/(mol K)]       0.05707695 [mEh/K] (mol. weight = 27.0109 [u], P = 101325.00 [Pa])
+    Rotational S           17.015 [cal/(mol K)]       71.191 [J/(mol K)]       0.02711529 [mEh/K] (symmetry no. = 1)
+    Vibrational S           0.252 [cal/(mol K)]        1.055 [J/(mol K)]       0.00040201 [mEh/K]
+  Total S                  53.084 [cal/(mol K)]      222.102 [J/(mol K)]       0.08459424 [mEh/K]
+  Correction S              0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+
+  Constant volume heat capacity, Cv
+    Electronic Cv           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+    Translational Cv        2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Rotational Cv           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Vibrational Cv          0.933 [cal/(mol K)]        3.902 [J/(mol K)]       0.00148630 [mEh/K]
+  Total Cv                  6.894 [cal/(mol K)]       28.846 [J/(mol K)]       0.01098673 [mEh/K]
+  Correction Cv             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+
+  Constant pressure heat capacity, Cp
+    Electronic Cp           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+    Translational Cp        4.968 [cal/(mol K)]       20.786 [J/(mol K)]       0.00791703 [mEh/K]
+    Rotational Cp           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Vibrational Cp          0.933 [cal/(mol K)]        3.902 [J/(mol K)]       0.00148630 [mEh/K]
+  Total Cp                  8.881 [cal/(mol K)]       37.160 [J/(mol K)]       0.01415354 [mEh/K]
+  Correction Cp             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+
+  ==> Thermochemistry Energy Analysis <==
+
+  Raw electronic energy, E0
+  Total E0, Electronic energy at well bottom at 0 [K]                  -92.67516810 [Eh]
+
+  Zero-point energy, ZPE_vib = Sum_i nu_i / 2
+    Electronic ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational ZPE       0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Rotational ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Vibrational ZPE         6.186 [kcal/mol]       25.881 [kJ/mol]       0.00985740 [Eh]        2163.448 [cm^-1]
+  Correction ZPE            6.186 [kcal/mol]       25.881 [kJ/mol]       0.00985740 [Eh]        2163.448 [cm^-1]
+  Total ZPE, Electronic energy at 0 [K]                                -92.66531071 [Eh]
+
+  Thermal Energy, E (includes ZPE)
+    Electronic E            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational E         0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Rotational E            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Vibrational E           6.247 [kcal/mol]       26.138 [kJ/mol]       0.00995542 [Eh]
+  Correction E              8.025 [kcal/mol]       33.575 [kJ/mol]       0.01278797 [Eh]
+  Total E, Electronic energy at  298.15 [K]                            -92.66238013 [Eh]
+
+  Enthalpy, H_trans = E_trans + k_B * T
+    Electronic H            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational H         1.481 [kcal/mol]        6.197 [kJ/mol]       0.00236046 [Eh]
+    Rotational H            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Vibrational H           6.247 [kcal/mol]       26.138 [kJ/mol]       0.00995542 [Eh]
+  Correction H              8.617 [kcal/mol]       36.054 [kJ/mol]       0.01373216 [Eh]
+  Total H, Enthalpy at  298.15 [K]                                     -92.66143595 [Eh]
+
+  Gibbs free energy, G = H - T * S
+    Electronic G            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational G        -9.197 [kcal/mol]      -38.482 [kJ/mol]      -0.01465703 [Eh]
+    Rotational G           -4.184 [kcal/mol]      -17.507 [kJ/mol]      -0.00666815 [Eh]
+    Vibrational G           6.172 [kcal/mol]       25.823 [kJ/mol]       0.00983556 [Eh]
+  Correction G             -7.210 [kcal/mol]      -30.166 [kJ/mol]      -0.01148962 [Eh]
+  Total G, Free enthalpy at  298.15 [K]                                -92.68665772 [Eh]
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.6169570705079365  1.0422703480732367  0.0000000000000000
+	       7.000000            14.003074        0.6561039639920636 -0.7152141444267631  0.0000000000000000
+	       1.000000             1.007825       -1.7701361439079364 -2.4726986369267632  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.170124           1.148380
+	 R(2,3)           =         2.995896           1.585360
+	 B(1,2,3)         =         1.570796          90.000000
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.14838        1.14953        0.02351       1.17189
+	               R(2,3)       1.58536       -0.80063       -0.23450       1.35086
+	             B(1,2,3)      90.00000       -0.00133      -13.02187      76.97813
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     1     -92.67516810   -9.27e+01      1.40e-01      9.87e-02 o    4.43e-01      2.89e-01 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4256900963   0.4215940346   0.0000000000
+	    N   0.3491594782  -0.4575785374   0.0000000000
+	    H  -0.8394694452  -1.0994405751   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.729927634098     0.968552473086     0.000000000000
+    N            0.734325850006    -0.692842904898     0.000000000000
+    H           -1.511857279884    -1.905786366556     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:04 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.729927634098     0.968552473086     0.000000000000    12.000000000000
+         N            0.734325850006    -0.692842904898     0.000000000000    14.003074004430
+         H           -1.511857279884    -1.905786366556     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     10.10623  B =      1.88531  C =      1.58890 [cm^-1]
+  Rotational constants: A = 302977.13554  B =  56520.27810  C =  47634.14509 [MHz]
+  Nuclear repulsion =   23.721766813928177
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 1.0205918741E-02.
+  Reciprocal condition number of the overlap matrix is 2.6923035977E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.76700310091168   -9.27670e+01   1.85561e-02 
+   @RHF iter   1:   -92.71864246905936    4.83606e-02   2.40610e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72055114617129   -1.90868e-03   9.48281e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72096477493072   -4.13629e-04   4.66790e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72105148430384   -8.67094e-05   2.41408e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72107179298439   -2.03087e-05   5.08645e-05 DIIS
+   @RHF iter   6:   -92.72107280680866   -1.01382e-06   1.32501e-05 DIIS
+   @RHF iter   7:   -92.72107290074224   -9.39336e-08   4.61397e-06 DIIS
+   @RHF iter   8:   -92.72107291563215   -1.48899e-08   1.09728e-06 DIIS
+   @RHF iter   9:   -92.72107291649307   -8.60922e-10   2.81913e-07 DIIS
+   @RHF iter  10:   -92.72107291654802   -5.49534e-11   6.37504e-08 DIIS
+   @RHF iter  11:   -92.72107291654982   -1.79057e-12   1.24963e-08 DIIS
+   @RHF iter  12:   -92.72107291654990   -8.52651e-14   2.94982e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.649161     2Ap   -11.333476     3Ap    -1.335977  
+       4Ap    -0.667678     5Ap    -0.613588     1App   -0.529782  
+       6Ap    -0.491777  
+
+    Virtual:                                                              
+
+       7Ap     0.092247     8Ap     0.170448     2App    0.179911  
+       9Ap     0.486581    10Ap     0.736877     3App    0.749518  
+      11Ap     0.789001    12Ap     0.865791    13Ap     0.954233  
+       4App    1.001874    14Ap     1.067695    15Ap     1.213410  
+      16Ap     1.585871  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72107291654990
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.7217668139281770
+    One-Electron Energy =                -171.6428022574045542
+    Two-Electron Energy =                  55.1999625269264769
+    Total Energy =                        -92.7210729165499004
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1592284           -0.7511421           -0.5919138
+ Dipole Y            :          0.4493199           -0.9443719           -0.4950520
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.7716465
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:04 2022
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.87 seconds =       0.08 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:04 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.729927634098     0.968552473086     0.000000000000    12.000000000000
+         N            0.734325850006    -0.692842904898     0.000000000000    14.003074004430
+         H           -1.511857279884    -1.905786366556     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.721766813928177
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.045524707663    -0.050106895163     0.000000000000
+       2        0.015430324979     0.084031264692     0.000000000000
+       3       -0.060955032642    -0.033924369529     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:04 2022
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.89 seconds =       0.08 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.7299276340980669  0.9685524730861496  0.0000000000000000
+	       7.000000            14.003074        0.7343258500061878 -0.6928429048983930  0.0000000000000000
+	       1.000000             1.007825       -1.5118572798835586 -1.9057863665555503  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.214559           1.171894
+	 R(2,3)           =         2.552757           1.350861
+	 B(1,2,3)         =         1.343522          76.978133
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.17189        0.55769        0.01558       1.18748
+	               R(2,3)       1.35086       -0.57468       -0.19944       1.15142
+	             B(1,2,3)      76.97813       -0.00017      -18.74915      58.22898
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     2     -92.72107292   -4.59e-02      6.98e-02      5.61e-02 o    3.77e-01      2.89e-01 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4933380645   0.3467630882   0.0000000000
+	    N   0.3986077655  -0.4371567960   0.0000000000
+	    H  -0.7029826836  -0.7722057855   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.859037570901     0.846886261393     0.000000000000
+    N            0.826495766483    -0.634507624028     0.000000000000
+    H           -1.255208484749    -1.267658452820     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:04 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.859037570901     0.846886261393     0.000000000000    12.000000000000
+         N            0.826495766483    -0.634507624028     0.000000000000    14.003074004430
+         H           -1.255208484749    -1.267658452820     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     18.13992  B =      1.84924  C =      1.67816 [cm^-1]
+  Rotational constants: A = 543820.98043  B =  55438.74150  C =  50309.99023 [MHz]
+  Nuclear repulsion =   24.722630781527492
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 1.0122536950E-02.
+  Reciprocal condition number of the overlap matrix is 2.4317957883E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.78004225160626   -9.27800e+01   2.88586e-02 
+   @RHF iter   1:   -92.71257040506268    6.74718e-02   3.85468e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.71668013422493   -4.10973e-03   1.39183e-03 ADIIS/DIIS
+   @RHF iter   3:   -92.71736106707843   -6.80933e-04   7.76809e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.71751650094880   -1.55434e-04   3.48193e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.71755952299857   -4.30220e-05   9.63048e-05 DIIS
+   @RHF iter   6:   -92.71756515928539   -5.63629e-06   2.98869e-05 DIIS
+   @RHF iter   7:   -92.71756569696694   -5.37682e-07   7.72357e-06 DIIS
+   @RHF iter   8:   -92.71756572826770   -3.13008e-08   1.32761e-06 DIIS
+   @RHF iter   9:   -92.71756572931062   -1.04292e-09   5.13322e-07 DIIS
+   @RHF iter  10:   -92.71756572952432   -2.13703e-10   1.15252e-07 DIIS
+   @RHF iter  11:   -92.71756572953275   -8.42704e-12   1.61336e-08 DIIS
+   @RHF iter  12:   -92.71756572953294   -1.84741e-13   2.03172e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.669120     2Ap   -11.337890     3Ap    -1.397870  
+       4Ap    -0.697089     5Ap    -0.663827     1App   -0.544054  
+       6Ap    -0.500093  
+
+    Virtual:                                                              
+
+       7Ap     0.141175     2App    0.162155     8Ap     0.224793  
+       9Ap     0.476337    10Ap     0.720129     3App    0.743893  
+      11Ap     0.780002    12Ap     0.889467     4App    0.986962  
+      13Ap     1.006947    14Ap     1.031477    15Ap     1.141188  
+      16Ap     1.536648  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.71756572953294
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             24.7226307815274922
+    One-Electron Energy =                -173.2605070143067110
+    Two-Electron Energy =                  55.8203105032462830
+    Total Energy =                        -92.7175657295329358
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.2585840           -0.6239635           -0.3653796
+ Dipole Y            :          0.3213089           -0.6278943           -0.3065853
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.4769662
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:04 2022
+Module time:
+	user time   =       0.10 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.02 seconds =       0.08 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:04 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.859037570901     0.846886261393     0.000000000000    12.000000000000
+         N            0.826495766483    -0.634507624028     0.000000000000    14.003074004430
+         H           -1.255208484749    -1.267658452820     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   24.722630781527492
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.018541805822    -0.068484959302     0.000000000000
+       2       -0.011976826695    -0.009443641435     0.000000000000
+       3        0.030518632517     0.077928600737     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       5.04 seconds =       0.08 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.8590375709013505  0.8468862613927842  0.0000000000000000
+	       7.000000            14.003074        0.8264957664833230 -0.6345076240282970  0.0000000000000000
+	       1.000000             1.007825       -1.2552084847493308 -1.2676584528201711  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.244003           1.187475
+	 R(2,3)           =         2.175861           1.151416
+	 B(1,2,3)         =         1.016287          58.228980
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18748        0.25774        0.00733       1.19481
+	               R(2,3)       1.15142        0.42738        0.24948       1.40089
+	             B(1,2,3)      58.22898        0.01087        0.57051      58.79949
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     3     -92.71756573    3.51e-03      1.43e-01      8.96e-02 o    4.71e-01      2.72e-01 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4122756565   0.4717986321   0.0000000000
+	    N   0.5224644112  -0.2723994710   0.0000000000
+	    H  -0.7916368608  -0.7578291903   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.888995572186     0.815774178534     0.000000000000
+    N            0.877407154325    -0.590556419540     0.000000000000
+    H           -1.605884351004    -1.507885642057     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.888995572186     0.815774178534     0.000000000000    12.000000000000
+         N            0.877407154325    -0.590556419540     0.000000000000    14.003074004430
+         H           -1.605884351004    -1.507885642057     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     12.14642  B =      1.82049  C =      1.58320 [cm^-1]
+  Rotational constants: A = 364140.60240  B =  54576.93294  C =  47463.20744 [MHz]
+  Nuclear repulsion =   23.713235626627544
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 1.0524198909E-02.
+  Reciprocal condition number of the overlap matrix is 2.6890156807E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.61474103554932   -9.26147e+01   1.70862e-02 
+   @RHF iter   1:   -92.72062065103731   -1.05880e-01   2.55217e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72237164788443   -1.75100e-03   8.75230e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72270277819716   -3.31130e-04   5.34863e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72279568884605   -9.29106e-05   2.84855e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72283374422133   -3.80554e-05   6.12869e-05 DIIS
+   @RHF iter   6:   -92.72283601140802   -2.26719e-06   1.75108e-05 DIIS
+   @RHF iter   7:   -92.72283612808604   -1.16678e-07   5.35155e-06 DIIS
+   @RHF iter   8:   -92.72283614051706   -1.24310e-08   8.38192e-07 DIIS
+   @RHF iter   9:   -92.72283614078985   -2.72792e-10   1.28141e-07 DIIS
+   @RHF iter  10:   -92.72283614079879   -8.93863e-12   4.56286e-08 DIIS
+   @RHF iter  11:   -92.72283614080058   -1.79057e-12   1.30239e-08 DIIS
+   @RHF iter  12:   -92.72283614080069   -1.13687e-13   2.67011e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.673498     2Ap   -11.331335     3Ap    -1.341140  
+       4Ap    -0.685029     5Ap    -0.629591     1App   -0.532886  
+       6Ap    -0.491690  
+
+    Virtual:                                                              
+
+       7Ap     0.106504     2App    0.164396     8Ap     0.186721  
+       9Ap     0.468620     3App    0.750695    10Ap     0.760737  
+      11Ap     0.777194    12Ap     0.902478    13Ap     0.940026  
+       4App    0.989398    14Ap     1.059414    15Ap     1.112379  
+      16Ap     1.524173  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72283614080069
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.7132356266275437
+    One-Electron Energy =                -171.5018047891574611
+    Two-Electron Energy =                  55.0657330217292156
+    Total Energy =                        -92.7228361408006947
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.3362169           -0.7980077           -0.4617908
+ Dipole Y            :          0.3372062           -0.7471355           -0.4099293
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.6174891
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.16 seconds =       0.09 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.888995572186     0.815774178534     0.000000000000    12.000000000000
+         N            0.877407154325    -0.590556419540     0.000000000000    14.003074004430
+         H           -1.605884351004    -1.507885642057     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.713235626627544
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.001412893963     0.012518208202     0.000000000000
+       2        0.019419914479     0.002237839337     0.000000000000
+       3       -0.018007020516    -0.014756047539     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.18 seconds =       0.09 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.8889955721855224  0.8157741785343108  0.0000000000000000
+	       7.000000            14.003074        0.8774071543253829 -0.5905564195397378  0.0000000000000000
+	       1.000000             1.007825       -1.6058843510041403 -1.5078856420573181  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.257863           1.194810
+	 R(2,3)           =         2.647306           1.400894
+	 B(1,2,3)         =         1.026245          58.799487
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.19481       -0.07334       -0.00142       1.19339
+	               R(2,3)       1.40089       -0.18129       -0.04991       1.35099
+	             B(1,2,3)      58.79949       -0.00153       -1.29737      57.50212
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     4     -92.72283614   -5.27e-03      2.20e-02      1.80e-02 o    9.43e-02      5.60e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4841226683   0.4150395949   0.0000000000
+	    N   0.4521034214  -0.3250040879   0.0000000000
+	    H  -0.8239104813  -0.7687941196   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.893241677671     0.808475285833     0.000000000000
+    N            0.875969223439    -0.590004595567     0.000000000000
+    H           -1.535347585030    -1.428646212652     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.893241677671     0.808475285833     0.000000000000    12.000000000000
+         N            0.875969223439    -0.590004595567     0.000000000000    14.003074004430
+         H           -1.535347585030    -1.428646212652     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     13.43285  B =      1.82485  C =      1.60660 [cm^-1]
+  Rotational constants: A = 402706.71524  B =  54707.72566  C =  48164.56703 [MHz]
+  Nuclear repulsion =   23.943572662790583
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 1.0374833120E-02.
+  Reciprocal condition number of the overlap matrix is 2.6090377021E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.74817661993701   -9.27482e+01   3.72969e-03 
+   @RHF iter   1:   -92.72417407397671    2.40025e-02   5.17655e-04 ADIIS/DIIS
+   @RHF iter   2:   -92.72423678969388   -6.27157e-05   1.37341e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72424237636078   -5.58667e-06   7.28543e-05 DIIS
+   @RHF iter   4:   -92.72424361209821   -1.23574e-06   3.91729e-05 DIIS
+   @RHF iter   5:   -92.72424405479526   -4.42697e-07   6.84159e-06 DIIS
+   @RHF iter   6:   -92.72424408489158   -3.00963e-08   2.40799e-06 DIIS
+   @RHF iter   7:   -92.72424408908333   -4.19175e-09   6.98749e-07 DIIS
+   @RHF iter   8:   -92.72424408940743   -3.24107e-10   1.93534e-07 DIIS
+   @RHF iter   9:   -92.72424408943073   -2.32916e-11   6.48653e-08 DIIS
+   @RHF iter  10:   -92.72424408943395   -3.22586e-12   1.86309e-08 DIIS
+   @RHF iter  11:   -92.72424408943418   -2.27374e-13   3.40602e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.674362     2Ap   -11.330628     3Ap    -1.351689  
+       4Ap    -0.692510     5Ap    -0.636243     1App   -0.535669  
+       6Ap    -0.492796  
+
+    Virtual:                                                              
+
+       7Ap     0.115945     2App    0.163583     8Ap     0.196132  
+       9Ap     0.468415     3App    0.749739    10Ap     0.750095  
+      11Ap     0.779783    12Ap     0.897595    13Ap     0.957275  
+       4App    0.988143    14Ap     1.050754    15Ap     1.117469  
+      16Ap     1.527792  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72424408943418
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.9435726627905829
+    One-Electron Energy =                -171.9078391846522322
+    Two-Electron Energy =                  55.2400224324274660
+    Total Energy =                        -92.7242440894341797
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.3324170           -0.7630131           -0.4305961
+ Dipole Y            :          0.3206481           -0.7078267           -0.3871786
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.5790684
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.31 seconds =       0.09 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.893241677671     0.808475285833     0.000000000000    12.000000000000
+         N            0.875969223439    -0.590004595567     0.000000000000    14.003074004430
+         H           -1.535347585030    -1.428646212652     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.943572662790583
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.008004084836    -0.001852629619     0.000000000000
+       2        0.014711947446    -0.001815801052     0.000000000000
+       3       -0.006707862610     0.003668430671     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.33 seconds =       0.09 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.8932416776712441  0.8084752858329166  0.0000000000000000
+	       7.000000            14.003074        0.8759692234391555 -0.5900045955674077  0.0000000000000000
+	       1.000000             1.007825       -1.5353475850295366 -1.4286462126515309  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.255184           1.193392
+	 R(2,3)           =         2.552992           1.350985
+	 B(1,2,3)         =         1.003601          57.502119
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.19339       -0.04227       -0.00491       1.18848
+	               R(2,3)       1.35099       -0.04227        0.04814       1.39912
+	             B(1,2,3)      57.50212        0.00110       -5.09155      52.41057
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     5     -92.72424409   -1.41e-03      1.45e-02      9.35e-03 o    9.10e-02      7.36e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4816369470   0.3792367944   0.0000000000
+	    N   0.4961893535  -0.2962880475   0.0000000000
+	    H  -0.8361635480  -0.7233460542   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.932957257265     0.739538694985     0.000000000000
+    N            0.914866648949    -0.537018247170     0.000000000000
+    H           -1.602915437272    -1.344040919458     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.932957257265     0.739538694985     0.000000000000    12.000000000000
+         N            0.914866648949    -0.537018247170     0.000000000000    14.003074004430
+         H           -1.602915437272    -1.344040919458     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     14.29640  B =      1.82613  C =      1.61929 [cm^-1]
+  Rotational constants: A = 428595.25774  B =  54745.94685  C =  48545.11260 [MHz]
+  Nuclear repulsion =   24.089747014751300
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 9.8029170467E-03.
+  Reciprocal condition number of the overlap matrix is 2.4565145663E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.73499898277691   -9.27350e+01   9.24432e-03 
+   @RHF iter   1:   -92.72192097073898    1.30780e-02   1.54725e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72276359462337   -8.42624e-04   8.24206e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72298011658599   -2.16522e-04   5.62480e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72309196391868   -1.11847e-04   1.63514e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72310912919824   -1.71653e-05   3.11625e-05 DIIS
+   @RHF iter   6:   -92.72310971777721   -5.88579e-07   9.99687e-06 DIIS
+   @RHF iter   7:   -92.72310977221596   -5.44388e-08   2.71292e-06 DIIS
+   @RHF iter   8:   -92.72310977660237   -4.38641e-09   1.01636e-06 DIIS
+   @RHF iter   9:   -92.72310977741768   -8.15305e-10   3.53373e-07 DIIS
+   @RHF iter  10:   -92.72310977754168   -1.24004e-10   5.02316e-08 DIIS
+   @RHF iter  11:   -92.72310977754353   -1.84741e-12   7.31933e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.677686     2Ap   -11.322146     3Ap    -1.350629  
+       4Ap    -0.713912     5Ap    -0.628593     1App   -0.536840  
+       6Ap    -0.489658  
+
+    Virtual:                                                              
+
+       7Ap     0.103759     2App    0.164910     8Ap     0.219436  
+       9Ap     0.460204    10Ap     0.744107     3App    0.751041  
+      11Ap     0.787713    12Ap     0.895848    13Ap     0.982755  
+       4App    0.988056    14Ap     1.043133    15Ap     1.146794  
+      16Ap     1.528641  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72310977754353
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             24.0897470147512998
+    One-Electron Energy =                -172.1867827598580050
+    Two-Electron Energy =                  55.3739259675631743
+    Total Energy =                        -92.7231097775435273
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.3768094           -0.7965924           -0.4197830
+ Dipole Y            :          0.2706028           -0.6659365           -0.3953337
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.5766338
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.45 seconds =       0.09 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.932957257265     0.739538694985     0.000000000000    12.000000000000
+         N            0.914866648949    -0.537018247170     0.000000000000    14.003074004430
+         H           -1.602915437272    -1.344040919458     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   24.089747014751300
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.012416915107    -0.006389114867     0.000000000000
+       2       -0.001906401345    -0.009186540555     0.000000000000
+       3        0.014323316452     0.015575655422     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.47 seconds =       0.09 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9329572572653139  0.7395386949853554  0.0000000000000000
+	       7.000000            14.003074        0.9148666489487636 -0.5370182471701974  0.0000000000000000
+	       1.000000             1.007825       -1.6029154372720318 -1.3440409194575151  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.245896           1.188477
+	 R(2,3)           =         2.643958           1.399122
+	 B(1,2,3)         =         0.914737          52.410571
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18848       -0.05425       -0.00430       1.18417
+	               R(2,3)       1.39912        0.15154        0.05467       1.45380
+	             B(1,2,3)      52.41057        0.00210        1.16298      53.57356
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     6     -92.72310978    1.13e-03      2.77e-02      1.95e-02 o    1.03e-01      6.10e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4764233785   0.4048218002   0.0000000000
+	    N   0.4971308373  -0.2693134251   0.0000000000
+	    H  -0.8785069165  -0.7395749941   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.925418796001     0.741125580885     0.000000000000
+    N            0.914332040157    -0.532805366391     0.000000000000
+    H           -1.685246562255    -1.421470939181     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.925418796001     0.741125580885     0.000000000000    12.000000000000
+         N            0.914332040157    -0.532805366391     0.000000000000    14.003074004430
+         H           -1.685246562255    -1.421470939181     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     12.85755  B =      1.83724  C =      1.60753 [cm^-1]
+  Rotational constants: A = 385459.56632  B =  55078.93273  C =  48192.61329 [MHz]
+  Nuclear repulsion =   23.934297786622921
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 9.7674828870E-03.
+  Reciprocal condition number of the overlap matrix is 2.4867391280E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.70496404274407   -9.27050e+01   4.33480e-03 
+   @RHF iter   1:   -92.72380003172719   -1.88360e-02   5.26240e-04 ADIIS/DIIS
+   @RHF iter   2:   -92.72387278820030   -7.27565e-05   1.52063e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72388321326083   -1.04251e-05   6.86071e-05 DIIS
+   @RHF iter   4:   -92.72388592911058   -2.71585e-06   4.11258e-05 DIIS
+   @RHF iter   5:   -92.72388648208607   -5.52975e-07   1.59657e-05 DIIS
+   @RHF iter   6:   -92.72388666690367   -1.84818e-07   4.28681e-06 DIIS
+   @RHF iter   7:   -92.72388668068818   -1.37845e-08   1.11275e-06 DIIS
+   @RHF iter   8:   -92.72388668147295   -7.84766e-10   4.34738e-07 DIIS
+   @RHF iter   9:   -92.72388668160632   -1.33369e-10   1.56959e-07 DIIS
+   @RHF iter  10:   -92.72388668162573   -1.94120e-11   3.12637e-08 DIIS
+   @RHF iter  11:   -92.72388668162617   -4.40536e-13   4.20768e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.674978     2Ap   -11.321728     3Ap    -1.342304  
+       4Ap    -0.703627     5Ap    -0.623965     1App   -0.535188  
+       6Ap    -0.488734  
+
+    Virtual:                                                              
+
+       7Ap     0.095681     2App    0.168017     8Ap     0.210784  
+       9Ap     0.460685     3App    0.751298    10Ap     0.758719  
+      11Ap     0.784692    12Ap     0.904168    13Ap     0.963536  
+       4App    0.990801    14Ap     1.047994    15Ap     1.143820  
+      16Ap     1.529027  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72388668162617
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.9342977866229205
+    One-Electron Energy =                -171.9353218951720805
+    Two-Electron Energy =                  55.2771374269229838
+    Total Energy =                        -92.7238866816261691
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.3791140           -0.8374351           -0.4583210
+ Dipole Y            :          0.2818271           -0.7043550           -0.4225279
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.6233683
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.59 seconds =       0.09 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.925418796001     0.741125580885     0.000000000000    12.000000000000
+         N            0.914332040157    -0.532805366391     0.000000000000    14.003074004430
+         H           -1.685246562255    -1.421470939181     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.934297786622921
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.007067618777     0.010148443930     0.000000000000
+       2       -0.007641253165     0.000301133319     0.000000000000
+       3        0.000573634387    -0.010449577248     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.62 seconds =       0.09 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9254187960013579  0.7411255808854105  0.0000000000000000
+	       7.000000            14.003074        0.9143320401567560 -0.5328053663910164  0.0000000000000000
+	       1.000000             1.007825       -1.6852465622550761 -1.4214709391809837  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.237763           1.184173
+	 R(2,3)           =         2.747278           1.453797
+	 B(1,2,3)         =         0.935035          53.573556
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18417        0.00027        0.00542       1.18959
+	               R(2,3)       1.45380       -0.02338       -0.06256       1.39124
+	             B(1,2,3)      53.57356       -0.00211        4.47779      58.05134
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     7     -92.72388668   -7.77e-04      2.77e-02      1.61e-02 o    1.18e-01      8.20e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4854270040   0.4341643982   0.0000000000
+	    N   0.4484702137  -0.3026937882   0.0000000000
+	    H  -0.8607041433  -0.7734423266   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.888457814477     0.807030738846     0.000000000000
+    N            0.876352156370    -0.585429426669     0.000000000000
+    H           -1.597628828802    -1.475015238356     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.888457814477     0.807030738846     0.000000000000    12.000000000000
+         N            0.876352156370    -0.585429426669     0.000000000000    14.003074004430
+         H           -1.597628828802    -1.475015238356     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     12.52235  B =      1.83541  C =      1.60078 [cm^-1]
+  Rotational constants: A = 375410.60848  B =  55024.13916  C =  47990.19056 [MHz]
+  Nuclear repulsion =   23.856610419205197
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 1.0282149264E-02.
+  Reciprocal condition number of the overlap matrix is 2.6131613825E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.70120389779041   -9.27012e+01   8.25736e-03 
+   @RHF iter   1:   -92.72233367644523   -2.11298e-02   1.48784e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72312139447791   -7.87718e-04   7.77234e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72332958391972   -2.08189e-04   5.31179e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72342923384845   -9.96499e-05   1.51916e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72344308888930   -1.38550e-05   3.44454e-05 DIIS
+   @RHF iter   6:   -92.72344371589183   -6.27003e-07   1.05783e-05 DIIS
+   @RHF iter   7:   -92.72344377476055   -5.88687e-08   2.41384e-06 DIIS
+   @RHF iter   8:   -92.72344377834108   -3.58052e-09   7.87774e-07 DIIS
+   @RHF iter   9:   -92.72344377880178   -4.60702e-10   2.84595e-07 DIIS
+   @RHF iter  10:   -92.72344377887464   -7.28591e-11   4.52227e-08 DIIS
+   @RHF iter  11:   -92.72344377887617   -1.53477e-12   6.13149e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.673129     2Ap   -11.329100     3Ap    -1.346006  
+       4Ap    -0.687995     5Ap    -0.631875     1App   -0.534924  
+       6Ap    -0.491713  
+
+    Virtual:                                                              
+
+       7Ap     0.108717     2App    0.166077     8Ap     0.191797  
+       9Ap     0.468320     3App    0.750154    10Ap     0.758002  
+      11Ap     0.777883    12Ap     0.901833    13Ap     0.946488  
+       4App    0.989870    14Ap     1.056703    15Ap     1.120629  
+      16Ap     1.529216  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72344377887617
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.8566104192051966
+    One-Electron Energy =                -171.7706249789781907
+    Two-Electron Energy =                  55.1905707808968202
+    Total Energy =                        -92.7234437788761738
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.3401626           -0.7939106           -0.4537481
+ Dipole Y            :          0.3229630           -0.7308368           -0.4078738
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.6101216
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.74 seconds =       0.10 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.888457814477     0.807030738846     0.000000000000    12.000000000000
+         N            0.876352156370    -0.585429426669     0.000000000000    14.003074004430
+         H           -1.597628828802    -1.475015238356     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.856610419205197
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.004219244131     0.004041869147     0.000000000000
+       2        0.009382753564     0.006107121744     0.000000000000
+       3       -0.013601997695    -0.010148990890     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.76 seconds =       0.10 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.8884578144765022  0.8070307388458542  0.0000000000000000
+	       7.000000            14.003074        0.8763521563704442 -0.5854294266688387  0.0000000000000000
+	       1.000000             1.007825       -1.5976288288021603 -1.4750152383556034  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.247999           1.189590
+	 R(2,3)           =         2.629058           1.391237
+	 B(1,2,3)         =         1.013187          58.051343
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18959        0.00666       -0.01059       1.17900
+	               R(2,3)       1.39124       -0.13375        0.05232       1.44355
+	             B(1,2,3)      58.05134       -0.00099       -6.70403      51.34731
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     8     -92.72344378    4.43e-04      1.62e-02      1.20e-02 o    1.17e-01      8.92e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4828042037   0.3597092482   0.0000000000
+	    N   0.5019717166  -0.2885664742   0.0000000000
+	    H  -0.8710023186  -0.7344208593   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.937391497568     0.712247346076     0.000000000000
+    N            0.923565286694    -0.512816223126     0.000000000000
+    H           -1.670979617310    -1.355358902704     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.937391497568     0.712247346076     0.000000000000    12.000000000000
+         N            0.923565286694    -0.512816223126     0.000000000000    14.003074004430
+         H           -1.670979617310    -1.355358902704     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     13.88983  B =      1.84718  C =      1.63036 [cm^-1]
+  Rotational constants: A = 416406.61751  B =  55377.01686  C =  48876.97367 [MHz]
+  Nuclear repulsion =   24.151997939479088
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 9.4033861817E-03.
+  Reciprocal condition number of the overlap matrix is 2.3714674465E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.74643520687746   -9.27464e+01   1.22766e-02 
+   @RHF iter   1:   -92.72221661195411    2.42186e-02   2.01817e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72369699012071   -1.48038e-03   1.06435e-03 ADIIS/DIIS
+   @RHF iter   3:   -92.72407858315033   -3.81593e-04   7.23448e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72426338925891   -1.84806e-04   2.25620e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72429549859997   -3.21093e-05   4.76209e-05 DIIS
+   @RHF iter   6:   -92.72429700284870   -1.50425e-06   1.51893e-05 DIIS
+   @RHF iter   7:   -92.72429714607411   -1.43225e-07   5.04117e-06 DIIS
+   @RHF iter   8:   -92.72429716426660   -1.81925e-08   2.04767e-06 DIIS
+   @RHF iter   9:   -92.72429716788048   -3.61388e-09   5.78583e-07 DIIS
+   @RHF iter  10:   -92.72429716819607   -3.15595e-10   7.82951e-08 DIIS
+   @RHF iter  11:   -92.72429716819980   -3.72324e-12   1.20799e-08 DIIS
+   @RHF iter  12:   -92.72429716819991   -1.13687e-13   2.18419e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.675268     2Ap   -11.317500     3Ap    -1.347711  
+       4Ap    -0.715695     5Ap    -0.624936     1App   -0.537231  
+       6Ap    -0.488300  
+
+    Virtual:                                                              
+
+       7Ap     0.097540     2App    0.169248     8Ap     0.223428  
+       9Ap     0.457736    10Ap     0.749869     3App    0.750918  
+      11Ap     0.788020    12Ap     0.900227    13Ap     0.985094  
+       4App    0.991127    14Ap     1.043859    15Ap     1.164724  
+      16Ap     1.535975  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72429716819991
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             24.1519979394790880
+    One-Electron Energy =                -172.3393077893930183
+    Two-Electron Energy =                  55.4630126817140265
+    Total Energy =                        -92.7242971681999109
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.3852828           -0.8303716           -0.4450888
+ Dipole Y            :          0.2586053           -0.6715884           -0.4129830
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.6071730
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.88 seconds =       0.10 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.937391497568     0.712247346076     0.000000000000    12.000000000000
+         N            0.923565286694    -0.512816223126     0.000000000000    14.003074004430
+         H           -1.670979617310    -1.355358902704     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   24.151997939479088
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.005249645090    -0.003857945994     0.000000000000
+       2       -0.020496522572    -0.001381688932     0.000000000000
+       3        0.015246877482     0.005239634926     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:05 2022
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.91 seconds =       0.10 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          6 seconds =       0.10 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9373914975684429  0.7122473460758039  0.0000000000000000
+	       7.000000            14.003074        0.9235652866935539 -0.5128162231262210  0.0000000000000000
+	       1.000000             1.007825       -1.6709796173100051 -1.3553589027040116  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.227990           1.179002
+	 R(2,3)           =         2.727919           1.443553
+	 B(1,2,3)         =         0.896180          51.347308
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.17900        0.05360        0.00820       1.18720
+	               R(2,3)       1.44355        0.13281       -0.04500       1.39856
+	             B(1,2,3)      51.34731        0.00006        3.77866      55.12597
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     9     -92.72429717   -8.53e-04      1.61e-02      1.00e-02 o    8.50e-02      6.28e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4932944787   0.4152587153   0.0000000000
+	    N   0.4629219844  -0.2883672939   0.0000000000
+	    H  -0.8611883543  -0.7385820596   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.910844067981     0.770682929833     0.000000000000
+    N            0.896143164035    -0.558977522355     0.000000000000
+    H           -1.606062736098    -1.409760127211     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:05 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.910844067981     0.770682929833     0.000000000000    12.000000000000
+         N            0.896143164035    -0.558977522355     0.000000000000    14.003074004430
+         H           -1.606062736098    -1.409760127211     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     13.30136  B =      1.83644  C =      1.61365 [cm^-1]
+  Rotational constants: A = 398764.67276  B =  55055.05465  C =  48376.06108 [MHz]
+  Nuclear repulsion =   23.991234318078480
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 9.9868311950E-03.
+  Reciprocal condition number of the overlap matrix is 2.5208442145E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.69554281870759   -9.26955e+01   7.32888e-03 
+   @RHF iter   1:   -92.72286852119863   -2.73257e-02   1.26584e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72345866368798   -5.90142e-04   6.43494e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72361857329514   -1.59910e-04   4.39513e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72368661628533   -6.80430e-05   1.47229e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72369927844969   -1.26622e-05   3.87014e-05 DIIS
+   @RHF iter   6:   -92.72370015325050   -8.74801e-07   1.08572e-05 DIIS
+   @RHF iter   7:   -92.72370022238314   -6.91326e-08   3.29308e-06 DIIS
+   @RHF iter   8:   -92.72370023008619   -7.70305e-09   1.07078e-06 DIIS
+   @RHF iter   9:   -92.72370023100638   -9.20181e-10   3.39184e-07 DIIS
+   @RHF iter  10:   -92.72370023110982   -1.03441e-10   3.97751e-08 DIIS
+   @RHF iter  11:   -92.72370023111081   -9.94760e-13   4.85659e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.675236     2Ap   -11.325076     3Ap    -1.348873  
+       4Ap    -0.700354     5Ap    -0.630245     1App   -0.536393  
+       6Ap    -0.490643  
+
+    Virtual:                                                              
+
+       7Ap     0.106001     2App    0.166237     8Ap     0.205814  
+       9Ap     0.464305     3App    0.750464    10Ap     0.752464  
+      11Ap     0.782675    12Ap     0.899660    13Ap     0.963072  
+       4App    0.989269    14Ap     1.049930    15Ap     1.132463  
+      16Ap     1.529787  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72370023111081
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.9912343180784795
+    One-Electron Energy =                -172.0162282550226394
+    Two-Electron Energy =                  55.3012937058333449
+    Total Energy =                        -92.7237002311108114
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.3615318           -0.7981250           -0.4365932
+ Dipole Y            :          0.2940164           -0.6985052           -0.4044888
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.5951679
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:06 2022
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       6.03 seconds =       0.10 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:06 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.910844067981     0.770682929833     0.000000000000    12.000000000000
+         N            0.896143164035    -0.558977522355     0.000000000000    14.003074004430
+         H           -1.606062736098    -1.409760127211     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.991234318078480
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000457618509    -0.000150901710     0.000000000000
+       2        0.000206989871     0.000511081112     0.000000000000
+       3       -0.000664608380    -0.000360179402     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:06 2022
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.05 seconds =       0.10 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9108440679806772  0.7706829298333211  0.0000000000000000
+	       7.000000            14.003074        0.8961431640345600 -0.5589775223554766  0.0000000000000000
+	       1.000000             1.007825       -1.6060627360984958 -1.4097601272111933  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.243479           1.187198
+	 R(2,3)           =         2.642890           1.398557
+	 B(1,2,3)         =         0.962130          55.125967
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18720        0.00377        0.00002       1.18722
+	               R(2,3)       1.39856       -0.00614        0.00178       1.40033
+	             B(1,2,3)      55.12597       -0.00003       -0.16413      54.96184
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	    10     -92.72370023    5.97e-04      7.45e-04      5.41e-04 o    3.36e-03      2.55e-03 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4823238298   0.4063466897   0.0000000000
+	    N   0.4753919822  -0.2952716529   0.0000000000
+	    H  -0.8507393346  -0.7450582916   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.912276167028     0.768544318085     0.000000000000
+    N            0.897544423753    -0.557322193964     0.000000000000
+    H           -1.608480571429    -1.407295755988     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:06 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.912276167028     0.768544318085     0.000000000000    12.000000000000
+         N            0.897544423753    -0.557322193964     0.000000000000    14.003074004430
+         H           -1.608480571429    -1.407295755988     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =     13.32442  B =      1.83589  C =      1.61357 [cm^-1]
+  Rotational constants: A = 399455.97417  B =  55038.57027  C =  48373.48649 [MHz]
+  Nuclear repulsion =   23.992241573980753
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.337007.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 9.9750107002E-03.
+  Reciprocal condition number of the overlap matrix is 2.5177942457E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.72409033242110   -9.27241e+01   2.89521e-04 
+   @RHF iter   1:   -92.72369843916672    3.91893e-04   4.93254e-05 DIIS
+   @RHF iter   2:   -92.72369932857345   -8.89407e-07   2.51440e-05 DIIS
+   @RHF iter   3:   -92.72369956901122   -2.40438e-07   1.75910e-05 DIIS
+   @RHF iter   4:   -92.72369966869262   -9.96814e-08   5.13025e-06 DIIS
+   @RHF iter   5:   -92.72369968493948   -1.62469e-08   8.05638e-07 DIIS
+   @RHF iter   6:   -92.72369968532783   -3.88354e-10   2.51152e-07 DIIS
+   @RHF iter   7:   -92.72369968536245   -3.46176e-11   4.54319e-08 DIIS
+   @RHF iter   8:   -92.72369968536368   -1.23634e-12   1.97671e-08 DIIS
+   @RHF iter   9:   -92.72369968536393   -2.41585e-13   4.28348e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.675363     2Ap   -11.324866     3Ap    -1.348709  
+       4Ap    -0.701016     5Ap    -0.629959     1App   -0.536369  
+       6Ap    -0.490541  
+
+    Virtual:                                                              
+
+       7Ap     0.105576     2App    0.166211     8Ap     0.206505  
+       9Ap     0.464019     3App    0.750523    10Ap     0.752342  
+      11Ap     0.782962    12Ap     0.899615    13Ap     0.963822  
+       4App    0.989244    14Ap     1.049603    15Ap     1.133153  
+      16Ap     1.529613  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72369968536393
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.9922415739807526
+    One-Electron Energy =                -172.0182361940087787
+    Two-Electron Energy =                  55.3022949346640971
+    Total Energy =                        -92.7236996853639255
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.3629064           -0.7993266           -0.4364202
+ Dipole Y            :          0.2926446           -0.6972852           -0.4046406
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.5951442
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:06 2022
+Module time:
+	user time   =       0.08 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.16 seconds =       0.10 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 15:30:06 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.912276167028     0.768544318085     0.000000000000    12.000000000000
+         N            0.897544423753    -0.557322193964     0.000000000000    14.003074004430
+         H           -1.608480571429    -1.407295755988     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.992241573980753
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           1
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000077793242     0.000082885234     0.000000000000
+       2       -0.000024100184     0.000036342933     0.000000000000
+       3       -0.000053693058    -0.000119228166     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 15:30:06 2022
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.18 seconds =       0.10 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9122761670280402  0.7685443180851512  0.0000000000000000
+	       7.000000            14.003074        0.8975444237531188 -0.5573221939637774  0.0000000000000000
+	       1.000000             1.007825       -1.6084805714291592 -1.4072957559880008  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.243518           1.187219
+	 R(2,3)           =         2.646246           1.400333
+	 B(1,2,3)         =         0.959265          54.961838
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18722        0.00011        0.00002       1.18724
+	               R(2,3)       1.40033       -0.00073       -0.00036       1.39997
+	             B(1,2,3)      54.96184       -0.00002       -0.00228      54.95956
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	    11     -92.72369969    5.46e-07 *    2.53e-04 *    1.55e-04 o    6.77e-04 *    3.92e-04 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4828409676   0.4066580185   0.0000000000
+	    N   0.4748536233  -0.2950216955   0.0000000000
+	    H  -0.8509796207  -0.7445712312   0.0000000000
+
+
+    Final optimized geometry and variables:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.912276167028     0.768544318085     0.000000000000
+    N            0.897544423753    -0.557322193964     0.000000000000
+    H           -1.608480571429    -1.407295755988     0.000000000000
+
+    TS optimization of CNH - analytic hessian with symmetry...............................PASSED
+    TS optimization of CNH - finite difference hessian with symmetry......................PASSED
+
+    Psi4 stopped on: Tuesday, 06 December 2022 03:30PM
+    Psi4 wall time for execution: 0:00:07.52
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/opt16/output.ref
+++ b/tests/opt16/output.ref
@@ -1,0 +1,7861 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.7a1.dev138 
+
+                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+
+    Process ID: 330641
+    Host:       nidavellir
+    PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! 6-31G(d) optimization of SF4 starting from linear bond angle
+#! that is not linear in the optimized structure but is in a 
+#! symmetry plane of the molecule.
+
+SCF_E = -92.7236996864523064
+
+molecule {
+0 1
+C  -0.0399606537   1.7574844925   0.0000000000    
+N   1.2331003808   0.0000000000   0.0000000000    
+H  -1.1931397271  -1.7574844925   0.0000000000    
+units bohr
+}
+
+set {
+  scf_type pk
+  basis 6-31G
+  opt_type ts
+  full_hess_every 0
+}
+
+thisenergy = optimize('scf', dertype='gradient')
+
+compare_values(SCF_E, thisenergy, 5, "6-31G(D) SCF optimization of SF4") #TEST 
+
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:29 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.472698636927     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      7.21755  B =      1.89464  C =      1.50070 [cm^-1]
+  Rotational constants: A = 216376.62079  B =  56799.75018  C =  44989.75501 [MHz]
+  Nuclear repulsion =   23.312194649889427
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.6850361242E-03.
+  Reciprocal condition number of the overlap matrix is 2.7456671621E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        16      16 
+     A"         4       4 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81613896682580   -9.18161e+01   0.00000e+00 
+   @RHF iter   1:   -92.61386260678688   -7.97724e-01   1.57396e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66021533756283   -4.63527e-02   1.07246e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67364182145670   -1.34265e-02   2.50489e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67491387466457   -1.27205e-03   8.26547e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67514619775849   -2.32323e-04   1.92086e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67516667680232   -2.04790e-05   3.81285e-05 DIIS
+   @RHF iter   7:   -92.67516788606345   -1.20926e-06   1.45091e-05 DIIS
+   @RHF iter   8:   -92.67516808836463   -2.02301e-07   4.03440e-06 DIIS
+   @RHF iter   9:   -92.67516810204485   -1.36802e-08   6.27437e-07 DIIS
+   @RHF iter  10:   -92.67516810225041   -2.05560e-10   1.45473e-07 DIIS
+   @RHF iter  11:   -92.67516810226411   -1.36993e-11   4.77525e-08 DIIS
+   @RHF iter  12:   -92.67516810226587   -1.76215e-12   7.39513e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.636708     2Ap   -11.316726     3Ap    -1.313328  
+       4Ap    -0.649977     5Ap    -0.560432     1App   -0.521926  
+       6Ap    -0.480887  
+
+    Virtual:                                                              
+
+       7Ap     0.000802     8Ap     0.200208     2App    0.201502  
+       9Ap     0.492584    10Ap     0.752596     3App    0.759105  
+      11Ap     0.814506    12Ap     0.847100    13Ap     0.918069  
+       4App    1.015285    14Ap     1.105823    15Ap     1.261470  
+      16Ap     1.611281  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.67516810226587
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3121946498894275
+    One-Electron Energy =                -171.0147567493457075
+    Two-Electron Energy =                  55.0273939971904156
+    Total Energy =                        -92.6751681022658715
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1110436           -0.8791508           -0.7681073
+ Dipole Y            :          0.4540718           -1.2255756           -0.7715037
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    1.0886720
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:30 2022
+Module time:
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:30 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.472698636927     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.312194649889427
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.088378963710    -0.108268439938     0.000000000000
+       2       -0.013103085332     0.170005341321     0.000000000000
+       3       -0.075275878378    -0.061736901383     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:30 2022
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.73 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+         ----------------------------------------------------------
+                                   FINDIF
+                     R. A. King and Jonathon Misiewicz
+         ----------------------------------------------------------
+
+  Using finite-differences of gradients to determine vibrational frequencies and 
+  normal modes. Resulting frequencies are only valid at stationary points.
+    Generating geometries for use with 3-point formula.
+    Displacement size will be 5.00e-03.
+    Number of atoms is 3.
+    Number of irreps is 2.
+    Number of SALCs is 6.
+    Translations projected? 1. Rotations projected? 0.
+    Index of SALCs per irrep:
+      1 :  0  1  2  3 
+      2 :  4  5 
+    Number of SALCs per irrep:
+      Irrep 1: 4
+      Irrep 2: 2
+    Number of geometries (including reference) is 11.
+    Number of displacements per irrep:
+      Irrep 1: 8
+      Irrep 2: 2
+ 11 displacements needed ...
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //    FiniteDifference Computations  //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.7a1.dev138 
+
+                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+
+    Process ID: 330641
+    Host:       nidavellir
+    PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input QCSchema <==
+
+--------------------------------------------------------------------------
+{'driver': 'gradient',
+ 'extras': {'psiapi': True, 'wfn_qcvars_only': True},
+ 'id': None,
+ 'keywords': {'FULL_HESS_EVERY': 0,
+              'OPT_TYPE': 'TS',
+              'PARENT_SYMMETRY': 'Cs(Z)',
+              'SCF_TYPE': 'PK',
+              'SCF__D_CONVERGENCE': 1e-08,
+              'SCF__E_CONVERGENCE': 1e-08,
+              'SCF__INTS_TOLERANCE': 1e-12,
+              'function_kwargs': {}},
+ 'model': {'basis': '6-31g', 'method': 'scf'},
+ 'molecule': {'atom_labels': ['', '', ''],
+              'atomic_numbers': [6, 7, 1],
+              'fix_com': True,
+              'fix_orientation': True,
+              'fragment_charges': [0.0],
+              'fragment_multiplicities': [1],
+              'fragments': [[0, 1, 2]],
+              'geometry': [-0.6169570705079365, 1.0422703480732367, 0.0, 0.6561039639920636, -0.7152141444267631, 0.0,
+                           -1.7701361439079364, -2.472698636926763, 0.0],
+              'mass_numbers': [12, 14, 1],
+              'masses': [12.0, 14.00307400443, 1.00782503223],
+              'molecular_charge': 0.0,
+              'molecular_multiplicity': 1,
+              'name': 'CHN',
+              'provenance': {'creator': 'QCElemental',
+                             'routine': 'qcelemental.molparse.from_string',
+                             'version': 'v0.25.0'},
+              'real': [True, True, True],
+              'schema_name': 'qcschema_molecule',
+              'schema_version': 2,
+              'symbols': ['C', 'N', 'H'],
+              'validated': True},
+ 'protocols': {'stdout': True},
+ 'provenance': {'creator': 'QCElemental', 'routine': 'qcelemental.models.results', 'version': 'v0.25.0'},
+ 'schema_name': 'qcschema_input',
+ 'schema_version': 1}
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:30 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.472698636927     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      7.21755  B =      1.89464  C =      1.50070 [cm^-1]
+  Rotational constants: A = 216376.62079  B =  56799.75018  C =  44989.75501 [MHz]
+  Nuclear repulsion =   23.312194649889427
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.6850361242E-03.
+  Reciprocal condition number of the overlap matrix is 2.7456671621E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        16      16 
+     A"         4       4 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81613896682582   -9.18161e+01   0.00000e+00 
+   @RHF iter   1:   -92.61386260678680   -7.97724e-01   1.57396e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66021533756283   -4.63527e-02   1.07246e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67364182145673   -1.34265e-02   2.50489e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67491387466454   -1.27205e-03   8.26547e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67514619775852   -2.32323e-04   1.92086e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67516667680231   -2.04790e-05   3.81285e-05 DIIS
+   @RHF iter   7:   -92.67516788606348   -1.20926e-06   1.45091e-05 DIIS
+   @RHF iter   8:   -92.67516808836471   -2.02301e-07   4.03440e-06 DIIS
+   @RHF iter   9:   -92.67516810204486   -1.36802e-08   6.27437e-07 DIIS
+   @RHF iter  10:   -92.67516810225042   -2.05560e-10   1.45473e-07 DIIS
+   @RHF iter  11:   -92.67516810226410   -1.36708e-11   4.77525e-08 DIIS
+   @RHF iter  12:   -92.67516810226579   -1.69109e-12   7.39513e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.636708     2Ap   -11.316726     3Ap    -1.313328  
+       4Ap    -0.649977     5Ap    -0.560432     1App   -0.521926  
+       6Ap    -0.480887  
+
+    Virtual:                                                              
+
+       7Ap     0.000802     8Ap     0.200208     2App    0.201502  
+       9Ap     0.492584    10Ap     0.752596     3App    0.759105  
+      11Ap     0.814506    12Ap     0.847100    13Ap     0.918069  
+       4App    1.015285    14Ap     1.105823    15Ap     1.261470  
+      16Ap     1.611281  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.67516810226579
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3121946498894275
+    One-Electron Energy =                -171.0147567493454801
+    Two-Electron Energy =                  55.0273939971902806
+    Total Energy =                        -92.6751681022657863
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1110436           -0.8791508           -0.7681073
+ Dipole Y            :          0.4540718           -1.2255756           -0.7715037
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    1.0886720
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+Module time:
+	user time   =       0.61 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       2.05 seconds =       0.03 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:31 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.472698636927     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.312194649889427
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.088378963710    -0.108268439938     0.000000000000
+       2       -0.013103085332     0.170005341321     0.000000000000
+       3       -0.075275878378    -0.061736901383     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.12 seconds =       0.04 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
+    Psi4 wall time for execution: 0:00:00.21
+
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.7a1.dev138 
+
+                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+
+    Process ID: 330641
+    Host:       nidavellir
+    PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input QCSchema <==
+
+--------------------------------------------------------------------------
+{'driver': 'gradient',
+ 'extras': {'psiapi': True, 'wfn_qcvars_only': True},
+ 'id': None,
+ 'keywords': {'FULL_HESS_EVERY': 0,
+              'OPT_TYPE': 'TS',
+              'PARENT_SYMMETRY': 'Cs(Z)',
+              'SCF_TYPE': 'PK',
+              'SCF__D_CONVERGENCE': 1e-08,
+              'SCF__E_CONVERGENCE': 1e-08,
+              'SCF__INTS_TOLERANCE': 1e-12,
+              'function_kwargs': {'write_orbitals': False}},
+ 'model': {'basis': '6-31g', 'method': 'scf'},
+ 'molecule': {'atom_labels': ['', '', ''],
+              'atomic_numbers': [6, 7, 1],
+              'fix_com': True,
+              'fix_orientation': True,
+              'fragment_charges': [0.0],
+              'fragment_multiplicities': [1],
+              'fragments': [[0, 1, 2]],
+              'geometry': [-0.6180330728421718, 1.0422703480732367, 0.0, 0.6569641408528426, -0.7152141444267631, 0.0,
+                           -1.7692759670471574, -2.472698636926763, 0.0],
+              'mass_numbers': [12, 14, 1],
+              'masses': [12.0, 14.00307400443, 1.00782503223],
+              'molecular_charge': 0.0,
+              'molecular_multiplicity': 1,
+              'name': 'CHN',
+              'provenance': {'creator': 'QCElemental',
+                             'routine': 'qcelemental.molparse.from_string',
+                             'version': 'v0.25.0'},
+              'real': [True, True, True],
+              'schema_name': 'qcschema_molecule',
+              'schema_version': 2,
+              'symbols': ['C', 'N', 'H'],
+              'validated': True},
+ 'protocols': {'stdout': True},
+ 'provenance': {'creator': 'QCElemental', 'routine': 'qcelemental.models.results', 'version': 'v0.25.0'},
+ 'schema_name': 'qcschema_input',
+ 'schema_version': 1}
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:31 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.618033072842     1.042270348073     0.000000000000    12.000000000000
+         N            0.656964140853    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.769275967047    -2.472698636927     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      7.21614  B =      1.89302  C =      1.49962 [cm^-1]
+  Rotational constants: A = 216334.43369  B =  56751.40478  C =  44957.59679 [MHz]
+  Nuclear repulsion =   23.302329811695742
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.7049696899E-03.
+  Reciprocal condition number of the overlap matrix is 2.7515202933E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        16      16 
+     A"         4       4 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81505307663748   -9.18151e+01   0.00000e+00 
+   @RHF iter   1:   -92.61405130606653   -7.98998e-01   1.57376e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66036188095381   -4.63106e-02   1.07335e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67381037248433   -1.34485e-02   2.50666e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67508429492827   -1.27392e-03   8.26319e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67531649409455   -2.32199e-04   1.92007e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67533693574730   -2.04417e-05   3.80508e-05 DIIS
+   @RHF iter   7:   -92.67533813889904   -1.20315e-06   1.44669e-05 DIIS
+   @RHF iter   8:   -92.67533833997150   -2.01072e-07   4.03068e-06 DIIS
+   @RHF iter   9:   -92.67533835363656   -1.36651e-08   6.26281e-07 DIIS
+   @RHF iter  10:   -92.67533835384124   -2.04679e-10   1.44841e-07 DIIS
+   @RHF iter  11:   -92.67533835385480   -1.35572e-11   4.76260e-08 DIIS
+   @RHF iter  12:   -92.67533835385649   -1.69109e-12   7.41751e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.636866     2Ap   -11.316963     3Ap    -1.313071  
+       4Ap    -0.650042     5Ap    -0.560381     1App   -0.521776  
+       6Ap    -0.480946  
+
+    Virtual:                                                              
+
+       7Ap     0.000905     8Ap     0.199950     2App    0.201212  
+       9Ap     0.492522    10Ap     0.752669     3App    0.759127  
+      11Ap     0.814388    12Ap     0.847051    13Ap     0.918153  
+       4App    1.015143    14Ap     1.105577    15Ap     1.260467  
+      16Ap     1.610639  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.67533835385649
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3023298116957420
+    One-Electron Energy =                -170.9952458566346820
+    Two-Electron Energy =                  55.0175776910824723
+    Total Energy =                        -92.6753383538564890
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1112829           -0.8787254           -0.7674425
+ Dipole Y            :          0.4554085           -1.2255756           -0.7701670
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    1.0872558
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+Module time:
+	user time   =       0.80 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.07 seconds =       0.05 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:31 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.618033072842     1.042270348073     0.000000000000    12.000000000000
+         N            0.656964140853    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.769275967047    -2.472698636927     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.302329811695742
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.087484526022    -0.106821850245     0.000000000000
+       2       -0.012261034438     0.168546692331     0.000000000000
+       3       -0.075223491584    -0.061724842086     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.14 seconds =       0.05 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
+    Psi4 wall time for execution: 0:00:00.25
+
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.7a1.dev138 
+
+                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+
+    Process ID: 330641
+    Host:       nidavellir
+    PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input QCSchema <==
+
+--------------------------------------------------------------------------
+{'driver': 'gradient',
+ 'extras': {'psiapi': True, 'wfn_qcvars_only': True},
+ 'id': None,
+ 'keywords': {'FULL_HESS_EVERY': 0,
+              'OPT_TYPE': 'TS',
+              'PARENT_SYMMETRY': 'Cs(Z)',
+              'SCF_TYPE': 'PK',
+              'SCF__D_CONVERGENCE': 1e-08,
+              'SCF__E_CONVERGENCE': 1e-08,
+              'SCF__INTS_TOLERANCE': 1e-12,
+              'function_kwargs': {'write_orbitals': False}},
+ 'model': {'basis': '6-31g', 'method': 'scf'},
+ 'molecule': {'atom_labels': ['', '', ''],
+              'atomic_numbers': [6, 7, 1],
+              'fix_com': True,
+              'fix_orientation': True,
+              'fragment_charges': [0.0],
+              'fragment_multiplicities': [1],
+              'fragments': [[0, 1, 2]],
+              'geometry': [-0.6158810681737011, 1.0422703480732367, 0.0, 0.6552437871312846, -0.7152141444267631, 0.0,
+                           -1.7709963207687154, -2.472698636926763, 0.0],
+              'mass_numbers': [12, 14, 1],
+              'masses': [12.0, 14.00307400443, 1.00782503223],
+              'molecular_charge': 0.0,
+              'molecular_multiplicity': 1,
+              'name': 'CHN',
+              'provenance': {'creator': 'QCElemental',
+                             'routine': 'qcelemental.molparse.from_string',
+                             'version': 'v0.25.0'},
+              'real': [True, True, True],
+              'schema_name': 'qcschema_molecule',
+              'schema_version': 2,
+              'symbols': ['C', 'N', 'H'],
+              'validated': True},
+ 'protocols': {'stdout': True},
+ 'provenance': {'creator': 'QCElemental', 'routine': 'qcelemental.models.results', 'version': 'v0.25.0'},
+ 'schema_name': 'qcschema_input',
+ 'schema_version': 1}
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:31 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.615881068174     1.042270348073     0.000000000000    12.000000000000
+         N            0.655243787131    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.770996320769    -2.472698636927     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      7.21897  B =      1.89625  C =      1.50177 [cm^-1]
+  Rotational constants: A = 216419.22327  B =  56848.06095  C =  45021.90312 [MHz]
+  Nuclear repulsion =   23.322059672546320
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.6651599845E-03.
+  Reciprocal condition number of the overlap matrix is 2.7398315673E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        16      16 
+     A"         4       4 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81722378948035   -9.18172e+01   0.00000e+00 
+   @RHF iter   1:   -92.61367205194610   -7.96448e-01   1.57417e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66006691234628   -4.63949e-02   1.07157e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67347153580761   -1.34046e-02   2.50312e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67474172387801   -1.27019e-03   8.26773e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67497416942943   -2.32446e-04   1.92166e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67499468582993   -2.05164e-05   3.82062e-05 DIIS
+   @RHF iter   7:   -92.67499590120974   -1.21538e-06   1.45511e-05 DIIS
+   @RHF iter   8:   -92.67499610473793   -2.03528e-07   4.03807e-06 DIIS
+   @RHF iter   9:   -92.67499611843292   -1.36950e-08   6.28588e-07 DIIS
+   @RHF iter  10:   -92.67499611863930   -2.06384e-10   1.46102e-07 DIIS
+   @RHF iter  11:   -92.67499611865306   -1.37561e-11   4.78758e-08 DIIS
+   @RHF iter  12:   -92.67499611865485   -1.79057e-12   7.37205e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.636550     2Ap   -11.316489     3Ap    -1.313584  
+       4Ap    -0.649913     5Ap    -0.560482     1App   -0.522076  
+       6Ap    -0.480828  
+
+    Virtual:                                                              
+
+       7Ap     0.000698     8Ap     0.200466     2App    0.201793  
+       9Ap     0.492645    10Ap     0.752522     3App    0.759083  
+      11Ap     0.814625    12Ap     0.847149    13Ap     0.917984  
+       4App    1.015428    14Ap     1.106068    15Ap     1.262475  
+      16Ap     1.611924  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.67499611865485
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3220596725463203
+    One-Electron Energy =                -171.0342653946867699
+    Two-Electron Energy =                  55.0372096034856071
+    Total Energy =                        -92.6749961186548461
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1108034           -0.8795762           -0.7687728
+ Dipole Y            :          0.4527356           -1.2255756           -0.7728399
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    1.0900886
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+Module time:
+	user time   =       0.67 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.96 seconds =       0.07 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:31 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.615881068174     1.042270348073     0.000000000000    12.000000000000
+         N            0.655243787131    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.770996320769    -2.472698636927     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.322059672546320
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.089273635109    -0.109720008419     0.000000000000
+       2       -0.013945308034     0.171468883614     0.000000000000
+       3       -0.075328327075    -0.061748875194     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.02 seconds =       0.07 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
+    Psi4 wall time for execution: 0:00:00.21
+
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.7a1.dev138 
+
+                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+
+    Process ID: 330641
+    Host:       nidavellir
+    PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input QCSchema <==
+
+--------------------------------------------------------------------------
+{'driver': 'gradient',
+ 'extras': {'psiapi': True, 'wfn_qcvars_only': True},
+ 'id': None,
+ 'keywords': {'FULL_HESS_EVERY': 0,
+              'OPT_TYPE': 'TS',
+              'PARENT_SYMMETRY': 'Cs(Z)',
+              'SCF_TYPE': 'PK',
+              'SCF__D_CONVERGENCE': 1e-08,
+              'SCF__E_CONVERGENCE': 1e-08,
+              'SCF__INTS_TOLERANCE': 1e-12,
+              'function_kwargs': {'write_orbitals': False}},
+ 'model': {'basis': '6-31g', 'method': 'scf'},
+ 'molecule': {'atom_labels': ['', '', ''],
+              'atomic_numbers': [6, 7, 1],
+              'fix_com': True,
+              'fix_orientation': True,
+              'fragment_charges': [0.0],
+              'fragment_multiplicities': [1],
+              'fragments': [[0, 1, 2]],
+              'geometry': [-0.6169570705079365, 1.0411943457390014, 0.0, 0.6561039639920636, -0.7143539675659841, 0.0,
+                           -1.7701361439079364, -2.4718384600659844, 0.0],
+              'mass_numbers': [12, 14, 1],
+              'masses': [12.0, 14.00307400443, 1.00782503223],
+              'molecular_charge': 0.0,
+              'molecular_multiplicity': 1,
+              'name': 'CHN',
+              'provenance': {'creator': 'QCElemental',
+                             'routine': 'qcelemental.molparse.from_string',
+                             'version': 'v0.25.0'},
+              'real': [True, True, True],
+              'schema_name': 'qcschema_molecule',
+              'schema_version': 2,
+              'symbols': ['C', 'N', 'H'],
+              'validated': True},
+ 'protocols': {'stdout': True},
+ 'provenance': {'creator': 'QCElemental', 'routine': 'qcelemental.models.results', 'version': 'v0.25.0'},
+ 'schema_name': 'qcschema_input',
+ 'schema_version': 1}
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:31 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.041194345739     0.000000000000    12.000000000000
+         N            0.656103963992    -0.714353967566     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.471838460066     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      7.21677  B =      1.89758  C =      1.50251 [cm^-1]
+  Rotational constants: A = 216353.41741  B =  56888.02104  C =  45044.11128 [MHz]
+  Nuclear repulsion =   23.326993136524873
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.6570482411E-03.
+  Reciprocal condition number of the overlap matrix is 2.7370338356E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        16      16 
+     A"         4       4 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81785097141164   -9.18179e+01   0.00000e+00 
+   @RHF iter   1:   -92.61361603207096   -7.95765e-01   1.57443e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66003044370039   -4.64144e-02   1.07159e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67343357605608   -1.34031e-02   2.50182e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67470260896921   -1.26903e-03   8.26795e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67493481031573   -2.32201e-04   1.92038e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67495527967959   -2.04694e-05   3.80781e-05 DIIS
+   @RHF iter   7:   -92.67495648628214   -1.20660e-06   1.44890e-05 DIIS
+   @RHF iter   8:   -92.67495668814226   -2.01860e-07   4.03301e-06 DIIS
+   @RHF iter   9:   -92.67495670181580   -1.36735e-08   6.25431e-07 DIIS
+   @RHF iter  10:   -92.67495670201937   -2.03570e-10   1.44186e-07 DIIS
+   @RHF iter  11:   -92.67495670203276   -1.33866e-11   4.73451e-08 DIIS
+   @RHF iter  12:   -92.67495670203441   -1.64846e-12   7.30193e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.636555     2Ap   -11.316430     3Ap    -1.313773  
+       4Ap    -0.649856     5Ap    -0.560644     1App   -0.522187  
+       6Ap    -0.480842  
+
+    Virtual:                                                              
+
+       7Ap     0.000759     8Ap     0.200474     2App    0.201865  
+       9Ap     0.492642    10Ap     0.752380     3App    0.759030  
+      11Ap     0.814615    12Ap     0.847327    13Ap     0.918035  
+       4App    1.015455    14Ap     1.106080    15Ap     1.262684  
+      16Ap     1.612027  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.67495670203441
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3269931365248731
+    One-Electron Energy =                -171.0433231044125080
+    Two-Electron Energy =                  55.0413732658532382
+    Total Energy =                        -92.6749567020344074
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1111522           -0.8791508           -0.7679987
+ Dipole Y            :          0.4521996           -1.2251502           -0.7729506
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    1.0896213
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+Module time:
+	user time   =       0.67 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.84 seconds =       0.08 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:31 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.041194345739     0.000000000000    12.000000000000
+         N            0.656103963992    -0.714353967566     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.471838460066     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.326993136524873
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.089832287790    -0.110101180825     0.000000000000
+       2       -0.014578864726     0.171841217764     0.000000000000
+       3       -0.075253423064    -0.061740036939     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.91 seconds =       0.08 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
+    Psi4 wall time for execution: 0:00:00.22
+
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.7a1.dev138 
+
+                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+
+    Process ID: 330641
+    Host:       nidavellir
+    PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input QCSchema <==
+
+--------------------------------------------------------------------------
+{'driver': 'gradient',
+ 'extras': {'psiapi': True, 'wfn_qcvars_only': True},
+ 'id': None,
+ 'keywords': {'FULL_HESS_EVERY': 0,
+              'OPT_TYPE': 'TS',
+              'PARENT_SYMMETRY': 'Cs(Z)',
+              'SCF_TYPE': 'PK',
+              'SCF__D_CONVERGENCE': 1e-08,
+              'SCF__E_CONVERGENCE': 1e-08,
+              'SCF__INTS_TOLERANCE': 1e-12,
+              'function_kwargs': {'write_orbitals': False}},
+ 'model': {'basis': '6-31g', 'method': 'scf'},
+ 'molecule': {'atom_labels': ['', '', ''],
+              'atomic_numbers': [6, 7, 1],
+              'fix_com': True,
+              'fix_orientation': True,
+              'fragment_charges': [0.0],
+              'fragment_multiplicities': [1],
+              'fragments': [[0, 1, 2]],
+              'geometry': [-0.6169570705079365, 1.043346350407472, 0.0, 0.6561039639920636, -0.7160743212875421, 0.0,
+                           -1.7701361439079364, -2.473558813787542, 0.0],
+              'mass_numbers': [12, 14, 1],
+              'masses': [12.0, 14.00307400443, 1.00782503223],
+              'molecular_charge': 0.0,
+              'molecular_multiplicity': 1,
+              'name': 'CHN',
+              'provenance': {'creator': 'QCElemental',
+                             'routine': 'qcelemental.molparse.from_string',
+                             'version': 'v0.25.0'},
+              'real': [True, True, True],
+              'schema_name': 'qcschema_molecule',
+              'schema_version': 2,
+              'symbols': ['C', 'N', 'H'],
+              'validated': True},
+ 'protocols': {'stdout': True},
+ 'provenance': {'creator': 'QCElemental', 'routine': 'qcelemental.models.results', 'version': 'v0.25.0'},
+ 'schema_name': 'qcschema_input',
+ 'schema_version': 1}
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:31 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.043346350407     0.000000000000    12.000000000000
+         N            0.656103963992    -0.716074321288     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.473558813788     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      7.21832  B =      1.89170  C =      1.49889 [cm^-1]
+  Rotational constants: A = 216399.88667  B =  56711.65977  C =  44935.47383 [MHz]
+  Nuclear repulsion =   23.297411828981428
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.7131045745E-03.
+  Reciprocal condition number of the overlap matrix is 2.7543280064E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        16      16 
+     A"         4       4 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81442686017978   -9.18144e+01   0.00000e+00 
+   @RHF iter   1:   -92.61410539783108   -7.99679e-01   1.57350e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66039642890759   -4.62910e-02   1.07334e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67384651646560   -1.34501e-02   2.50797e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67512159963691   -1.27508e-03   8.26297e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67535404309200   -2.32443e-04   1.92135e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67537453197396   -2.04889e-05   3.81796e-05 DIIS
+   @RHF iter   7:   -92.67537574393906   -1.21197e-06   1.45295e-05 DIIS
+   @RHF iter   8:   -92.67537594669200   -2.02753e-07   4.03589e-06 DIIS
+   @RHF iter   9:   -92.67537596037963   -1.36876e-08   6.29481e-07 DIIS
+   @RHF iter  10:   -92.67537596058722   -2.07592e-10   1.46778e-07 DIIS
+   @RHF iter  11:   -92.67537596060109   -1.38698e-11   4.81650e-08 DIIS
+   @RHF iter  12:   -92.67537596060286   -1.77636e-12   7.49020e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.636861     2Ap   -11.317022     3Ap    -1.312882  
+       4Ap    -0.650098     5Ap    -0.560220     1App   -0.521666  
+       6Ap    -0.480932  
+
+    Virtual:                                                              
+
+       7Ap     0.000845     8Ap     0.199942     2App    0.201140  
+       9Ap     0.492525    10Ap     0.752811     3App    0.759179  
+      11Ap     0.814398    12Ap     0.846874    13Ap     0.918103  
+       4App    1.015117    14Ap     1.105563    15Ap     1.260260  
+      16Ap     1.610539  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.67537596060286
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.2974118289814278
+    One-Electron Energy =                -170.9862149971144163
+    Two-Electron Energy =                  55.0134272075301141
+    Total Energy =                        -92.6753759606028638
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1109351           -0.8791508           -0.7682157
+ Dipole Y            :          0.4559464           -1.2260010           -0.7700546
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    1.0877221
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:31 2022
+Module time:
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.72 seconds =       0.10 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:31 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.043346350407     0.000000000000    12.000000000000
+         N            0.656103963992    -0.716074321288     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.473558813788     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.297411828981428
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.086934118552    -0.106442535854     0.000000000000
+       2       -0.011635955946     0.168176419487     0.000000000000
+       3       -0.075298162606    -0.061733883632     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       5.79 seconds =       0.10 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
+    Psi4 wall time for execution: 0:00:00.21
+
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.7a1.dev138 
+
+                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+
+    Process ID: 330641
+    Host:       nidavellir
+    PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input QCSchema <==
+
+--------------------------------------------------------------------------
+{'driver': 'gradient',
+ 'extras': {'psiapi': True, 'wfn_qcvars_only': True},
+ 'id': None,
+ 'keywords': {'FULL_HESS_EVERY': 0,
+              'OPT_TYPE': 'TS',
+              'PARENT_SYMMETRY': 'Cs(Z)',
+              'SCF_TYPE': 'PK',
+              'SCF__D_CONVERGENCE': 1e-08,
+              'SCF__E_CONVERGENCE': 1e-08,
+              'SCF__INTS_TOLERANCE': 1e-12,
+              'function_kwargs': {'write_orbitals': False}},
+ 'model': {'basis': '6-31g', 'method': 'scf'},
+ 'molecule': {'atom_labels': ['', '', ''],
+              'atomic_numbers': [6, 7, 1],
+              'fix_com': True,
+              'fix_orientation': True,
+              'fragment_charges': [0.0],
+              'fragment_multiplicities': [1],
+              'fragments': [[0, 1, 2]],
+              'geometry': [-0.6169570705079365, 1.0422703480732367, 0.0, 0.6557577476759937, -0.7152141444267631, 0.0,
+                           -1.7653256931447308, -2.472698636926763, 0.0],
+              'mass_numbers': [12, 14, 1],
+              'masses': [12.0, 14.00307400443, 1.00782503223],
+              'molecular_charge': 0.0,
+              'molecular_multiplicity': 1,
+              'name': 'CHN',
+              'provenance': {'creator': 'QCElemental',
+                             'routine': 'qcelemental.molparse.from_string',
+                             'version': 'v0.25.0'},
+              'real': [True, True, True],
+              'schema_name': 'qcschema_molecule',
+              'schema_version': 2,
+              'symbols': ['C', 'N', 'H'],
+              'validated': True},
+ 'protocols': {'stdout': True},
+ 'provenance': {'creator': 'QCElemental', 'routine': 'qcelemental.models.results', 'version': 'v0.25.0'},
+ 'schema_name': 'qcschema_input',
+ 'schema_version': 1}
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:32 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.655757747676    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.765325693145    -2.472698636927     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      7.23947  B =      1.89453  C =      1.50158 [cm^-1]
+  Rotational constants: A = 217033.78823  B =  56796.61293  C =  45016.12681 [MHz]
+  Nuclear repulsion =   23.317922835158754
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.6802053135E-03.
+  Reciprocal condition number of the overlap matrix is 2.7434815300E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        16      16 
+     A"         4       4 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81715549720876   -9.18172e+01   0.00000e+00 
+   @RHF iter   1:   -92.61439123410250   -7.97236e-01   1.57266e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66064044329177   -4.62492e-02   1.06997e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67400441141210   -1.33640e-02   2.50299e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67527287979414   -1.26847e-03   8.23907e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67550401260425   -2.31133e-04   1.91797e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67552444224918   -2.04296e-05   3.81433e-05 DIIS
+   @RHF iter   7:   -92.67552564975938   -1.20751e-06   1.44917e-05 DIIS
+   @RHF iter   8:   -92.67552585084535   -2.01086e-07   4.01401e-06 DIIS
+   @RHF iter   9:   -92.67552586434283   -1.34975e-08   6.28972e-07 DIIS
+   @RHF iter  10:   -92.67552586455034   -2.07507e-10   1.47572e-07 DIIS
+   @RHF iter  11:   -92.67552586456439   -1.40545e-11   4.83611e-08 DIIS
+   @RHF iter  12:   -92.67552586456594   -1.54898e-12   7.46102e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.636635     2Ap   -11.316728     3Ap    -1.313444  
+       4Ap    -0.650198     5Ap    -0.560627     1App   -0.521983  
+       6Ap    -0.480906  
+
+    Virtual:                                                              
+
+       7Ap     0.001269     8Ap     0.200232     2App    0.201521  
+       9Ap     0.492619    10Ap     0.752457     3App    0.759072  
+      11Ap     0.814488    12Ap     0.847016    13Ap     0.918093  
+       4App    1.015279    14Ap     1.105837    15Ap     1.262138  
+      16Ap     1.611735  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.67552586456594
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3179228351587540
+    One-Electron Energy =                -171.0258553534937107
+    Two-Electron Energy =                  55.0324066537690086
+    Total Energy =                        -92.6755258645659410
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1096827           -0.8767639           -0.7670812
+ Dipole Y            :          0.4539239           -1.2255756           -0.7716516
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    1.0880532
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+Module time:
+	user time   =       0.67 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.61 seconds =       0.11 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:32 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.655757747676    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.765325693145    -2.472698636927     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.317922835158754
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.088399119817    -0.108587088477     0.000000000000
+       2       -0.013049034395     0.170371957130     0.000000000000
+       3       -0.075350085422    -0.061784868652     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       6.68 seconds =       0.11 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
+    Psi4 wall time for execution: 0:00:00.22
+
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.7a1.dev138 
+
+                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+
+    Process ID: 330641
+    Host:       nidavellir
+    PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input QCSchema <==
+
+--------------------------------------------------------------------------
+{'driver': 'gradient',
+ 'extras': {'psiapi': True, 'wfn_qcvars_only': True},
+ 'id': None,
+ 'keywords': {'FULL_HESS_EVERY': 0,
+              'OPT_TYPE': 'TS',
+              'PARENT_SYMMETRY': 'Cs(Z)',
+              'SCF_TYPE': 'PK',
+              'SCF__D_CONVERGENCE': 1e-08,
+              'SCF__E_CONVERGENCE': 1e-08,
+              'SCF__INTS_TOLERANCE': 1e-12,
+              'function_kwargs': {'write_orbitals': False}},
+ 'model': {'basis': '6-31g', 'method': 'scf'},
+ 'molecule': {'atom_labels': ['', '', ''],
+              'atomic_numbers': [6, 7, 1],
+              'fix_com': True,
+              'fix_orientation': True,
+              'fragment_charges': [0.0],
+              'fragment_multiplicities': [1],
+              'fragments': [[0, 1, 2]],
+              'geometry': [-0.6169570705079365, 1.0422703480732367, 0.0, 0.6564501803081335, -0.7152141444267631, 0.0,
+                           -1.774946594671142, -2.472698636926763, 0.0],
+              'mass_numbers': [12, 14, 1],
+              'masses': [12.0, 14.00307400443, 1.00782503223],
+              'molecular_charge': 0.0,
+              'molecular_multiplicity': 1,
+              'name': 'CHN',
+              'provenance': {'creator': 'QCElemental',
+                             'routine': 'qcelemental.molparse.from_string',
+                             'version': 'v0.25.0'},
+              'real': [True, True, True],
+              'schema_name': 'qcschema_molecule',
+              'schema_version': 2,
+              'symbols': ['C', 'N', 'H'],
+              'validated': True},
+ 'protocols': {'stdout': True},
+ 'provenance': {'creator': 'QCElemental', 'routine': 'qcelemental.models.results', 'version': 'v0.25.0'},
+ 'schema_name': 'qcschema_input',
+ 'schema_version': 1}
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:32 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656450180308    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.774946594671    -2.472698636927     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      7.19573  B =      1.89474  C =      1.49982 [cm^-1]
+  Rotational constants: A = 215722.49214  B =  56802.86279  C =  44963.35808 [MHz]
+  Nuclear repulsion =   23.306471235563706
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.6898583460E-03.
+  Reciprocal condition number of the overlap matrix is 2.7478510709E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        16      16 
+     A"         4       4 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81512449151978   -9.18151e+01   0.00000e+00 
+   @RHF iter   1:   -92.61333410052731   -7.98210e-01   1.57527e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.65979030855006   -4.64562e-02   1.07496e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67327958135601   -1.34893e-02   2.50681e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67455523463667   -1.27565e-03   8.29197e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67478875647591   -2.33522e-04   1.92382e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67480928691360   -2.05304e-05   3.81203e-05 DIIS
+   @RHF iter   7:   -92.67481049833448   -1.21142e-06   1.45300e-05 DIIS
+   @RHF iter   8:   -92.67481070194199   -2.03608e-07   4.05540e-06 DIIS
+   @RHF iter   9:   -92.67481071580896   -1.38670e-08   6.26004e-07 DIIS
+   @RHF iter  10:   -92.67481071601262   -2.03656e-10   1.43390e-07 DIIS
+   @RHF iter  11:   -92.67481071602597   -1.33582e-11   4.71279e-08 DIIS
+   @RHF iter  12:   -92.67481071602754   -1.56319e-12   7.32596e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.636781     2Ap   -11.316724     3Ap    -1.313212  
+       4Ap    -0.649758     5Ap    -0.560235     1App   -0.521869  
+       6Ap    -0.480869  
+
+    Virtual:                                                              
+
+       7Ap     0.000335     8Ap     0.200185     2App    0.201484  
+       9Ap     0.492549    10Ap     0.752736     3App    0.759138  
+      11Ap     0.814525    12Ap     0.847185    13Ap     0.918048  
+       4App    1.015292    14Ap     1.105808    15Ap     1.260801  
+      16Ap     1.610827  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.67481071602754
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3064712355637056
+    One-Electron Energy =                -171.0036689246194328
+    Two-Electron Energy =                  55.0223869730281763
+    Total Energy =                        -92.6748107160275367
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1124043           -0.8815378           -0.7691335
+ Dipole Y            :          0.4542167           -1.2255756           -0.7713589
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    1.0892937
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+Module time:
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       7.48 seconds =       0.12 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:32 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656450180308    -0.715214144427     0.000000000000    14.003074004430
+         H           -1.774946594671    -2.472698636927     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.306471235563706
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.088358409552    -0.107949703797     0.000000000000
+       2       -0.013156910807     0.169638565521     0.000000000000
+       3       -0.075201498746    -0.061688861724     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       7.54 seconds =       0.13 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
+    Psi4 wall time for execution: 0:00:00.21
+
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.7a1.dev138 
+
+                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+
+    Process ID: 330641
+    Host:       nidavellir
+    PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input QCSchema <==
+
+--------------------------------------------------------------------------
+{'driver': 'gradient',
+ 'extras': {'psiapi': True, 'wfn_qcvars_only': True},
+ 'id': None,
+ 'keywords': {'FULL_HESS_EVERY': 0,
+              'OPT_TYPE': 'TS',
+              'PARENT_SYMMETRY': 'Cs(Z)',
+              'SCF_TYPE': 'PK',
+              'SCF__D_CONVERGENCE': 1e-08,
+              'SCF__E_CONVERGENCE': 1e-08,
+              'SCF__INTS_TOLERANCE': 1e-12,
+              'function_kwargs': {'write_orbitals': False}},
+ 'model': {'basis': '6-31g', 'method': 'scf'},
+ 'molecule': {'atom_labels': ['', '', ''],
+              'atomic_numbers': [6, 7, 1],
+              'fix_com': True,
+              'fix_orientation': True,
+              'fragment_charges': [0.0],
+              'fragment_multiplicities': [1],
+              'fragments': [[0, 1, 2]],
+              'geometry': [-0.6169570705079365, 1.0422703480732367, 0.0, 0.6561039639920636, -0.715560360742833, 0.0,
+                           -1.7701361439079364, -2.4678881861635573, 0.0],
+              'mass_numbers': [12, 14, 1],
+              'masses': [12.0, 14.00307400443, 1.00782503223],
+              'molecular_charge': 0.0,
+              'molecular_multiplicity': 1,
+              'name': 'CHN',
+              'provenance': {'creator': 'QCElemental',
+                             'routine': 'qcelemental.molparse.from_string',
+                             'version': 'v0.25.0'},
+              'real': [True, True, True],
+              'schema_name': 'qcschema_molecule',
+              'schema_version': 2,
+              'symbols': ['C', 'N', 'H'],
+              'validated': True},
+ 'protocols': {'stdout': True},
+ 'provenance': {'creator': 'QCElemental', 'routine': 'qcelemental.models.results', 'version': 'v0.25.0'},
+ 'schema_name': 'qcschema_input',
+ 'schema_version': 1}
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:32 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.715560360743     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.467888186164     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      7.22955  B =      1.89482  C =      1.50133 [cm^-1]
+  Rotational constants: A = 216736.60277  B =  56805.40430  C =  45008.84701 [MHz]
+  Nuclear repulsion =   23.314060077038508
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.6883619328E-03.
+  Reciprocal condition number of the overlap matrix is 2.7455770523E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        16      16 
+     A"         4       4 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81672763988399   -9.18167e+01   0.00000e+00 
+   @RHF iter   1:   -92.61433705847890   -7.97609e-01   1.57317e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66060332869651   -4.62663e-02   1.07142e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67400107762772   -1.33977e-02   2.50341e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67527068953864   -1.26961e-03   8.24470e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67550174903701   -2.31059e-04   1.91653e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67552210314325   -2.03541e-05   3.79158e-05 DIIS
+   @RHF iter   7:   -92.67552329525404   -1.19211e-06   1.43841e-05 DIIS
+   @RHF iter   8:   -92.67552349360167   -1.98348e-07   4.01007e-06 DIIS
+   @RHF iter   9:   -92.67552350710938   -1.35077e-08   6.23683e-07 DIIS
+   @RHF iter  10:   -92.67552350731223   -2.02860e-10   1.44117e-07 DIIS
+   @RHF iter  11:   -92.67552350732565   -1.34150e-11   4.74441e-08 DIIS
+   @RHF iter  12:   -92.67552350732728   -1.63425e-12   7.37602e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.636794     2Ap   -11.316854     3Ap    -1.313428  
+       4Ap    -0.650122     5Ap    -0.560729     1App   -0.521976  
+       6Ap    -0.480967  
+
+    Virtual:                                                              
+
+       7Ap     0.001302     8Ap     0.200018     2App    0.201360  
+       9Ap     0.492554    10Ap     0.752384     3App    0.759034  
+      11Ap     0.814381    12Ap     0.847214    13Ap     0.918219  
+       4App    1.015193    14Ap     1.105643    15Ap     1.261363  
+      16Ap     1.611193  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.67552350732728
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3140600770385085
+    One-Electron Energy =                -171.0174286700033122
+    Two-Electron Energy =                  55.0278450856375230
+    Total Energy =                        -92.6755235073272843
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1116495           -0.8791508           -0.7675013
+ Dipole Y            :          0.4541965           -1.2231886           -0.7689922
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    1.0864655
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+Module time:
+	user time   =       0.69 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       8.38 seconds =       0.14 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:32 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.715560360743     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.467888186164     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.314060077038508
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.088087838368    -0.107933070513     0.000000000000
+       2       -0.012762626901     0.169523271373     0.000000000000
+       3       -0.075325211467    -0.061590200860     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       8.45 seconds =       0.14 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
+    Psi4 wall time for execution: 0:00:00.22
+
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.7a1.dev138 
+
+                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+
+    Process ID: 330641
+    Host:       nidavellir
+    PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input QCSchema <==
+
+--------------------------------------------------------------------------
+{'driver': 'gradient',
+ 'extras': {'psiapi': True, 'wfn_qcvars_only': True},
+ 'id': None,
+ 'keywords': {'FULL_HESS_EVERY': 0,
+              'OPT_TYPE': 'TS',
+              'PARENT_SYMMETRY': 'Cs(Z)',
+              'SCF_TYPE': 'PK',
+              'SCF__D_CONVERGENCE': 1e-08,
+              'SCF__E_CONVERGENCE': 1e-08,
+              'SCF__INTS_TOLERANCE': 1e-12,
+              'function_kwargs': {'write_orbitals': False}},
+ 'model': {'basis': '6-31g', 'method': 'scf'},
+ 'molecule': {'atom_labels': ['', '', ''],
+              'atomic_numbers': [6, 7, 1],
+              'fix_com': True,
+              'fix_orientation': True,
+              'fragment_charges': [0.0],
+              'fragment_multiplicities': [1],
+              'fragments': [[0, 1, 2]],
+              'geometry': [-0.6169570705079365, 1.0422703480732367, 0.0, 0.6561039639920636, -0.7148679281106932, 0.0,
+                           -1.7701361439079364, -2.477509087689969, 0.0],
+              'mass_numbers': [12, 14, 1],
+              'masses': [12.0, 14.00307400443, 1.00782503223],
+              'molecular_charge': 0.0,
+              'molecular_multiplicity': 1,
+              'name': 'CHN',
+              'provenance': {'creator': 'QCElemental',
+                             'routine': 'qcelemental.molparse.from_string',
+                             'version': 'v0.25.0'},
+              'real': [True, True, True],
+              'schema_name': 'qcschema_molecule',
+              'schema_version': 2,
+              'symbols': ['C', 'N', 'H'],
+              'validated': True},
+ 'protocols': {'stdout': True},
+ 'provenance': {'creator': 'QCElemental', 'routine': 'qcelemental.models.results', 'version': 'v0.25.0'},
+ 'schema_name': 'qcschema_input',
+ 'schema_version': 1}
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:32 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.714867928111     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.477509087690     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      7.20558  B =      1.89444  C =      1.50006 [cm^-1]
+  Rotational constants: A = 216017.93684  B =  56794.00061  C =  44970.62318 [MHz]
+  Nuclear repulsion =   23.310334609371353
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.6817090020E-03.
+  Reciprocal condition number of the overlap matrix is 2.7457535395E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        16      16 
+     A"         4       4 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81555261778567   -9.18156e+01   0.00000e+00 
+   @RHF iter   1:   -92.61338687877875   -7.97834e-01   1.57476e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.65982625781143   -4.64394e-02   1.07351e-02 ADIIS/DIIS
+   @RHF iter   3:   -92.67328168166154   -1.34554e-02   2.50638e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67455618303055   -1.27450e-03   8.28629e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67478977534053   -2.33592e-04   1.92522e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67481038012903   -2.06048e-05   3.83427e-05 DIIS
+   @RHF iter   7:   -92.67481160678246   -1.22665e-06   1.46346e-05 DIIS
+   @RHF iter   8:   -92.67481181309991   -2.06317e-07   4.05880e-06 DIIS
+   @RHF iter   9:   -92.67481182695431   -1.38544e-08   6.31217e-07 DIIS
+   @RHF iter  10:   -92.67481182716274   -2.08431e-10   1.46842e-07 DIIS
+   @RHF iter  11:   -92.67481182717677   -1.40261e-11   4.80637e-08 DIIS
+   @RHF iter  12:   -92.67481182717844   -1.67688e-12   7.41399e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.636622     2Ap   -11.316598     3Ap    -1.313229  
+       4Ap    -0.649832     5Ap    -0.560135     1App   -0.521876  
+       6Ap    -0.480808  
+
+    Virtual:                                                              
+
+       7Ap     0.000302     8Ap     0.200399     2App    0.201645  
+       9Ap     0.492614    10Ap     0.752809     3App    0.759175  
+      11Ap     0.814631    12Ap     0.846986    13Ap     0.917920  
+       4App    1.015378    14Ap     1.106002    15Ap     1.261575  
+      16Ap     1.611367  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.67481182717844
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3103346093713526
+    One-Electron Energy =                -171.0120944196803521
+    Two-Electron Energy =                  55.0269479831305475
+    Total Energy =                        -92.6748118271784449
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1104390           -0.8791508           -0.7687118
+ Dipole Y            :          0.4539438           -1.2279625           -0.7740186
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    1.0908816
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+Module time:
+	user time   =       0.75 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       9.35 seconds =       0.16 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:32 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.714867928111     0.000000000000    14.003074004430
+         H           -1.770136143908    -2.477509087690     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.310334609371353
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.088670077585    -0.108603676807     0.000000000000
+       2       -0.013444573697     0.170486290607     0.000000000000
+       3       -0.075225503889    -0.061882613800     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:32 2022
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       9.42 seconds =       0.16 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
+    Psi4 wall time for execution: 0:00:00.24
+
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.7a1.dev138 
+
+                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+
+    Process ID: 330641
+    Host:       nidavellir
+    PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input QCSchema <==
+
+--------------------------------------------------------------------------
+{'driver': 'gradient',
+ 'extras': {'psiapi': True, 'wfn_qcvars_only': True},
+ 'id': None,
+ 'keywords': {'FULL_HESS_EVERY': 0,
+              'OPT_TYPE': 'TS',
+              'PARENT_SYMMETRY': 'Cs(Z)',
+              'SCF_TYPE': 'PK',
+              'SCF__D_CONVERGENCE': 1e-08,
+              'SCF__E_CONVERGENCE': 1e-08,
+              'SCF__INTS_TOLERANCE': 1e-12,
+              'function_kwargs': {'write_orbitals': False}},
+ 'model': {'basis': '6-31g', 'method': 'scf'},
+ 'molecule': {'atom_labels': ['', '', ''],
+              'atomic_numbers': [6, 7, 1],
+              'fix_com': True,
+              'fix_orientation': True,
+              'fragment_charges': [0.0],
+              'fragment_multiplicities': [1],
+              'fragments': [[0, 1, 2]],
+              'geometry': [-0.6169570705079365, 1.0422703480732367, -0.0010760023342353525, 0.6561039639920636,
+                           -0.7152141444267631, 0.0008601768607789678, -1.7701361439079364, -2.472698636926763,
+                           0.0008601768607789679],
+              'mass_numbers': [12, 14, 1],
+              'masses': [12.0, 14.00307400443, 1.00782503223],
+              'molecular_charge': 0.0,
+              'molecular_multiplicity': 1,
+              'name': 'CHN',
+              'provenance': {'creator': 'QCElemental',
+                             'routine': 'qcelemental.molparse.from_string',
+                             'version': 'v0.25.0'},
+              'real': [True, True, True],
+              'schema_name': 'qcschema_molecule',
+              'schema_version': 2,
+              'symbols': ['C', 'N', 'H'],
+              'validated': True},
+ 'protocols': {'stdout': True},
+ 'provenance': {'creator': 'QCElemental', 'routine': 'qcelemental.models.results', 'version': 'v0.25.0'},
+ 'schema_name': 'qcschema_input',
+ 'schema_version': 1}
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:32 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073    -0.001076002334    12.000000000000
+         N            0.656103963992    -0.715214144427     0.000860176861    14.003074004430
+         H           -1.770136143908    -2.472698636927     0.000860176861     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      7.21755  B =      1.89463  C =      1.50070 [cm^-1]
+  Rotational constants: A = 216376.61809  B =  56799.70567  C =  44989.72697 [MHz]
+  Nuclear repulsion =   23.312186724791463
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.6850514591E-03.
+  Reciprocal condition number of the overlap matrix is 2.7456718156E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         20      20 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81613806426915   -9.18161e+01   0.00000e+00 
+   @RHF iter   1:   -92.61386274480782   -7.97725e-01   1.29792e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66021544226815   -4.63527e-02   8.84375e-03 ADIIS/DIIS
+   @RHF iter   3:   -92.67368238807418   -1.34669e-02   2.00015e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67491490066924   -1.23251e-03   6.77634e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67514643242184   -2.31532e-04   1.57974e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67516680732209   -2.03749e-05   3.13216e-05 DIIS
+   @RHF iter   7:   -92.67516800739651   -1.20007e-06   1.19403e-05 DIIS
+   @RHF iter   8:   -92.67516820887290   -2.01476e-07   3.32711e-06 DIIS
+   @RHF iter   9:   -92.67516822255816   -1.36853e-08   5.17251e-07 DIIS
+   @RHF iter  10:   -92.67516822276369   -2.05532e-10   1.19797e-07 DIIS
+   @RHF iter  11:   -92.67516822277729   -1.35998e-11   3.93164e-08 DIIS
+   @RHF iter  12:   -92.67516822277896   -1.67688e-12   6.08813e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -15.636708     2A    -11.316726     3A     -1.313328  
+       4A     -0.649977     5A     -0.560432     6A     -0.521926  
+       7A     -0.480887  
+
+    Virtual:                                                              
+
+       8A      0.000802     9A      0.200208    10A      0.201502  
+      11A      0.492584    12A      0.752596    13A      0.759105  
+      14A      0.814506    15A      0.847100    16A      0.918069  
+      17A      1.015285    18A      1.105823    19A      1.261469  
+      20A      1.611280  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     7 ]
+    NA   [     7 ]
+    NB   [     7 ]
+
+  @RHF Final Energy:   -92.67516822277896
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3121867247914629
+    One-Electron Energy =                -171.0147413270739776
+    Two-Electron Energy =                  55.0273863795035396
+    Total Energy =                        -92.6751682227789644
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1110436           -0.8791508           -0.7681072
+ Dipole Y            :          0.4540728           -1.2255756           -0.7715028
+ Dipole Z            :         -0.0002700            0.0004254            0.0001554
+ Magnitude           :                                                    1.0886713
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+Module time:
+	user time   =       0.78 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      10.36 seconds =       0.17 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:33 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073    -0.001076002334    12.000000000000
+         N            0.656103963992    -0.715214144427     0.000860176861    14.003074004430
+         H           -1.770136143908    -2.472698636927     0.000860176861     1.007825032230
+
+  Nuclear repulsion =   23.312186724791463
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.088378172761    -0.108267355391     0.000124484919
+       2       -0.013102298597     0.170004250728    -0.000129694256
+       3       -0.075275874165    -0.061736895337     0.000005209338
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      10.43 seconds =       0.17 minutes
+	system time =       0.30 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
+    Psi4 wall time for execution: 0:00:00.25
+
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.7a1.dev138 
+
+                         Git: Rev {findif-scf-read} 7b4cf84 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 06 December 2022 02:18PM
+
+    Process ID: 330641
+    Host:       nidavellir
+    PSIDATADIR: /home/zander/github/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input QCSchema <==
+
+--------------------------------------------------------------------------
+{'driver': 'gradient',
+ 'extras': {'psiapi': True, 'wfn_qcvars_only': True},
+ 'id': None,
+ 'keywords': {'FULL_HESS_EVERY': 0,
+              'OPT_TYPE': 'TS',
+              'PARENT_SYMMETRY': 'Cs(Z)',
+              'SCF_TYPE': 'PK',
+              'SCF__D_CONVERGENCE': 1e-08,
+              'SCF__E_CONVERGENCE': 1e-08,
+              'SCF__INTS_TOLERANCE': 1e-12,
+              'function_kwargs': {'write_orbitals': False}},
+ 'model': {'basis': '6-31g', 'method': 'scf'},
+ 'molecule': {'atom_labels': ['', '', ''],
+              'atomic_numbers': [6, 7, 1],
+              'fix_com': True,
+              'fix_orientation': True,
+              'fragment_charges': [0.0],
+              'fragment_multiplicities': [1],
+              'fragments': [[0, 1, 2]],
+              'geometry': [-0.6169570705079365, 1.0422703480732367, 0.0, 0.6561039639920636, -0.7152141444267631,
+                           -0.00034621631606994956, -1.7701361439079364, -2.472698636926763, 0.004810450763205726],
+              'mass_numbers': [12, 14, 1],
+              'masses': [12.0, 14.00307400443, 1.00782503223],
+              'molecular_charge': 0.0,
+              'molecular_multiplicity': 1,
+              'name': 'CHN',
+              'provenance': {'creator': 'QCElemental',
+                             'routine': 'qcelemental.molparse.from_string',
+                             'version': 'v0.25.0'},
+              'real': [True, True, True],
+              'schema_name': 'qcschema_molecule',
+              'schema_version': 2,
+              'symbols': ['C', 'N', 'H'],
+              'validated': True},
+ 'protocols': {'stdout': True},
+ 'provenance': {'creator': 'QCElemental', 'routine': 'qcelemental.models.results', 'version': 'v0.25.0'},
+ 'schema_name': 'qcschema_input',
+ 'schema_version': 1}
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:33 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.715214144427    -0.000346216316    14.003074004430
+         H           -1.770136143908    -2.472698636927     0.004810450763     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      7.21753  B =      1.89464  C =      1.50070 [cm^-1]
+  Rotational constants: A = 216375.97494  B =  56799.74999  C =  44989.72697 [MHz]
+  Nuclear repulsion =   23.312189571102063
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.6850382496E-03.
+  Reciprocal condition number of the overlap matrix is 2.7456688260E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         20      20 
+   -------------------------
+    Total      20      20
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -91.81613795286238   -9.18161e+01   0.00000e+00 
+   @RHF iter   1:   -92.61386200448652   -7.97724e-01   1.29792e-02 ADIIS/DIIS
+   @RHF iter   2:   -92.66021485034986   -4.63528e-02   8.84376e-03 ADIIS/DIIS
+   @RHF iter   3:   -92.67368184126222   -1.34670e-02   2.00015e-03 ADIIS/DIIS
+   @RHF iter   4:   -92.67491435599470   -1.23251e-03   6.77636e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.67514588917956   -2.31533e-04   1.57975e-04 ADIIS/DIIS
+   @RHF iter   6:   -92.67516626417752   -2.03750e-05   3.13217e-05 DIIS
+   @RHF iter   7:   -92.67516746426148   -1.20008e-06   1.19404e-05 DIIS
+   @RHF iter   8:   -92.67516766574062   -2.01479e-07   3.32713e-06 DIIS
+   @RHF iter   9:   -92.67516767942624   -1.36856e-08   5.17251e-07 DIIS
+   @RHF iter  10:   -92.67516767963181   -2.05574e-10   1.19796e-07 DIIS
+   @RHF iter  11:   -92.67516767964547   -1.36566e-11   3.93160e-08 DIIS
+   @RHF iter  12:   -92.67516767964700   -1.53477e-12   6.08806e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -15.636708     2A    -11.316726     3A     -1.313328  
+       4A     -0.649977     5A     -0.560432     6A     -0.521926  
+       7A     -0.480887  
+
+    Virtual:                                                              
+
+       8A      0.000801     9A      0.200208    10A      0.201502  
+      11A      0.492584    12A      0.752596    13A      0.759105  
+      14A      0.814507    15A      0.847100    16A      0.918069  
+      17A      1.015285    18A      1.105823    19A      1.261470  
+      20A      1.611280  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     7 ]
+    NA   [     7 ]
+    NB   [     7 ]
+
+  @RHF Final Energy:   -92.67516767964700
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.3121895711020635
+    One-Electron Energy =                -171.0147473234867448
+    Two-Electron Energy =                  55.0273900727376741
+    Total Energy =                        -92.6751676796470036
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.1110439           -0.8791508           -0.7681069
+ Dipole Y            :          0.4540716           -1.2255756           -0.7715039
+ Dipole Z            :         -0.0005650            0.0023869            0.0018219
+ Magnitude           :                                                    1.0886735
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+Module time:
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      11.25 seconds =       0.19 minutes
+	system time =       0.32 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:33 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.616957070508     1.042270348073     0.000000000000    12.000000000000
+         N            0.656103963992    -0.715214144427    -0.000346216316    14.003074004430
+         H           -1.770136143908    -2.472698636927     0.004810450763     1.007825032230
+
+  Nuclear repulsion =   23.312189571102063
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.088379049109    -0.108268366964    -0.000036134196
+       2       -0.013103371597     0.170005223871    -0.000130203177
+       3       -0.075275677512    -0.061736856908     0.000166337373
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      11.32 seconds =       0.19 minutes
+	system time =       0.33 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
+    Psi4 wall time for execution: 0:00:00.21
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //      FiniteDifference Results     //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+  Computing second-derivative from gradients using projected, 
+  symmetry-adapted, cartesian coordinates.
+
+  11 gradients passed in, including the reference geometry.
+  Generating complete list of displacements from unique ones.
+
+    Operation 2 takes plus displacements of irrep A" to minus ones.
+
+-------------------------------------------------------------
+
+
+  ==> Harmonic Vibrational Analysis <==
+
+  non-mass-weighted Hessian:       Symmetric? True   Hermitian? True   Lin Dep Dim?  3 (0)
+  projection of translations (True) and rotations (False) removed 3 degrees of freedom (6)
+  total projector:                 Symmetric? True   Hermitian? True   Lin Dep Dim?  3 (3)
+  mass-weighted Hessian:           Symmetric? True   Hermitian? True   Lin Dep Dim?  3 (0)
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000i [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  low-frequency mode:    0.0000  [cm^-1]
+  pre-proj  all modes:['889.6493i' '509.4143i' '226.7097i' '0.0000i' '0.0000' '0.0000'
+ '905.3863' '947.7049' '2473.8044']
+  projected mass-weighted Hessian: Symmetric? True   Hermitian? True   Lin Dep Dim?  3 (3)
+  post-proj low-frequency mode:  889.6493i [cm^-1] (V)
+  post-proj low-frequency mode:  509.4143i [cm^-1] (V)
+  post-proj low-frequency mode:  226.7097i [cm^-1] (V)
+  post-proj low-frequency mode:    0.0000i [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj low-frequency mode:    0.0000  [cm^-1] (TR)
+  post-proj  all modes:['889.6493i' '509.4143i' '226.7097i' '0.0000i' '0.0000' '0.0000'
+ '905.3863' '947.7049' '2473.8044']
+
+  Note that "Vibration"s include 3 un-projected rotation-like modes.
+  Vibration                       1                   2                   3           
+  Freq [cm^-1]                889.6493i           509.4143i           226.7097i       
+  Irrep                           Ap                 App                  Ap          
+  Reduced mass [u]              2.0532             11.2032              1.8088        
+  Force const [mDyne/A]        -0.9575             -1.7129             -0.0548        
+  Turning point v=0 [a0]        0.0000              0.0000              0.0000        
+  RMS dev v=0 [a0 u^1/2]        0.0000              0.0000              0.0000        
+  IR activ [km/mol]            14.2343              0.0578             64.2327        
+  Char temp [K]                 0.0000              0.0000              0.0000        
+  ----------------------------------------------------------------------------------
+      1   C                0.15  0.12  0.00   -0.00 -0.00  0.72   -0.19 -0.13 -0.00   
+      2   N               -0.19 -0.11 -0.00   -0.00 -0.00 -0.59    0.10  0.09 -0.00   
+      3   H                0.94  0.15 -0.00   -0.00 -0.00 -0.37    0.92  0.28 -0.00   
+
+  Vibration                       7                   8                   9           
+  Freq [cm^-1]                 905.3863            947.7049           2473.8044       
+  Irrep                           Ap                 App                  Ap          
+  Reduced mass [u]              1.0493              1.0564             12.6706        
+  Force const [mDyne/A]         0.5068              0.5590             45.6856        
+  Turning point v=0 [a0]        0.3560              0.3468              0.0620        
+  RMS dev v=0 [a0 u^1/2]        0.2579              0.2520              0.1560        
+  IR activ [km/mol]            169.2822            130.3260            223.8653       
+  Char temp [K]               1302.6493           1363.5363           3559.2538       
+  ----------------------------------------------------------------------------------
+      1   C                0.02 -0.03 -0.00    0.00 -0.00 -0.01   -0.44  0.61  0.00   
+      2   N               -0.01 -0.04  0.00   -0.00 -0.00 -0.06    0.37 -0.53  0.00   
+      3   H               -0.23  0.97 -0.00   -0.00  0.00  1.00    0.03  0.12 -0.00   
+
+  ==> Thermochemistry Components <==
+
+  Entropy, S
+    Electronic S            0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K] (multiplicity = 1)
+    Translational S        35.816 [cal/(mol K)]      149.856 [J/(mol K)]       0.05707695 [mEh/K] (mol. weight = 27.0109 [u], P = 101325.00 [Pa])
+    Rotational S           17.015 [cal/(mol K)]       71.191 [J/(mol K)]       0.02711529 [mEh/K] (symmetry no. = 1)
+    Vibrational S           0.252 [cal/(mol K)]        1.055 [J/(mol K)]       0.00040201 [mEh/K]
+  Total S                  53.084 [cal/(mol K)]      222.102 [J/(mol K)]       0.08459425 [mEh/K]
+  Correction S              0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+
+  Constant volume heat capacity, Cv
+    Electronic Cv           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+    Translational Cv        2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Rotational Cv           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Vibrational Cv          0.933 [cal/(mol K)]        3.902 [J/(mol K)]       0.00148630 [mEh/K]
+  Total Cv                  6.894 [cal/(mol K)]       28.846 [J/(mol K)]       0.01098673 [mEh/K]
+  Correction Cv             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+
+  Constant pressure heat capacity, Cp
+    Electronic Cp           0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+    Translational Cp        4.968 [cal/(mol K)]       20.786 [J/(mol K)]       0.00791703 [mEh/K]
+    Rotational Cp           2.981 [cal/(mol K)]       12.472 [J/(mol K)]       0.00475022 [mEh/K]
+    Vibrational Cp          0.933 [cal/(mol K)]        3.902 [J/(mol K)]       0.00148630 [mEh/K]
+  Total Cp                  8.881 [cal/(mol K)]       37.160 [J/(mol K)]       0.01415354 [mEh/K]
+  Correction Cp             0.000 [cal/(mol K)]        0.000 [J/(mol K)]       0.00000000 [mEh/K]
+
+  ==> Thermochemistry Energy Analysis <==
+
+  Raw electronic energy, E0
+  Total E0, Electronic energy at well bottom at 0 [K]                  -92.67516810 [Eh]
+
+  Zero-point energy, ZPE_vib = Sum_i nu_i / 2
+    Electronic ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational ZPE       0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Rotational ZPE          0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Vibrational ZPE         6.186 [kcal/mol]       25.881 [kJ/mol]       0.00985739 [Eh]        2163.448 [cm^-1]
+  Correction ZPE            6.186 [kcal/mol]       25.881 [kJ/mol]       0.00985739 [Eh]        2163.448 [cm^-1]
+  Total ZPE, Electronic energy at 0 [K]                                -92.66531071 [Eh]
+
+  Thermal Energy, E (includes ZPE)
+    Electronic E            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational E         0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Rotational E            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Vibrational E           6.247 [kcal/mol]       26.138 [kJ/mol]       0.00995542 [Eh]
+  Correction E              8.025 [kcal/mol]       33.575 [kJ/mol]       0.01278797 [Eh]
+  Total E, Electronic energy at  298.15 [K]                            -92.66238013 [Eh]
+
+  Enthalpy, H_trans = E_trans + k_B * T
+    Electronic H            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational H         1.481 [kcal/mol]        6.197 [kJ/mol]       0.00236046 [Eh]
+    Rotational H            0.889 [kcal/mol]        3.718 [kJ/mol]       0.00141628 [Eh]
+    Vibrational H           6.247 [kcal/mol]       26.138 [kJ/mol]       0.00995542 [Eh]
+  Correction H              8.617 [kcal/mol]       36.054 [kJ/mol]       0.01373215 [Eh]
+  Total H, Enthalpy at  298.15 [K]                                     -92.66143595 [Eh]
+
+  Gibbs free energy, G = H - T * S
+    Electronic G            0.000 [kcal/mol]        0.000 [kJ/mol]       0.00000000 [Eh]
+    Translational G        -9.197 [kcal/mol]      -38.482 [kJ/mol]      -0.01465703 [Eh]
+    Rotational G           -4.184 [kcal/mol]      -17.507 [kJ/mol]      -0.00666815 [Eh]
+    Vibrational G           6.172 [kcal/mol]       25.823 [kJ/mol]       0.00983556 [Eh]
+  Correction G             -7.210 [kcal/mol]      -30.166 [kJ/mol]      -0.01148962 [Eh]
+  Total G, Free enthalpy at  298.15 [K]                                -92.68665772 [Eh]
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.6169570705079365  1.0422703480732367  0.0000000000000000
+	       7.000000            14.003074        0.6561039639920636 -0.7152141444267631  0.0000000000000000
+	       1.000000             1.007825       -1.7701361439079364 -2.4726986369267632  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.170124           1.148380
+	 R(2,3)           =         2.995896           1.585360
+	 B(1,2,3)         =         1.570796          90.000000
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.14838        1.14953        0.02351       1.17189
+	               R(2,3)       1.58536       -0.80063       -0.23450       1.35086
+	             B(1,2,3)      90.00000       -0.00133      -13.02157      76.97843
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     1     -92.67516810   -9.27e+01      1.40e-01      9.87e-02 o    4.43e-01      2.89e-01 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4256887905   0.4215963120   0.0000000000
+	    N   0.3491576732  -0.4575790279   0.0000000000
+	    H  -0.8394689459  -1.0994423620   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.804435228761     0.796701565135     0.000000000000
+    N            0.659812377000    -0.864699043446     0.000000000000
+    H           -1.586366398663    -2.077644954970     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:33 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.804435228761     0.796701565135     0.000000000000    12.000000000000
+         N            0.659812377000    -0.864699043446     0.000000000000    14.003074004430
+         H           -1.586366398663    -2.077644954970     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      8.99079  B =      1.87307  C =      1.55013 [cm^-1]
+  Rotational constants: A = 269537.02054  B =  56153.27523  C =  46471.71468 [MHz]
+  Nuclear repulsion =   23.721764077245705
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 1.0205920108E-02.
+  Reciprocal condition number of the overlap matrix is 2.6923050876E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.76700450835595   -9.27670e+01   1.85558e-02 
+   @RHF iter   1:   -92.71864274902882    4.83618e-02   2.40606e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72055134704449   -1.90860e-03   9.48258e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72096495473735   -4.13608e-04   4.66783e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72105166123798   -8.67065e-05   2.41405e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72107196980951   -2.03086e-05   5.08633e-05 DIIS
+   @RHF iter   6:   -92.72107298359424   -1.01378e-06   1.32500e-05 DIIS
+   @RHF iter   7:   -92.72107307752657   -9.39323e-08   4.61395e-06 DIIS
+   @RHF iter   8:   -92.72107309241659   -1.48900e-08   1.09728e-06 DIIS
+   @RHF iter   9:   -92.72107309327740   -8.60808e-10   2.81905e-07 DIIS
+   @RHF iter  10:   -92.72107309333234   -5.49392e-11   6.37484e-08 DIIS
+   @RHF iter  11:   -92.72107309333410   -1.76215e-12   1.24961e-08 DIIS
+   @RHF iter  12:   -92.72107309333414   -4.26326e-14   2.94974e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.649161     2Ap   -11.333476     3Ap    -1.335976  
+       4Ap    -0.667678     5Ap    -0.613588     1App   -0.529781  
+       6Ap    -0.491777  
+
+    Virtual:                                                              
+
+       7Ap     0.092247     8Ap     0.170448     2App    0.179911  
+       9Ap     0.486581    10Ap     0.736877     3App    0.749518  
+      11Ap     0.789001    12Ap     0.865791    13Ap     0.954234  
+       4App    1.001874    14Ap     1.067695    15Ap     1.213412  
+      16Ap     1.585872  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72107309333414
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.7217640772457052
+    One-Electron Energy =                -171.6427990003683135
+    Two-Electron Energy =                  55.1999618297884780
+    Total Energy =                        -92.7210730933341409
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          1.2023752           -1.7942911           -0.5919159
+ Dipole Y            :          2.8552761           -3.3503289           -0.4950528
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.7716487
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+Module time:
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      11.99 seconds =       0.20 minutes
+	system time =       0.34 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:33 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.804435228761     0.796701565135     0.000000000000    12.000000000000
+         N            0.659812377000    -0.864699043446     0.000000000000    14.003074004430
+         H           -1.586366398663    -2.077644954970     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.721764077245705
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.045524436210    -0.050107442403     0.000000000000
+       2        0.015431053242     0.084031870482     0.000000000000
+       3       -0.060955489452    -0.033924428079     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      12.06 seconds =       0.20 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.8044352287612170  0.7967015651354833  0.0000000000000000
+	       7.000000            14.003074        0.6598123770001038 -0.8646990434456613  0.0000000000000000
+	       1.000000             1.007825       -1.5863663986626961 -2.0776449549701117  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.214559           1.171894
+	 R(2,3)           =         2.552755           1.350860
+	 B(1,2,3)         =         1.343527          76.978432
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.17189        0.55769        0.01558       1.18748
+	               R(2,3)       1.35086       -0.57469       -0.19945       1.15141
+	             B(1,2,3)      76.97843       -0.00017      -18.74912      58.22931
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     2     -92.72107309   -4.59e-02      6.98e-02      5.61e-02 o    3.77e-01      2.89e-01 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.5327656135   0.2558242334   0.0000000000
+	    N   0.3591769269  -0.5280995535   0.0000000000
+	    H  -0.7424113766  -0.8631497578   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -1.006781098526     0.483437737402     0.000000000000
+    N            0.678746022334    -0.997963523179     0.000000000000
+    H           -1.402954174232    -1.631116647503     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:33 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -1.006781098526     0.483437737402     0.000000000000    12.000000000000
+         N            0.678746022334    -0.997963523179     0.000000000000    14.003074004430
+         H           -1.402954174232    -1.631116647503     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      8.62145  B =      1.82161  C =      1.50386 [cm^-1]
+  Rotational constants: A = 258464.66679  B =  54610.35468  C =  45084.55213 [MHz]
+  Nuclear repulsion =   24.722621027960130
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 1.0122560536E-02.
+  Reciprocal condition number of the overlap matrix is 2.4318027632E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.78004220967478   -9.27800e+01   2.88584e-02 
+   @RHF iter   1:   -92.71257113266431    6.74711e-02   3.85466e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.71668081947855   -4.10969e-03   1.39181e-03 ADIIS/DIIS
+   @RHF iter   3:   -92.71736174893206   -6.80929e-04   7.76791e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.71751717769342   -1.55429e-04   3.48192e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.71756019866150   -4.30210e-05   9.63037e-05 DIIS
+   @RHF iter   6:   -92.71756583478877   -5.63613e-06   2.98866e-05 DIIS
+   @RHF iter   7:   -92.71756637245811   -5.37669e-07   7.72349e-06 DIIS
+   @RHF iter   8:   -92.71756640375803   -3.12999e-08   1.32758e-06 DIIS
+   @RHF iter   9:   -92.71756640480085   -1.04282e-09   5.13311e-07 DIIS
+   @RHF iter  10:   -92.71756640501461   -2.13760e-10   1.15250e-07 DIIS
+   @RHF iter  11:   -92.71756640502305   -8.44125e-12   1.61333e-08 DIIS
+   @RHF iter  12:   -92.71756640502304    1.42109e-14   2.03167e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.669120     2Ap   -11.337891     3Ap    -1.397869  
+       4Ap    -0.697088     5Ap    -0.663828     1App   -0.544053  
+       6Ap    -0.500093  
+
+    Virtual:                                                              
+
+       7Ap     0.141176     2App    0.162155     8Ap     0.224792  
+       9Ap     0.476338    10Ap     0.720130     3App    0.743893  
+      11Ap     0.780001    12Ap     0.889467     4App    0.986962  
+      13Ap     1.006946    14Ap     1.031477    15Ap     1.141188  
+      16Ap     1.536648  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.71756640502304
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             24.7226210279601304
+    One-Electron Energy =                -173.2604916957059515
+    Two-Electron Energy =                  55.8203042627228001
+    Total Energy =                        -92.7175664050230353
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          2.3270357           -2.6924186           -0.3653829
+ Dipole Y            :          5.4096502           -5.7162349           -0.3065847
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.4769683
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+Module time:
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      12.59 seconds =       0.21 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:33 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -1.006781098526     0.483437737402     0.000000000000    12.000000000000
+         N            0.678746022334    -0.997963523179     0.000000000000    14.003074004430
+         H           -1.402954174232    -1.631116647503     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   24.722621027960130
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.018541255121    -0.068483363009     0.000000000000
+       2       -0.011976320057    -0.009443278357     0.000000000000
+       3        0.030517575177     0.077926641367     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      12.66 seconds =       0.21 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -1.0067810985259733  0.4834377374016347  0.0000000000000000
+	       7.000000            14.003074        0.6787460223343709 -0.9979635231793742  0.0000000000000000
+	       1.000000             1.007825       -1.4029541742322071 -1.6311166475025503  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.244003           1.187475
+	 R(2,3)           =         2.175858           1.151415
+	 B(1,2,3)         =         1.016293          58.229315
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18748        0.25773        0.00733       1.19481
+	               R(2,3)       1.15141        0.42737        0.24947       1.40089
+	             B(1,2,3)      58.22931        0.01087        0.57041      58.79972
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     3     -92.71756641    3.51e-03      1.43e-01      8.96e-02 o    4.71e-01      2.72e-01 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4904593682   0.2794688876   0.0000000000
+	    N   0.4442778630  -0.4647328576   0.0000000000
+	    H  -0.8698185581  -0.9501611080   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.926833881619     0.528119658192     0.000000000000
+    N            0.839563484751    -0.878217822354     0.000000000000
+    H           -1.643718853556    -1.795544269119     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:33 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.926833881619     0.528119658192     0.000000000000    12.000000000000
+         N            0.839563484751    -0.878217822354     0.000000000000    14.003074004430
+         H           -1.643718853556    -1.795544269119     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      9.06431  B =      1.78866  C =      1.49387 [cm^-1]
+  Rotational constants: A = 271741.26216  B =  53622.61110  C =  44785.16891 [MHz]
+  Nuclear repulsion =   23.713241563811991
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 1.0524214905E-02.
+  Reciprocal condition number of the overlap matrix is 2.6890182749E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.61474224629335   -9.26147e+01   1.70861e-02 
+   @RHF iter   1:   -92.72062081898893   -1.05879e-01   2.55215e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72237178434141   -1.75097e-03   8.75226e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72270290736446   -3.31123e-04   5.34866e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72279581682389   -9.29095e-05   2.84850e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72283387174733   -3.80549e-05   6.12861e-05 DIIS
+   @RHF iter   6:   -92.72283613886414   -2.26712e-06   1.75106e-05 DIIS
+   @RHF iter   7:   -92.72283625553818   -1.16674e-07   5.35149e-06 DIIS
+   @RHF iter   8:   -92.72283626796852   -1.24303e-08   8.38167e-07 DIIS
+   @RHF iter   9:   -92.72283626824139   -2.72877e-10   1.28098e-07 DIIS
+   @RHF iter  10:   -92.72283626825035   -8.95284e-12   4.56037e-08 DIIS
+   @RHF iter  11:   -92.72283626825194   -1.59162e-12   1.30223e-08 DIIS
+   @RHF iter  12:   -92.72283626825208   -1.42109e-13   2.67021e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.673497     2Ap   -11.331335     3Ap    -1.341141  
+       4Ap    -0.685029     5Ap    -0.629592     1App   -0.532886  
+       6Ap    -0.491690  
+
+    Virtual:                                                              
+
+       7Ap     0.106505     2App    0.164396     8Ap     0.186720  
+       9Ap     0.468621     3App    0.750695    10Ap     0.760737  
+      11Ap     0.777194    12Ap     0.902477    13Ap     0.940026  
+       4App    0.989398    14Ap     1.059414    15Ap     1.112379  
+      16Ap     1.524174  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72283626825208
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.7132415638119909
+    One-Electron Energy =                -171.5018150268838042
+    Two-Electron Energy =                  55.0657371948197465
+    Total Energy =                        -92.7228362682520810
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.8659871           -1.3277778           -0.4617906
+ Dipole Y            :          4.3644235           -4.7743511           -0.4099275
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.6174878
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+Module time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      13.17 seconds =       0.22 minutes
+	system time =       0.38 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:33 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.926833881619     0.528119658192     0.000000000000    12.000000000000
+         N            0.839563484751    -0.878217822354     0.000000000000    14.003074004430
+         H           -1.643718853556    -1.795544269119     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.713241563811991
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.001412974981     0.012517255912     0.000000000000
+       2        0.019420423588     0.002238229910     0.000000000000
+       3       -0.018007448606    -0.014755485823     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:33 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      13.24 seconds =       0.22 minutes
+	system time =       0.38 seconds =       0.01 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9268338816187616  0.5281196581923154  0.0000000000000000
+	       7.000000            14.003074        0.8395634847513129 -0.8782178223540624  0.0000000000000000
+	       1.000000             1.007825       -1.6437188535563609 -1.7955442691185426  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.257863           1.194810
+	 R(2,3)           =         2.647297           1.400889
+	 B(1,2,3)         =         1.026249          58.799721
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.19481       -0.07334       -0.00142       1.19339
+	               R(2,3)       1.40089       -0.18129       -0.04991       1.35098
+	             B(1,2,3)      58.79972       -0.00153       -1.29791      57.50182
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     4     -92.72283627   -5.27e-03      2.20e-02      1.80e-02 o    9.43e-02      5.60e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.5041473994   0.2628145030   0.0000000000
+	    N   0.4320803869  -0.4772269799   0.0000000000
+	    H  -0.8439330508  -0.9210126011   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.952700511752     0.496647432537     0.000000000000
+    N            0.816513595477    -0.901828291731     0.000000000000
+    H           -1.594802334149    -1.740461574086     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:33 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.952700511752     0.496647432537     0.000000000000    12.000000000000
+         N            0.816513595477    -0.901828291731     0.000000000000    14.003074004430
+         H           -1.594802334149    -1.740461574086     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      9.07718  B =      1.79378  C =      1.49780 [cm^-1]
+  Rotational constants: A = 272127.04918  B =  53776.26493  C =  44902.81521 [MHz]
+  Nuclear repulsion =   23.943591559989084
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 1.0374810444E-02.
+  Reciprocal condition number of the overlap matrix is 2.6090285763E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.74817822163004   -9.27482e+01   3.73007e-03 
+   @RHF iter   1:   -92.72417400607576    2.40042e-02   5.17699e-04 ADIIS/DIIS
+   @RHF iter   2:   -92.72423673161084   -6.27255e-05   1.37366e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72424231803510   -5.58642e-06   7.28872e-05 DIIS
+   @RHF iter   4:   -92.72424355413963   -1.23610e-06   3.91680e-05 DIIS
+   @RHF iter   5:   -92.72424399677284   -4.42633e-07   6.83826e-06 DIIS
+   @RHF iter   6:   -92.72424402683707   -3.00642e-08   2.40733e-06 DIIS
+   @RHF iter   7:   -92.72424403102683   -4.18976e-09   6.98860e-07 DIIS
+   @RHF iter   8:   -92.72424403135115   -3.24320e-10   1.93538e-07 DIIS
+   @RHF iter   9:   -92.72424403137448   -2.33342e-11   6.48373e-08 DIIS
+   @RHF iter  10:   -92.72424403137776   -3.28271e-12   1.86239e-08 DIIS
+   @RHF iter  11:   -92.72424403137798   -2.13163e-13   3.40647e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.674362     2Ap   -11.330627     3Ap    -1.351690  
+       4Ap    -0.692511     5Ap    -0.636244     1App   -0.535669  
+       6Ap    -0.492796  
+
+    Virtual:                                                              
+
+       7Ap     0.115945     2App    0.163583     8Ap     0.196133  
+       9Ap     0.468415     3App    0.749739    10Ap     0.750094  
+      11Ap     0.779784    12Ap     0.897594    13Ap     0.957277  
+       4App    0.988143    14Ap     1.050753    15Ap     1.117470  
+      16Ap     1.527792  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72424403137798
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.9435915599890841
+    One-Electron Energy =                -171.9078719582187489
+    Two-Electron Energy =                  55.2400363668516974
+    Total Energy =                        -92.7242440313779781
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          1.1648173           -1.5954102           -0.4305929
+ Dipole Y            :          4.6861981           -5.0733750           -0.3871769
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.5790650
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      13.75 seconds =       0.23 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.952700511752     0.496647432537     0.000000000000    12.000000000000
+         N            0.816513595477    -0.901828291731     0.000000000000    14.003074004430
+         H           -1.594802334149    -1.740461574086     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.943591559989084
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.008005096672    -0.001853672517     0.000000000000
+       2        0.014711320471    -0.001816693317     0.000000000000
+       3       -0.006706223799     0.003670365834     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      13.82 seconds =       0.23 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9527005117516689  0.4966474325368037  0.0000000000000000
+	       7.000000            14.003074        0.8165135954770494 -0.9018282917313836  0.0000000000000000
+	       1.000000             1.007825       -1.5948023341491901 -1.7404615740857095  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.255184           1.193392
+	 R(2,3)           =         2.552989           1.350983
+	 B(1,2,3)         =         1.003596          57.501816
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.19339       -0.04227       -0.00491       1.18848
+	               R(2,3)       1.35098       -0.04225        0.04814       1.39912
+	             B(1,2,3)      57.50182        0.00110       -5.08902      52.41280
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     5     -92.72424403   -1.41e-03      1.45e-02      9.35e-03 o    9.10e-02      7.36e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.5130909459   0.2142500316   0.0000000000
+	    N   0.4647199027  -0.4612977590   0.0000000000
+	    H  -0.8676290200  -0.8883773505   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.969601365282     0.404873882073     0.000000000000
+    N            0.878193341197    -0.871726426883     0.000000000000
+    H           -1.639581226339    -1.678789888471     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.969601365282     0.404873882073     0.000000000000    12.000000000000
+         N            0.878193341197    -0.871726426883     0.000000000000    14.003074004430
+         H           -1.639581226339    -1.678789888471     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      9.08223  B =      1.79110  C =      1.49606 [cm^-1]
+  Rotational constants: A = 272278.51734  B =  53695.77173  C =  44850.79224 [MHz]
+  Nuclear repulsion =   24.089627845612348
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.8031301032E-03.
+  Reciprocal condition number of the overlap matrix is 2.4565850733E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.73498861283764   -9.27350e+01   9.24005e-03 
+   @RHF iter   1:   -92.72192305926815    1.30656e-02   1.54663e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72276501536169   -8.41956e-04   8.23903e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72298137606516   -2.16361e-04   5.62272e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72309314664290   -1.11771e-04   1.63440e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72311029684539   -1.71502e-05   3.11390e-05 DIIS
+   @RHF iter   6:   -92.72311088445996   -5.87615e-07   9.99133e-06 DIIS
+   @RHF iter   7:   -92.72311093883670   -5.43767e-08   2.71100e-06 DIIS
+   @RHF iter   8:   -92.72311094321688   -4.38018e-09   1.01583e-06 DIIS
+   @RHF iter   9:   -92.72311094403129   -8.14410e-10   3.53126e-07 DIIS
+   @RHF iter  10:   -92.72311094415515   -1.23862e-10   5.01959e-08 DIIS
+   @RHF iter  11:   -92.72311094415689   -1.73372e-12   7.31511e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.677685     2Ap   -11.322149     3Ap    -1.350627  
+       4Ap    -0.713900     5Ap    -0.628594     1App   -0.536840  
+       6Ap    -0.489659  
+
+    Virtual:                                                              
+
+       7Ap     0.103760     2App    0.164910     8Ap     0.219424  
+       9Ap     0.460207    10Ap     0.744115     3App    0.751041  
+      11Ap     0.787709    12Ap     0.895851    13Ap     0.982737  
+       4App    0.988057    14Ap     1.043138    15Ap     1.146776  
+      16Ap     1.528639  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72311094415689
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             24.0896278456123483
+    One-Electron Energy =                -172.1865713138318199
+    Two-Electron Energy =                  55.3738325240625926
+    Total Energy =                        -92.7231109441568861
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.8900394           -1.3098360           -0.4197967
+ Dipole Y            :          4.9562896           -5.3516316           -0.3953420
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.5766494
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      14.36 seconds =       0.24 minutes
+	system time =       0.42 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.969601365282     0.404873882073     0.000000000000    12.000000000000
+         N            0.878193341197    -0.871726426883     0.000000000000    14.003074004430
+         H           -1.639581226339    -1.678789888471     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   24.089627845612348
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.012406893783    -0.006378751708     0.000000000000
+       2       -0.001902289533    -0.009180105035     0.000000000000
+       3        0.014309183315     0.015558856743     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      14.43 seconds =       0.24 minutes
+	system time =       0.42 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9696013652817181  0.4048738820734400  0.0000000000000000
+	       7.000000            14.003074        0.8781933411965031 -0.8717264268825471  0.0000000000000000
+	       1.000000             1.007825       -1.6395812263385943 -1.6787898884711820  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.245897           1.188478
+	 R(2,3)           =         2.643963           1.399125
+	 B(1,2,3)         =         0.914776          52.412796
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18848       -0.05423       -0.00430       1.18418
+	               R(2,3)       1.39912        0.15139        0.05462       1.45374
+	             B(1,2,3)      52.41280        0.00210        1.16180      53.57459
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     6     -92.72311094    1.13e-03      2.76e-02      1.95e-02 o    1.03e-01      6.09e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4958319511   0.2277101030   0.0000000000
+	    N   0.4777105495  -0.4464474087   0.0000000000
+	    H  -0.8978786616  -0.9166877723   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.936986591742     0.430309730711     0.000000000000
+    N            0.902742105703    -0.843663331781     0.000000000000
+    H           -1.696744764385    -1.732288832210     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.936986591742     0.430309730711     0.000000000000    12.000000000000
+         N            0.902742105703    -0.843663331781     0.000000000000    14.003074004430
+         H           -1.696744764385    -1.732288832210     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      9.12616  B =      1.79887  C =      1.50267 [cm^-1]
+  Rotational constants: A = 273595.44694  B =  53928.62977  C =  45048.98606 [MHz]
+  Nuclear repulsion =   23.934366020514354
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.7676622416E-03.
+  Reciprocal condition number of the overlap matrix is 2.4867611876E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.70498545355733   -9.27050e+01   4.33046e-03 
+   @RHF iter   1:   -92.72379998739139   -1.88145e-02   5.25708e-04 ADIIS/DIIS
+   @RHF iter   2:   -92.72387259735798   -7.26100e-05   1.51917e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72388300222855   -1.04049e-05   6.85489e-05 DIIS
+   @RHF iter   4:   -92.72388571230405   -2.71008e-06   4.11070e-05 DIIS
+   @RHF iter   5:   -92.72388626475909   -5.52455e-07   1.59485e-05 DIIS
+   @RHF iter   6:   -92.72388644921094   -1.84452e-07   4.28267e-06 DIIS
+   @RHF iter   7:   -92.72388646296814   -1.37572e-08   1.11202e-06 DIIS
+   @RHF iter   8:   -92.72388646375174   -7.83601e-10   4.34369e-07 DIIS
+   @RHF iter   9:   -92.72388646388501   -1.33269e-10   1.56801e-07 DIIS
+   @RHF iter  10:   -92.72388646390444   -1.94262e-11   3.12313e-08 DIIS
+   @RHF iter  11:   -92.72388646390472   -2.84217e-13   4.20329e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.674979     2Ap   -11.321730     3Ap    -1.342310  
+       4Ap    -0.703626     5Ap    -0.623970     1App   -0.535190  
+       6Ap    -0.488735  
+
+    Virtual:                                                              
+
+       7Ap     0.095690     2App    0.168016     8Ap     0.210781  
+       9Ap     0.460688     3App    0.751297    10Ap     0.758712  
+      11Ap     0.784690    12Ap     0.904162    13Ap     0.963538  
+       4App    0.990799    14Ap     1.047995    15Ap     1.143811  
+      16Ap     1.529027  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72388646390472
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.9343660205143536
+    One-Electron Energy =                -171.9354225860151928
+    Two-Electron Energy =                  55.2771701015961270
+    Total Energy =                        -92.7238864639047193
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.5411754           -0.9994696           -0.4582942
+ Dipole Y            :          4.6335632           -5.0560738           -0.4225106
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.6233368
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      14.95 seconds =       0.25 minutes
+	system time =       0.44 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.936986591742     0.430309730711     0.000000000000    12.000000000000
+         N            0.902742105703    -0.843663331781     0.000000000000    14.003074004430
+         H           -1.696744764385    -1.732288832210     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.934366020514354
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.007059359329     0.010137731543     0.000000000000
+       2       -0.007634132653     0.000300232738     0.000000000000
+       3        0.000574773324    -0.010437964281     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      15.02 seconds =       0.25 minutes
+	system time =       0.45 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9369865917421235  0.4303097307112949  0.0000000000000000
+	       7.000000            14.003074        0.9027421057032951 -0.8436633317811943  0.0000000000000000
+	       1.000000             1.007825       -1.6967447643849807 -1.7322888322103898  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.237769           1.184176
+	 R(2,3)           =         2.747178           1.453744
+	 B(1,2,3)         =         0.935053          53.574593
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18418        0.00027        0.00541       1.18959
+	               R(2,3)       1.45374       -0.02334       -0.06251       1.39124
+	             B(1,2,3)      53.57459       -0.00210        4.47323      58.04782
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     7     -92.72388646   -7.76e-04      2.76e-02      1.60e-02 o    1.18e-01      8.20e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.4915559297   0.2696452832   0.0000000000
+	    N   0.4423704031  -0.4671744112   0.0000000000
+	    H  -0.8668145366  -0.9378959499   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.928906082415     0.509555736252     0.000000000000
+    N            0.835958907788    -0.882831690023     0.000000000000
+    H           -1.638042075797    -1.772366479509     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.928906082415     0.509555736252     0.000000000000    12.000000000000
+         N            0.835958907788    -0.882831690023     0.000000000000    14.003074004430
+         H           -1.638042075797    -1.772366479509     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      9.07964  B =      1.80187  C =      1.50350 [cm^-1]
+  Rotational constants: A = 272200.74258  B =  54018.59187  C =  45073.66446 [MHz]
+  Nuclear repulsion =   23.856759412603612
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 1.0281880624E-02.
+  Reciprocal condition number of the overlap matrix is 2.6130674925E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.70123570088862   -9.27012e+01   8.24953e-03 
+   @RHF iter   1:   -92.72233657760313   -2.11009e-02   1.48638e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72312277411734   -7.86197e-04   7.76480e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72333057168944   -2.07798e-04   5.30679e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72343003292261   -9.94612e-05   1.51769e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72344386205926   -1.38291e-05   3.44035e-05 DIIS
+   @RHF iter   6:   -92.72344448751080   -6.25452e-07   1.05684e-05 DIIS
+   @RHF iter   7:   -92.72344454627381   -5.87630e-08   2.41138e-06 DIIS
+   @RHF iter   8:   -92.72344454984730   -3.57349e-09   7.87215e-07 DIIS
+   @RHF iter   9:   -92.72344455030732   -4.60020e-10   2.84334e-07 DIIS
+   @RHF iter  10:   -92.72344455038009   -7.27738e-11   4.51723e-08 DIIS
+   @RHF iter  11:   -92.72344455038160   -1.50635e-12   6.12486e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.673132     2Ap   -11.329096     3Ap    -1.346010  
+       4Ap    -0.688009     5Ap    -0.631874     1App   -0.534926  
+       6Ap    -0.491713  
+
+    Virtual:                                                              
+
+       7Ap     0.108716     2App    0.166077     8Ap     0.191813  
+       9Ap     0.468315     3App    0.750155    10Ap     0.757996  
+      11Ap     0.777888    12Ap     0.901832    13Ap     0.946505  
+       4App    0.989869    14Ap     1.056694    15Ap     1.120636  
+      16Ap     1.529215  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72344455038160
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.8567594126036120
+    One-Electron Energy =                -171.7708893217541117
+    Two-Electron Energy =                  55.1906853587688815
+    Total Energy =                        -92.7234445503816005
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.9060457           -1.3597662           -0.4537205
+ Dipole Y            :          4.4869873           -4.8948539           -0.4078666
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.6100962
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      15.54 seconds =       0.26 minutes
+	system time =       0.46 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.928906082415     0.509555736252     0.000000000000    12.000000000000
+         N            0.835958907788    -0.882831690023     0.000000000000    14.003074004430
+         H           -1.638042075797    -1.772366479509     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.856759412603612
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.004212111616     0.004039185304     0.000000000000
+       2        0.009374944806     0.006098107885     0.000000000000
+       3       -0.013587056422    -0.010137293189     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      15.60 seconds =       0.26 minutes
+	system time =       0.46 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9289060824152746  0.5095557362515007  0.0000000000000000
+	       7.000000            14.003074        0.8359589077879728 -0.8828316900225756  0.0000000000000000
+	       1.000000             1.007825       -1.6380420757965073 -1.7723664795092144  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.247997           1.189589
+	 R(2,3)           =         2.629059           1.391238
+	 B(1,2,3)         =         1.013126          58.047825
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18959        0.00663       -0.01050       1.17909
+	               R(2,3)       1.39124       -0.13360        0.05134       1.44258
+	             B(1,2,3)      58.04782       -0.00099       -6.63573      51.41209
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     8     -92.72344455    4.42e-04      1.62e-02      1.20e-02 o    1.16e-01      8.80e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.5041690815   0.2029621064   0.0000000000
+	    N   0.4800660348  -0.4462876036   0.0000000000
+	    H  -0.8918970166  -0.8920995808   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.952741484875     0.383542794990     0.000000000000
+    N            0.907193327976    -0.843361343976     0.000000000000
+    H           -1.685441093524    -1.685823884294     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.952741484875     0.383542794990     0.000000000000    12.000000000000
+         N            0.907193327976    -0.843361343976     0.000000000000    14.003074004430
+         H           -1.685441093524    -1.685823884294     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      9.14483  B =      1.80853  C =      1.50992 [cm^-1]
+  Rotational constants: A = 274155.06845  B =  54218.49991  C =  45266.36120 [MHz]
+  Nuclear repulsion =   24.150685522476330
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.4115252645E-03.
+  Reciprocal condition number of the overlap matrix is 2.3734103857E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.74646331702283   -9.27465e+01   1.21446e-02 
+   @RHF iter   1:   -92.72223763173527    2.42257e-02   1.99625e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72368391394855   -1.44628e-03   1.05289e-03 ADIIS/DIIS
+   @RHF iter   3:   -92.72405609303168   -3.72179e-04   7.15346e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72423676482268   -1.80672e-04   2.22626e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72426803372949   -3.12689e-05   4.69123e-05 DIIS
+   @RHF iter   6:   -92.72426949465478   -1.46093e-06   1.48877e-05 DIIS
+   @RHF iter   7:   -92.72426963199607   -1.37341e-07   4.92012e-06 DIIS
+   @RHF iter   8:   -92.72426964923724   -1.72412e-08   2.00663e-06 DIIS
+   @RHF iter   9:   -92.72426965269624   -3.45899e-09   5.71743e-07 DIIS
+   @RHF iter  10:   -92.72426965300502   -3.08788e-10   7.74665e-08 DIIS
+   @RHF iter  11:   -92.72426965300880   -3.78009e-12   1.19140e-08 DIIS
+   @RHF iter  12:   -92.72426965300876    4.26326e-14   2.15947e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.675276     2Ap   -11.317613     3Ap    -1.347805  
+       4Ap    -0.715435     5Ap    -0.625049     1App   -0.537251  
+       6Ap    -0.488342  
+
+    Virtual:                                                              
+
+       7Ap     0.097705     2App    0.169215     8Ap     0.223151  
+       9Ap     0.457862    10Ap     0.749878     3App    0.750904  
+      11Ap     0.787922    12Ap     0.900183    13Ap     0.984751  
+       4App    0.991091    14Ap     1.043950    15Ap     1.164165  
+      16Ap     1.535921  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72426965300876
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             24.1506855224763299
+    One-Electron Energy =                -172.3363651366070144
+    Two-Electron Energy =                  55.4614099611219231
+    Total Energy =                        -92.7242696530087755
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.6068481           -1.0515367           -0.4446886
+ Dipole Y            :          4.8752349           -5.2880965           -0.4128617
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.6067971
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      16.14 seconds =       0.27 minutes
+	system time =       0.48 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.952741484875     0.383542794990     0.000000000000    12.000000000000
+         N            0.907193327976    -0.843361343976     0.000000000000    14.003074004430
+         H           -1.685441093524    -1.685823884294     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   24.150685522476330
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.005271573177    -0.003917522440     0.000000000000
+       2       -0.020254679398    -0.001266906300     0.000000000000
+       3        0.014983106222     0.005184428740     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      16.21 seconds =       0.27 minutes
+	system time =       0.48 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9527414848751103  0.3835427949900482  0.0000000000000000
+	       7.000000            14.003074        0.9071933279755539 -0.8433613439764761  0.0000000000000000
+	       1.000000             1.007825       -1.6854410935242525 -1.6858238842938613  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.228150           1.179086
+	 R(2,3)           =         2.726077           1.442578
+	 B(1,2,3)         =         0.897310          51.412091
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.17909        0.05403        0.00810       1.18719
+	               R(2,3)       1.44258        0.13060       -0.04402       1.39856
+	             B(1,2,3)      51.41209        0.00006        3.71184      55.12393
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     9     -92.72426965   -8.25e-04      1.59e-02      9.92e-03 o    8.32e-02      6.15e-02 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.5014386017   0.2406566128   0.0000000000
+	    N   0.4547806115  -0.4629438392   0.0000000000
+	    H  -0.8693420731  -0.9131378516   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.947581625927     0.454775088542     0.000000000000
+    N            0.859410802950    -0.874837067505     0.000000000000
+    H           -1.642818427447    -1.725580454317     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.947581625927     0.454775088542     0.000000000000    12.000000000000
+         N            0.859410802950    -0.874837067505     0.000000000000    14.003074004430
+         H           -1.642818427447    -1.725580454317     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      9.09289  B =      1.80148  C =      1.50359 [cm^-1]
+  Rotational constants: A = 272597.95124  B =  54007.08399  C =  45076.52626 [MHz]
+  Nuclear repulsion =   23.991517966838867
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.9862181741E-03.
+  Reciprocal condition number of the overlap matrix is 2.5206727049E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.69609992466528   -9.26961e+01   7.20062e-03 
+   @RHF iter   1:   -92.72289930795834   -2.67994e-02   1.24280e-03 ADIIS/DIIS
+   @RHF iter   2:   -92.72346759728606   -5.68289e-04   6.32461e-04 ADIIS/DIIS
+   @RHF iter   3:   -92.72362132823386   -1.53731e-04   4.32161e-04 ADIIS/DIIS
+   @RHF iter   4:   -92.72368713581099   -6.58076e-05   1.44221e-04 ADIIS/DIIS
+   @RHF iter   5:   -92.72369931289812   -1.21771e-05   3.78513e-05 DIIS
+   @RHF iter   6:   -92.72370014964179   -8.36744e-07   1.06469e-05 DIIS
+   @RHF iter   7:   -92.72370021605124   -6.64095e-08   3.22665e-06 DIIS
+   @RHF iter   8:   -92.72370022343762   -7.38638e-09   1.04899e-06 DIIS
+   @RHF iter   9:   -92.72370022432031   -8.82693e-10   3.32858e-07 DIIS
+   @RHF iter  10:   -92.72370022442003   -9.97176e-11   3.90713e-08 DIIS
+   @RHF iter  11:   -92.72370022442102   -9.94760e-13   4.77764e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.675235     2Ap   -11.325070     3Ap    -1.348880  
+       4Ap    -0.700363     5Ap    -0.630245     1App   -0.536397  
+       6Ap    -0.490643  
+
+    Virtual:                                                              
+
+       7Ap     0.106000     2App    0.166242     8Ap     0.205827  
+       9Ap     0.464303     3App    0.750464    10Ap     0.752459  
+      11Ap     0.782677    12Ap     0.899659    13Ap     0.963089  
+       4App    0.989271    14Ap     1.049926    15Ap     1.132489  
+      16Ap     1.529800  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72370022442102
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.9915179668388667
+    One-Electron Energy =                -172.0167717574415747
+    Two-Electron Energy =                  55.3015535661816884
+    Total Energy =                        -92.7237002244210089
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.8758443           -1.3124326           -0.4365883
+ Dipole Y            :          4.7162975           -5.1207894           -0.4044919
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.5951664
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      16.72 seconds =       0.28 minutes
+	system time =       0.49 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.947581625927     0.454775088542     0.000000000000    12.000000000000
+         N            0.859410802950    -0.874837067505     0.000000000000    14.003074004430
+         H           -1.642818427447    -1.725580454317     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.991517966838867
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000473057712    -0.000168007209     0.000000000000
+       2        0.000180620602     0.000520298652     0.000000000000
+       3       -0.000653678314    -0.000352291443     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      16.79 seconds =       0.28 minutes
+	system time =       0.50 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9475816259267723  0.4547750885420321  0.0000000000000000
+	       7.000000            14.003074        0.8594108029495456 -0.8748370675052539  0.0000000000000000
+	       1.000000             1.007825       -1.6428184274465825 -1.7255804543170672  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.243455           1.187185
+	 R(2,3)           =         2.642899           1.398562
+	 B(1,2,3)         =         0.962094          55.123927
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18719        0.00396        0.00003       1.18722
+	               R(2,3)       1.39856       -0.00603        0.00176       1.40033
+	             B(1,2,3)      55.12393       -0.00002       -0.16209      54.96184
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	    10     -92.72370022    5.69e-04      7.32e-04      5.39e-04 o    3.33e-03      2.52e-03 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.5017629596   0.2391995735   0.0000000000
+	    N   0.4559457344  -0.4624255062   0.0000000000
+	    H  -0.8701828381  -0.9121991452   0.0000000000
+
+
+    Structure for next step:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.948194573488     0.452021683184     0.000000000000
+    N            0.861612566092    -0.873857560067     0.000000000000
+    H           -1.644407243028    -1.723806556397     0.000000000000
+
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.948194573488     0.452021683184     0.000000000000    12.000000000000
+         N            0.861612566092    -0.873857560067     0.000000000000    14.003074004430
+         H           -1.644407243028    -1.723806556397     0.000000000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      9.09403  B =      1.80078  C =      1.50313 [cm^-1]
+  Rotational constants: A = 272632.03292  B =  53986.10831  C =  45062.84434 [MHz]
+  Nuclear repulsion =   23.992292195213906
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: 6-31G
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry C          line    87 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 2 entry N          line   102 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+    atoms 3 entry H          line    26 file /home/zander/github/psi4/objdir/stage/share/psi4/basis/6-31g.gbs 
+
+  Reading orbitals from file /tmp/output.default.330641.180.npy, no projection.
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 4
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3972 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+    28.92 percent of shell quartets recomputed by reordering.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              4
+
+  Minimum eigenvalue in the overlap matrix is 9.9749474481E-03.
+  Reciprocal condition number of the overlap matrix is 2.5177734004E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A'        16      16       6       6       6       0
+     A"         4       4       1       1       1       0
+   -------------------------------------------------------
+    Total      20      20       7       7       7       0
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -92.72406815609587   -9.27241e+01   2.85793e-04 
+   @RHF iter   1:   -92.72369847261261    3.69683e-04   4.86558e-05 DIIS
+   @RHF iter   2:   -92.72369933905993   -8.66447e-07   2.47652e-05 DIIS
+   @RHF iter   3:   -92.72369957389226   -2.34832e-07   1.73266e-05 DIIS
+   @RHF iter   4:   -92.72369967024072   -9.63485e-08   5.06370e-06 DIIS
+   @RHF iter   5:   -92.72369968604514   -1.58044e-08   7.90387e-07 DIIS
+   @RHF iter   6:   -92.72369968641760   -3.72467e-10   2.45745e-07 DIIS
+   @RHF iter   7:   -92.72369968645076   -3.31539e-11   4.46432e-08 DIIS
+   @RHF iter   8:   -92.72369968645202   -1.26477e-12   2.01497e-08 DIIS
+   @RHF iter   9:   -92.72369968645235   -3.26850e-13   6.30537e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -15.675363     2Ap   -11.324865     3Ap    -1.348711  
+       4Ap    -0.701016     5Ap    -0.629960     1App   -0.536370  
+       6Ap    -0.490541  
+
+    Virtual:                                                              
+
+       7Ap     0.105578     2App    0.166211     8Ap     0.206506  
+       9Ap     0.464019     3App    0.750522    10Ap     0.752341  
+      11Ap     0.782962    12Ap     0.899614    13Ap     0.963824  
+       4App    0.989244    14Ap     1.049603    15Ap     1.133155  
+      16Ap     1.529615  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     6,    1 ]
+    NA   [     6,    1 ]
+    NB   [     6,    1 ]
+
+  @RHF Final Energy:   -92.72369968645235
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             23.9922921952139063
+    One-Electron Energy =                -172.0183300537175626
+    Two-Electron Energy =                  55.3023381720513143
+    Total Energy =                        -92.7236996864523348
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.8658667           -1.3022867           -0.4364200
+ Dipole Y            :          4.7240431           -5.1286794           -0.4046363
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.5951412
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.36 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      17.28 seconds =       0.29 minutes
+	system time =       0.51 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on nidavellir
+*** at Tue Dec  6 14:18:34 2022
+
+
+         ------------------------------------------------------------
+                                   SCF GRAD                          
+                          Rob Parrish, Justin Turney,                
+                       Andy Simmonett, and Alex Sokolov              
+         ------------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.948194573488     0.452021683184     0.000000000000    12.000000000000
+         N            0.861612566092    -0.873857560067     0.000000000000    14.003074004430
+         H           -1.644407243028    -1.723806556397     0.000000000000     1.007825032230
+
+  Nuclear repulsion =   23.992292195213906
+
+  ==> Basis Set <==
+
+  Basis Set: 6-31G
+    Blend: 6-31G
+    Number of shells: 12
+    Number of basis functions: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> DirectJKGrad: Integral-Direct SCF Gradients <==
+
+    Gradient:                    1
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           4
+    Schwarz Cutoff:          1E-12
+
+
+  -Total Gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000079919257     0.000078872197     0.000000000000
+       2       -0.000027266308     0.000038229016     0.000000000000
+       3       -0.000052652950    -0.000117101213     0.000000000000
+
+
+*** tstop() called on nidavellir at Tue Dec  6 14:18:34 2022
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      17.34 seconds =       0.29 minutes
+	system time =       0.52 seconds =       0.01 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+    			-----------------------------------------
+
+    			 OPTKING 3.0: for geometry optimizations 
+
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       6.000000            12.000000       -0.9481945734882358  0.4520216831837158  0.0000000000000000
+	       7.000000            14.003074        0.8616125660921277 -0.8738575600665194  0.0000000000000000
+	       1.000000             1.007825       -1.6444072430277010 -1.7238065563974854  0.0000000000000000
+
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         2.243515           1.187217
+	 R(2,3)           =         2.646233           1.400326
+	 B(1,2,3)         =         0.959265          54.961835
+
+
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       1.18722        0.00015        0.00002       1.18724
+	               R(2,3)       1.40033       -0.00072       -0.00035       1.39997
+	             B(1,2,3)      54.96184       -0.00002       -0.00228      54.95956
+	-------------------------------------------------------------------------------
+
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	    11     -92.72369969    5.38e-07 *    2.49e-04 *    1.53e-04 o    6.64e-04 *    3.85e-04 o  ~
+	----------------------------------------------------------------------------------------------
+
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    C  -0.5018473538   0.2391625741   0.0000000000
+	    N   0.4558420576  -0.4625236650   0.0000000000
+	    H  -0.8699947670  -0.9120639871   0.0000000000
+
+
+    Final optimized geometry and variables:
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+    C           -0.948194573488     0.452021683184     0.000000000000
+    N            0.861612566092    -0.873857560067     0.000000000000
+    H           -1.644407243028    -1.723806556397     0.000000000000
+
+    6-31G(D) SCF optimization of SF4......................................................PASSED
+
+    Psi4 stopped on: Tuesday, 06 December 2022 02:18PM
+    Psi4 wall time for execution: 0:00:05.70
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/opt16/test_input.py
+++ b/tests/opt16/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("opt;noc1")
+def test_opt16():
+    ctest_runner(__file__)
+


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Fixes a bug encountered when running optimizations in BAKERJCC96. All calculations in a finite difference
calculation were writing orbitals to disk and overwriting the old orbitals. Only reference calculation should
be saved. In cases were the symmetry was lowered in one of the last displacements, subsequent gradient calculations
were failing to read orbitals.

```  
File "/home/zander/github/psi4/objdir/stage/lib/psi4/driver/procrouting/proc.py", line 1761, in scf_helper
    raise ValidationError("Cannot compute projection of different symmetries.")
```

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] scf_helper assumes orbitals should always be written. Passes `write_orbitals` = `false` through kwargs for displacements

## Questions
- [ ] The new test is an optimization, would a test in ddd-function-kwargs  or similar be preferred?

## Checklist
- [x] Tests added for any new features
- [x] full ctest (Psi4, Psi4 + [CheMPS2, DFTD3, dkh, gCP, gdma, simint, ecpint])

## Status
- [x] Ready for review
- [x] Ready for merge
