### PR TITLE
Better Error Message for Issue #2890

### DIFF
--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -95,7 +95,10 @@ Matrix compute_numeric_overlap(const DFTGrid &grid, const std::shared_ptr<BasisS
                 S_nump[mu][nu] += S_num_blockp[mu_local][nu_local];
             }
         }
-
+        outfile->Printf("S_num_block: \n");
+        outfile->Printf("----------- \n");
+	S_num_block.print_out();
+	outfile->Printf("\n");
     }
 
     S_num.hermitivitize();

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -247,7 +247,7 @@ void DFJCOSK::common_init() {
         double* w = init_block->w();
         for (int ipoint = 0; ipoint < init_block->npoints(); ++ipoint) {
             if (w[ipoint] < 0.0) {
-	      throw PSIEXCEPTION("The initial COSX grid configuration contains negative weights! This will crash COSX, as per https://github.com/psi4/psi4/issues/2890. A proper fix is incoming, but for now, adjust either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL to remove negative weights.");
+	      throw PSIEXCEPTION("The definition of the current initial grid includes negative weights. As these are not suitable for the COSX implementation, please choose another initial grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL.");
 	    }
         }
     }
@@ -256,7 +256,7 @@ void DFJCOSK::common_init() {
         double* w = final_block->w();
         for (int ipoint = 0; ipoint < final_block->npoints(); ++ipoint) {
             if (w[ipoint] < 0.0) {
-	      throw PSIEXCEPTION("The final COSX grid configuration contains negative weights! This will crash COSX, as per https://github.com/psi4/psi4/issues/2890. A proper fix is incoming, but for now, adjust either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL to remove negative weights.");
+	      throw PSIEXCEPTION("The definition of the current final grid includes negative weights. As these are not suitable for the COSX implementation, please choose another final grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL.");
 	    }
         }
     }

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -26,9 +26,6 @@
  * @END LICENSE
  */
 
-#include <cassert>
-#include <cmath>
-
 #include "jk.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libfock/cubature.h"
@@ -82,9 +79,9 @@ Matrix compute_numeric_overlap(const DFTGrid &grid, const std::shared_ptr<BasisS
         for (size_t p = 0; p < npoints_block; p++) {
             for (size_t k = 0; k < nbf_block; k++) {
                 X_blockp[p][k] = point_values->get(p, k) * std::sqrt(w[p]);
-	    }
+            }
         }
- 
+
         // significant basis functions at these grid points
         const auto &bf_map = block->functions_local_to_global();
 
@@ -251,19 +248,19 @@ void DFJCOSK::common_init() {
         for (int ipoint = 0; ipoint < init_block->npoints(); ++ipoint) {
             if (w[ipoint] < 0.0) {
 	      throw PSIEXCEPTION("The initial COSX grid configuration contains negative weights! This will crash COSX, as per https://github.com/psi4/psi4/issues/2890. A proper fix is incoming, but for now, adjust either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL to remove negative weights.");
-	    } 
+	    }
         }
-    }	    
+    }
 
     for (const auto &final_block : grid_final_->blocks()) {
         double* w = final_block->w();
         for (int ipoint = 0; ipoint < final_block->npoints(); ++ipoint) {
             if (w[ipoint] < 0.0) {
 	      throw PSIEXCEPTION("The final COSX grid configuration contains negative weights! This will crash COSX, as per https://github.com/psi4/psi4/issues/2890. A proper fix is incoming, but for now, adjust either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL to remove negative weights.");
-	    } 
+	    }
         }
-    }	    
- 
+    }
+
     timer_off("Grid Construction");
 
     // => Overlap Fitting Metric <= //

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -81,14 +81,9 @@ Matrix compute_numeric_overlap(const DFTGrid &grid, const std::shared_ptr<BasisS
         auto X_blockp = X_block.pointer();
         for (size_t p = 0; p < npoints_block; p++) {
             for (size_t k = 0; k < nbf_block; k++) {
-                outfile->Printf("    Point value: %f; Weight value: %f \n", point_values->get(p, k), w[p]); 
                 X_blockp[p][k] = point_values->get(p, k) * std::sqrt(w[p]);
 	    }
         }
-        outfile->Printf("X_block: \n");
-        outfile->Printf("-------- \n");
-	X_block.print_out();
-	outfile->Printf("\n");
  
         // significant basis functions at these grid points
         const auto &bf_map = block->functions_local_to_global();
@@ -103,10 +98,6 @@ Matrix compute_numeric_overlap(const DFTGrid &grid, const std::shared_ptr<BasisS
                 S_nump[mu][nu] += S_num_blockp[mu_local][nu_local];
             }
         }
-        outfile->Printf("S_num_block: \n");
-        outfile->Printf("------------ \n");
-	S_num_block.print_out();
-	outfile->Printf("\n");
     }
 
     S_num.hermitivitize();
