### PR TITLE
DFJK Expert I/O Control Part 2: DiskDFJK

### DIFF
--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -723,13 +723,13 @@ be selected in all cases so that the correct implementation can be selected by
 |PSIfours| internal routines. Expert users can manually switch between MEM_DF and
 DISK_DF; however, they may find documented exceptions during use as several
 post SCF algorithms require a specific implementation. Additionally, expert users 
-can manually switch between the in-memory and on-disk options *within* MEM_DF using 
+can manually switch between the in-memory and on-disk options *within* MEM_DF or DISK_DF using 
 the |scf__scf_subtype| option. Using ``SCF_SUBTYPE = AUTO``, where |PSIfour| 
-automatically selects the in-memory or on-disk option for MEM_DF based on memory and molecule, is the default 
-and recommended option. However, the in-memory or on-disk algorithms for MEM_DF can be forced by using
+automatically selects the in-memory or on-disk option for MEM_DF/DISK_DF based on memory and molecule, is the default 
+and recommended option. However, the in-memory or on-disk algorithms for MEM_DF and DISK_DF can be forced by using
 ``SCF_SUBTYPE = INCORE`` or ``SCF_SUBTYPE = OUT_OF_CORE``, respectively.
 Note that an exception will be thrown if 
-``SCF_SUBTYPE = INCORE`` is used with MEM_DF without allocating sufficient memory to 
+``SCF_SUBTYPE = INCORE`` is used without allocating sufficient memory to 
 |PSIfour|.
 
 For some of these algorithms, Schwarz and/or density sieving can be used to

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -51,8 +51,8 @@ using namespace psi;
 
 namespace psi {
 
-CDJK::CDJK(std::shared_ptr<BasisSet> primary, double cholesky_tolerance)
-    : DiskDFJK(primary, primary), cholesky_tolerance_(cholesky_tolerance) {}
+CDJK::CDJK(std::shared_ptr<BasisSet> primary, Options& options, double cholesky_tolerance)
+    : DiskDFJK(primary, primary, options), cholesky_tolerance_(cholesky_tolerance) {}
 CDJK::~CDJK() {}
 void CDJK::initialize_JK_disk() { throw PsiException("Disk algorithm for CD JK not implemented.", __FILE__, __LINE__); }
 size_t CDJK::memory_estimate() {

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -295,7 +295,7 @@ bool DiskDFJK::is_core() {
     // .. or forcibly disable AO_core_ if user specifies ...
     } else if (subalgo_ == "NO_INCORE") {
         if (print_ > 0) {
-            outfile->Printf("  FORCE_MEM = NO_INCORE selected. Out-of-core MEM_DF algorithm will be used.\n");
+            outfile->Printf("  FORCE_MEM = NO_INCORE selected. Out-of-core DISK_DF algorithm will be used.\n\n");
         }
 	
 	do_core = false; 
@@ -306,7 +306,7 @@ bool DiskDFJK::is_core() {
             throw PSIEXCEPTION("FORCE_MEM=FORCE_INCORE was specified, but there is not enough memory to do in-core! Increase the amount of memory allocated to Psi4 or allow for out-of-core to be used.\n");
         } else {
             if (print_ > 0) {
-                outfile->Printf("  FORCE_MEM=FORCE_INCORE selected. In-core MEM_DF algorithm will be used.\n");
+                outfile->Printf("  FORCE_MEM=FORCE_INCORE selected. In-core DISK_DF algorithm will be used.\n\n");
             }
             do_core = true; 
         }

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -288,19 +288,19 @@ void DiskDFJK::print_header() const {
 bool DiskDFJK::is_core() {
     auto do_core = is_core_;
 
-    // determine AO_core_ either automatically...
+    // determine do_core either automatically...
     if (subalgo_ == "AUTO") {
         do_core = memory_estimate() < memory_;
 
-    // .. or forcibly disable AO_core_ if user specifies ...
+    // .. or forcibly disable do_core if user specifies ...
     } else if (subalgo_ == "OUT_OF_CORE") {
         if (print_ > 0) {
             outfile->Printf("  SCF_SUBTYPE = OUT_OF_CORE selected. Out-of-core DISK_DF algorithm will be used.\n\n");
         }
-	
-	do_core = false; 
 
-   // .. or force AO_core_ if user specifies
+	do_core = false;
+
+   // .. or force do_core if user specifies
     } else if (subalgo_ == "INCORE") {
         if (memory_estimate() > memory_) {
             throw PSIEXCEPTION("SCF_SUBTYPE=INCORE was specified, but there is not enough memory to do in-core! Increase the amount of memory allocated to Psi4 or allow for out-of-core to be used.\n");
@@ -308,7 +308,7 @@ bool DiskDFJK::is_core() {
             if (print_ > 0) {
                 outfile->Printf("  SCF_SUBTYPE=INCORE selected. In-core DISK_DF algorithm will be used.\n\n");
             }
-            do_core = true; 
+            do_core = true;
         }
     } else {
         throw PSIEXCEPTION("Invalid SCF_SUBTYPE option! The choices for SCF_SUBTYPE are AUTO, INCORE, and OUT_OF_CORE.");

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -65,7 +65,7 @@ void DiskDFJK::common_init() {
     df_ints_io_ = "NONE";
     condition_ = 1.0E-12;
     unit_ = PSIF_DFSCF_BJ;
-    if (options_["FORCE_MEM"].has_changed()) set_subalgo(options_.get_str("FORCE_MEM"));
+    if (options_["SCF_SUBTYPE"].has_changed()) set_subalgo(options_.get_str("SCF_SUBTYPE"));
     is_core_ = true;
     psio_ = PSIO::shared_object();
     // We need to make an integral object so we can figure out memory requirements from the sieve
@@ -293,25 +293,25 @@ bool DiskDFJK::is_core() {
         do_core = memory_estimate() < memory_;
 
     // .. or forcibly disable AO_core_ if user specifies ...
-    } else if (subalgo_ == "NO_INCORE") {
+    } else if (subalgo_ == "OUT_OF_CORE") {
         if (print_ > 0) {
-            outfile->Printf("  FORCE_MEM = NO_INCORE selected. Out-of-core DISK_DF algorithm will be used.\n\n");
+            outfile->Printf("  SCF_SUBTYPE = OUT_OF_CORE selected. Out-of-core DISK_DF algorithm will be used.\n\n");
         }
 	
 	do_core = false; 
 
    // .. or force AO_core_ if user specifies
-    } else if (subalgo_ == "FORCE_INCORE") {
+    } else if (subalgo_ == "INCORE") {
         if (memory_estimate() > memory_) {
-            throw PSIEXCEPTION("FORCE_MEM=FORCE_INCORE was specified, but there is not enough memory to do in-core! Increase the amount of memory allocated to Psi4 or allow for out-of-core to be used.\n");
+            throw PSIEXCEPTION("SCF_SUBTYPE=INCORE was specified, but there is not enough memory to do in-core! Increase the amount of memory allocated to Psi4 or allow for out-of-core to be used.\n");
         } else {
             if (print_ > 0) {
-                outfile->Printf("  FORCE_MEM=FORCE_INCORE selected. In-core DISK_DF algorithm will be used.\n\n");
+                outfile->Printf("  SCF_SUBTYPE=INCORE selected. In-core DISK_DF algorithm will be used.\n\n");
             }
             do_core = true; 
         }
     } else {
-        throw PSIEXCEPTION("Invalid FORCE_MEM option! The choices for FORCE_MEM are AUTO, FORCE_INCORE, and NO_INCORE.");
+        throw PSIEXCEPTION("Invalid SCF_SUBTYPE option! The choices for SCF_SUBTYPE are AUTO, INCORE, and OUT_OF_CORE.");
     }
 
     return do_core;

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -298,7 +298,7 @@ bool DiskDFJK::is_core() {
             outfile->Printf("  SCF_SUBTYPE = OUT_OF_CORE selected. Out-of-core DISK_DF algorithm will be used.\n\n");
         }
 
-	do_core = false;
+        do_core = false;
 
    // .. or force do_core if user specifies
     } else if (subalgo_ == "INCORE") {

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -89,7 +89,7 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
     }
 
     if (jk_type == "CD") {
-        CDJK* jk = new CDJK(primary, options.get_double("CHOLESKY_TOLERANCE"));
+        auto jk = std::make_shared<CDJK>(primary, options, options.get_double("CHOLESKY_TOLERANCE"));
 
         if (options["INTS_TOLERANCE"].has_changed()) jk->set_cutoff(options.get_double("INTS_TOLERANCE"));
         if (options["SCREENING"].has_changed()) jk->set_csam(options.get_str("SCREENING") == "CSAM");
@@ -101,10 +101,10 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
         if (options["DF_INTS_NUM_THREADS"].has_changed())
             jk->set_df_ints_num_threads(options.get_int("DF_INTS_NUM_THREADS"));
 
-        return std::shared_ptr<JK>(jk);
+        return jk;
 
     } else if (jk_type == "DISK_DF") {
-        auto jk = std::make_shared<DiskDFJK>(primary, auxiliary);
+        auto jk = std::make_shared<DiskDFJK>(primary, auxiliary, options);
         _set_dfjk_options<DiskDFJK>(jk, options);
         if (options["DF_INTS_IO"].has_changed()) jk->set_df_ints_io(options.get_str("DF_INTS_IO"));
 

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -912,9 +912,12 @@ class PSI_API DiskDFJK : public JK {
     double condition_;
     /// File number for (Q|mn) tensor
     size_t unit_;
-    // Use in-core or out-of-core algo?
+    // Which subalgorithm (in-core or out-of-core) do we use?
+    // AUTO lets DFHelper decide based on memory allocated
+    // INCORE forces the in-core subalgorithm (is_core_ = true)
+    // OUT_OF_CORE forces the out-of-core subalgorithm (is_core_ = false)
     std::string subalgo_ = "AUTO";
-    /// Core or disk?
+    // Use in-core subalgorithm?
     bool is_core_;
     /// Maximum number of rows to handle at a time
     int max_rows_;
@@ -1034,7 +1037,7 @@ class PSI_API DiskDFJK : public JK {
     void set_df_ints_num_threads(int val) { df_ints_num_threads_ = val; }
     ///
     /// Indicates whether to use the in-core or out-of-core
-    //  subalgorithm available in MemDFJK, or to let
+    //  subalgorithm available in DiskDFJK, or to let
     //  Psi4 select automatically based on allocated memory
     /// defaults to AUTO (Psi4 selects by default)
     ///

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -892,6 +892,9 @@ class GTFockJK : public JK {
  */
 class PSI_API DiskDFJK : public JK {
    protected:
+    /// Options object
+    Options& options_;
+	   
     // => DF-Specific stuff <= //
 
     std::string name() override { return "DiskDFJK"; }
@@ -909,6 +912,8 @@ class PSI_API DiskDFJK : public JK {
     double condition_;
     /// File number for (Q|mn) tensor
     size_t unit_;
+    // Use in-core or out-of-core algo?
+    std::string subalgo_ = "AUTO";
     /// Core or disk?
     bool is_core_;
     /// Maximum number of rows to handle at a time
@@ -989,7 +994,7 @@ class PSI_API DiskDFJK : public JK {
      *        structure as this molecule
      * @param auxiliary auxiliary basis set for this system.
      */
-    DiskDFJK(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary);
+    DiskDFJK(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary, Options& options_);
 
     /// Destructor
     ~DiskDFJK() override;
@@ -1027,6 +1032,13 @@ class PSI_API DiskDFJK : public JK {
      * @param val a positive integer
      */
     void set_df_ints_num_threads(int val) { df_ints_num_threads_ = val; }
+    ///
+    /// Indicates whether to use the in-core or out-of-core
+    //  subalgorithm available in MemDFJK, or to let
+    //  Psi4 select automatically based on allocated memory
+    /// defaults to AUTO (Psi4 selects by default)
+    ///
+    void set_subalgo(std::string subalgo) { subalgo_ = subalgo; }
 
     // => Accessors <= //
 
@@ -1083,7 +1095,7 @@ class PSI_API CDJK : public DiskDFJK {
      *        structure as this molecule
      * @param cholesky_tolerance tolerance for cholesky decomposition.
      */
-    CDJK(std::shared_ptr<BasisSet> primary, double cholesky_tolerance);
+    CDJK(std::shared_ptr<BasisSet> primary, Options& options, double cholesky_tolerance);
 
     /// Destructor
     ~CDJK() override;

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -894,7 +894,7 @@ class PSI_API DiskDFJK : public JK {
    protected:
     /// Options object
     Options& options_;
-	   
+
     // => DF-Specific stuff <= //
 
     std::string name() override { return "DiskDFJK"; }

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1419,8 +1419,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
             depending on available memory or other hardware constraints, allow the best
             sub-algorithm for the molecule and conditions (``AUTO`` ; usual mode) or
             forcibly select a sub-algorithm (usually only for debugging or profiling).
-            Presently, ``SCF_TYPE=MEM_DF`` can have ``INCORE`` or ``OUT_OF_CORE`` selected.
-            (This also applies for ``SCF_TYPE=DF`` when ``MEM_DF`` active.) !expert -*/
+            Presently, ``SCF_TYPE=MEM_DF`` and ``SCF_TYPE=DISK_DF`` can have ``INCORE`` 
+	    or ``OUT_OF_CORE`` selected. (This also applies for ``SCF_TYPE=DF``.) !expert -*/
 	options.add_str("SCF_SUBTYPE", "AUTO", "AUTO INCORE OUT_OF_CORE");
         /*- Keep JK object for later use? -*/
         options.add_bool("SAVE_JK", false);

--- a/samples/linK-2/input.dat
+++ b/samples/linK-2/input.dat
@@ -21,9 +21,9 @@ molecule mol {
 }
 
 set {
-    scf_type link 
-    df_scf_guess false
-    basis cc-pVTZ
+    scf_type disk_df 
+    force_mem auto
+    basis aug-cc-pVQZ
     e_convergence 1.0e-10
     screening density
     incfock true
@@ -31,6 +31,8 @@ set {
     linK_ints_tolerance 1.0e-12
 }
 
-linK_energy = energy('b3lyp')
+memory 3 GB
+
+linK_energy = energy('hf')
 psi4.compare_values(ref_energy, linK_energy, 8, "B3LYP Energy (using LinK algo)")
 compare(1, variable("SCF ITERATIONS") < 13.0, "LinK Incfock Efficient")

--- a/samples/linK-2/input.dat
+++ b/samples/linK-2/input.dat
@@ -21,9 +21,9 @@ molecule mol {
 }
 
 set {
-    scf_type disk_df 
-    force_mem auto
-    basis aug-cc-pVQZ
+    scf_type link 
+    df_scf_guess false
+    basis cc-pVTZ
     e_convergence 1.0e-10
     screening density
     incfock true
@@ -31,8 +31,6 @@ set {
     linK_ints_tolerance 1.0e-12
 }
 
-memory 3 GB
-
-linK_energy = energy('hf')
+linK_energy = energy('b3lyp')
 psi4.compare_values(ref_energy, linK_energy, 8, "B3LYP Energy (using LinK algo)")
 compare(1, variable("SCF ITERATIONS") < 13.0, "LinK Incfock Efficient")


### PR DESCRIPTION
## Description

This PR is part two of a mini-project regarding the two DFJK algorithms present in Psi4. The first PR (https://github.com/psi4/psi4/pull/2848) applied to MemDFJK, and the second PR (this one) applies to DiskDFJK. The goal of this PR project is to add an expert keyword to allow user control over which subalgorithm is used by either MemDFJK or DiskDFJK. See, MemDFJK and DiskDFJK, despite their name, each have separate "subalgorithms" optimized to be run either in-core or out-of-core. While MemDFJK and DiskDFJK can be independently selected with `SCF_TYPE`, their subalgorithms cannot be; subalgorithm selection was previously controlled exclusively through memory allocated to Psi4. The mini-project this PR is part of, is meant to rectify that issue.

In the previous PR of this project, the `SCF_SUBTYPE` keyword was introduced, an expert option allowing for forced execution of a given subalgorithm. The default option, `AUTO`, has the code select the subalgorithm automatically, as before. `INCORE` forces MemDFJK to use the in-core subalgorithm, and throws an exception if not enough memory is allocated to Psi4 to do so. `OUT_OF_CORE` forces MemDFJK to use the out-of-core subalgorithm, even if enough memory is allocated to Psi4 to use the in-core subalgorithm.

This current PR takes the `SCF_SUBTYPE` keyword, previously applied to MemDFJK, and applies it to the DiskDFJK algorithm, with the same effects.

## User API & Changelog headlines
- N/A

## Dev notes & details
- [X] Implements functionality of the SCF_SUBTYPE keyword to the DiskDFJK class (i.e., the DISK_DF SCF_TYPE).

## Questions
- N/A

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [x] Ready for merge 