### PR TITLE
Fix fsapt + external potential - nocom/noreorient

### DIFF
--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -81,7 +81,10 @@ class MDIEngine():
 
         # Molecule all MDI operations are performed on
         input_molecule = kwargs.pop('molecule', psi4.core.get_active_molecule())
+        _ini_cart = getattr(input_molecule, "_initial_cartesian", None)
         self.molecule = input_molecule.clone()
+        if _ini_cart:
+            self.molecule._initial_cartesian = _ini_cart
         psi4.core.set_active_molecule(self.molecule)
 
         # Most recent SCF energy
@@ -270,6 +273,7 @@ class MDIEngine():
             coords = MDI_Recv(3 * natom, MDI_DOUBLE, self.comm)
         matrix = psi4.core.Matrix.from_array(np.array(coords).reshape(-1, 3))
         self.molecule.set_geometry(matrix)
+        self.molecule._initial_cartesian = matrix
 
     # Respond to the >MASSES command
     def recv_masses(self, masses=None):

--- a/psi4/driver/molutil.py
+++ b/psi4/driver/molutil.py
@@ -170,10 +170,15 @@ def _molecule_from_arrays(cls,
         nonphysical=nonphysical,
         mtol=mtol,
         verbose=verbose)
+
+    qmol = core.Molecule.from_dict(molrec)
+    geom = np.array(molrec["geom"]).reshape((-1, 3))
+    qmol._initial_cartesian = core.Matrix.from_array(geom)
+
     if return_dict:
-        return core.Molecule.from_dict(molrec), molrec
+        return qmol, molrec
     else:
-        return core.Molecule.from_dict(molrec)
+        return qmol
 
 
 @classmethod

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1613,7 +1613,7 @@ def scf_helper(name, post_scf=True, **kwargs):
                        """further calculations in C1 point group.\n""")
 
     # PE needs to use exactly input orientation to correspond to potfile
-    if core.get_option("SCF", "PE"):
+    if core.get_option("SCF", "PE") or "external_potentials" in kwargs:
         c1_molecule = scf_molecule.clone()
         if getattr(scf_molecule, "_initial_cartesian", None) is not None:
             c1_molecule._initial_cartesian = scf_molecule._initial_cartesian.clone()
@@ -4839,11 +4839,14 @@ def run_fisapt(name, **kwargs):
     # Shifting to C1 so we need to copy the active molecule
     if sapt_dimer.schoenflies_symbol() != 'c1':
         core.print_out('  FISAPT does not make use of molecular symmetry, further calculations in C1 point group.\n')
+        _ini_cart = getattr(sapt_dimer, "_initial_cartesian", None)
         sapt_dimer = sapt_dimer.clone()
         sapt_dimer.reset_point_group('c1')
         sapt_dimer.fix_orientation(True)
         sapt_dimer.fix_com(True)
         sapt_dimer.update_geometry()
+        if _ini_cart:
+            sapt_dimer._initial_cartesian = _ini_cart
 
     if core.get_option('SCF', 'REFERENCE') != 'RHF':
         raise ValidationError('FISAPT requires requires \"reference rhf\".')

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1623,7 +1623,7 @@ def scf_helper(name, post_scf=True, **kwargs):
             c1_molecule.fix_com(True)
             c1_molecule.update_geometry()
         else:
-            raise ValidationError("Set no_com/no_reorient/symmetry c1 by hand for PE on non-Cartesian molecules.")
+            raise ValidationError("Set no_com/no_reorient/symmetry c1 by hand for PE or external potentials on non-Cartesian molecules.")
 
         scf_molecule = c1_molecule
         core.print_out("""  PE does not make use of molecular symmetry: """

--- a/tests/cc31/CMakeLists.txt
+++ b/tests/cc31/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(TestingMacros)
 
-add_regression_test(cc31 "psi;cc;cart")
+add_regression_test(cc31 "psi;cc;cart;quicktests")

--- a/tests/cc31/test_input.py
+++ b/tests/cc31/test_input.py
@@ -1,6 +1,6 @@
 from addons import *
 
-@ctest_labeler("cc;cart")
+@ctest_labeler("cc;cart;quick")
 def test_cc31():
     ctest_runner(__file__)
 

--- a/tests/fsapt-ext-abc-au/input.dat
+++ b/tests/fsapt-ext-abc-au/input.dat
@@ -8,9 +8,6 @@ memory 1 GB
 mol = psi4.core.Molecule.from_arrays(
     elez=[1, 8, 1, 1, 8, 1, 1, 8, 1],
     fragment_separators=[3, 6],
-    fix_com=True,
-    fix_orientation=True,
-    fix_symmetry='c1',
     geom=np.array([
   0.0290, -1.1199, -1.5243,
   0.9481, -1.3990, -1.3587,

--- a/tests/fsapt-ext/input.dat
+++ b/tests/fsapt-ext/input.dat
@@ -14,8 +14,6 @@ O   2.516175   0.894012  -1.014512
 H   1.942080   1.572902  -1.410984
 H   3.056412   0.561271  -1.739079
 symmetry c1
-no_reorient
-no_com
 }
 
 # External potential containing the third water from the trimer with TIP3P charges

--- a/tests/pytests/test_mdi.py
+++ b/tests/pytests/test_mdi.py
@@ -138,4 +138,4 @@ def test_mdi_water():
     # Test the EXIT command
     engine.exit()
 
-    return 0
+    return None


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
@carolinesargent identified a bug where running FSAPT with an external potential w/o having frozen the orientation with no_com + no_reorient would run but give the wrong answer. :-(

External potentials has long been one of those cases where we required the user to freeze the orientation at molecule creation time so that the potential could be set in the same frame. This couldn't be fixed driver-side because as soon as the `core.Mol` builds w/o freeze directives, it loses the original Cartesian coordinates. (The clone, set_nocom, set_noreorient calls in the driver allow _regular_ sapt to forego user setting by preventing the dimer, monoA, monoB from having different frames.)

Happily, in the intervening period, @maxscheurer ran into exactly this problem for polarizable embedding potentials and solved it by tacking a copy of the original Cartesians onto the molecule. So we're applying this to FSAPT also. 

I've been getting some segfaults that I think are a quirk of my directory, hence the cc31 testing.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Fixes bug where FSAPT with an external potential and without no_com/no_reorient set would return wrong answer.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Let's use this route to accommodate aux info in the frame of the Cartesianmol

## Checklist
- [x] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
