### PR TITLE
`UV::compute_Vx` Bugfix

### DIFF
--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -2970,7 +2970,7 @@ void UV::compute_Vx(std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret)
                     rho_bk_z[P] = C_DDOT(nlocal, phi_z[P], 1, Tbp[P], 1);
                     gamma_bbk[P] = rho_bk_x[P] * rho_bx[P];
                     gamma_bbk[P] += rho_bk_y[P] * rho_by[P];
-                    gamma_bbk[P] += rho_ak_z[P] * rho_bz[P];
+                    gamma_bbk[P] += rho_bk_z[P] * rho_bz[P];
                     gamma_bbk[P] *= 2.0;
 
                     // Alpha-Beta


### PR DESCRIPTION
## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Fix obvious bug in `UV::compute_X`
- [x] `UV::compute_Vx` is still not production-ready, sadly. While the function is correct _to within screening tolerance_, the screening procedure breaks the hermiticity of the exchange-correlation hessian. I've observed matrix elements <x_i | V'' | x_j> and <x_j | V'' | x_i> disagreements on the order of 1e-5. This leads to errors in converging Davidson algorithm tightly for TD-UKS. The problems are there for both LDA and GGA, but more severe for GGA because there are more terms to screen.

## Status
- [x] Ready for review
- [x] Ready for merge
