### PR TITLE
update PCMSolver interface to v1.2.3

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -129,7 +129,7 @@ jobs:
           - psi4/label/dev::libecpint
           - psi4/label/dev::dkh
           - psi4/label/dev::gdma
-          - psi4/label/dev::pcmsolver
+          #- psi4/label/dev::pcmsolver
           - psi4/label/dev::simint
             # runtime
         EOF
@@ -159,7 +159,7 @@ jobs:
           sed -i "s;- psi4/label/dev::libecpint;;g" build.yaml
           sed -i "s;- psi4/label/dev::dkh;;g" build.yaml
           sed -i "s;- psi4/label/dev::gdma;;g" build.yaml
-          sed -i "s;- psi4/label/dev::pcmsolver;;g" build.yaml
+          #sed -i "s;- psi4/label/dev::pcmsolver;;g" build.yaml
           sed -i "s;- psi4/label/dev::simint;;g" build.yaml
         fi
         #
@@ -193,7 +193,7 @@ jobs:
           - psi4/label/dev::dkh
           - psi4/label/dev::libecpint
           - psi4/label/dev::gdma
-          - psi4/label/dev::pcmsolver
+          #- psi4/label/dev::pcmsolver
           - psi4/label/dev::simint
             # qc opt'l
           #- psi4/label/dev::dftd3
@@ -374,8 +374,8 @@ jobs:
           -D CMAKE_INSIST_FIND_PACKAGE_ecpint=ON \
           -D ENABLE_gdma=ON \
           -D CMAKE_INSIST_FIND_PACKAGE_gdma=ON \
-          -D ENABLE_PCMSolver=ON \
-          -D CMAKE_INSIST_FIND_PACKAGE_PCMSolver=ON \
+          -D ENABLE_PCMSolver=OFF \
+          -D CMAKE_INSIST_FIND_PACKAGE_PCMSolver=OFF \
           -D ENABLE_simint=ON \
           -D SIMINT_VECTOR=sse \
           -D CMAKE_INSIST_FIND_PACKAGE_simint=ON \
@@ -415,8 +415,8 @@ jobs:
           -D CMAKE_INSIST_FIND_PACKAGE_ecpint=ON \
           -D ENABLE_gdma=ON \
           -D CMAKE_INSIST_FIND_PACKAGE_gdma=ON \
-          -D ENABLE_PCMSolver=ON \
-          -D CMAKE_INSIST_FIND_PACKAGE_PCMSolver=ON \
+          -D ENABLE_PCMSolver=OFF \
+          -D CMAKE_INSIST_FIND_PACKAGE_PCMSolver=OFF \
           -D ENABLE_simint=ON \
           -D SIMINT_VECTOR=sse \
           -D CMAKE_INSIST_FIND_PACKAGE_simint=ON \

--- a/external/upstream/pcmsolver/CMakeLists.txt
+++ b/external/upstream/pcmsolver/CMakeLists.txt
@@ -1,5 +1,5 @@
     if(${ENABLE_PCMSolver})
-    find_package(PCMSolver 1.2.1 CONFIG QUIET)
+    find_package(PCMSolver 1.2.3 CONFIG QUIET)
 
     if(${PCMSolver_FOUND})
         get_property(_loc TARGET PCMSolver::pcm PROPERTY LOCATION)
