### PR TITLE
DFJK Expert I/O Control Bonus: PKJK

### DIFF
--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -215,7 +215,7 @@ def scf_initialize(self):
         core.print_out("\n  ==> Pre-Iterations <==\n\n")
 
         # force SCF_SUBTYPE to AUTO during SCF guess
-        optstash = p4util.OptionsState(["SCF_SUBTYPE"])
+        optstash = p4util.OptionsState(["SCF", "SCF_SUBTYPE"])
         core.set_local_option("SCF", "SCF_SUBTYPE", "AUTO")
 
         core.timer_on("HF: Guess")

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -214,16 +214,15 @@ def scf_initialize(self):
 
         core.print_out("\n  ==> Pre-Iterations <==\n\n")
 
-        # disable scf_subtype for SAD guess
-        scf_subtype_cache = core.get_local_option("SCF", "SCF_SUBTYPE")
+        # force SCF_SUBTYPE to AUTO during SCF guess
+        optstash = p4util.OptionsState(["SCF_SUBTYPE"])
         core.set_local_option("SCF", "SCF_SUBTYPE", "AUTO")
 
         core.timer_on("HF: Guess")
         self.guess()
         core.timer_off("HF: Guess")
 
-        # re-enable scf_subtype after SAD guess is done
-        core.set_local_option("SCF", "SCF_SUBTYPE", scf_subtype_cache)
+        optstash.restore()
 
         # Print out initial docc/socc/etc data
         if self.get_print():                    

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -214,9 +214,17 @@ def scf_initialize(self):
 
         core.print_out("\n  ==> Pre-Iterations <==\n\n")
 
+        # disable scf_subtype for SAD guess
+        scf_subtype_cache = core.get_local_option("SCF", "SCF_SUBTYPE")
+        core.set_local_option("SCF", "SCF_SUBTYPE", "AUTO")
+
         core.timer_on("HF: Guess")
         self.guess()
         core.timer_off("HF: Guess")
