### PR TITLE
Remove deprecated overloads of Matrix::diagonalize

### DIFF
--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -1692,10 +1692,6 @@ double Matrix::vector_dot(const Matrix *const rhs) {
 
 double Matrix::vector_dot(const SharedMatrix &rhs) { return vector_dot(rhs.get()); }
 
-void Matrix::diagonalize(Matrix *eigvectors, Vector *eigvalues, diagonalize_order nMatz /* = ascending*/) {
-    diagonalize(*eigvectors, *eigvalues, nMatz);
-}
-
 void Matrix::diagonalize(Matrix &eigvectors, Vector &eigvalues, diagonalize_order nMatz /* = ascending*/) {
     if (symmetry_) {
         throw PSIEXCEPTION("Matrix::diagonalize: Matrix is non-totally symmetric.");
@@ -1724,47 +1720,6 @@ void Matrix::diagonalize(Matrix &eigvectors, Vector &eigvalues, diagonalize_orde
 void Matrix::diagonalize(SharedMatrix &eigvectors, std::shared_ptr<Vector> &eigvalues,
                          diagonalize_order nMatz /* = ascending*/) {
     diagonalize(*eigvectors, *eigvalues, nMatz);
-}
-
-void Matrix::diagonalize(SharedMatrix &eigvectors, Vector &eigvalues, diagonalize_order nMatz /* = ascending*/) {
-    diagonalize(*eigvectors, eigvalues, nMatz);
-}
-
-void Matrix::diagonalize(SharedMatrix &metric, SharedMatrix & /*eigvectors*/, std::shared_ptr<Vector> &eigvalues,
-                         diagonalize_order /*nMatz*/) {
-    if (symmetry_) {
-        throw PSIEXCEPTION("Matrix::diagonalize: Matrix non-totally symmetric.");
-    }
-
-    // this and metric are destroyed in the process, so let's make a copy
-    // that we work with.
-    Matrix t(*this);
-    Matrix m(metric);
-
-    int lwork = 3 * max_nrow();
-    std::vector<double> work(lwork);
-
-    for (int h = 0; h < nirrep_; ++h) {
-        if (!rowspi_[h] && !colspi_[h]) continue;
-
-        int err = C_DSYGV(1, 'V', 'U', rowspi_[h], t.matrix_[h][0], rowspi_[h], m.matrix_[h][0], rowspi_[h],
-                          eigvalues->pointer(h), work.data(), lwork);
-
-        if (err != 0) {
-            if (err < 0) {
-                outfile->Printf("Matrix::diagonalize with metric: C_DSYGV: argument %d has invalid parameter.\n", -err);
-
-                abort();
-            }
-            if (err > 0) {
-                outfile->Printf("Matrix::diagonalize with metric: C_DSYGV: error value: %d\n", err);
-
-                abort();
-            }
-        }
-
-        // TODO: Sort the data according to eigenvalues.
-    }
 }
 
 std::tuple<SharedMatrix, SharedVector, SharedMatrix> Matrix::svd_temps() {

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -864,22 +864,8 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
 
     /// @{
     /// Diagonalizes this, eigvectors and eigvalues must be created by caller.  Only for symmetric matrices.
-    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and 1.7 will be the last release to have it.")
-    void diagonalize(Matrix* eigvectors, Vector* eigvalues, diagonalize_order nMatz = ascending);
-    
     void diagonalize(Matrix& eigvectors, Vector& eigvalues, diagonalize_order nMatz = ascending);
     void diagonalize(SharedMatrix& eigvectors, std::shared_ptr<Vector>& eigvalues, diagonalize_order nMatz = ascending);
-
-    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and 1.7 will be the last release to have it.")
-    void diagonalize(SharedMatrix& eigvectors, Vector& eigvalues, diagonalize_order nMatz = ascending);
-    /// @}
-
-    /// @{
-    /// Diagonalizes this, applying supplied metric, eigvectors and eigvalues must be created by caller.  Only for
-    /// symmetric matrices.
-    PSI_DEPRECATED("This Matrix::diagonalize overload is deprecated and 1.7 will be the last release to have it.")
-    void diagonalize(SharedMatrix& metric, SharedMatrix& eigvectors, std::shared_ptr<Vector>& eigvalues,
-                     diagonalize_order nMatz = ascending);
     /// @}
 
     /// @{


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR removes the `Matrix::diagonalize` overloads deprecated in PR #2738 and closes #2693 as done/superseded.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Deprecated `PSI_API` member function `Matrix::diagonalize(Matrix* eigvectors, Vector* eigvalues, diagonalize_order nMatz = ascending)` is removed.
- [x] Deprecated `PSI_API` member function `Matrix::diagonalize(SharedMatrix& eigvectors, Vector& eigvalues, diagonalize_order nMatz = ascending)` is removed.
- [x] Deprecated `PSI_API` member function `Matrix::diagonalize(SharedMatrix& metric, SharedMatrix& eigvectors, std::shared_ptr<Vector>& eigvalues, diagonalize_order nMatz = ascending)` is removed.

## Checklist
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