@@ -23,7 +23,8 @@
 
         ExternalProject_Add(pcmsolver_external
             #URL https://github.com/PCMSolver/pcmsolver/archive/v1.3.1.tar.gz
-            URL https://github.com/loriab/pcmsolver/archive/v1211.tar.gz
+            #URL https://github.com/loriab/pcmsolver/archive/v1211.tar.gz
+            URL https://github.com/loriab/pcmsolver/archive/v123_plus.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/pcmsolver/CMakeLists.txt
+++ b/external/upstream/pcmsolver/CMakeLists.txt
@@ -21,10 +21,12 @@
             set(_so_only OFF)
         endif()
 
+        set(_pcmsolver_dir "share/cmake/PCMSolver")
+
         ExternalProject_Add(pcmsolver_external
             #URL https://github.com/PCMSolver/pcmsolver/archive/v1.3.1.tar.gz
             #URL https://github.com/loriab/pcmsolver/archive/v1211.tar.gz
-            URL https://github.com/loriab/pcmsolver/archive/v123_plus.tar.gz
+            URL https://github.com/loriab/pcmsolver/archive/v123_plus_ming.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -36,7 +38,8 @@
                        -DPYMOD_INSTALL_LIBDIR=${PYMOD_INSTALL_LIBDIR}
                        -DCMAKE_INSTALL_DATADIR=${CMAKE_INSTALL_DATADIR}
                        -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
-                       -DPYTHON_INTERPRETER=${Python_EXECUTABLE}
+                       -DCMAKECONFIG_INSTALL_DIR=${_pcmsolver_dir}
+                       -DPython_EXECUTABLE=${Python_EXECUTABLE}
                        -DSTATIC_LIBRARY_ONLY=${_a_only}
                        -DSHARED_LIBRARY_ONLY=${_so_only}
                        -DENABLE_OPENMP=OFF
@@ -56,7 +59,7 @@
                              -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
                              -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS})
 
-        set(PCMSolver_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/PCMSolver CACHE PATH "path to internally built PCMSolverConfig.cmake" FORCE)
+        set(PCMSolver_DIR ${STAGED_INSTALL_PREFIX}/${_pcmsolver_dir} CACHE PATH "path to internally built PCMSolverConfig.cmake" FORCE)
     endif()
 else()
     add_library(pcmsolver_external INTERFACE)  # dummy