+
+        # re-enable scf_subtype after SAD guess is done
+        core.set_local_option("SCF", "SCF_SUBTYPE", scf_subtype_cache)
+
         # Print out initial docc/socc/etc data
         if self.get_print():                    
             lack_occupancy = core.get_local_option('SCF', 'GUESS') in ['SAD']

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -556,6 +556,9 @@ void throw_deprecation_errors(std::string const& key, std::string const& module 
     if (module == "SCF" && key == "PK_NO_INCORE") {
         py_psi_print_out("WARNING!\n\tRemove keyword PK_NO_INCORE! PK_NO_INCORE has been replaced by the SCF_SUBTYPE=NO_INCORE option. Using PK_NO_INCORE will raise an error in v1.8.\n");
     }
+    if (module == "SCF" && key == "PK_ALGO") {
+        py_psi_print_out("WARNING!\n\tRemove keyword PK_ALGO! PK_ALGO has been replaced by the SCF_SUBTYPE=YOSHIMINE_OUT_OF_CORE and REORDER_OUT_OF_CORE options. Using PK_ALGO will raise an error in v1.8.\n");
+    }
 }
 
 Options& py_psi_get_options() { return Process::environment.options; }

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -553,6 +553,9 @@ void throw_deprecation_errors(std::string const& key, std::string const& module 
     if (module == "SCF" && key == "DIIS_MIN_VECS") {
         py_psi_print_out("WARNING!\n\tRemove keyword DIIS_MIN_VECS! This keyword does nothing. Using it will raise an error in v1.7.\n");
     }
+    if (module == "SCF" && key == "PK_NO_INCORE") {
+        py_psi_print_out("WARNING!\n\tRemove keyword PK_NO_INCORE! PK_NO_INCORE has been replaced by the SCF_SUBTYPE=NO_INCORE option. Using PK_NO_INCORE will raise an error in v1.8.\n");
+    }
 }
 
 Options& py_psi_get_options() { return Process::environment.options; }

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -111,17 +111,19 @@ std::shared_ptr<PKManager> PKManager::build_PKManager(std::shared_ptr<PSIO> psio
     bool do_reord = false;
     bool do_yosh = false;
     bool do_incore = false;
-    if (options["PK_ALGO"].has_changed() && subalgo != "INCORE") {
-        if (algo == "REORDER") {
-            do_reord = true;
-        } else if (algo == "YOSHIMINE") {
-            do_yosh = true;
-        }
-    } else {
-        if (algo_factor * memory > pk_size) {
-            do_reord = true;
+    if (subalgo != "INCORE") {
+        if (options["PK_ALGO"].has_changed()) { 
+            if (algo == "REORDER") {
+                do_reord = true;
+            } else if (algo == "YOSHIMINE") {
+                do_yosh = true;
+            }
         } else {
-            do_yosh = true;
+            if (algo_factor * memory > pk_size) {
+                do_reord = true;
+            } else {
+                do_yosh = true;
+            }
         }
     }
     

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -88,7 +88,7 @@ std::shared_ptr<PKManager> PKManager::build_PKManager(std::shared_ptr<PSIO> psio
                                                       size_t memory, Options& options, bool dowK, double omega_in) {
     std::string algo = options.get_str("PK_ALGO");
     std::string subalgo = options.get_str("SCF_SUBTYPE");
-    
+
     // We introduce another safety factor in the memory, otherwise
     // we are apparently prone to being killed by the OS.
     // TODO: Check for memory leaks ? Trace memory usage ?
@@ -106,13 +106,13 @@ std::shared_ptr<PKManager> PKManager::build_PKManager(std::shared_ptr<PSIO> psio
     if (dowK) {
         ncorebuf = 3;
     }
-  
-    // determine which sub-algorithm to use  
+
+    // determine which sub-algorithm to use
     bool do_reord = false;
     bool do_yosh = false;
     bool do_incore = false;
     if (subalgo != "INCORE") {
-        if (options["PK_ALGO"].has_changed()) { 
+        if (options["PK_ALGO"].has_changed()) {
             if (algo == "REORDER") {
                 do_reord = true;
             } else if (algo == "YOSHIMINE") {
@@ -126,11 +126,11 @@ std::shared_ptr<PKManager> PKManager::build_PKManager(std::shared_ptr<PSIO> psio
             }
         }
     }
-    
+
     // throw exception if INCORE requested without enough memory...
     if (ncorebuf * pk_size > memory && subalgo == "INCORE") {
         throw PSIEXCEPTION("SCF_SUBTYPE=INCORE was specified, but there is not enough memory to do in-core! Increase the amount of memory allocated to Psi4 or allow for out-of-core to be used.\n");
-    
+
     // ..or do INCORE if OUT_OF_CORE not explicitly requested and enough memory 
     } else if (ncorebuf * pk_size < memory && subalgo != "OUT_OF_CORE")  {
 	do_incore = true;

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -131,7 +131,7 @@ std::shared_ptr<PKManager> PKManager::build_PKManager(std::shared_ptr<PSIO> psio
     if (ncorebuf * pk_size > memory && subalgo == "INCORE") {
         throw PSIEXCEPTION("SCF_SUBTYPE=INCORE was specified, but there is not enough memory to do in-core! Increase the amount of memory allocated to Psi4 or allow for out-of-core to be used.\n");
 
-    // ..or do INCORE if OUT_OF_CORE not explicitly requested and enough memory 
+    // ..or do INCORE if OUT_OF_CORE not explicitly requested and enough memory
     } else if (ncorebuf * pk_size < memory && subalgo != "OUT_OF_CORE")  {
 	do_incore = true;
     }

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -87,8 +87,9 @@ void ijklBasisIterator::next() {
 std::shared_ptr<PKManager> PKManager::build_PKManager(std::shared_ptr<PSIO> psio, std::shared_ptr<BasisSet> primary,
                                                       size_t memory, Options& options, bool dowK, double omega_in) {
     std::string algo = options.get_str("PK_ALGO");
-    bool noincore = options.get_bool("PK_NO_INCORE");
-
+    std::string subalgo = options.get_str("SCF_SUBTYPE");
+    bool noincore = subalgo == "OUT_OF_CORE";
+    
     // We introduce another safety factor in the memory, otherwise
     // we are apparently prone to being killed by the OS.
     // TODO: Check for memory leaks ? Trace memory usage ?

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -116,9 +116,9 @@ std::shared_ptr<PKManager> PKManager::build_PKManager(std::shared_ptr<PSIO> psio
     bool do_incore = false;
 
     // specify particular out-of-core subalgorithm...
-    if (subalgo == "OOC_REORDER") {
+    if (subalgo == "REORDER_OUT_OF_CORE") {
 	do_reord = true;
-    } else if (subalgo == "OOC_YOSHIMINE") {
+    } else if (subalgo == "YOSHIMINE_OUT_OF_CORE") {
         do_yosh = true;
 
     // ...or automatically select an out-of-core subalgorithm...
@@ -140,6 +140,7 @@ std::shared_ptr<PKManager> PKManager::build_PKManager(std::shared_ptr<PSIO> psio
 
     // ...or just let psi4 pick any subalgorithm
     } else if (subalgo == "AUTO") {
+
         if (ncorebuf * pk_size < memory) {
             do_incore = true;
 	} else if (algo_factor * memory > pk_size) {
@@ -150,7 +151,7 @@ std::shared_ptr<PKManager> PKManager::build_PKManager(std::shared_ptr<PSIO> psio
 
     // throw an exception on an invalid SCF_SUBTYPE
     } else {
-        throw PSIEXCEPTION("Invalid SCF_SUBTYPE option! The valid choices of SCF_SUBTYPE for SCF_TYPE=PK are AUTO, INCORE, OUT_OF_CORE, OOC_YOSHIMINE, and OOC_REORDER.");
+        throw PSIEXCEPTION("Invalid SCF_SUBTYPE option! The valid choices of SCF_SUBTYPE for SCF_TYPE=PK are AUTO, INCORE, OUT_OF_CORE, YOSHIMINE_OUT_OF_CORE, and REORDER_OUT_OF_CORE.");
     }
 
     std::shared_ptr<PKManager> pkmgr;

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -117,7 +117,7 @@ std::shared_ptr<PKManager> PKManager::build_PKManager(std::shared_ptr<PSIO> psio
 
     // specify particular out-of-core subalgorithm...
     if (subalgo == "REORDER_OUT_OF_CORE") {
-	do_reord = true;
+        do_reord = true;
     } else if (subalgo == "YOSHIMINE_OUT_OF_CORE") {
         do_yosh = true;
 
@@ -131,23 +131,22 @@ std::shared_ptr<PKManager> PKManager::build_PKManager(std::shared_ptr<PSIO> psio
 
     // ...or force the in-core algorithm...
     } else if (subalgo == "INCORE") {
-	// throw an exception if in-core is forced, but not enough memory is allocated
+        // throw an exception if in-core is forced, but not enough memory is allocated
         if (ncorebuf * pk_size > memory) {
             throw PSIEXCEPTION("SCF_SUBTYPE=INCORE was specified, but there is not enough memory to do in-core! Increase the amount of memory allocated to Psi4 or allow for out-of-core to be used.\n");
         } else {
             do_incore = true;
-	}
+        }
 
     // ...or just let psi4 pick any subalgorithm
     } else if (subalgo == "AUTO") {
-
         if (ncorebuf * pk_size < memory) {
             do_incore = true;
-	} else if (algo_factor * memory > pk_size) {
+        } else if (algo_factor * memory > pk_size) {
             do_reord = true;
-	} else {
+        } else {
             do_yosh = true;
-	}
+        }
 
     // throw an exception on an invalid SCF_SUBTYPE
     } else {
@@ -205,9 +204,9 @@ PKManager::PKManager(std::shared_ptr<BasisSet> primary, size_t memory, Options& 
 #ifdef _OPENMP
     nthreads_ = Process::environment.get_n_threads();
     if (nthreads_ > pk_size_) {
-	outfile->Printf("  WARNING! More threads than unique shell quartets to compute!\n");
-	outfile->Printf("  Decreasing thread count to %d.\n", pk_size_);	
-	nthreads_ = pk_size_;
+        outfile->Printf("  WARNING! More threads than unique shell quartets to compute!\n");
+        outfile->Printf("  Decreasing thread count to %d.\n", pk_size_);
+        nthreads_ = pk_size_;
     }
 #endif
 }

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1401,11 +1401,6 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_str("DF_BASIS_SCF", "");
         /*- Maximum numbers of batches to read PK supermatrix. !expert -*/
         options.add_int("PK_MAX_BUCKETS", 500);
-        /*- Select the out-of-core PK subalgorithm to use, given an
-	    out-of-core PK subalgorithm is utilized. The in-core PK subalgorithm
-	    can be forced by setting ``SCF_SUBTYPE=INCORE``.
-	    For debug purposes, selection will be automated later. !expert -*/
-        options.add_str("PK_ALGO", "REORDER", "REORDER YOSHIMINE");
         /*- All densities are considered non symmetric, debug only. !expert -*/
         options.add_bool("PK_ALL_NONSYM", false);
         /*- Max memory per buf for PK algo REORDER, for debug and tuning -*/
@@ -1420,10 +1415,10 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
             depending on available memory or other hardware constraints, allow the best
             sub-algorithm for the molecule and conditions (``AUTO`` ; usual mode) or
             forcibly select a sub-algorithm (usually only for debugging or profiling).
-            Presently, ``SCF_TYPE=DF`` (including its constituents ``SCF_TYPE=MEM_DF`` 
-	    and ``SCF_TYPE=DISK_DF``) and ``SCF_TYPE=PK``  can have ``INCORE`` 
-	    or ``OUT_OF_CORE`` selected. !expert -*/
-	options.add_str("SCF_SUBTYPE", "AUTO", "AUTO INCORE OUT_OF_CORE");
+            Presently, ``SCF_TYPE=MEM_DF`` (including ``SCF_TYPE=DF`` using the in-core subalgorithm)
+	    can have ``INCORE`` and ``OUT_OF_CORE`` selected; and ``SCF_TYPE=PK``  can have ``INCORE``,
+	    ``OUT_OF_CORE``, ``OOC_YOSHIMINE``, and ``OOC_REORDER`` selected. !expert -*/
+	options.add_str("SCF_SUBTYPE", "AUTO", "AUTO INCORE OUT_OF_CORE OOC_YOSHIMINE OOC_REORDER");
         /*- Keep JK object for later use? -*/
         options.add_bool("SAVE_JK", false);
         /*- Memory safety factor for allocating JK -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1415,10 +1415,10 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
             depending on available memory or other hardware constraints, allow the best
             sub-algorithm for the molecule and conditions (``AUTO`` ; usual mode) or
             forcibly select a sub-algorithm (usually only for debugging or profiling).
-            Presently, ``SCF_TYPE=MEM_DF`` (including ``SCF_TYPE=DF`` using the in-core subalgorithm)
-	    can have ``INCORE`` and ``OUT_OF_CORE`` selected; and ``SCF_TYPE=PK``  can have ``INCORE``,
-	    ``OUT_OF_CORE``, ``YOSHIMINE_OUT_OF_CORE``, and ``REORDER_OUT_OF_CORE`` selected. !expert -*/
-	options.add_str("SCF_SUBTYPE", "AUTO", "AUTO INCORE OUT_OF_CORE YOSHIMINE_OUT_OF_CORE REORDER_OUT_OF_CORE");
+            Presently, ``SCF_SUBTYPE=DF``, ``SCF_SUBTYPE=MEM_DF``, and ``SCF_SUBTYPE=DISK_DF`` 
+	        can have ``INCORE`` and ``OUT_OF_CORE`` selected; and ``SCF_TYPE=PK``  can have ``INCORE``,
+	        ``OUT_OF_CORE``, ``YOSHIMINE_OUT_OF_CORE``, and ``REORDER_OUT_OF_CORE`` selected. !expert -*/
+	    options.add_str("SCF_SUBTYPE", "AUTO", "AUTO INCORE OUT_OF_CORE YOSHIMINE_OUT_OF_CORE REORDER_OUT_OF_CORE");
         /*- Keep JK object for later use? -*/
         options.add_bool("SAVE_JK", false);
         /*- Memory safety factor for allocating JK -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1403,8 +1403,6 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_int("PK_MAX_BUCKETS", 500);
         /*- Select the PK algorithm to use. For debug purposes, selection will be automated later. !expert -*/
         options.add_str("PK_ALGO", "REORDER", "REORDER YOSHIMINE");
-        /*- Deactivate in core algorithm. For debug purposes. !expert -*/
-        options.add_bool("PK_NO_INCORE", false);
         /*- All densities are considered non symmetric, debug only. !expert -*/
         options.add_bool("PK_ALL_NONSYM", false);
         /*- Max memory per buf for PK algo REORDER, for debug and tuning -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1401,7 +1401,10 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_str("DF_BASIS_SCF", "");
         /*- Maximum numbers of batches to read PK supermatrix. !expert -*/
         options.add_int("PK_MAX_BUCKETS", 500);
-        /*- Select the PK algorithm to use. For debug purposes, selection will be automated later. !expert -*/
+        /*- Select the out-of-core PK subalgorithm to use, given an
+	    out-of-core PK subalgorithm is utilized. The in-core PK subalgorithm
+	    can be forced by setting ``SCF_SUBTYPE=INCORE``.
+	    For debug purposes, selection will be automated later. !expert -*/
         options.add_str("PK_ALGO", "REORDER", "REORDER YOSHIMINE");
         /*- All densities are considered non symmetric, debug only. !expert -*/
         options.add_bool("PK_ALL_NONSYM", false);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1417,8 +1417,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
             forcibly select a sub-algorithm (usually only for debugging or profiling).
             Presently, ``SCF_TYPE=MEM_DF`` (including ``SCF_TYPE=DF`` using the in-core subalgorithm)
 	    can have ``INCORE`` and ``OUT_OF_CORE`` selected; and ``SCF_TYPE=PK``  can have ``INCORE``,
-	    ``OUT_OF_CORE``, ``OOC_YOSHIMINE``, and ``OOC_REORDER`` selected. !expert -*/
-	options.add_str("SCF_SUBTYPE", "AUTO", "AUTO INCORE OUT_OF_CORE OOC_YOSHIMINE OOC_REORDER");
+	    ``OUT_OF_CORE``, ``YOSHIMINE_OUT_OF_CORE``, and ``REORDER_OUT_OF_CORE`` selected. !expert -*/
+	options.add_str("SCF_SUBTYPE", "AUTO", "AUTO INCORE OUT_OF_CORE YOSHIMINE_OUT_OF_CORE REORDER_OUT_OF_CORE");
         /*- Keep JK object for later use? -*/
         options.add_bool("SAVE_JK", false);
         /*- Memory safety factor for allocating JK -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1417,8 +1417,9 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
             depending on available memory or other hardware constraints, allow the best
             sub-algorithm for the molecule and conditions (``AUTO`` ; usual mode) or
             forcibly select a sub-algorithm (usually only for debugging or profiling).
-            Presently, ``SCF_TYPE=MEM_DF`` and ``SCF_TYPE=DISK_DF`` can have ``INCORE`` 
-	    or ``OUT_OF_CORE`` selected. (This also applies for ``SCF_TYPE=DF``.) !expert -*/
+            Presently, ``SCF_TYPE=DF`` (including its constituents ``SCF_TYPE=MEM_DF`` 
+	    and ``SCF_TYPE=DISK_DF``) and ``SCF_TYPE=PK``  can have ``INCORE`` 
+	    or ``OUT_OF_CORE`` selected. !expert -*/
 	options.add_str("SCF_SUBTYPE", "AUTO", "AUTO INCORE OUT_OF_CORE");
         /*- Keep JK object for later use? -*/
         options.add_bool("SAVE_JK", false);


### PR DESCRIPTION
## Description
This PR is a companion PR to https://github.com/psi4/psi4/pull/2848 and https://github.com/psi4/psi4/pull/2924. Those two PRs introduced the `SCF_SUBTYPE` keyword to Psi4, allowing for specifications of subalgorithms in SCF methods where appropriate, and applied the `SCF_SUBTYPE` keyword to MemDFJK and DiskDFJK, respectively.

As it turns out, the DFJK algorithms aren't the only JK algorithms where this new keyword may be useful.

The PKJK algorithm contains a number of subalgorithms, as well - an in-core algorithm (labeled InCore in the code) and two out-of-core algorithms (labeled Reorder and Yoshimine in the code). PKJK has some amount of control over which subalgorithm is utilized already - the `PK_ALGO` keyword specifies whether the Reorder or Yoshimine out-of-core algorithm is to be used, if an out-of-core algorithm is used; while the `PK_NO_INCORE` keyword disables the InCore PK algorithm and forces one of the out-of-core algorithms to be used. If the functionality of `PK_NO_INCORE` seems familiar, that's because it is - it is effectively the _exact_ same thing as `SCF_SUBTYPE=OUT_OF_CORE` for MemDFJK (in https://github.com/psi4/psi4/pull/2848) and DiskDFJK (in https://github.com/psi4/psi4/pull/2924).

The goal of this PR is to clean that up; `PK_NO_INCORE` is replaced by `SCF_SUBTYPE` for PKJK. `SCF_SUBTYPE=OUT_OF_CORE` has the exact same effect that `PK_NO_INCORE=TRUE` had previously. `SCF_SUBTYPE=AUTO` has PKJK select in-core or out-of-core by default, as per usual. Finally, `SCF_SUBTYPE=INCORE` allows PKJK to force-execute its in-core algorithm, a new functionality for PKJK as far as I am aware. As usual with `SCF_SUBTYPE`, setting it to `INCORE` without allocating sufficient memory to Psi4 will throw an exception.

## User API & Changelog headlines
- [X] The `PK_NO_INCORE` keyword has been removed.
- [X] The `SCF_SUBTYPE` keyword has been added for PKJK. `SCF_SUBTYPE=AUTO` has PKJK select the subalgorithm by default. `SCF_SUBTYPE=OUT_OF_CORE` forces PKJK to use one of the two out-of-core algorithms (equivalent to `PK_NO_INCORE=TRUE` previously). `SCF_SUBTYPE=INCORE` forces PKJK to use its in-core algorithm, and throws an exception if insufficient memory is allocated.

## Dev notes & details
- [X] The `PK_NO_INCORE` keyword for PKJK has been replaced with the new `SCF_SUBTYPE` keyword.

## Questions
-N/A

## Checklist
- [X] Tests added for any

 new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)
## Status
- [X] Ready for review
- [ ] Ready for merge