### PR TITLE
ecosys gha on qcarchive next

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -235,10 +235,10 @@ jobs:
         EOF
         if [[ "${{ runner.os }}" == "Linux" ]]; then
           # "next" packages aren't self-contained, and "0.15.8" not available fro py310. try again someday
-          sed -i "s;- qcfractal;;g" aux.yaml
-          sed -i "s;- qcportal;;g" aux.yaml
-          #sed -i "s;- qcfractal;- qcarchive/label/next::qcfractal;g" aux.yaml
-          #sed -i "s;- qcportal;- qcarchive/label/next::qcportal;g" aux.yaml
+          # sed -i "s;- qcfractal;;g" aux.yaml
+          # sed -i "s;- qcportal;;g" aux.yaml
+          sed -i "s;- qcfractal;- qcarchive/label/next::qcarchivetesting;g" aux.yaml
+          sed -i "s;- qcportal;- postgresql;g" aux.yaml
         fi
         if [[ "${{ runner.os }}" == "macOS" ]]; then
           sed -E -i.bak "s;- qcfractal;- qcfractal=0.15.8.1;g" aux.yaml


### PR DESCRIPTION
## Description
now tests the "next" half of #2821 on GHA. Linux is testing "next" and Mac is testing master.

## Checklist
- [x] activated existing test. (if there are other changes, I'll delete the commented lines)

## Status
- [x] Ready for review
- [x] Ready for merge