--- a/psi4/src/psi4/libpsipcm/psipcm.cc
+++ b/psi4/src/psi4/libpsipcm/psipcm.cc
@@ -153,6 +153,7 @@ PCM::PCM(const std::string &pcmsolver_parsed_fname, int print_level, std::shared
 
     context_ = detail::init_PCMSolver(pcmsolver_parsed_fname_, molecule);
     outfile->Printf("  **PSI4:PCMSOLVER Interface Active**\n");
+    pcmsolver_citation(detail::host_writer);
     pcmsolver_print(context_.get());
     ntess_ = pcmsolver_get_cavity_size(context_.get());
     ntessirr_ = pcmsolver_get_irreducible_cavity_size(context_.get());

--- a/tests/pcmsolver/dft/input.dat
+++ b/tests/pcmsolver/dft/input.dat
@@ -3,7 +3,7 @@
 
 nucenergy   =  12.0367196636183458 # TEST
 polenergy   =  -0.0060921680888660 # TEST
-totalenergy = -56.55724707152022   # TEST
+totalenergy = -56.55724704841      # TEST  # adjusted after PEDRA pruning in v1.2.3  -56.55724707152022
 
 molecule NH3 {
 N     -0.0000000001    -0.1040380466      0.0000000000

--- a/tests/pcmsolver/dipole/input.dat
+++ b/tests/pcmsolver/dipole/input.dat
@@ -7,11 +7,12 @@ ref_energies = { 'HF'    : [-76.0203919443, -76.0223213132,  # TEST
                             -76.4165432999241, -76.42017454551062]  # TEST
                }
 # Reference values, in atomic units, for finite difference formulas
-ref_3pt = { 'HF'    : 0.9646844572, # TEST
-            'B3LYP' : 0.9078186547597511  # TEST
+# * adjusted after PEDRA pruning in v1.2.3
+ref_3pt = { 'HF'    : 0.9646843842,  #TEST  0.9646844572
+            'B3LYP' : 0.9078185863,  #TEST  0.9078186547597511
           }
-ref_5pt = { 'HF'    : 0.9646862512, # TEST
-            'B3LYP' : 0.9078210741364501  # TEST
+ref_5pt = { 'HF'    : 0.9646861782,  #TEST  0.9646862512
+            'B3LYP' : 0.9078210056,  #TEST  0.9078210741364501
           }
 
 molecule h2o {

--- a/tests/pcmsolver/ghost/input.dat
+++ b/tests/pcmsolver/ghost/input.dat
@@ -2,7 +2,7 @@
 
 nucenergy   =  12.0367196636183458 #TEST
 polenergy   =  -0.0059568153047844 #TEST
-totalenergy = -55.802798823871 #TEST
+totalenergy = -55.802798786575     #TEST  # adjusted after PEDRA pruning in v1.2.3  -55.802798823871
 
 ref={}
 ref['noCP'] = 0.011128150727074626 #TEST

--- a/tests/pcmsolver/scf/input.dat
+++ b/tests/pcmsolver/scf/input.dat
@@ -2,12 +2,12 @@
 
 nucenergy   =  12.0367196636183458 #TEST
 polenergy   =  -0.0053060443528559 #TEST
-totalenergy = -55.4559426361734040 #TEST
+totalenergy = -55.455942603983     #TEST  # adjusted after PEDRA pruning in v1.2.3  -55.4559426361734040
 
 df_polenergy   =  -0.0053052777747797 #TEST
-df_totalenergy = -55.4560830407201300 #TEST
+df_totalenergy = -55.456083008532     #TEST  # ditto v1.2.3  -55.4560830407201300
 cd_polenergy   =  -0.0053065685148796 #TEST
-cd_totalenergy = -55.4559161829875300 #TEST
+cd_totalenergy = -55.455916150789     #TEST  # ditto v1.2.3  -55.4559161829875300
 
 molecule NH3 {
 N     -0.0000000001    -0.1040380466      0.0000000000

--- a/tests/pytests/test_addons.py
+++ b/tests/pytests/test_addons.py
@@ -570,7 +570,7 @@ def test_pcmsolver(how, request):
 
     nucenergy   =  12.0367196636183458
     polenergy   =  -0.0053060443528559
-    totalenergy = -55.4559426361734040
+    totalenergy = -55.455942603983  # adjusted after PEDRA pruning in v1.2.3  -55.4559426361734040
 
     NH3 = psi4.geometry("""
     symmetry c1

--- a/tests/pytests/test_addons_qcschema.py
+++ b/tests/pytests/test_addons_qcschema.py
@@ -312,7 +312,7 @@ def test_pcmsolver():
 
     nucenergy = 12.0367196636183458
     polenergy = -0.0053060443528559
-    totalenergy = -55.4559426361734040
+    totalenergy = -55.455942603983  # adjusted after PEDRA pruning in v1.2.3  -55.4559426361734040
 
     #    pcm_string = """
     #       Units = Angstrom


### PR DESCRIPTION
## Description
For reasons described at https://github.com/PCMSolver/pcmsolver/issues/201, Psi4 has been fixed at PCMSolver v1.2.1 . This updates to v1.2.x with very small (e.g., 1e-8) tweaks to ref values. I do finally understand why v1.3.x was failing, but those are much larger changes to ref values (e.g., 1e-2; probably washes out in relative energies), so I'd like @robertodr  to weigh in.

UPDATE: The plan is to go with v1.2 for now and wait on v1.3. The conda package is RTG at 1.2 but isn't merged yet. A later rebuild of the 1.8 conda package could include pcmsolver support.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Update PCMSolver to v1.2.3 ~or v1.3.x~

## Dev notes & details
- [x] add pcmsolver citation printing to psi4 output file
- [ ] build c-f package https://github.com/conda-forge/staged-recipes/pull/22286
- [x] update ecosys GHA to test pcmsolver
- [x] this runs fine locally, and I'm confident in it, so marking ready for review. it'll take a while for CI to catch up to that optimism.

## Checklist
- [ ] ~Tests added for any new features~
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
