### PR TITLE
Rework factorial and n-choose-k functions in libqt

### DIFF
--- a/psi4/src/psi4/libqt/probabil.cc
+++ b/psi4/src/psi4/libqt/probabil.cc
@@ -32,73 +32,26 @@
   \ingroup QT
 */
 
+#include "qt.h"
+#include "psi4/libpsi4util/exception.h"
 namespace psi {
 
-/*!
-** factorial(): Returns n!
-**
-** Parameters:
-**    \param n  = number to take factorial of
-**
-** Returns:
-**    n factorial, as a double word (since n! can get very large).
-** \ingroup QT
-*/
-double factorial(int n) {
-    if (n == 0 || n == 1) return (1.0);
-    if (n < 0)
-        return (0.0);
-    else {
-        return ((double)n * factorial(n - 1));
-    }
+/// @brief Returns n!
+/// @param n : number to take factorial of
+/// @return n factorial, as a 64-bit int (since n! can get very large)
+/// \ingroup QT
+uint64_t factorial(const uint64_t n) {
+    if (n <= 1) return 1;
+    return (n * factorial(n - 1));
 }
 
-/*!
-** combinations() : Calculates the number of ways to choose k objects
-**    from n objects, or "n choose k"
-**
-** Parameters:
-**   \param n   =  number of objects in total
-**   \param k   =  number of objects taken at a time
-**
-** Returns:
-**    number of combinations of n objects taken k at a time ("n choose k")
-**    (returned as a double).
-**
-** \ingroup QT
-*/
-double combinations(int n, int k) {
-    double comb;
-
-    if (n == k)
-        return (1.0);
-    else if (k > n)
-        return (0.0);
-    else if (k == 0)
-        return (1.0);
-    comb = factorial(n) / (factorial(k) * factorial(n - k));
-
-    return (comb);
+/// @brief Calculates the number of ways to choose k objects from n objects, or "n choose k"
+/// @param n : number of objects in total
+/// @param k : number of objects taken at a time
+/// @return number of combinations of n objects taken k at a time ("n choose k")
+/// \ingroup QT
+uint64_t combinations(const uint64_t n, const uint64_t k) {
+    if (k > n) throw PSIEXCEPTION("Cannot compute n choose k if k > n!");
+    return factorial(n) / (factorial(k) * factorial(n - k));
 }
-
-/*
-** test combinations routines
-**
-#include <cstdio>
-
-main()
-{
-   int i, j ;
-   double factorial() ;
-   double combinations() ;
-
-   printf("Enter two numbers: ") ;
-   scanf("%d %d", &i, &j) ;
-   printf("i! = %.2f\n", factorial(i)) ;
-   printf("j! = %.2f\n", factorial(j)) ;
-   printf("i choose j = %.2f\n", combinations(i,j)) ;
-}
-**
-*/
-
 }  // namespace psi

--- a/psi4/src/psi4/libqt/probabil.cc
+++ b/psi4/src/psi4/libqt/probabil.cc
@@ -42,6 +42,7 @@ namespace psi {
 /// \ingroup QT
 uint64_t factorial(const uint64_t n) {
     if (n <= 1) return 1;
+    if (n > 20) throw PSIEXCEPTION("Cannot compute n! if n > 20, as the result would overflow in a 64-bit integer.");
     return (n * factorial(n - 1));
 }
 

--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -50,8 +50,8 @@ class Wavefunction;
 void dx_write(std::shared_ptr<Wavefunction> wfn, Options& options, double** D);
 void dx_read(double** V_eff, double* phi_ao, double* phi_so, int nao, int nso, double** u);
 void fill_sym_matrix(double** A, int size);
-double combinations(int n, int k);
-double factorial(int n);
+uint64_t combinations(const uint64_t n, const uint64_t k);
+uint64_t factorial(const uint64_t n);
 void schmidt(double** A, int rows, int cols, std::string out_fname);
 PSI_DEPRECATED("The libqt schmidt_add function is deprecated and 1.7 will be the last release to have it.")
 PSI_API int schmidt_add(double** A, int rows, int cols, double* v);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR reworks and simplifies `libqt/probabil.cc`. Excessive conditionals are removed, sanity checks now throw instead of returning zero, and the `double` kludge is supplanted by `uint64_t`

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `factorial` and `combinations` now return `uint64_t` instead of `double`, and take `const uint64_t` instead of `int`
- [x] `factorial` now throws if the result would overflow
- [x] `combinations` now throws if computing n-choose-k is impossible

## Checklist
- [x] No new features
- [x] CI tests are passing

## Status
- [x] Ready for review
- [x] Ready for merge
