### PR TITLE
Triplet TDDFT

### DIFF
--- a/doc/sphinxman/source/tdscf.rst
+++ b/doc/sphinxman/source/tdscf.rst
@@ -133,7 +133,6 @@ Known limitations
 ~~~~~~~~~~~~~~~~~
 
 .. warning:: The implementation cannot currently handle the following cases:
-             - Excited states of triplet symmetry from a restricted DFT reference.
              - Functionals with meta or VV10 components.
 
 .. warning:: The length-gauge rotatory strengths |PSIfour| computes are

--- a/psi4/driver/procrouting/response/scf_products.py
+++ b/psi4/driver/procrouting/response/scf_products.py
@@ -201,6 +201,8 @@ class TDRSCFEngine(SingleMatPerVector):
         else:
             self.product_cache = ProductCache("A")
 
+        self.needs_J_like = self.singlet or self.wfn.functional().needs_xc()
+
         # orbitals and eigenvalues
         self.Co = self.wfn.Ca_subset("SO", "OCC")
         self.Cv = self.wfn.Ca_subset("SO", "VIR")
@@ -257,7 +259,7 @@ class TDRSCFEngine(SingleMatPerVector):
 
         # Build base one and two electron quantities
         Fx = self.wfn.onel_Hx(compute_vectors)
-        twoel = self.wfn.twoel_Hx(compute_vectors, False, "SO")
+        twoel = self.wfn.twoel_Hx_full(compute_vectors, False, "SO", self.singlet)
         Jx, Kx = self._split_twoel(twoel)
 
         # Switch between rpa and tda
@@ -345,7 +347,7 @@ class TDRSCFEngine(SingleMatPerVector):
                 H1X_so = self.vector_axpy(-1.0, Kxit, H1X_so)
                 # H2x = K^T  - K singlet/triplet
                 H2X_so = self.vector_axpy(-1.0, Kxi, Kxit)
-                if self.singlet:
+                if self.needs_J_like:
                     # H1x += 4*J (singlet only)
                     H1X_so = self.vector_axpy(4.0, Jxi, H1X_so)
 
@@ -355,7 +357,7 @@ class TDRSCFEngine(SingleMatPerVector):
 
         else:
             for Fxi, Jxi in zip(Fx, Jx):
-                if self.singlet:
+                if self.needs_J_like:
                     H1X_so = self.vector_scale(4.0, Jxi)
                     H1X.append(self.vector_axpy(1.0, Fxi, self._so_to_mo(H1X_so)))
                 else:
@@ -375,13 +377,13 @@ class TDRSCFEngine(SingleMatPerVector):
         if Kx is not None:
             for Fxi, Jxi, Kxi in zip(Fx, Jx, Kx):
                 Ax_so = self.vector_scale(-1.0, self.vector_copy(Kxi))
-                if self.singlet:
+                if self.needs_J_like:
                     Ax_so = self.vector_axpy(2.0, Jxi, Ax_so)
                 Ax.append(self.vector_axpy(1.0, Fxi, self._so_to_mo(Ax_so)))
 
         else:
             for Fxi, Jxi in zip(Fx, Jx):
-                if self.singlet:
+                if self.needs_J_like:
                     Ax.append(self.vector_axpy(1.0, Fxi, self._so_to_mo(self.vector_scale(2.0, Jxi))))
                 else:
                     Ax.append(self.vector_copy(Fxi))

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -399,9 +399,6 @@ def _validate_tdscf(*, wfn, states, triplets, guess) -> None:
     # determine how many states per irrep to seek and apportion them between singlets/triplets and irreps.
 
     # validate calculation
-    if restricted and wfn.functional().needs_xc() and do_triplets:
-        raise ValidationError("TDSCF: Restricted Vx kernel only spin-adapted for singlets")
-
     if wfn.functional().is_meta() or wfn.functional().needs_vv10():
         raise ValidationError("TDSCF: Kohn-Sham Vx kernel does not support meta or VV10 functionals.")
 

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -405,6 +405,7 @@ void export_wavefunction(py::module& m) {
              "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed "
              "BasisSet *basis*",
              "basis"_a)
+        .def("twoel_Hx_full", &scf::RHF::twoel_Hx_full, "Two-electron Hessian-vector products. Triplet supported.")
         .def("mintshelper", &Wavefunction::mintshelper, "The MintsHelper object");
 
     py::class_<scf::ROHF, std::shared_ptr<scf::ROHF>, scf::HF>(m, "ROHF", "docstring")

