### PR TITLE
Add deprecation notices to Matrix::swap_rows and Matrix::swap_columns

### DIFF
--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -1009,8 +1009,14 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     ///
     void sort_cols(const IntVector& sortvec);
     /// Swap rows i and j
+    PSI_DEPRECATED(
+        "Matrix::swap_rows and Matrix::swap_columns are being deprecated due to a lack of users. Unless someone speaks "
+        "up, 1.8 will be the last release to have them.")
     void swap_rows(int h, int i, int j);
     /// Swap cols i and j
+    PSI_DEPRECATED(
+        "Matrix::swap_rows and Matrix::swap_columns are being deprecated due to a lack of users. Unless someone speaks "
+        "up, 1.8 will be the last release to have them.")
     void swap_columns(int h, int i, int j);
 
     /*! Average off-diagonal elements */


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
`Matrix::swap_rows` and `Matrix::swap_columns` do no seem to have any internal users, but since `Matrix` as a whole is `PSI_API`, it would be rude to suddenly remove them. This PR adds deprecation notices.

The motivation for removal is that these two functions are the only internal users of the DSWAP BLAS interface.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] `PSI_API` functions `Matrix::swap_rows` and `Matrix::swap_columns` are now deprecated due to a lack of users. Unless someone speaks up, 1.8 will be the last release to have them.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Deprecation notices added to `matrix.h`

## Checklist
- [x] No new features
- [ ] CI tests are passing

## Status
- [x] Ready for review
- [ ] Ready for merge
