### PR TITLE
daxpby workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ if(DEFINED ENV{LGTM_SRC})
 else ()
     cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
     cmake_policy(SET CMP0094 NEW)
+    cmake_policy(SET CMP0075 NEW)
 endif()
                                               # 3.15: useable FindPython with NumPy component and LOCATION
                                               # 3.8: CXX_STANDARD recognizes C++17

--- a/psi4/header.py
+++ b/psi4/header.py
@@ -35,7 +35,7 @@ from .metadata import __version__, version_formatter
 
 if "undef" in __version__:
     raise TypeError(
-        """Using custom build without tags. Please pull git tags with `git pull origin master --tags`. If building from source, `git fetch upstream "refs/tags/*:refs/tags/*"`."""
+        """Using custom build without tags. Please pull git tags with `git pull origin master --tags`. If building from source, `git fetch upstream "refs/tags/*:refs/tags/*"` and re-make."""
     )
 
 time_string = datetime.datetime.now().strftime('%A, %d %B %Y %I:%M%p')

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -316,6 +316,7 @@ void export_mints(py::module& m) {
     typedef double (Vector::*vector_getitem_2)(int, int) const;
     typedef double (Vector::*vector_one_double)(const Vector& other);
     typedef void (Vector::*vector_two)(double scale, const Vector& other);
+    typedef void (Vector::*vector_three)(double alpha, double beta, const Vector &other);
 
     py::class_<Dimension>(m, "Dimension", "Initializes and defines Dimension Objects")
         .def(py::init<int>())
@@ -381,7 +382,8 @@ void export_mints(py::module& m) {
         .def("dimpi", &Vector::dimpi, "Returns the Dimension object")
         .def("nirrep", &Vector::nirrep, "Returns the number of irreps")
         .def("vector_dot", vector_one_double(&Vector::vector_dot), "Take the dot product of two vectors", "other"_a)
-        .def("axpy", vector_two(&Vector::axpy), "Adds to this vector another vector scaled by a", "a"_a, "other"_a)
+        .def("axpy", vector_two(&Vector::axpy), "Adds to this vector (unscaled) another vector scaled by a; self <- a * other + self", "a"_a, "other"_a)
+        .def("axpby", vector_three(&Vector::axpby), "Adds to this vector scaled by b another vector scaled by a; self <- a * other + b * self", "a"_a, "b"_a, "other"_a)
         .def("save", &Vector::save, "Save the vector to disk", "psio"_a, "file"_a)
         .def("load", &Vector::load, "Load the vector from disk", "psio"_a, "file"_a)
         .def("get_block", &Vector::get_block, "Get a vector block", "slice"_a)

--- a/psi4/src/psi4/libqt/CMakeLists.txt
+++ b/psi4/src/psi4/libqt/CMakeLists.txt
@@ -31,6 +31,10 @@ list(APPEND CMAKE_REQUIRED_LIBRARIES tgt::blas)
 check_function_exists(daxpby _has_daxpby)
 cmake_pop_check_state()
 
+if(NOT _has_daxpby)
+  message(WARNING "${Yellow}Your BLAS library does not seem to be providing the DAXPBY subroutine. If you are seeing this message, and you are not building with Apple Accelerate, you may want to re-check that the correct BLAS/LAPACK libraries are being used by the build system.${ColourReset}")
+endif()
+
 psi4_add_module(lib qt sources)
 target_compile_definitions(qt
   PRIVATE

--- a/psi4/src/psi4/libqt/CMakeLists.txt
+++ b/psi4/src/psi4/libqt/CMakeLists.txt
@@ -21,8 +21,20 @@ list(APPEND sources
   timer.cc
   )
 
+# cmake_symbol_exists() or check_cxx_source_runs() are preferable to check_function_exists()
+#   according to CMake docs. But both require an explicit header, either in the call or in the code,
+#   and that's tough with multiple BLAS/LAPACK backends. So, we'll see if this is robust enough.
+include(CMakePushCheckState)
+include(CheckFunctionExists)
+cmake_push_check_state()
+list(APPEND CMAKE_REQUIRED_LIBRARIES tgt::blas)
+check_function_exists(daxpby _has_daxpby)
+cmake_pop_check_state()
+
 psi4_add_module(lib qt sources)
 target_compile_definitions(qt
   PRIVATE
+    $<$<BOOL:${_has_daxpby}>:BLAS_HAS_DAXPBY>
     FC_SYMBOL=${FC_SYMBOL}
   )
+unset(_has_daxpby)

--- a/psi4/src/psi4/libqt/CMakeLists.txt
+++ b/psi4/src/psi4/libqt/CMakeLists.txt
@@ -27,18 +27,28 @@ list(APPEND sources
 include(CMakePushCheckState)
 include(CheckFunctionExists)
 cmake_push_check_state()
-list(APPEND CMAKE_REQUIRED_LIBRARIES tgt::blas)
+list(APPEND CMAKE_REQUIRED_LIBRARIES tgt::lapack)
 check_function_exists(daxpby _has_daxpby)
-cmake_pop_check_state()
-
 if(NOT _has_daxpby)
-  message(WARNING "${Yellow}Your BLAS library does not seem to be providing the DAXPBY subroutine. If you are seeing this message, and you are not building with Apple Accelerate, you may want to re-check that the correct BLAS/LAPACK libraries are being used by the build system.${ColourReset}")
+  message(WARNING "${Yellow}Your BLAS/LAPACK library does not seem to be providing the DAXPBY subroutine. DAXPBY calls will be re-routed through DSCAL and DAXPY. If you are seeing this message, and you are not building with Apple Accelerate, you may want to re-check that the correct BLAS/LAPACK libraries are being used by the build system. Redo CMake configuration for changes to register.${ColourReset}")
 endif()
+
+check_function_exists(dggsvd3 _has_dggsvd3)
+check_function_exists(dggsvp3 _has_dggsvp3)
+if(NOT (_has_dggsvd3 AND _has_dggsvp3))
+  message(WARNING "${Yellow}Your BLAS/LAPACK library does not seem to be providing the DGGSVD3 and DGGSVP3 subroutines. No re-routing is available. If you are seeing this message, and you are not building with Apple Accelerate, you may want to re-check that the correct BLAS/LAPACK libraries are being used by the build system. Redo CMake configuration for changes to register.${ColourReset}")
+endif()
+cmake_pop_check_state()
 
 psi4_add_module(lib qt sources)
 target_compile_definitions(qt
   PRIVATE
     $<$<BOOL:${_has_daxpby}>:BLAS_HAS_DAXPBY>
+    $<$<BOOL:${_has_dggsvd3}>:BLAS_HAS_DGGSVD3>
+    $<$<BOOL:${_has_dggsvp3}>:BLAS_HAS_DGGSVP3>
     FC_SYMBOL=${FC_SYMBOL}
   )
+
 unset(_has_daxpby)
+unset(_has_dggsvd3)
+unset(_has_dggsvp3)

--- a/psi4/src/psi4/libqt/blas_intfc.cc
+++ b/psi4/src/psi4/libqt/blas_intfc.cc
@@ -148,12 +148,26 @@ void PSI_API C_DAXPY(size_t length, double a, const double *x, int inc_x, double
 void PSI_API C_DAXPBY(size_t length, double a, const double *x, int inc_x, double b, double *y, int inc_y) {
     int big_blocks = (int)(length / INT_MAX);
     int small_size = (int)(length % INT_MAX);
+#ifdef BLAS_HAS_DAXPBY
     for (int block = 0; block <= big_blocks; block++) {
         const double *x_s = &x[static_cast<size_t>(block) * inc_x * INT_MAX];
         double *y_s = &y[static_cast<size_t>(block) * inc_y * INT_MAX];
         signed int length_s = (block == big_blocks) ? small_size : INT_MAX;
         ::F_DAXPBY(&length_s, &a, x_s, &inc_x, &b, y_s, &inc_y);
     }
+#else
+    for (int block = 0; block <= big_blocks; block++) {
+        double *y_s = &y[static_cast<size_t>(block) * inc_y * INT_MAX];
+        signed int length_s = (block == big_blocks) ? small_size : INT_MAX;
+        ::F_DSCAL(&length_s, &b, y_s, &inc_y);
+    }
+    for (int block = 0; block <= big_blocks; block++) {
+        const double *x_s = &x[static_cast<size_t>(block) * inc_x * INT_MAX];
+        double *y_s = &y[static_cast<size_t>(block) * inc_y * INT_MAX];
+        signed int length_s = (block == big_blocks) ? small_size : INT_MAX;
+        ::F_DAXPY(&length_s, &a, x_s, &inc_x, y_s, &inc_y);
+    }
+#endif
 }
 
 /*!

--- a/psi4/src/psi4/libqt/lapack_intfc.cc
+++ b/psi4/src/psi4/libqt/lapack_intfc.cc
@@ -6017,6 +6017,7 @@ int C_DGGRQF(int m, int p, int n, double* a, int lda, double* taua, double* b, i
  *
  *  DGGSVD3 replaces the deprecated subroutine DGGSVD.
  **/
+#ifdef BLAS_HAS_DGGSVD3
 int C_DGGSVD3(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* l, double* a, int lda, double* b,
               int ldb, double* alpha, double* beta, double* u, int ldu, double* v, int ldv, double* q, int ldq,
               double* work, int lwork, int* iwork) {
@@ -6025,6 +6026,7 @@ int C_DGGSVD3(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int*
                 &lwork, iwork, &info);
     return info;
 }
+#endif
 
 /**
  * \par Purpose:
@@ -6258,6 +6260,7 @@ int C_DGGSVD3(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int*
  *
  * DGGSVP3 replaces the deprecated subroutine DGGSVP.
  **/
+#ifdef BLAS_HAS_DGGSVP3
 int C_DGGSVP3(char jobu, char jobv, char jobq, int m, int p, int n, double* a, int lda, double* b, int ldb, double tola,
               double tolb, int* k, int* l, double* u, int ldu, double* v, int ldv, double* q, int ldq, int* iwork,
               double* tau, double* work, int lwork) {
@@ -6266,6 +6269,7 @@ int C_DGGSVP3(char jobu, char jobv, char jobq, int m, int p, int n, double* a, i
                 tau, work, &lwork, &info);
     return info;
 }
+#endif
 
 /**
  *  Purpose

--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -226,12 +226,16 @@ int C_DGGQRF(int n, int m, int p, double* a, int lda, double* taua, double* b, i
              int lwork);
 int C_DGGRQF(int m, int p, int n, double* a, int lda, double* taua, double* b, int ldb, double* taub, double* work,
              int lwork);
+#ifdef BLAS_HAS_DGGSVD3
 int C_DGGSVD3(char jobu, char jobv, char jobq, int m, int n, int p, int* k, int* l, double* a, int lda, double* b,
               int ldb, double* alpha, double* beta, double* u, int ldu, double* v, int ldv, double* q, int ldq,
               double* work, int lwork, int* iwork);
+#endif
+#ifdef BLAS_HAS_DGGSVP3
 int C_DGGSVP3(char jobu, char jobv, char jobq, int m, int p, int n, double* a, int lda, double* b, int ldb, double tola,
               double tolb, int* k, int* l, double* u, int ldu, double* v, int ldv, double* q, int ldq, int* iwork,
               double* tau, double* work, int lwork);
+#endif
 int C_DGTCON(char norm, int n, double* dl, double* d, double* du, double* du2, int* ipiv, double anorm, double* rcond,
              double* work, int* iwork);
 int C_DGTRFS(char trans, int n, int nrhs, double* dl, double* d, double* du, double* dlf, double* df, double* duf,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Some setups were using a BLAS that doesn't support the extension AXPBY, so #2887 caused runtime can't-find-symbol errors. Most notably, this occurred for Mac users linking to Accelerate. This bypasses the trouble by rerouting to dscal+daxpy
- [x] clarifies who's getting scaled in the export docs.
- Note that the CI error was due to ongoing changes in QCArchive `next` branch. I've pinned the dep back a release so that psi4's interface to it can be fixed later.

## Questions
- [ ] Can someone confirm this works with the Accelerate setup? Below is a quick test.
```
import psi4
import numpy as np


vecX = np.array([1., 1., 1.])
pvecX = psi4.core.Vector.from_array(vecX)
print(pvecX.np)  # 1

vecY = np.array([5., 5., 5.])
pvecY = psi4.core.Vector.from_array(vecY)
print(pvecY.np)  # 5

pvecX2 = pvecX.clone()
pvecX2.axpy(2.0, pvecY)
print(pvecX2.np)  # 11

pvecX2 = pvecX.clone()
pvecX2.axpby(2.0, 1.0, pvecY)
print(pvecX2.np)  # 11

pvecX2 = pvecX.clone()
pvecX2.axpby(2.0, 3.0, pvecY)
print(pvecX2.np)  # 13
```

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
