### PR TITLE
Restore DCT-06 with spin restriction.

### DIFF
--- a/psi4/src/psi4/dct/dct_compute_RHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_RHF.cc
@@ -52,7 +52,7 @@ double DCTSolver::compute_energy_RHF() {
     orbitalsDone_ = false;
     cumulantDone_ = false;
     energyConverged_ = false;
-    initialize_orbitals_from_reference_U();
+    initialize_orbitals_from_reference_R();
 
     // If DCT computation type is density fitting, build b(Q|mn)
     if (options_.get_str("DCT_TYPE") == "DF") {
@@ -139,7 +139,7 @@ void DCTSolver::run_simult_dct_RHF() {
     global_dpd_->buf4_init(&Lbb, PSIF_DCT_DPD, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                            "Amplitude <oo|vv>");
     diisManager.set_error_vector_size(scf_error_a_.get(), scf_error_b_.get(), &Laa, &Lab, &Lbb);
-    diisManager.set_error_vector_size(Fa_.get(), Fb_.get(), &Laa, &Lab, &Lbb);
+    diisManager.set_vector_size(Fa_.get(), Fb_.get(), &Laa, &Lab, &Lbb);
     global_dpd_->buf4_close(&Laa);
     global_dpd_->buf4_close(&Lab);
     global_dpd_->buf4_close(&Lbb);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,7 +42,7 @@ foreach(test_name aediis-1
                   cisd-h2o+-2 cisd-h2o-clpse cisd-opt-fd cisd-sp cisd-sp-2
                   ci-property cubeprop cubeprop-frontier decontract dct-grad1 dct-grad2
                   dct-grad3 dct-grad4 dct1 dct2 dct3 dct4 dct5 dct6 dct7 dct8 dct9
-                  dct10 dct11 ao-dfcasscf-sp density-screen-1 density-screen-2 dfcasscf-sa-sp
+                  dct10 dct11 dct12 ao-dfcasscf-sp density-screen-1 density-screen-2 dfcasscf-sa-sp
                   dfcasscf-fzc-sp dfcasscf-sp dfccd1 dfccdl1 dfccd-grad1 dfccsd1 dfccsdl1 dfccsd-grad1
                   dfccsd-t-grad1
                   dfccsdt1 dfccsdat1 dfmp2-1 dfmp2-2 dfmp2-3 dfmp2-4 dfmp2-fc dfmp2-freq1 dfmp2-freq2

--- a/tests/dct12/CMakeLists.txt
+++ b/tests/dct12/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(dct12 "psi;noc1;dct")

--- a/tests/dct12/input.dat
+++ b/tests/dct12/input.dat
@@ -1,0 +1,25 @@
+#! Spin-restricted DC-06 counterpart of dct1.
+
+refnuc      =  0.66147151334 #TEST
+refscf      = -5.71032245823742 #TEST
+refmp2      = -5.76128209224125 #TEST
+refdctscf  = -5.62714230598082 #TEST
+refdct     = -5.7753165991245554 #TEST
+
+molecule he2 {
+    He
+    He 1 3.2
+}
+
+set {
+    r_convergence 12
+    basis       6-31G**
+}
+
+set dct_functional dc-06
+energy('dct')
+compare_values(refnuc, he2.nuclear_repulsion_energy(), 10, "Nuclear Repulsion Energy"); #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 10, "SCF Energy");             #TEST
+compare_values(refmp2, variable("MP2 TOTAL ENERGY"), 10, "MP2 Energy");                   #TEST
+compare_values(refdctscf, variable("DCT SCF ENERGY"), 10, "DC-06 SCF Energy");     #TEST
+compare_values(refdct, variable("DCT TOTAL ENERGY"), 10, "DC-06 Energy");                #TEST

--- a/tests/dct12/output.ref
+++ b/tests/dct12/output.ref
@@ -1,0 +1,360 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.8a1.dev17 
+
+                         Git: Rev {gh2231} b76cc86 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Monday, 23 January 2023 03:35PM
+
+    Process ID: 11818
+    Host:       jonathons-mbp.wireless.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Spin-restricted DC-06 counterpart of dct1.
+
+refnuc      =  0.66147151334 #TEST
+refscf      = -5.71032245823742 #TEST
+refmp2      = -5.76128209224125 #TEST
+refdctscf  = -5.62714230598082 #TEST
+refdct     = -5.7753165991245554 #TEST
+
+molecule he2 {
+    He
+    He 1 3.2
+}
+
+set {
+    r_convergence 12
+    basis       6-31G**
+}
+
+set dct_functional dc-06
+energy('dct')
+compare_values(refnuc, he2.nuclear_repulsion_energy(), 10, "Nuclear Repulsion Energy"); #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 10, "SCF Energy");             #TEST
+compare_values(refmp2, variable("MP2 TOTAL ENERGY"), 10, "MP2 Energy");                   #TEST
+compare_values(refdctscf, variable("DCT SCF ENERGY"), 10, "DC-06 SCF Energy");     #TEST
+compare_values(refdct, variable("DCT TOTAL ENERGY"), 10, "DC-06 Energy");                #TEST
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Jan 23 15:35:34 2023
+
+   => Loading Basis Set <=
+
+    Name: 6-31G**
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry HE         line    54 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/6-31gss.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         HE           0.000000000000     0.000000000000    -1.600000000000     4.002603254130
+         HE           0.000000000000     0.000000000000     1.600000000000     4.002603254130
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      0.82259  C =      0.82259 [cm^-1]
+  Rotational constants: A = ************  B =  24660.65993  C =  24660.65993 [MHz]
+  Nuclear repulsion =    0.661471513337500
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 4
+  Nalpha       = 2
+  Nbeta        = 2
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G**
+    Blend: 6-31G**
+    Number of shells: 6
+    Number of basis functions: 10
+    Number of Cartesian functions: 10
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:               6
+      Number of primitives:             10
+      Number of atomic orbitals:        10
+      Number of basis functions:        10
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 3080 doubles for integral storage.
+  We computed 212 shell quartets total.
+  Whereas there are 231 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.6457028609E-01.
+  Reciprocal condition number of the overlap matrix is 2.2292017993E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag         3       3 
+     B1g        0       0 
+     B2g        1       1 
+     B3g        1       1 
+     Au         0       0 
+     B1u        3       3 
+     B2u        1       1 
+     B3u        1       1 
+   -------------------------
+    Total      10      10
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:    -5.71032270527206   -5.71032e+00   0.00000e+00 
+   @RHF iter   1:    -5.71032243225501    2.73017e-07   5.04685e-05 DIIS
+   @RHF iter   2:    -5.71032245810352   -2.58485e-08   3.62238e-06 DIIS
+   @RHF iter   3:    -5.71032245823732   -1.33793e-10   2.70921e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag    -0.915192     1B1u   -0.913062  
+
+    Virtual:                                                              
+
+       2Ag     1.385550     2B1u    1.414364     3Ag     2.181995  
+       1B2u    2.182002     1B3u    2.182002     1B2g    2.182002  
+       1B3g    2.182002     3B1u    2.182025  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     1,    0,    0,    0,    0,    1,    0,    0 ]
+    NA   [     1,    0,    0,    0,    0,    1,    0,    0 ]
+    NB   [     1,    0,    0,    0,    0,    1,    0,    0 ]
+
+  @RHF Final Energy:    -5.71032245823732
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.6614715133374998
+    One-Electron Energy =                  -9.0870793185850687
+    Two-Electron Energy =                   2.7152853470102540
+    Total Energy =                         -5.7103224582373153
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Jan 23 15:35:34 2023
+Module time:
+	user time   =       0.20 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.20 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of threads:                 1
+      Number of atoms:                   2
+      Number of AO shells:               6
+      Number of SO shells:               3
+      Number of primitives:             10
+      Number of atomic orbitals:        10
+      Number of basis functions:        10
+
+      Number of irreps:                  8
+      Integral cutoff                 1.00e-12
+      Number of functions per irrep: [   3    0    1    1    0    3    1    1 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 292 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Jan 23 15:35:34 2023
+
+
+
+	***********************************************************************************
+	*                             Density Cumulant Theory                             *
+	*                by Alexander Sokolov, Andy Simmonett, and Xiao Wang              *
+	***********************************************************************************
+
+
+	Transforming two-electron integrals (transformation type: restricted)...
+	Computing MP2 amplitude guess...
+
+	*Total Hartree-Fock energy        =   -5.710322458237315
+	 Total MP2 correlation energy     =   -0.050959634004317
+	*Total MP2 energy                 =   -5.761282092241632
+
+	DCT Functional:    		 DC-06
+	DCT Type:          		 CONV
+	Algorithm:          		 SIMULTANEOUS
+	AO-Basis Integrals: 		 DISK
+
+	*=================================================================================*
+	* Cycle  RMS [F, Kappa]   RMS Lambda Error   delta E        Total Energy     DIIS *
+	*---------------------------------------------------------------------------------*
+	* 1        1.502e-05         1.616e-02     -3.506e-02     -5.796341305134068      *
+	* 2        2.172e-06         3.682e-03      1.560e-02     -5.780738272708851      *
+	* 3        3.508e-06         9.119e-04      4.071e-03     -5.776667247227996  S   *
+	* 4        1.707e-06         2.345e-04      1.013e-03     -5.775654257395320  S   *
+	* 5        6.249e-07         6.175e-05      2.522e-04     -5.775402092679598  S   *
+	* 6        2.031e-07         1.650e-05      6.356e-05     -5.775338533222913  S/E *
+	* 7        8.186e-11         1.199e-07      2.211e-05     -5.775316420340826  S/E *
+	* 8        2.633e-11         1.084e-07     -3.405e-07     -5.775316760798543  S/E *
+	* 9        3.896e-12         5.695e-08      7.679e-08     -5.775316684004538  S/E *
+	* 10       1.456e-12         1.851e-08      5.726e-08     -5.775316626743119  S/E *
+	* 11       6.799e-14         1.904e-09      2.477e-08     -5.775316601972753  S/E *
+	* 12       2.551e-14         3.381e-10      2.342e-09     -5.775316599631178  S/E *
+	* 13       4.398e-15         2.783e-11      5.485e-10     -5.775316599082673  S/E *
+	* 14       3.796e-16         5.466e-12     -5.029e-11     -5.775316599132964  S/E *
+	* 15       8.840e-17         8.897e-14      8.137e-12     -5.775316599124827  S/E *
+	*=================================================================================*
+
+	*   DC-06 SCF Energy                                 =      -5.627142305946145
+	*   DC-06 Lambda Energy                              =      -0.148174293178682
+	*   DC-06 Total Energy                               =      -5.775316599124827
+
+	Orbital occupations:
+		Doubly occupied orbitals
+		   1Ag       1.9844     1B1u      1.9843  
+
+		Virtual orbitals
+		   2Ag       0.0087     2B1u      0.0085     3Ag       0.0023     3B1u      0.0023  
+		   1B3g      0.0023     1B2g      0.0023     1B3u      0.0023     1B2u      0.0023  
+		
+
+
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Jan 23 15:35:35 2023
+Module time:
+	user time   =       0.12 seconds =       0.00 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.33 seconds =       0.01 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+    Nuclear Repulsion Energy..............................................................PASSED
+    SCF Energy............................................................................PASSED
+    MP2 Energy............................................................................PASSED
+    DC-06 SCF Energy......................................................................PASSED
+    DC-06 Energy..........................................................................PASSED
+
+    Psi4 stopped on: Monday, 23 January 2023 03:35PM
+    Psi4 wall time for execution: 0:00:00.71
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dct12/test_input.py
+++ b/tests/dct12/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("noc1;dct")
+def test_dct12():
+    ctest_runner(__file__)
+


### PR DESCRIPTION
## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Fixed a bug disabling non-orbital optimized DCT with spin restriction.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] l. 55 keeps the alpha and beta orbitals pointing to the same object.
- [x] l. 142 is the central bugfix

## Checklist
- [x] Tests added for newly working features

## Status
- [x] Ready for review
- [x] Ready for merge
