### PR TITLE
COSX Reformulation for Negative Grid Weights

### DIFF
--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -258,7 +258,6 @@ void CompositeJK::common_init() {
             linK_ints_cutoff_ = options_.get_double("LINK_INTS_TOLERANCE");
         } else {
             linK_ints_cutoff_ = cutoff_;
-
         }
     
     // Chain-of-Spheres Exchange (COSX)
@@ -329,6 +328,7 @@ void CompositeJK::common_init() {
 	            }
             }
 	        if (warning_printed_init) break;
+        }
 
         auto warning_printed_final = false;
         for (const auto &final_block : grid_final_->blocks()) {
@@ -392,7 +392,6 @@ void CompositeJK::common_init() {
         ;
     } else {
         throw PSIEXCEPTION("Invalid Composite K algorithm selected!");
-
     }
 }
 

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -249,6 +249,7 @@ void CompositeJK::common_init() {
         throw PSIEXCEPTION("Invalid Composite J algorithm selected!");
     }
 
+<<<<<<< HEAD:psi4/src/psi4/libfock/CompositeJK.cc
     // => Set up separate K algorithm <= //
 
     // Linear Exchange (LinK)
@@ -258,12 +259,14 @@ void CompositeJK::common_init() {
             linK_ints_cutoff_ = options_.get_double("LINK_INTS_TOLERANCE");
         } else {
             linK_ints_cutoff_ = cutoff_;
+
         }
     
     // Chain-of-Spheres Exchange (COSX)
     } else if (k_type_ == "COSX") {
         timer_on("CompositeJK: COSX Grid Construction");
 
+<<<<<<< HEAD:psi4/src/psi4/libfock/CompositeJK.cc
         // TODO: specify bool "DFT_REMOVE_DISTANT_POINTS" in the DFTGrid constructors
 
         // Create a small DFTGrid for the initial SCF iterations
@@ -322,7 +325,7 @@ void CompositeJK::common_init() {
             const auto w = init_block->w();
             for (int ipoint = 0; ipoint < init_block->npoints(); ++ipoint) {
                 if (w[ipoint] < 0.0) {
-	                outfile->Printf("  WARNING: The definition of the current initial grid includes negative weights, which the original COSX formulation does not support! If this is of concern, please choose another initial grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL.\n");
+	                outfile->Printf("  WARNING: The definition of the current initial grid includes negative weights, which the original COSX formulation does not support!\n    If this is of concern, please choose another initial grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL.\n\n");
 	                warning_printed_init = true;
 		            break;
 	            }
@@ -335,7 +338,7 @@ void CompositeJK::common_init() {
             const auto w = final_block->w();
             for (int ipoint = 0; ipoint < final_block->npoints(); ++ipoint) {
                 if (w[ipoint] < 0.0) {
-	                outfile->Printf("  WARNING: The definition of the current final grid includes negative weights, which the original COSX formulation does not support! If this is of concern, please choose another final grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL.\n");
+	                outfile->Printf("  WARNING: The definition of the current final grid includes negative weights, which the original COSX formulation does not support!\n    If this is of concern, please choose another final grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL.\n\n");
                     warning_printed_final = true;
 	                break;
 	            }
@@ -1596,7 +1599,7 @@ void CompositeJK::build_COSK(std::vector<std::shared_ptr<Matrix>>& D, std::vecto
 
                     // contract A_nu_tau with F_tau to get contribution to G_nu
                     // symmetry permitting, also contract A_nu_tau with F_nu to get contribution to G_tau
-                    // we fold sign(w) into the formation of G to correct for the modified definition of X 
+                    // we fold sign(w) into the formation of G to correct for the modified definition of X
                     for(size_t jki = 0; jki < njk; jki++) {
                         auto F_blockp = F_block[jki]->pointer();
                         auto G_blockp = G_block[jki]->pointer();

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -1448,14 +1448,14 @@ void CompositeJK::build_COSK(std::vector<std::shared_ptr<Matrix>>& D, std::vecto
 
         // resize the buffer of basis function values
         auto X_block_nosign = std::make_shared<Matrix>(npoints_block, nbf_block);  // points x nbf_block
-        auto X_block_sign = std::make_shared<Matrix>(npoints_block, nbf_block);  // points x nbf_block
+        //auto X_block_sign = std::make_shared<Matrix>(npoints_block, nbf_block);  // points x nbf_block
 
         auto X_block_nosignp = X_block_nosign->pointer();
-	auto X_block_signp = X_block_sign->pointer();
+	//auto X_block_signp = X_block_sign->pointer();
         for (size_t p = 0; p < npoints_block; p++) {
             for (size_t k = 0; k < nbf_block; k++) {
                 X_block_nosignp[p][k] = point_values->get(p, k) * std::sqrt(std::fabs(w[p]));
-                X_block_signp[p][k] = sign(w[p])*X_block_nosignp[p][k];
+                //X_block_signp[p][k] = sign(w[p])*X_block_nosignp[p][k];
             }
         }
 
@@ -1464,11 +1464,11 @@ void CompositeJK::build_COSK(std::vector<std::shared_ptr<Matrix>>& D, std::vecto
         auto X_block_bfmaxp = X_block_bfmax.pointer();
         for (size_t p = 0; p < npoints_block; p++) {
             for (size_t k = 0; k < nbf_block; k++) {
-                X_block_bfmaxp[p] = std::max(X_block_bfmaxp[p], std::abs(X_block_signp[p][k]));
+                X_block_bfmaxp[p] = std::max(X_block_bfmaxp[p], std::abs(X_block_nosignp[p][k]));
             }
         }
 
-        double X_block_max = X_block_sign->absmax();
+        double X_block_max = X_block_nosign->absmax();
 
         // => F Matrix <= //
 
@@ -1478,7 +1478,14 @@ void CompositeJK::build_COSK(std::vector<std::shared_ptr<Matrix>>& D, std::vecto
         // contract density with basis functions values at these grid points
         std::vector<SharedMatrix> F_block(njk);
         for(size_t jki = 0; jki < njk; jki++) {
-            F_block[jki] = linalg::doublet(X_block_sign, D_block[jki], false, true);
+            F_block[jki] = linalg::doublet(X_block_nosign, D_block[jki], false, true);
+        }
+
+        for (size_t p = 0; p < npoints_block; p++) {
+            for (size_t k = 0; k < nbf_block; k++) {
+                X_block_nosignp[p][k] *= sign(w[p]);
+                //X_block_signp[p][k] = sign(w[p])*X_block_nosignp[p][k];
+            }
         }
 
         // shell maxima of F_block

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -83,7 +83,7 @@ Matrix compute_numeric_overlap(const DFTGrid &grid, const std::shared_ptr<BasisS
 
         // lambda for returning sign of double
         auto sign = [ ](double val) {
-            return (0.0 < val) - (val < 0.0);
+            return static_cast<double>( (0.0 < val) - (val < 0.0) );
         };
 
         // resize the buffer of basis function values
@@ -249,7 +249,6 @@ void CompositeJK::common_init() {
         throw PSIEXCEPTION("Invalid Composite J algorithm selected!");
     }
 
-<<<<<<< HEAD:psi4/src/psi4/libfock/CompositeJK.cc
     // => Set up separate K algorithm <= //
 
     // Linear Exchange (LinK)
@@ -266,7 +265,6 @@ void CompositeJK::common_init() {
     } else if (k_type_ == "COSX") {
         timer_on("CompositeJK: COSX Grid Construction");
 
-<<<<<<< HEAD:psi4/src/psi4/libfock/CompositeJK.cc
         // TODO: specify bool "DFT_REMOVE_DISTANT_POINTS" in the DFTGrid constructors
 
         // Create a small DFTGrid for the initial SCF iterations
@@ -325,20 +323,19 @@ void CompositeJK::common_init() {
             const auto w = init_block->w();
             for (int ipoint = 0; ipoint < init_block->npoints(); ++ipoint) {
                 if (w[ipoint] < 0.0) {
-	                outfile->Printf("  WARNING: The definition of the current initial grid includes negative weights, which the original COSX formulation does not support!\n    If this is of concern, please choose another initial grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL.\n\n");
+	                outfile->Printf("  INFO: The definition of the current initial grid includes negative weights, which the original COSX formulation does not support!\n    If this is of concern, please choose another initial grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL.\n\n");
 	                warning_printed_init = true;
 		            break;
 	            }
             }
 	        if (warning_printed_init) break;
-        }
 
         auto warning_printed_final = false;
         for (const auto &final_block : grid_final_->blocks()) {
             const auto w = final_block->w();
             for (int ipoint = 0; ipoint < final_block->npoints(); ++ipoint) {
                 if (w[ipoint] < 0.0) {
-	                outfile->Printf("  WARNING: The definition of the current final grid includes negative weights, which the original COSX formulation does not support!\n    If this is of concern, please choose another final grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL.\n\n");
+	                outfile->Printf("  INFO: The definition of the current final grid includes negative weights, which the original COSX formulation does not support!\n    If this is of concern, please choose another final grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL.\n\n");
                     warning_printed_final = true;
 	                break;
 	            }
@@ -1539,7 +1536,7 @@ void CompositeJK::build_COSK(std::vector<std::shared_ptr<Matrix>>& D, std::vecto
         // lambda for returning sign of double
         // needed for formation of G
         auto sign = [ ](double val) {
-            return (0.0 < val) - (val < 0.0);
+            return static_cast<double>( (0.0 < val) - (val < 0.0) );
         };
 
         // calculate A_NU_TAU at all grid points in this block

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -83,7 +83,7 @@ Matrix compute_numeric_overlap(const DFTGrid &grid, const std::shared_ptr<BasisS
 
         // lambda for returning sign of double
         auto sign = [ ](double val) {
-            return static_cast<double>( (0.0 < val) - (val < 0.0) );
+            return (val >= 0.0) ? 1.0 : -1.0;
         };
 
         // resize the buffer of basis function values
@@ -1536,7 +1536,7 @@ void CompositeJK::build_COSK(std::vector<std::shared_ptr<Matrix>>& D, std::vecto
         // lambda for returning sign of double
         // needed for formation of G
         auto sign = [ ](double val) {
-            return static_cast<double>( (0.0 < val) - (val < 0.0) );
+            return (val >= 0.0) ? 1.0 : -1.0;
         };
 
         // calculate A_NU_TAU at all grid points in this block

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -320,7 +320,7 @@ void CompositeJK::common_init() {
             const auto w = init_block->w();
             for (int ipoint = 0; ipoint < init_block->npoints(); ++ipoint) {
                 if (w[ipoint] < 0.0) {
-	              outfile->Printf("  WARNING: The definition of the current initial grid includes negative weights, which the original COSX formulation does not support! If this is of concern, please choose another initial grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL. ");
+	              outfile->Printf("  WARNING: The definition of the current initial grid includes negative weights, which the original COSX formulation does not support! If this is of concern, please choose another initial grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL.\n");
 	              break;
 	        }
         }
@@ -329,7 +329,7 @@ void CompositeJK::common_init() {
             const auto w = final_block->w();
             for (int ipoint = 0; ipoint < final_block->npoints(); ++ipoint) {
                 if (w[ipoint] < 0.0) {
-	                outfile->Printf("  WARNING: The definition of the current final grid includes negative weights, which the original COSX formulation does not support! If this is of concern, please choose another final grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL. ");
+	                outfile->Printf("  WARNING: The definition of the current final grid includes negative weights, which the original COSX formulation does not support! If this is of concern, please choose another final grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL.\n");
 	                break;
 	        }
         }

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -259,7 +259,7 @@ void CompositeJK::common_init() {
         } else {
             linK_ints_cutoff_ = cutoff_;
         }
-
+    
     // Chain-of-Spheres Exchange (COSX)
     } else if (k_type_ == "COSX") {
         timer_on("CompositeJK: COSX Grid Construction");
@@ -312,26 +312,26 @@ void CompositeJK::common_init() {
         };
         grid_final_ = std::make_shared<DFTGrid>(primary_->molecule(), primary_, grid_final_int_options, grid_final_str_options, grid_final_float_options, options_);
 
-        // Sanity-check of grids to ensure no negative grid weights
-        // COSX crashes when grids with negative weights are used,
+        // Print out warning if grid with negative grid weights is used 
+        // Original Nesse COSX formulation does not support negative grid weights
         // which can happen with certain grid configurations
         // See https://github.com/psi4/psi4/issues/2890
         for (const auto &init_block : grid_init_->blocks()) {
             const auto w = init_block->w();
             for (int ipoint = 0; ipoint < init_block->npoints(); ++ipoint) {
                 if (w[ipoint] < 0.0) {
-                    throw PSIEXCEPTION("The definition of the current initial grid includes negative weights. As these are not suitable for the COSX implementation, please choose another initial grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL.");
-                }
-            }
+	              outfile->Printf("  WARNING: The definition of the current initial grid includes negative weights, which the original COSX formulation does not support! If this is of concern, please choose another initial grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL. ");
+	              break;
+	        }
         }
-
+    
         for (const auto &final_block : grid_final_->blocks()) {
             const auto w = final_block->w();
             for (int ipoint = 0; ipoint < final_block->npoints(); ++ipoint) {
                 if (w[ipoint] < 0.0) {
-                    throw PSIEXCEPTION("The definition of the current final grid includes negative weights. As these are not suitable for the COSX implementation, please choose another final grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL.");
-                }
-            }
+	                outfile->Printf("  WARNING: The definition of the current final grid includes negative weights, which the original COSX formulation does not support! If this is of concern, please choose another final grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL. ");
+	                break;
+	        }
         }
 
         timer_off("CompositeJK: COSX Grid Construction");

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -1455,7 +1455,7 @@ void CompositeJK::build_COSK(std::vector<std::shared_ptr<Matrix>>& D, std::vecto
         auto X_blockp = X_block->pointer();
         for (size_t p = 0; p < npoints_block; p++) {
             for (size_t k = 0; k < nbf_block; k++) {
-                X_blockp[p][k] = point_values->get(p, k) * std::sqrt(std::fabs(w[p]));
+                X_blockp[p][k] = point_values->get(p, k) * std::sqrt(std::abs(w[p]));
             }
         }
 

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -316,22 +316,30 @@ void CompositeJK::common_init() {
         // Original Nesse COSX formulation does not support negative grid weights
         // which can happen with certain grid configurations
         // See https://github.com/psi4/psi4/issues/2890
+        auto warning_printed_init = false;
         for (const auto &init_block : grid_init_->blocks()) {
             const auto w = init_block->w();
             for (int ipoint = 0; ipoint < init_block->npoints(); ++ipoint) {
                 if (w[ipoint] < 0.0) {
-	              outfile->Printf("  WARNING: The definition of the current initial grid includes negative weights, which the original COSX formulation does not support! If this is of concern, please choose another initial grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL.\n");
-	              break;
-	        }
+	                outfile->Printf("  WARNING: The definition of the current initial grid includes negative weights, which the original COSX formulation does not support! If this is of concern, please choose another initial grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_INITIAL.\n");
+	                warning_printed_init = true;
+		            break;
+	            }
+            }
+	        if (warning_printed_init) break;
         }
-    
+
+        auto warning_printed_final = false;
         for (const auto &final_block : grid_final_->blocks()) {
             const auto w = final_block->w();
             for (int ipoint = 0; ipoint < final_block->npoints(); ++ipoint) {
                 if (w[ipoint] < 0.0) {
 	                outfile->Printf("  WARNING: The definition of the current final grid includes negative weights, which the original COSX formulation does not support! If this is of concern, please choose another final grid through adjusting either COSX_PRUNING_SCHEME or COSX_SPHERICAL_POINTS_FINAL.\n");
+                    warning_printed_final = true;
 	                break;
-	        }
+	            }
+            }
+	        if (warning_printed_final) break;
         }
 
         timer_off("CompositeJK: COSX Grid Construction");
@@ -383,6 +391,7 @@ void CompositeJK::common_init() {
         ;
     } else {
         throw PSIEXCEPTION("Invalid Composite K algorithm selected!");
+
     }
 }
 

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -94,7 +94,7 @@ Matrix compute_numeric_overlap(const DFTGrid &grid, const std::shared_ptr<BasisS
         auto X_block_signp = X_block_sign.pointer();
         for (size_t p = 0; p < npoints_block; p++) {
             for (size_t k = 0; k < nbf_block; k++) {
-                X_block_nosignp[p][k] = point_values->get(p, k) * std::sqrt(std::fabs(w[p]));
+                X_block_nosignp[p][k] = point_values->get(p, k) * std::sqrt(std::abs(w[p]));
                 X_block_signp[p][k] = sign(w[p])*X_block_nosignp[p][k];
             }
         }


### PR DESCRIPTION
## Description
This PR is a follow-up to https://github.com/psi4/psi4/pull/2906, and what can be considered an official solution to the issue discussed in https://github.com/psi4/psi4/issues/2890. The current issue is that COSX does not work with certain grid configurations - specifically, it does not work with grids that have negative grid weights, due to the use of an intermediate matrix in COSX that uses the square root of negative grid weights. https://github.com/psi4/psi4/pull/2906 "fixed" this issue by having COSX throw an exception when grids with negative weights were encountered. This PR provides a COSX reformulation that allows COSX to work with negative grid weights.

The reformulation does two primary things:
- The $X$ matrix (Eq. 4 in [Neese 2009](https://doi.org/10.1016/j.chemphys.2008.10.036)) is redefined as $X_{\kappa g} = \sqrt{|w_{g}|} \kappa(r_{g})$. In words, $X_{\kappa g}$ now uses the square root of the _magnitude_ of the weights, instead of the square root of the raw weights.
- To correct for the above, the computation of the $G$ matrix (Eq. 7 in [Neese 2009](https://doi.org/10.1016/j.chemphys.2008.10.036)) is performed as $G_{\nu g} = \sum_{\tau} \text{sign}(w_{g}) A_{\nu \tau} (r_{g}) F_{\tau g}$ . In words, the sign of the corresponding grid weights are included in the formation of $G_{\nu g}$, when $A_{\nu \tau}$ and $F_{\tau g}$ are contracted.

One other thing comes out as a consequence of this:
- For overlap fitting, the numerical overlap matrix $S_{N}$ (Eq. 13 in [Izsák 2011](https://doi.org/10.1063/1.3646921)) is computed as $S_{N} = X * X_{\text{alt}}^{T}$, where $X_{\kappa g} = \sqrt{|w_{g}|} \kappa(r_{g})$ (the same as the first bullet point in the reformulation above), and $X_{\text{alt},\kappa g} = \text{sign}(w_{g}) \sqrt{|w_{g}|} \kappa(r_{g})$. Essentially, $S_{N}$ now uses two variants of the $X$ matrix in its formulation, one of which folds the grid weight sign into itself.

## User API & Changelog headlines
- [X] COSX can now be used with a wider variety of grids, as a bug preventing COSX to be used with specific grid configurations has been fixed.
## Dev notes & details
- [X] The COSX implementation has been reformulated to enable calculations with grids containing negative grid weights.

## Questions
- [x] Is the current way of handling computation of the numerical overlap matrix acceptable? Currently, two X matrices are used to form the numerical overlap matrix. One goal of folding the grid weight sign into the formation of G was to prevent the use of multiple X matrices. However, I don't think that can be done here without removing the call to `linalg::doublet` in the `compute_numeric_overlap` function. One could probably do a slightly-modified, manually-implemented matrix multiply with the grid weight folded in, and construct $S_{N}$ with a single $X$ matrix that way. But that comes at the cost of not utilizing BLAS. What does everyone consider preferable?
- [ ] What, exactly, is the best way to test this? I would like to add a test to `test_dfjcosk.py` for a new grid weight option with negative weights. Unfortunately, it seems that other codes that have COSX just don't have grid options that lead to negative grid weights. For now, I've been comparing against Psi4 COSX calculations using similar grid sizes and ensuring the calculations have similar energies, but I certainly wouldn't consider that robust.

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge 