### PR TITLE
Add build_polarized function.

### DIFF
--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -184,6 +184,45 @@ LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
     }
 }  // namespace psi
 LibXCFunctional::~LibXCFunctional() { xc_func_end(xc_functional_.get()); }
+std::shared_ptr<Functional> LibXCFunctional::build_polarized() {
+    if (!unpolarized_) {
+        throw PSIEXCEPTION("LibXCFunctional: Trying to build_polarized_functional from a polarized functional. Are you sure you meant to?");
+    }
+    // Build functional
+    auto func = std::make_shared<LibXCFunctional>(xc_func_name_, false);
+
+    // User omega
+    if (user_omega_) {
+        func->set_omega(omega_);
+    } else {
+        // The only way we enter this branch is if Functional::set_omega
+        // was called on this object. I can think of no justification for that,
+        // but just in case...
+        Functional::set_omega(omega_);
+    }
+
+    // User tweakers
+    if (user_tweakers_.size()) {
+        func->set_tweak(user_tweakers_, true);
+    }
+
+    func->set_alpha(alpha_);
+    func->set_gga(gga_);
+    func->set_meta(meta_);
+    func->set_lsda_cutoff(lsda_cutoff_);
+    func->set_meta_cutoff(meta_cutoff_);
+    func->set_density_cutoff(density_cutoff_);
+    func->exc_ = exc_;
+    func->vxc_ = vxc_;
+    func->fxc_ = fxc_;
+
+    func->set_name(name_);
+    func->set_description(description_);
+    func->set_citation(citation_);
+    func->set_xclib_description(xclib_description_);
+
+    return func;
+}
 std::shared_ptr<Functional> LibXCFunctional::build_worker() {
     // Build functional
     auto func = std::make_shared<LibXCFunctional>(xc_func_name_, unpolarized_);

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.h
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.h
@@ -49,9 +49,9 @@ class LibXCFunctional : public Functional {
     std::unique_ptr<xc_func_type> xc_functional_;
     int func_id_;
     bool user_omega_;
-    bool exc_;
-    bool vxc_;
-    bool fxc_;
+    bool exc_; // Can we compute functional at a point?
+    bool vxc_; // Can we compute first derivative at a point?
+    bool fxc_; // Can we compute second derivative at a point?
 
     // **ONLY** Used to pass information up the chain.
     // Exchange
@@ -76,6 +76,9 @@ class LibXCFunctional : public Functional {
     void compute_functional(const std::map<std::string, SharedVector>& in,
                             const std::map<std::string, SharedVector>& out, int npoints, int deriv) override;
 
+    // Clones a *polarized*, complete functional. Used, e.g., in spin-symmetry-
+    // breaking eigenvectors of the MO hessian or linear response eigenproblem.
+    std::shared_ptr<Functional> build_polarized() override;
     // Clones a *worker* for the functional. This is not a complete functional
     std::shared_ptr<Functional> build_worker() override;
 

--- a/psi4/src/psi4/libfunctional/functional.h
+++ b/psi4/src/psi4/libfunctional/functional.h
@@ -95,6 +95,9 @@ class Functional {
     // Build a base version of a DFA functional (say B97_X)
     static std::shared_ptr<Functional> build_base(const std::string& alias);
 
+    // Clones a *polarized*, complete functional. Used, e.g., in spin-symmetry-
+    // breaking eigenvectors of the MO hessian or linear response eigenproblem.
+    virtual std::shared_ptr<Functional> build_polarized() = 0;
     // Clones a *worker* for the functional. This is not a complete functional
     virtual std::shared_ptr<Functional> build_worker();
 

--- a/psi4/src/psi4/libfunctional/superfunctional.cc
+++ b/psi4/src/psi4/libfunctional/superfunctional.cc
@@ -108,8 +108,53 @@ std::shared_ptr<SuperFunctional> SuperFunctional::XC_build(std::string name, boo
 
     return sup;
 }
+std::shared_ptr<SuperFunctional> SuperFunctional::build_polarized() {
+    // Build the superfunctional
+    auto sup = std::make_shared<SuperFunctional>();
+
+    // Clone over parts
+    for (int i = 0; i < x_functionals_.size(); i++) {
+        sup->add_x_functional(x_functionals_[i]->build_polarized());
+    }
+    for (int i = 0; i < c_functionals_.size(); i++) {
+        sup->add_c_functional(c_functionals_[i]->build_polarized());
+    }
+
+    sup->deriv_ = deriv_;
+    sup->max_points_ = max_points_;
+    sup->libxc_xc_func_ = libxc_xc_func_;
+    if (needs_vv10_) {
+        sup->needs_vv10_ = true;
+        sup->vv10_b_ = vv10_b_;
+        sup->vv10_c_ = vv10_c_;
+        sup->vv10_beta_ = vv10_beta_;
+    }
+    if (needs_grac_) {
+        sup->needs_grac_ = true;
+        sup->grac_shift_ = grac_shift_;
+        sup->grac_alpha_ = grac_alpha_;
+        sup->grac_beta_ = grac_beta_;
+        sup->set_grac_x_functional(grac_x_functional_->build_polarized());
+        sup->set_grac_c_functional(grac_c_functional_->build_polarized());
+    }
+    sup->name_ = name_;
+    sup->description_ = description_;
+    sup->citation_ = citation_;
+    sup->xclib_description_ = xclib_description_;
+    sup->x_omega_ = x_omega_;
+    sup->c_omega_ = c_omega_;
+    sup->x_alpha_ = x_alpha_;
+    sup->x_beta_ = x_beta_;
+    sup->c_alpha_ = c_alpha_;
+    sup->c_ss_alpha_ = c_ss_alpha_;
+    sup->c_os_alpha_ = c_os_alpha_;
+    sup->density_tolerance_ = density_tolerance_;
+    sup->allocate();
+
+    return sup;
+}
 std::shared_ptr<SuperFunctional> SuperFunctional::build_worker() {
-    // Build the superfuncitonal
+    // Build the superfunctional
     auto sup = std::make_shared<SuperFunctional>();
 
     // Clone over parts

--- a/psi4/src/psi4/libfunctional/superfunctional.h
+++ b/psi4/src/psi4/libfunctional/superfunctional.h
@@ -161,6 +161,9 @@ class SuperFunctional {
     static std::shared_ptr<SuperFunctional> blank();
     static std::shared_ptr<SuperFunctional> XC_build(std::string name, bool unpolarized);
 
+    // Clones a *polarized*, complete superfunctional. Used, e.g., in spin-symmetry-
+    // breaking eigenvectors of the MO hessian or linear response eigenproblem.
+    std::shared_ptr<SuperFunctional> build_polarized();
     // Builds a worker version of the superfunctional
     std::shared_ptr<SuperFunctional> build_worker();
 


### PR DESCRIPTION
## Description
Adds a function to create a polarized (UKS) version of an unpolarized (RKS) functional. Needed for #2885. We can build the triplet derivatives only by taking combinations of the UKS derivatives. We can't just take single-spin-channel derivatives, as RKS can.

## Status
- [x] Ready for review
- [x] Ready for merge
