### PR TITLE
np.float update

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -34,7 +34,8 @@ jobs:
       if: ${{ github.repository == 'psi4/psi4' }}
       uses: conda-incubator/setup-miniconda@v2
       with:
-        mamba-version: "*"
+        miniforge-variant: Mambaforge
+        use-mamba: true
         activate-environment: test
         add-pip-as-python-dependency: true
         auto-activate-base: false

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -5,7 +5,7 @@ dependencies:
   - blas=*=mkl
   - intel-openmp!=2019.5
     # build
-  - cmake>=3.15
+  - cmake
   - doxygen
   - gxx_linux-64
     # core

--- a/psi4/driver/qcdb/bfs.py
+++ b/psi4/driver/qcdb/bfs.py
@@ -152,7 +152,7 @@ def _get_covalent_radii(elem):
     except AttributeError:
         caps = [qcel.periodictable.to_E(z) for z in elem]
 
-    covrad = np.fromiter((covalent_radii_lookup[caps[at]] for at in range(nat)), dtype=np.float, count=nat)
+    covrad = np.fromiter((covalent_radii_lookup[caps[at]] for at in range(nat)), dtype=float, count=nat)
     return np.divide(covrad, qcel.constants.bohr2angstroms)
 
 


### PR DESCRIPTION
## Description
- [x] Package build on Windows was getting the error below. From https://numpy.org/doc/stable/user/basics.types.html, I think this'll fix it. (Also probing whether an Azure error in another PR is repeatable.)

```
Tests failed for psi4-1.8a1.dev6+758d3af-py38_0.tar.bz2 - moving package to C:\tools\miniconda3\conda-bld\broken
WARNING:conda_build.build:Tests failed for psi4-1.8a1.dev6+758d3af-py38_0.tar.bz2 - moving package to C:\tools\miniconda3\conda-bld\broken
E         File "%PREFIX%\lib\site-packages\psi4\driver\qcdb\bfs.py", line 80, in BFS

E           radii = _get_covalent_radii(elem)

E         File "%PREFIX%\lib\site-packages\psi4\driver\qcdb\bfs.py", line 155, in _get_covalent_radii

E           covrad = np.fromiter((covalent_radii_lookup[caps[at]] for at in range(nat)), dtype=np.float, count=nat)

E         File "%PREFIX%\lib\site-packages\numpy\__init__.py", line 284, in __getattr__

E           raise AttributeError("module {!r} has no attribute "

E       

E       AttributeError: module 'numpy' has no attribute 'float'

E       

E       Printing out the relevant lines from the Psithon --> Python processed input file:

E             [10, 33], 

E             [11, 34, 35], 

E             [17], 

E             [18]] 

E           qmol = qcdb.Molecule.from_string(iceIh, dtype='xyz')

E       --> frag, arrs, bmols, bmol = qmol.BFS(seed_atoms=[[3,16], [21]], return_arrays=True, return_molecule=True, return_molecules=True)

E           compare_integers(frag == ref_fragmentation, 1, 'Q: BFS from qcdb.Molecule') 

E           compare_arrays(qmol.geometry(np_out=True)[[1, 14, 19]], arrs[0][3], 4, 'Q: geom back from BFS') 

E           compare_integers(15, bmol.nfragments(), 'Q: nfrag') 

E           compare_values(qmol.nuclear_repulsion_energy(), bmol.nuclear_repulsion_energy(), 4, 'Q: nre') 

E           compare_arrays(qmol.geometry(np_out=True)[[2, 13, 20]], bmols[4].geometry(np_out=True), 4, 'Q: frag geom back from BFS') 
```
- [x] The docs-pr build has been failing on several PRs due to the docs.yaml env not solving. It solves locally for me on conda, but apparently not on the mamba setup we have in the GHA. I've switched that out with a new "boot-conda" that I've been using over at L2. Seems to get the env solved. Probably now the master docs GHA will need the same treatment.

## Status
- [x] Ready for review
- [x] Ready for merge