@@ -280,17 +271,7 @@ void DFJCOSK::common_init() {
     auto S_num_init = compute_numeric_overlap(*grid_init_, primary_);
     auto S_num_final = compute_numeric_overlap(*grid_final_, primary_ );
 
-    outfile->Printf("S_num_init: \n");
-    outfile->Printf("----------- \n");
-    S_num_init.print_out();
-    outfile->Printf("\n");
-
     timer_off("Numeric Overlap");
-
-    outfile->Printf("S_num_final: \n");
-    outfile->Printf("------------ \n");
-    S_num_final.print_out();
-    outfile->Printf("\n");
 
     timer_on("Analytic Overlap");
 

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -257,7 +257,17 @@ void DFJCOSK::common_init() {
     auto S_num_init = compute_numeric_overlap(*grid_init_, primary_);
     auto S_num_final = compute_numeric_overlap(*grid_final_, primary_ );
 
+    outfile->Printf("S_num_init: \n");
+    outfile->Printf("----------- \n");
+    S_num_init.print_out();
+    outfile->Printf("\n");
+
     timer_off("Numeric Overlap");
+
+    outfile->Printf("S_num_final: \n");
+    outfile->Printf("------------ \n");
+    S_num_final.print_out();
+    outfile->Printf("\n");
 
     timer_on("Analytic Overlap");
 

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -81,7 +81,11 @@ Matrix compute_numeric_overlap(const DFTGrid &grid, const std::shared_ptr<BasisS
                 X_blockp[p][k] = point_values->get(p, k) * std::sqrt(w[p]);
             }
         }
-
+        outfile->Printf("X_block: \n");
+        outfile->Printf("-------- \n");
+	X_block.print_out();
+	outfile->Printf("\n");
+ 
         // significant basis functions at these grid points
         const auto &bf_map = block->functions_local_to_global();
 
@@ -96,7 +100,7 @@ Matrix compute_numeric_overlap(const DFTGrid &grid, const std::shared_ptr<BasisS
             }
         }
         outfile->Printf("S_num_block: \n");
-        outfile->Printf("----------- \n");
+        outfile->Printf("------------ \n");
 	S_num_block.print_out();
 	outfile->Printf("\n");
     }

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -26,6 +26,9 @@
  * @END LICENSE
  */
 
+#include <cassert>
+#include <cmath>
+
 #include "jk.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libfock/cubature.h"
@@ -78,8 +81,9 @@ Matrix compute_numeric_overlap(const DFTGrid &grid, const std::shared_ptr<BasisS
         auto X_blockp = X_block.pointer();
         for (size_t p = 0; p < npoints_block; p++) {
             for (size_t k = 0; k < nbf_block; k++) {
+                outfile->Printf("    Point value: %f; Weight value: %f \n", point_values->get(p, k), w[p]); 
                 X_blockp[p][k] = point_values->get(p, k) * std::sqrt(w[p]);
-            }
+	    }
         }
         outfile->Printf("X_block: \n");
         outfile->Printf("-------- \n");

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -244,7 +244,7 @@ void DFJCOSK::common_init() {
     // which can happen with certain grid configurations
     // See https://github.com/psi4/psi4/issues/2890
     for (const auto &init_block : grid_init_->blocks()) {
-        double* w = init_block->w();
+        const auto w = init_block->w();
         for (int ipoint = 0; ipoint < init_block->npoints(); ++ipoint) {
             if (w[ipoint] < 0.0) {
 	      throw PSIEXCEPTION("The definition of the current initial grid includes negative weights. As these are not suitable for the COSX implementation, please choose another initial grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL.");
@@ -253,7 +253,7 @@ void DFJCOSK::common_init() {
     }
 
     for (const auto &final_block : grid_final_->blocks()) {
-        double* w = final_block->w();
+        const auto w = final_block->w();
         for (int ipoint = 0; ipoint < final_block->npoints(); ++ipoint) {
             if (w[ipoint] < 0.0) {
 	      throw PSIEXCEPTION("The definition of the current final grid includes negative weights. As these are not suitable for the COSX implementation, please choose another final grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL.");

--- a/psi4/src/psi4/libfock/DFJCOSK.cc
+++ b/psi4/src/psi4/libfock/DFJCOSK.cc
@@ -254,6 +254,16 @@ void DFJCOSK::common_init() {
 	    } 
         }
     }	    
+
+    for (const auto &final_block : grid_final_->blocks()) {
+        double* w = final_block->w();
+        for (int ipoint = 0; ipoint < final_block->npoints(); ++ipoint) {
+            if (w[ipoint] < 0.0) {
+	      throw PSIEXCEPTION("The final COSX grid configuration contains negative weights! This will crash COSX, as per https://github.com/psi4/psi4/issues/2890. A proper fix is incoming, but for now, adjust either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL to remove negative weights.");
+	    } 
+        }
+    }	    
+ 
     timer_off("Grid Construction");
 
     // => Overlap Fitting Metric <= //


### PR DESCRIPTION
## Description
This PR provides a more useful error message when the issue described in https://github.com/psi4/psi4/issues/2890 is encountered. In short, the COSX K build method breaks with certain grid configurations - specifically, grid configurations which result in negative grid weights. How to best handle that issue - removing such grid configurations from Psi4 entirely, handling negative grid weights differently within COSX itself - is still under discussion, and this PR is _not_ meant to be a final fix to the aforementioned issue.

Rather, this PR is meant to provide a more informative error message in the case that an end user _does_ encounter this error. Currently, when this error is encountered, it shows up as either a DGESV error (if the initial COSX grid has negative weights) or an ADIIS minimization error (if the final COSX grid has negative weights). These error outputs don't help the end user figure out what is wrong at all. So, what this PR does, is add sanity checks to ensure that the COSX grids don't have negative weights, and throw an exception if they do. The sanity check exceptions explain to the user what the error is and how they can fix it (i.e., changing the grid pruning scheme and/or number of spherical points).

Again, I want to emphasize that this is _not_ intended to be a full fix to https://github.com/psi4/psi4/issues/2890. Rather, it is an intermediate step that is designed to better help end users avoid the problem if they run into it themselves.

## User API & Changelog headlines
N/A

## Dev notes & details
- [X] Add sanity checks to COSX to ensure that neither of the COSX grids have negative grid weights. An exception is thrown if either of the grids do.

## Questions
- [x] Probably better discussed on https://github.com/psi4/psi4/issues/2890, but how do we want to officially solve this problem? There has been some discussion on simply removing grid configurations which lead to negative weights, as well as discussions on reformulating the X matrix (the matrix central to the observed error) to be able to handle positive grid weights. 

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [x] Ready for merge
