### PR TITLE
Libxc citation

### DIFF
--- a/psi4/driver/procrouting/dft/dft_builder.py
+++ b/psi4/driver/procrouting/dft/dft_builder.py
@@ -405,6 +405,7 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
             sup.set_vv10_c(d_params["params"]["c"])
         dispersion = d_params
 
+    sup.set_xclib_description(core.LibXCFunctional.xclib_description())
     sup.set_max_points(npoints)
     sup.set_deriv(deriv)
     sup.set_name(func_dictionary["name"].upper())

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -188,7 +188,9 @@ void export_functional(py::module &m) {
         .def("needs_vv10", &SuperFunctional::needs_vv10, "Does this functional need VV10 dispersion.")
         .def("needs_grac", &SuperFunctional::needs_grac, "Does this functional need GRAC.")
         .def("print_out", &SuperFunctional::py_print, "Prints out functional details.")
-        .def("print_detail", &SuperFunctional::py_print_detail, "Prints all SuperFunctional information.");
+        .def("print_detail", &SuperFunctional::py_print_detail, "Prints all SuperFunctional information.")
+        .def("xclib_description", &SuperFunctional::xclib_description, "LibXC version and citation string.")
+        .def("set_xclib_description", &SuperFunctional::set_xclib_description, "Sets the LibXC version and citation string");
 
     typedef void (LibXCFunctional::*tweak_set1)(std::vector<double>, bool);
     typedef void (LibXCFunctional::*tweak_set2)(std::map<std::string, double>, bool);
@@ -203,6 +205,7 @@ void export_functional(py::module &m) {
         .def("set_omega", &LibXCFunctional::set_omega, "docstring")
         .def("set_density_cutoff", &LibXCFunctional::set_density_cutoff, "docstring")
         .def("density_cutoff", &LibXCFunctional::density_cutoff, "docstring")
+        .def("xclib_description", &LibXCFunctional::xclib_description, "query libxc for version and citation")
         .def("query_libxc", &LibXCFunctional::query_libxc, "query libxc regarding functional parameters.");
 
     py::class_<BasisFunctions, std::shared_ptr<BasisFunctions>>(m, "BasisFunctions", "docstring")

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -46,6 +46,12 @@ using namespace psi;
 
 namespace psi {
 
+std::string LibXCFunctional::xclib_description() {
+    auto xclib = "   => LibXC <=\n\n    Version " + std::string(xc_version_string()) + "\n    " +
+                         xc_reference() + " (" + xc_reference_doi() + ")";
+    return xclib;
+}
+
 LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
     xc_func_name_ = xc_name;
     func_id_ = xc_functional_get_number(xc_name.c_str());
@@ -68,10 +74,8 @@ LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
         throw PSIEXCEPTION("Could not find required LibXC functional");
     }
 
-    xclib_description_ = "   => LibXC <=\n\n    Version " + std::string(xc_version_string()) + "\n    " +
-                         xc_reference() + " (" + xc_reference_doi() + ")";
-
     // Extract citation information
+    xclib_description_ = xclib_description();
     name_ = xc_name;
     description_ = "    " + std::string(xc_functional_->info->name);
     for (size_t i = 0; i < 5; i++) {

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.h
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.h
@@ -96,6 +96,9 @@ class LibXCFunctional : public Functional {
     double vv10_b() { return vv10_b_; }
     double vv10_c() { return vv10_c_; }
     double density_cutoff() { return density_cutoff_; }
+
+    // Get libxc provenance stamp
+    static std::string xclib_description();
 };
 }  // namespace psi
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

closes #2867 


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] functionals created by dict (like TPSS or custom) weren't hitting XC_build where the libxc citation was being set. Fixed by setting the citation from a static fn on LibXCFunctional

## Checklist
- [ ] ~Tests added for any new features~
- [ ] ~[All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)~

## Status
- [x] Ready for review
- [x] Ready for merge
