### PR TITLE
Actually clear vectors in Molecule

### DIFF
--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -228,8 +228,8 @@ void Molecule::set_reinterpret_coordentry(bool rc) { reinterpret_coordentries_ =
 
 void Molecule::clear() {
     lock_frame_ = false;
-    atoms_.empty();
-    full_atoms_.empty();
+    atoms_.clear();
+    full_atoms_.clear();
 }
 
 void Molecule::add_atom(double Z, double x, double y, double z, std::string symbol, double mass, double charge,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
`Molecule::clear()` is currently almost a no-op, because it is calling `std::vector::empty()`, which is a getter function that does not modify the object. This PR corrects that.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] The `clear()` member function of `PSI_API` class `Molecule` now correctly clears `Molecule::atoms_`  and `Molecule::full_atoms_`

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Use `std::vector::clear()` instead of `std::vector::empty()` in `Molecule::clear()`

## Questions
- [ ] What is the user/caller expectation for the state of `Molecule::atoms_`  and `Molecule::full_atoms_` after `Molecule::clear()` returns? In `molecule.h` the comment suggests it should be "zeroed out": https://github.com/psi4/psi4/blob/61c0b47982ceafd92f567934a29601610fbb1520/psi4/src/psi4/libmints/molecule.h#L137-L138 But that is not what `std::vector::clear()` does, it destructs all elements, leaving the vector with a size of zero. Moreover, the elements of `Molecule::atoms_`  and `Molecule::full_atoms_` are  `std::shared_ptr`, so what does "zeroing" really mean here?

Is the comment misleading as I suspect it is, or do callers of `Molecule::clear()` really expect it to preserve the size of `Molecule::atoms_`  and `Molecule::full_atoms_`?

## Checklist
- [x] No new features
- [ ] Tests run by the CI are passing

## Status
- [x] Ready for review
- [ ] Ready for merge
