### PR TITLE
Enable getting basis sets through BSE library

### DIFF
--- a/psi4/driver/inputparser.py
+++ b/psi4/driver/inputparser.py
@@ -88,7 +88,7 @@ def quotify(string, isbasis=False):
     # This wraps anything that looks like a string in quotes, and removes leading
     # dollar signs from python variables
     if isbasis:
-        wordre = re.compile(r'(([$]?)([-+()*.,\w\"\'/\\]+))')
+        wordre = re.compile(r'(([$]?)([-+:()*.,\w\"\'/\\]+))')
     else:
         wordre = re.compile(r'(([$]?)([-+()*.\w\"\'/\\]+))')
     string = wordre.sub(process_word_quotes, string)
@@ -278,7 +278,7 @@ def process_basis_block(matchobj):
 
     symbol_re = re.compile(r'^\s*assign\s+(?P<symbol>[A-Z]{1,3})\s+(?P<basis>[-+*\(\)\w]+)\s*$', re.IGNORECASE)
     label_re = re.compile(
-        r'^\s*assign\s+(?P<label>(?P<symbol>[A-Z]{1,3})(?:(_\w+)|(\d+))?)\s+(?P<basis>[-+*\(\)\w]+)\s*$',
+        r'^\s*assign\s+(?P<label>(?P<symbol>[A-Z]{1,3})(?:(_\w+)|(\d+))?)\s+(?P<basis>[-+:*\(\)\w]+)\s*$',
         re.IGNORECASE)
     all_re = re.compile(r'^\s*assign\s+(?P<basis>[-+*\(\)\w]+)\s*$', re.IGNORECASE)
     basislabel = re.compile(r'\s*\[\s*([-*\(\)\w]+)\s*\]\s*')
@@ -672,7 +672,7 @@ def process_input(raw_input: str, print_level: int = 1) -> str:
     # with undesired multiline matches.  Better the double-negative [^\S\n] instead, which
     # will match any space, tab, etc., except a newline
     set_command = re.compile(
-        r'^(\s*?)set\s+(?:([-,\w]+)[^\S\n]+)?(\w+)(?:[^\S\n]|=)+((\[.*\])|(\$?[-+,*()\.\w]+))\s*$',
+        r'^(\s*?)set\s+(?:([-,\w]+)[^\S\n]+)?(\w+)(?:[^\S\n]|=)+((\[.*\])|(\$?[-+,*:()\.\w]+))\s*$',
         re.MULTILINE | re.IGNORECASE)
     temp = re.sub(set_command, process_set_command, temp)
 

--- a/psi4/driver/qcdb/libmintsbasisset.py
+++ b/psi4/driver/qcdb/libmintsbasisset.py
@@ -858,8 +858,31 @@ class BasisSet(object):
                 (bastitle, basgbs, postfunc) = bas
 
                 filename = cls.make_filename(basgbs)
-                # -- First seek bas string in input file strings
-                if filename[:-4] in seek['strings']:
+
+                # If name is prefixed with "bse:", then load from basis set exchange library
+                if bastitle.lower().startswith('bse:'):
+                    if not qcel.util.which_import('basis_set_exchange', return_bool=True):
+                        raise ModuleNotFoundError("Python module 'basis_set_exchange' not found. Solve by installing it: `conda install -c conda-forge basis-set-exchange` or `pip install basis-set-exchange`")
+
+                    import basis_set_exchange as bse
+
+                    index = 'bse %s' % (bastitle)
+
+                    if index not in names:
+                        basparts = bastitle.split(":")
+
+                        # If len=3, then bse:name:version
+                        # else it's just bse:name
+                        if len(basparts) == 3:
+                            _, basname, basver = basparts
+                        else:
+                            _, basname = basparts
+                            basver = None
+
+                        names[index] = bse.get_basis(basname, version=basver, fmt='psi4')
+
+                # -- seek bas string in input file strings
+                elif filename[:-4] in seek['strings']:
                     index = 'inputblock %s' % (filename[:-4])
                     # Store contents
                     if index not in names:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR allows for using basis sets from the Basis Set Exchange library (https://github.com/MolSSI-BSE/basis_set_exchange) directly in psi4.

To use a basis set from the BSE, you prefix the name of the basis set with `bse:`. Optionally, you can specify the version with a suffix (like `:1`)

```
# use most recent def2-tzvp version
set basis bse:def2-tzvp

# specifically use version 0 of sto-3g
set basis bse:sto-3g:0
```

Also can be used with `assign`

```
basis  {
   assign DZ
   assign C bse:sto-3g:0
}
```

Using these of course requires that the BSE be installed. This should be accessible from both schema/json and psithon.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] Add capability to use basis sets from the Basis Set Exchange

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Adds optional dependency to basis_set_exchange
- [ ] Adds handling for basis sets that start with `bse:`
- [ ] Modifies some regexes to allow for colons in basis set names

## Questions
None

## Checklist
- [ ] Optional dependency added to build chain
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
