### PR TITLE
Parallelize compute_esp_over_grid

### DIFF
--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1046,17 +1046,12 @@ void OEProp::compute_esp_over_grid() { epc_.compute_esp_over_grid(true); }
 void ESPPropCalc::compute_esp_over_grid(bool print_output) {
     auto mol = basisset_->molecule();
 
-    // TODO: move this into openMP section ?
     std::shared_ptr<ElectrostaticInt> epot(dynamic_cast<ElectrostaticInt*>(integral_->electrostatic().release()));
 
     if (print_output) {
         outfile->Printf("\n Electrostatic potential to be computed on the grid and written to grid_esp.dat\n");
     }
         
-    // TODO: remove this
-    outfile->Printf("\n DEBUG PRINT Q-POSEV  \n");
-
-    // TODO: move this into openMP section ?
     SharedMatrix Dtot = wfn_->matrix_subset_helper(Da_so_, Ca_so_, "AO", "D");
     if (same_dens_) {
         Dtot->scale(2.0);
@@ -1064,7 +1059,6 @@ void ESPPropCalc::compute_esp_over_grid(bool print_output) {
         Dtot->add(wfn_->matrix_subset_helper(Db_so_, Cb_so_, "AO", "D beta"));
     }
 
-    // TODO: move this into openMP section ?
     int nbf = basisset_->nbf();
     auto ints = std::make_shared<Matrix>("Ex integrals", nbf, nbf);
 


### PR DESCRIPTION
## Description

There was a race condition in the parallel calculation of ESP over grid in memory. This was fixed in PR #1900.
This PR brings back the OpenMP parallelization, the race condition is avoided by allowing each thread to hold its own copy of the `ElectrostaticInt` object. Thanks to @JonathonMisiewicz for the initial hint.

## User API & Changelog headlines
- [ ] Significant acceleration of the calculation of ESP over grid in memory

## Dev notes & details
- [ ] Created a vector of thread-specific `<ElectrostaticInt>` and `<Matrix>` objects for computing the ESP at a given grid point
- [ ] Added `#pragma omp parallel for schedule(dynamic)` to parallelize the outer loop over grid points

## Questions
- [ ] While working on this part of the code I noticed that `cubeprop` uses a scheme different from the one used by `oeprop` to compute ESP on a grid. I am not sure this is documented. Should it be?
- [ ] Initially my goal was to parallelize the computation of `compute_esp_over_grid` function which reads the grid from `grid.dat` file. The way it is designed now, the grid is read iteratively, so one grid point read->one ESP point computed->one ESP point written to the output `grid_esp.dat` file. This is not parallelizible. However, if one would read grid points in batches - this can be parallelized. What do you think? 

## Checklist
- [ ] Tests added for any new features => test already in place
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
