### PR TITLE
merge queue preparation

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -2,6 +2,7 @@ name: Docs
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
 

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,7 @@
 trigger:
   - master
+  - gh-readonly-queue/master
+  - 1.8.x
   - 1.7.x
   - 1.6.x
   - 1.5.x


### PR DESCRIPTION
## Description
We often have PRs held up because CI needs fixing. Then all the "broken" PRs have to rebase or hit the update button (which means their remotes are out-of-sync with the local branches). The beta GH merge queue might help this, since PRs are built on top of their predecessor, so a CI fix PR can be inserted at the head of the queue. This PR does hopefully the prep work needed and described in:
Following directions at https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

## Status
- [ ] Ready for review
- [ ] Ready for merge
