### PR TITLE
potential_ moved to subclasses.

### DIFF
--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -94,9 +94,7 @@ void CUHF::common_init() {
     same_a_b_dens_ = false;
     same_a_b_orbs_ = false;
 
-    if (functional_->needs_xc()) {
-        throw PSIEXCEPTION("CUHF: Cannot compute XC components!");
-    }
+    subclass_init();
 }
 
 void CUHF::damping_update(double damping_percentage) {
@@ -423,6 +421,12 @@ void CUHF::compute_SAD_guess(bool natorb) {
         // Form the total density used in energy evaluation
         Dt_->copy(Da_);
         Dt_->add(Db_);
+    }
+}
+
+void CUHF::setup_potential() {
+    if (functional_->needs_xc()) {
+        throw PSIEXCEPTION("CUHF: Cannot compute XC components!");
     }
 }
 }  // namespace scf

--- a/psi4/src/psi4/libscf_solver/cuhf.h
+++ b/psi4/src/psi4/libscf_solver/cuhf.h
@@ -33,6 +33,7 @@
 #include "psi4/libpsio/psio.hpp"
 
 namespace psi {
+class VBase;
 namespace scf {
 
 /*
@@ -85,6 +86,7 @@ class CUHF final : public HF {
     void compute_spin_contamination() override;
 
     void common_init();
+    void setup_potential() override;
 
    public:
     CUHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional);
@@ -103,6 +105,8 @@ class CUHF final : public HF {
 
     void damping_update(double) override;
     bool stability_analysis() override;
+
+    std::shared_ptr<VBase> V_potential() const override { return nullptr; };
 
     std::shared_ptr<CUHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
 

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -259,25 +259,6 @@ void HF::common_init() {
         print_header();
     }
 
-    // DFT stuff
-    if (functional_->needs_xc()) {
-        potential_ =
-            VBase::build_V(basisset_, functional_, options_, (options_.get_str("REFERENCE") == "RKS" ? "RV" : "UV"));
-        potential_->initialize();
-
-        // Do the GRAC
-        if (options_.get_double("DFT_GRAC_SHIFT") != 0.0) {
-            potential_->set_grac_shift(options_.get_double("DFT_GRAC_SHIFT"));
-        }
-
-        // Print the KS-specific stuff
-        if (print_) {
-            potential_->print_header();
-        }
-    } else {
-        potential_ = nullptr;
-    }
-
     // -D is zero by default
     set_scalar_variable("-D Energy", 0.0);  // no-autodoc
     energies_["-D"] = 0.0;
@@ -285,6 +266,23 @@ void HF::common_init() {
     // CPHF info
     cphf_nfock_builds_ = 0;
     cphf_converged_ = false;
+}
+
+void HF::subclass_init() {
+    // DFT stuff
+    setup_potential();
+
+    if (V_potential() != nullptr) {
+        // Do the GRAC
+        if (options_.get_double("DFT_GRAC_SHIFT") != 0.0) {
+            V_potential()->set_grac_shift(options_.get_double("DFT_GRAC_SHIFT"));
+        }
+
+        // Print the KS-specific stuff
+        if (print_) {
+            V_potential()->print_header();
+        }
+    }
 }
 
 void HF::damping_update(double damping_percentage) {

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -163,7 +163,6 @@ class HF : public Wavefunction {
 
     /// DFT variables
     std::shared_ptr<SuperFunctional> functional_;
-    std::shared_ptr<VBase> potential_;
 
     // CPHF info
     int cphf_nfock_builds_;
@@ -177,6 +176,10 @@ class HF : public Wavefunction {
 
     /// Common initializer
     void common_init();
+    /// Part of the common initializer that runs after subclass specific tasks
+    void subclass_init();
+    /// Construct the DFT potential.
+    virtual void setup_potential() { throw PSIEXCEPTION("setup_potential virtual"); };
 
     /// Maximum overlap method for prevention of oscillation/excited state SCF
     void MOM();
@@ -299,7 +302,9 @@ class HF : public Wavefunction {
     std::shared_ptr<SuperFunctional> functional() const { return functional_; }
 
     /// The DFT Potential object (or null if it has been deleted)
-    std::shared_ptr<VBase> V_potential() const { return potential_; }
+    /// This needs to be virtual so that subclasses can enforce their
+    /// particular potential's derived class.
+    virtual std::shared_ptr<VBase> V_potential() const { throw PSIEXCEPTION("V_potential virtual") ; }
 
     /// Returns the occupation vectors
     std::shared_ptr<Vector> occupation_a() const;

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -304,7 +304,7 @@ class HF : public Wavefunction {
     /// The DFT Potential object (or null if it has been deleted)
     /// This needs to be virtual so that subclasses can enforce their
     /// particular potential's derived class.
-    virtual std::shared_ptr<VBase> V_potential() const { throw PSIEXCEPTION("V_potential virtual") ; }
+    virtual std::shared_ptr<VBase> V_potential() const = 0;
 
     /// Returns the occupation vectors
     std::shared_ptr<Vector> occupation_a() const;

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -112,6 +112,8 @@ void RHF::common_init() {
 
     same_a_b_dens_ = true;
     same_a_b_orbs_ = true;
+
+    subclass_init();
 }
 
 void RHF::finalize() {
@@ -1025,5 +1027,15 @@ std::shared_ptr<RHF> RHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
 
     return hf_wfn;
 }
+
+void RHF::setup_potential() {
+    if (functional_->needs_xc()) {
+        potential_ = std::make_shared<RV>(functional_, basisset_, options_);
+        potential_->initialize();
+    } else {
+        potential_ = nullptr;
+    }
+}
+
 }  // namespace scf
 }  // namespace psi

--- a/psi4/src/psi4/libscf_solver/rhf.h
+++ b/psi4/src/psi4/libscf_solver/rhf.h
@@ -30,12 +30,12 @@
 #define RHF_H
 
 #include "psi4/libpsio/psio.hpp"
+#include "psi4/libfock/v.h"
 #include "hf.h"
 
 #include "psi4/pybind11.h"
 
 namespace psi {
-
 namespace scf {
 
 class RHF : public HF {
@@ -47,9 +47,12 @@ class RHF : public HF {
     SharedMatrix K_;
     SharedMatrix wK_;
 
+    std::shared_ptr<RV> potential_;
+
     double compute_initial_E() override;
 
     void common_init();
+    void setup_potential() override;
 
    public:
     RHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional);
@@ -73,6 +76,8 @@ class RHF : public HF {
     void damping_update(double) override;
     int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print) override;
     bool stability_analysis() override;
+
+    std::shared_ptr<VBase> V_potential() const override { return potential_; };
 
     /// Hessian-vector computers and solvers
     std::vector<SharedMatrix> onel_Hx(std::vector<SharedMatrix> x) override;

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -39,6 +39,7 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libfock/jk.h"
+#include "psi4/libfock/v.h"
 #include "psi4/libfunctional/superfunctional.h"
 #include "psi4/libiwl/iwl.hpp"
 #include "psi4/libmints/factory.h"
@@ -97,9 +98,7 @@ void ROHF::common_init() {
     same_a_b_dens_ = false;
     same_a_b_orbs_ = true;
 
-    if (functional_->needs_xc()) {
-        throw PSIEXCEPTION("ROHF: Cannot compute XC components!");
-    }
+    subclass_init();
 }
 
 void ROHF::format_guess() {
@@ -1326,5 +1325,12 @@ void ROHF::compute_SAD_guess(bool natorb) {
         Dt_->add(Db_);
     }
 }
+
+void ROHF::setup_potential() {
+    if (functional_->needs_xc()) {
+        throw PSIEXCEPTION("CUHF: Cannot compute XC components!");
+    }
+}
+
 }  // namespace scf
 }  // namespace psi

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -1328,7 +1328,7 @@ void ROHF::compute_SAD_guess(bool natorb) {
 
 void ROHF::setup_potential() {
     if (functional_->needs_xc()) {
-        throw PSIEXCEPTION("CUHF: Cannot compute XC components!");
+        throw PSIEXCEPTION("ROHF: Cannot compute XC components!");
     }
 }
 

--- a/psi4/src/psi4/libscf_solver/rohf.h
+++ b/psi4/src/psi4/libscf_solver/rohf.h
@@ -34,6 +34,7 @@
 #include "hf.h"
 
 namespace psi {
+class VBase;
 namespace scf {
 
 class ROHF : public HF {
@@ -64,6 +65,7 @@ class ROHF : public HF {
     void format_guess() override;
 
     void common_init();
+    void setup_potential() override;
 
    public:
     ROHF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> functional);
@@ -91,6 +93,8 @@ class ROHF : public HF {
     void damping_update(double) override;
     int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print) override;
     bool stability_analysis() override;
+
+    std::shared_ptr<VBase> V_potential() const override { return nullptr; };
 
     std::shared_ptr<ROHF> c1_deep_copy(std::shared_ptr<BasisSet> basis);
 };

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -122,6 +122,8 @@ void UHF::common_init() {
 
     same_a_b_dens_ = false;
     same_a_b_orbs_ = false;
+
+    subclass_init();
 }
 
 void UHF::finalize() {
@@ -1229,5 +1231,15 @@ std::shared_ptr<UHF> UHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
 
     return hf_wfn;
 }
+
+void UHF::setup_potential() {
+    if (functional_->needs_xc()) {
+        potential_ = std::make_shared<UV>(functional_, basisset_, options_);
+        potential_->initialize();
+    } else {
+        potential_ = nullptr;
+    }
+}
+
 }  // namespace scf
 }  // namespace psi

--- a/psi4/src/psi4/libscf_solver/uhf.h
+++ b/psi4/src/psi4/libscf_solver/uhf.h
@@ -29,8 +29,9 @@
 #ifndef __math_test_uhf_h__
 #define __math_test_uhf_h__
 
-#include "hf.h"
 #include "psi4/libpsio/psio.hpp"
+#include "psi4/libfock/v.h"
+#include "hf.h"
 
 namespace psi {
 namespace scf {
@@ -40,9 +41,12 @@ class UHF : public HF {
     SharedMatrix Da_old_, Db_old_;
     SharedMatrix Ga_, Gb_, J_, Ka_, Kb_, wKa_, wKb_;
 
+    std::shared_ptr<UV> potential_;
+
     double compute_initial_E() override;
 
     void common_init();
+    void setup_potential() override;
 
     // Guess mix performed?
     bool mix_performed_;
@@ -82,6 +86,8 @@ class UHF : public HF {
 
     void damping_update(double) override;
     int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print) override;
+
+    std::shared_ptr<VBase> V_potential() const override { return potential_; };
 
     /// Hessian-vector computers and solvers
     std::vector<SharedMatrix> onel_Hx(std::vector<SharedMatrix> x) override;


### PR DESCRIPTION
## Description
The `potential_` of SCF subclasses has been moved.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] The HF base class has been weakened from having a `std::shared_ptr<VBase> potential_` to having a method `get_potential()` that returns a `std::shared_ptr<VBase>`. After #2885, the subclasses may need to access subclass-specific methods.

## Checklist
- [x] Quicktests pass

## Status
- [x] Ready for review
- [x] Ready for merge
