### PR TITLE
set_output_file enhancements

### DIFF
--- a/psi4/__init__.py
+++ b/psi4/__init__.py
@@ -102,6 +102,4 @@ if "@ENABLE_libefp@".upper() in ["1", "ON", "YES", "TRUE", "Y"]:  # pylibefp
 
 # Create a custom logger
 import logging
-root = logging.getLogger()  # create root
-root.setLevel("ERROR")
 logger = logging.getLogger(__name__)  # create initial psi4 from root to be configured later in extras

--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -83,6 +83,8 @@ parser.add_argument("--mdi", default=None,
                     help="Sets MDI configuration options")
 parser.add_argument("--loglevel", default=20,
                     help="Sets logging level: WARN=30, INFO=20, DEBUG=10.")
+parser.add_argument("--inherit-loglevel", action='store_true',
+                    help="Takes no action on logging level, not even setting the default, thereby inheriting from existing logger.")
 
 # For plugins
 parser.add_argument("--plugin-name", help="""\
@@ -225,18 +227,23 @@ args["input"] = os.path.normpath(args["input"])
 # Setup scratch_messy
 _clean_functions = [psi4.core.clean, psi4.extras.clean_numpy_files]
 
-# Setup outfile
-if args["append"] is None:
-    args["append"] = False
-if (args["output"] != "stdout") and (args["qcschema"] is False):
-    psi4.set_output_file(args["output"], args["append"], loglevel=int(args["loglevel"]))
-
-# Set a few options
+# Set a few options (silently)
 psi4.core.set_num_threads(int(args["nthread"]), quiet=True)
 psi4.set_memory(args["memory"], quiet=True)
 psi4.extras._input_dir_ = os.path.dirname(os.path.abspath(args["input"]))
+
+# Setup outfile
+if args["append"] is None:
+    args["append"] = False
+if args["inherit-loglevel"] is None:
+    args["inherit-loglevel"] = False
 if args["qcschema"] is False:
-    psi4.print_header()
+    psi4.set_output_file(
+        args["output"],
+        args["append"],
+        loglevel=int(args["loglevel"]),
+        inherit_loglevel=args["inherit-loglevel"])
+
 start_time = datetime.datetime.now()
 
 # Initialize MDI

--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -235,14 +235,14 @@ psi4.extras._input_dir_ = os.path.dirname(os.path.abspath(args["input"]))
 # Setup outfile
 if args["append"] is None:
     args["append"] = False
-if args["inherit-loglevel"] is None:
-    args["inherit-loglevel"] = False
+if args["inherit_loglevel"] is None:
+    args["inherit_loglevel"] = False
 if args["qcschema"] is False:
     psi4.set_output_file(
         args["output"],
         args["append"],
         loglevel=int(args["loglevel"]),
-        inherit_loglevel=args["inherit-loglevel"])
+        inherit_loglevel=args["inherit_loglevel"])
 
 start_time = datetime.datetime.now()
 

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1325,13 +1325,21 @@ PYBIND11_MODULE(core, core) {
     core.def("dfocc", py_psi_dfocc, "ref_wfn"_a, "Runs the density-fitted orbital optimized CC codes.");
     core.def("get_options", py_psi_get_options, py::return_value_policy::reference, "Get options");
     core.def("set_output_file", [](const std::string ofname) {
-        auto mode = std::ostream::trunc;
-        outfile = std::make_shared<PsiOutStream>(ofname, mode);
+        if (ofname == "stdout") {
+            outfile = std::make_shared<PsiOutStream>();
+        } else {
+            auto mode = std::ostream::trunc;
+            outfile = std::make_shared<PsiOutStream>(ofname, mode);
+        }
         outfile_name = ofname;
     });
     core.def("set_output_file", [](const std::string ofname, bool append) {
-        auto mode = append ? std::ostream::app : std::ostream::trunc;
-        outfile = std::make_shared<PsiOutStream>(ofname, mode);
+        if (ofname == "stdout") {
+            outfile = std::make_shared<PsiOutStream>();
+        } else {
+            auto mode = append ? std::ostream::app : std::ostream::trunc;
+            outfile = std::make_shared<PsiOutStream>(ofname, mode);
+        }
         outfile_name = ofname;
     }, "ofname"_a, "append"_a = false, "Set the name for output file; prefer :func:`~psi4.set_output_file`");
     core.def("get_output_file", []() { return outfile_name; }, "Returns output file name (stem + suffix, no directory). 'stdout'.");


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] If you call `psi4.set_output_file()` (note that this is the usual fancy one, not the low-level `psi4.core.set_output_file()`), that file will have a psi4 header so suitable for cclib parsing. closes #2893
- [x] Sometimes you don't want psi4 managing the logging. Added a `inherit_loglevel` to exe and set_output_file so that psi4 doesn't tamper with loglevel. @bennybp request

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] we always had `set_output_file` and `print_header` separate, but I'm guessing that that was originally b/c former in C++ and latter in Py. Now that we have the former in python to set up logging, too, it's reasonable to combine them, I think. Note that in exe, we do need to set up threads & mem first so that header stats are as correct as possible.
- [x] I set it up so that the header prints whenever a new file is opened. seemed reasonable. had to rewire core.cc calls to take notice of "stdout". Any problem with that?
- [x] `-o stdout` now gets a logging file `stdout.log` bug? feature?
- [x] a plain `import psi4; psi4.energy()` is still going to print to screen w/o header. `import psi4; set_output_file("asdf"); psi4.energy()` newly has a header. DDD calcs still have repetitive header, but it's no worse that before.

## Questions
- [x] @AlexHeide, does removing those two `root` lines in `psi4.__init__.py` mess up your optking logging?

## Checklist
- [ ] ~Tests added for any new features~
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