--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -1672,7 +1672,7 @@ std::vector<SharedMatrix> RV::compute_fock_derivatives() {
     return Vx;
 }
 
-void RV::compute_Vx(std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret) {
+void RV::compute_Vx_full(std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret, bool singlet) {
     timer_on("RV: Form Vx");
 
     // => Validate object / inputs <=
@@ -1778,7 +1778,7 @@ void RV::compute_Vx(std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret)
 
         // ==> Compute functional values for block <==
         parallel_timer_on("Functional", rank);
-        auto& vals = fworker->compute_functional(pworker->point_values(), npoints);
+        auto& vals = fworker->compute_functional(pworker->point_values(), npoints, singlet);
         parallel_timer_off("Functional", rank);
 
         // ==> Define pointers to intermediates <==
@@ -2452,10 +2452,7 @@ SharedMatrix RV::compute_hessian() {
 // The triplet spin-adaptation of ∂^2/∂D^2 is needed when describing spin-symmetry breaking
 //    phenomena, e.g., excitation to a triplet or symmetry-breaking orbital rotations.
 //    This is derived by taking ∂^2/∂D^2[same-spin] - ∂^2/∂D^2[opposite-spin].
-//    In practice, this should look like taking the corresponding difference of f-derivatives
-//    and then ignoring all spin indices. Incidentally, the + combination provides the
-//    singlet spin-adpatation without redefining intermediates.
-//    WARNING! Treat this paragraph skeptically untl Psi4 actually has triplet TDDFT.
+//    Incidentally, the + combination provides the singlet spin-adaptation without redefining intermediates.
 // Geometric derivative equations assume D is a density that satisfies the SCF equations.
 //    Therefore, densities are assumed hermitian and ∂E/∂D = 0 means ∂E/∂D ∂D/∂x terms may be neglected.
 // Geometric derivative equations use a compound index (i, x) to refer to displacing atom i in the x

--- a/psi4/src/psi4/libfock/v.h
+++ b/psi4/src/psi4/libfock/v.h
@@ -174,10 +174,16 @@ class RV : public VBase {
 
     // compute_V assuming same orbitals for different spin. Computes V_alpha, not spin-summed V.
     void compute_V(std::vector<SharedMatrix> ret) override;
-    /// compute_Vx assuming same orbitals for different spin. ret[i] is Vx where x = Dx[i].
-    /// The "true" vector has 2^-0.5 Dx[i] for each input spin case and returns **half** the
-    /// α component of the output.
-    void compute_Vx(const std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret) override;
+    /// Compute the orbital derivative of the KS potential, contract against Dx, and
+    /// putting the result in ret. ret[i] is Vx where x = Dx[i]. The "true" vector has
+    /// 2^-0.5 Dx[i] for each input spin case and returns **half** the α component of the output.
+    /// The singlet flag controls whether to assume singlet spin-integration (β components
+    /// are the α components) or triplet (β components are -α components)
+    void compute_Vx_full(const std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret, bool singlet);
+    /// A convenience function to call compute_Vx_full for singlets.
+    /// And no, we can't just make singlet a default argument. Then compute_Vx has different signatures for
+    /// different VBase subclasses, so we can't call compute_Vx from VBase, which breaks the hessian code.
+    void compute_Vx(const std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret) override { compute_Vx_full(Dx, ret, true); };
     std::vector<SharedMatrix> compute_fock_derivatives() override;
     SharedMatrix compute_gradient() override;
     SharedMatrix compute_hessian() override;
@@ -195,8 +201,9 @@ class UV : public VBase {
     void finalize() override;
 
     void compute_V(std::vector<SharedMatrix> ret) override;
-    /// compute_Vx not assuming same orbitals for different spin.
-    /// ret[2n], ret[2n+1] are alpha and beta Vx where x concatenates Dx[2n] (alpha) and Dx[2n+1] (beta).
+    /// Compute the orbital derivative of the KS potential, contract against Dx, and
+    /// putting the result in ret. ret[i] is Vx where x = Dx[i].
+    /// ret[2n], ret[2n+1] are alpha and beta Vx where x concatenates Dx[2n] (α) and Dx[2n+1] (β).
     void compute_Vx(const std::vector<SharedMatrix> Dx, std::vector<SharedMatrix> ret) override;
     SharedMatrix compute_gradient() override;
 

--- a/psi4/src/psi4/libfunctional/superfunctional.h
+++ b/psi4/src/psi4/libfunctional/superfunctional.h
@@ -173,8 +173,9 @@ class SuperFunctional {
     // => Computers <= //
 
     // Populates values_
+    // If not spin polarized, singlet controls whether singlet or triplet is asked for.
     std::map<std::string, SharedVector>& compute_functional(const std::map<std::string, SharedVector>& vals,
-                                                            int npoints = -1);
+                                                            int npoints = -1, bool singlet = true);
     void test_functional(SharedVector rho_a, SharedVector rho_b, SharedVector gamma_aa, SharedVector gamma_ab,
                          SharedVector gamma_bb, SharedVector tau_a, SharedVector tau_b);
 

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -428,7 +428,7 @@ class HF : public Wavefunction {
 
     // External potentials
     void clear_external_potentials() { external_potentials_.clear(); }
-    void push_back_external_potential(const SharedMatrix& V) { external_potentials_.push_back(V); }
+    void push_back_external_potential(const SharedMatrix& Vext) { external_potentials_.push_back(Vext); }
     void set_external_cpscf_perturbation(const std::string name, PerturbedPotentialFunction fun) {
         external_cpscf_perturbations_[name] = fun;
     }

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -420,7 +420,7 @@ std::vector<SharedMatrix> RHF::onel_Hx(std::vector<SharedMatrix> x_vec) {
 
     return ret;
 }
-std::vector<SharedMatrix> RHF::twoel_Hx(std::vector<SharedMatrix> x_vec, bool combine, std::string return_basis) {
+std::vector<SharedMatrix> RHF::twoel_Hx_full(std::vector<SharedMatrix> x_vec, bool combine, std::string return_basis, bool singlet) {
     // Make sure we have a JK object
     if (!jk_) {
         throw PSIEXCEPTION("RHF::twoel_Hx: JK object is not initialized, please set option SAVE_JK to True.");
@@ -494,7 +494,7 @@ std::vector<SharedMatrix> RHF::twoel_Hx(std::vector<SharedMatrix> x_vec, bool co
             Dx.push_back(linalg::doublet(Cl[i], Cr[i], false, true));
             Vx.push_back(std::make_shared<Matrix>("Vx Temp", Dx[i]->rowspi(), Dx[i]->colspi(), Dx[i]->symmetry()));
         }
-        potential_->compute_Vx(Dx, Vx);
+        potential_->compute_Vx_full(Dx, Vx, singlet);
     }
 
     std::vector<SharedMatrix> V_ext_pert;
@@ -522,6 +522,11 @@ std::vector<SharedMatrix> RHF::twoel_Hx(std::vector<SharedMatrix> x_vec, bool co
 #endif
 
     std::vector<SharedMatrix> ret;
+    if (!singlet) {
+        for (size_t i = 0; i < x_vec.size(); i++) {
+            J[i]->zero();
+        }
+    }
     if (combine) {
         // Cocc_ni (4 * J[D]_nm - K[D]_nm - K[D]_mn) C_vir_ma
         for (size_t i = 0; i < x_vec.size(); i++) {

--- a/psi4/src/psi4/libscf_solver/rhf.h
+++ b/psi4/src/psi4/libscf_solver/rhf.h
@@ -82,7 +82,9 @@ class RHF : public HF {
     /// Hessian-vector computers and solvers
     std::vector<SharedMatrix> onel_Hx(std::vector<SharedMatrix> x) override;
     std::vector<SharedMatrix> twoel_Hx(std::vector<SharedMatrix> x, bool combine = true,
-                                       std::string return_basis = "MO") override;
+                                       std::string return_basis = "MO") override { return twoel_Hx_full(x, combine, return_basis, true); } ;
+    std::vector<SharedMatrix> twoel_Hx_full(std::vector<SharedMatrix> x, bool combine = true,
+                                       std::string return_basis = "MO", bool singlet = true);
     std::vector<SharedMatrix> cphf_Hx(std::vector<SharedMatrix> x) override;
     std::vector<SharedMatrix> cphf_solve(std::vector<SharedMatrix> x_vec, double conv_tol = 1.e-4, int max_iter = 10,
                                          int print_lvl = 1) override;

--- a/tests/pytests/test_tdscf_excitations.py
+++ b/tests/pytests/test_tdscf_excitations.py
@@ -194,10 +194,6 @@ def _rotatory_strength(e: float, etm: np.ndarray, mtm: np.ndarray, gauge: str = 
     pytest.param( "METHYLOXIRANE", 'RHF-3',     'wB97X',  'TDA',  'cc-pvdz', marks=[hyb_gga_lrc, RHF_triplet, TDA]),
 ]) # yapf: disable
 def test_tdscf(mol, ref, func, ptype, basis, molecules, reference_data):
-    # expected failures
-    if (ref == 'RHF-3') and (func != "HF"):
-        pytest.xfail("RKS Vx kernel only Spin Adapted for Singlet")
-
     molecule = molecules[mol]
     psi4.set_options({'scf_type': 'pk', 'e_convergence': 8, 'd_convergence': 8, 'save_jk': True, 'dft_radial_points': 99, 'dft_spherical_points': 590, 'dft_pruning_scheme': "None"})
     if ref == "UHF":


### PR DESCRIPTION
## Description
This PR has TDDFT triplets for LDA and GGA functionals. (Psi does not currently support any TDDFT for meta functionals.) This requires lots of moving parts, so this PR serves as a reference for how they all fit together. For ease of reviewing, I'll have smaller PRs that pull off independent pieces for analysis.

While I'm waiting for reviews, I'll update comments to show exactly how I know these spin-integration formulae are correct, for the benefit of future debuggers.

Closes #2841.

## Status

There are four parts that I can split into separate PRs for reviewer convenience. Then I can bring in this PR.

- [x] #2886
- [x] #2887
- [x] #2888
- [x] #2889

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Triplet TDDFT excitations from RKS are now supported.

## Theoretical Analysis

Why were DFT triplets harder than HF triplets? To understand this, we need to understand both the origin of the triplet matrix and the spin properties of the relevant matrix elements.

1. Starting from the UKS RPA/TDA matrices when Ca = Cb, we can do a similarity transformation to obtain the singlet and triplet RKS matrices. The new basis elements for the singlet block all take the form (i->a α + i->a β) / sqrt(2), while the new basis elements for the triplet block take form (i->a α - i->a β) / sqrt(2).
2. The electron potential is spin-free. Because the coulomb J and exchange K terms are expectation values of this, the associated integrals are spin free, assuming spin does not integrate to zero. For J, spin only integrates to zeroes if there is a spin mismatch in either the bra or the ket. Because we only consider Sz preserving excitations, no spin mismatches are possible. For K, a bra orbital needs to have the same spin as a ket orbital. Because both bra orbitals have the same spin, and both ket orbitals have the same spin, this requires that _all_ orbitals have the same spin. Meanwhile, the DFT V terms are second derivatives of the DFT energy with respect to orbital rotation generators. These are not spin-free.
3. Now let's combine the two above facts. After performing the spin-integration in the triplet case, you end up with [(α|α) - (α|β) - (β|α) + (β|β)]. Upon exploiting spin-restriction, this reduces to [(α|α) - (α|β)]. For J, the second term is equal to the first, so the two cancel. For K, the second term is zero, so you have the first integral. For V, the two terms are neither equal nor zero. The V term cannot be neglected, even though it's normally added to the J term, which here is zero.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] V is still bundled with J, but the RSCF products now mark that they may need to get a J-like term. This is no longer equivalent to being singlet or not.
- [x] Several methods have been modified to have a singlet flag, necessary to pass to compure_Vx whether to compute the singlet or triplet term.
- [x] HF classes no longer have a `potential_` attribute. Individual classes may need to access signatures of the specific subclass they have. Instead, subclasses now have a specific subclass for their `potential_` attribute if applicable. An abstract method has been added to the HF base class to get the potential when the subclass doesn't change the method signature.
- [x] RV::compute_Vx_full now exists alongside RV::compute_Vx. The former needs to exist so we can have a flag to control the spin-integration. The latter needs to exist to not break polymorphism when we don't need that flag.
- [x] A new function has been created to make a UKS version of an RKS functional.
- [x] If a triplet is requested, `compute_functional` will build a UKS functional, compute for that, and cannibalize the pieces to get the properly triplet spin-integrated quantity.
- [x] Ability to do `DAXPBY` added.
- [x] Updated a bad test value.

## Checklist
- [x] `test_tdscf_excitations.py` passes. All 70 of the tests.

## Status
- [x] Ready for review
- [ ] Ready for merge
