### PR TITLE
Capitalize atom symbols for geometric

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -821,7 +821,7 @@ def optimize_geometric(name, **kwargs):
             self.p4_kwargs = p4_kwargs
     
             molecule = geometric.molecule.Molecule()
-            molecule.elem = [p4_mol.symbol(i) for i in range(p4_mol.natom())]
+            molecule.elem = [p4_mol.symbol(i).capitalize() for i in range(p4_mol.natom())]
             molecule.xyzs = [p4_mol.geometry().np * qcel.constants.bohr2angstroms] 
             molecule.build_bonds()
                                  


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

The purpose of this PR is the following:
- Fix #2871 

The bug observed when optimizing a molecule containing `Cl` atom using `geometric` via Psi4. 

## User API & Changelog headlines

- [x] Fixing compatibility with geometric 1.0

## Dev notes & details

- [x] The atom list in Psi4 is upper-cased while geometric expects a capitalized one. This is not a problem for atom symbols containing a single letter like `H`, `C` etc. but becomes a problem for `Cl`, `Br` etc.

## Questions
- [x] Are there any tests of the Psi4/geometric interface?

## Checklist
- [x] Tests added for any new features -> not a new feature
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
