### PR TITLE
Deprecate ERISieve

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -1502,8 +1502,8 @@ def _core_wavefunction_frequencies(self):
     """Returns the results of a frequency analysis.
 
     Parameters
-    ----------
-    self
+    ------G----
+    selfG
         Wavefunction instance.
 
     Returns
@@ -1590,4 +1590,17 @@ def _core_erisieve_build(
 
     return core.ERISieve(orbital_basis, cutoff, do_csam)
 
+def _core_erisieve_shell_significant(self, M, N, R, S):
+    """
+    Determine if a given shell quartet (MN | RS) is sigificant or not. Return True if it is, and False if it is not.
+    """
+
+    warnings.warn(
+        "`ERISieve` is deprecated in favor of `TwoBodyAOInt`, and will be removed as soon as Psi4 v1.9 is released.\n",
+        category=FutureWarning,
+        stacklevel=2)
+
+    return core.ERISieve.shell_significant(M, N, R, S)
+
 core.ERISieve.build = _core_erisieve_build
+core.ERISieve.shell_significant = _core_erisieve_shell_significant

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -1588,7 +1588,12 @@ def _core_erisieve_build(
         category=FutureWarning,
         stacklevel=2)
 
-    return core.ERISieve(orbital_basis, cutoff, do_csam)
+    factory = core.IntegralFactory(orbital_basis)
+    
+    global erisieve_twobody 
+    erisieve_twobody = factory.eri(0)
+
+    return core.ERISieve(orbital_basis, cutoff, do_csam) 
 
 def _core_erisieve_shell_significant(self, M, N, R, S):
     """
@@ -1599,8 +1604,8 @@ def _core_erisieve_shell_significant(self, M, N, R, S):
         "`ERISieve` is deprecated in favor of `TwoBodyAOInt`, and will be removed as soon as Psi4 v1.9 is released.\n",
         category=FutureWarning,
         stacklevel=2)
-
-    return core.ERISieve.shell_significant(M, N, R, S)
+   
+    return erisieve_twobody.shell_significant(M, N, R, S)
 
 core.ERISieve.build = _core_erisieve_build
 core.ERISieve.shell_significant = _core_erisieve_shell_significant

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -37,7 +37,7 @@ Also, many Python extensions to core classes:
  - JK (constructor)
  - VBase (grid)
  - OEProp (avail prop)
-
+ - ERISieve (constructor, shell_significant)
 """
 
 __all__ = [
@@ -1553,3 +1553,41 @@ def _core_triplet(A, B, C, transA, transB, transC):
 
 core.Matrix.doublet = staticmethod(_core_doublet)
 core.Matrix.triplet = staticmethod(_core_triplet)
+
+@staticmethod
+def _core_erisieve_build(
+        orbital_basis: core.BasisSet,
+        cutoff: float,
+        do_csam: bool
+    ) -> core.ERISieve:
+    """
+    Constructs a Psi4 ERISieve object from an input basis.
+
+    Parameters
+    ----------
+    orbital_basis
+        Orbital basis to use in the ERISieve object.
+    cutoff
+        Integral cutoff threshold to use for sieve screening.
+    do_csam
+        Use CSAM screening? If True, CSAM screening is used;
+        else, Schwarz screening is used.
+
+    Returns
+    -------
+    ERISieve
+        Initialized ERISieve object.
+
+    Example
+    -------
+    >>> sieve = psi4.core.ERISieve.build(bas, cutoff, csam)
+
+    """
+    warnings.warn(
+        "`ERISieve` is deprecated in favor of `TwoBodyAOInt`, and will be removed as soon as Psi4 v1.9 is released.\n",
+        category=FutureWarning,
+        stacklevel=2)
+
+    return core.ERISieve(orbital_basis, cutoff, do_csam)
+
+core.ERISieve.build = _core_erisieve_build

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -1502,8 +1502,8 @@ def _core_wavefunction_frequencies(self):
     """Returns the results of a frequency analysis.
 
     Parameters
-    ------G----
-    selfG
+    ----------
+    self
         Wavefunction instance.
 
     Returns
@@ -1554,6 +1554,7 @@ def _core_triplet(A, B, C, transA, transB, transC):
 core.Matrix.doublet = staticmethod(_core_doublet)
 core.Matrix.triplet = staticmethod(_core_triplet)
 
+
 @staticmethod
 def _core_erisieve_build(
         orbital_basis: core.BasisSet,
@@ -1583,18 +1584,18 @@ def _core_erisieve_build(
     -------
     >>> sieve = psi4.core.ERISieve.build(bas, cutoff, csam)
     """
-    
+
     warnings.warn(
         "`ERISieve` is deprecated in favor of `TwoBodyAOInt`, and will be removed as soon as Psi4 v1.9 is released.\n",
         category=FutureWarning,
         stacklevel=2)
 
     factory = core.IntegralFactory(orbital_basis)
-    
-    global erisieve_twobody 
+
+    global erisieve_twobody
     erisieve_twobody = factory.eri(0)
 
-    return core.ERISieve(orbital_basis, cutoff, do_csam) 
+    return core.ERISieve(orbital_basis, cutoff, do_csam)
 
 def _core_erisieve_shell_significant(self, M, N, R, S):
     """
@@ -1605,8 +1606,9 @@ def _core_erisieve_shell_significant(self, M, N, R, S):
         "`ERISieve` is deprecated in favor of `TwoBodyAOInt`, and will be removed as soon as Psi4 v1.9 is released.\n",
         category=FutureWarning,
         stacklevel=2)
-   
+
     return erisieve_twobody.shell_significant(M, N, R, S)
+
 
 core.ERISieve.build = _core_erisieve_build
 core.ERISieve.shell_significant = _core_erisieve_shell_significant

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -37,7 +37,7 @@ Also, many Python extensions to core classes:
  - JK (constructor)
  - VBase (grid)
  - OEProp (avail prop)
- - ERISieve (constructor, shell_significant)
+ - ERISieve (constructor)
 """
 
 __all__ = [
@@ -1590,25 +1590,7 @@ def _core_erisieve_build(
         category=FutureWarning,
         stacklevel=2)
 
-    factory = core.IntegralFactory(orbital_basis)
-
-    global erisieve_twobody
-    erisieve_twobody = factory.eri(0)
-
     return core.ERISieve(orbital_basis, cutoff, do_csam)
-
-def _core_erisieve_shell_significant(self, M, N, R, S):
-    """
-    Determine if a given shell quartet (MN | RS) is sigificant or not. Return True if it is, and False if it is not.
-    """
-
-    warnings.warn(
-        "`ERISieve` is deprecated in favor of `TwoBodyAOInt`, and will be removed as soon as Psi4 v1.9 is released.\n",
-        category=FutureWarning,
-        stacklevel=2)
-
-    return erisieve_twobody.shell_significant(M, N, R, S)
 
 
 core.ERISieve.build = _core_erisieve_build
-core.ERISieve.shell_significant = _core_erisieve_shell_significant

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -1557,21 +1557,22 @@ core.Matrix.triplet = staticmethod(_core_triplet)
 @staticmethod
 def _core_erisieve_build(
         orbital_basis: core.BasisSet,
-        cutoff: float,
-        do_csam: bool
+        cutoff: float = 0.0,
+        do_csam: bool = False
     ) -> core.ERISieve:
     """
-    Constructs a Psi4 ERISieve object from an input basis.
+    Constructs a Psi4 ERISieve object from an input basis set, with an optional cutoff threshold for
+    ERI screening and an optional input to enable CSAM screening (over Schwarz screening).
 
     Parameters
     ----------
     orbital_basis
-        Orbital basis to use in the ERISieve object.
+        Basis set to use in the ERISieve object.
     cutoff
-        Integral cutoff threshold to use for sieve screening.
+        Integral cutoff threshold to use for Schwarz/CSAM screening. Defaults to 0.0, disabling screening entirely.
     do_csam
-        Use CSAM screening? If True, CSAM screening is used;
-        else, Schwarz screening is used.
+        Use CSAM screening? If True, CSAM screening is used; else, Schwarz screening is used. By default,
+        Schwarz screening is utilized.
 
     Returns
     -------
@@ -1581,8 +1582,8 @@ def _core_erisieve_build(
     Example
     -------
     >>> sieve = psi4.core.ERISieve.build(bas, cutoff, csam)
-
     """
+    
     warnings.warn(
         "`ERISieve` is deprecated in favor of `TwoBodyAOInt`, and will be removed as soon as Psi4 v1.9 is released.\n",
         category=FutureWarning,

--- a/psi4/src/psi4/libmints/sieve.h
+++ b/psi4/src/psi4/libmints/sieve.h
@@ -93,9 +93,9 @@ class BasisSet;
  *
  */
 
-class __attribute__((visibility("default"))) __attribute((deprecated(
+class __attribute__((visibility("default"))) __attribute__((deprecated(
     "ERISieve is deprecated in favor of TwoBodyAOInt, and "
-    "will be fully be removed as of Psi4 v1.9. "
+    "will be fully be removed as soon as Psi4 v1.9 releases. "
 ))) ERISieve {
    protected:
     /// Debug flag (defaults to 0)

--- a/psi4/src/psi4/libmints/sieve.h
+++ b/psi4/src/psi4/libmints/sieve.h
@@ -92,7 +92,11 @@ class BasisSet;
  *
  *
  */
-class PSI_API ERISieve {
+
+class __attribute__((visibility("default"))) __attribute((deprecated(
+    "ERISieve is deprecated in favor of TwoBodyAOInt, and "
+    "will be fully be removed as of Psi4 v1.9. "
+))) ERISieve {
    protected:
     /// Debug flag (defaults to 0)
     int debug_;
@@ -179,11 +183,7 @@ class PSI_API ERISieve {
 
    public:
     /// Constructor, basis set and first sieve cutoff
-    PSI_DEPRECATED(
-        "ERISieve is deprecated in favor of TwoBodyAOInt, and "
-         "will be fully be removed as of Psi4 v1.9. "
-    )
-    ERISieve(std::shared_ptr<BasisSet> primary, double sieve = 0.0, bool do_csam = false);
+   ERISieve(std::shared_ptr<BasisSet> primary, double sieve = 0.0, bool do_csam = false);
     /// Destructor, frees memory
     virtual ~ERISieve();
 
@@ -211,10 +211,6 @@ class PSI_API ERISieve {
     /// Is the shell quartet (MN|RS) significant according to sieve? (no restriction on MNRS order)
 
     // inline bool shell_significant(int M, int N, int R, int S) {
-    PSI_DEPRECATED(
-        "ERISieve is deprecated in favor of TwoBodyAOInt, and "
-         "will be fully be removed as of Psi4 v1.9. "
-    )
     bool shell_significant(int M, int N, int R, int S) {
         bool schwarz_bound =
             shell_pair_values_[N * nshell_ + M] * shell_pair_values_[R * nshell_ + S] >= sieve2_;

--- a/psi4/src/psi4/libmints/sieve.h
+++ b/psi4/src/psi4/libmints/sieve.h
@@ -183,7 +183,7 @@ class __attribute__((visibility("default"))) __attribute__((deprecated(
 
    public:
     /// Constructor, basis set and first sieve cutoff
-   ERISieve(std::shared_ptr<BasisSet> primary, double sieve = 0.0, bool do_csam = false);
+    ERISieve(std::shared_ptr<BasisSet> primary, double sieve = 0.0, bool do_csam = false);
     /// Destructor, frees memory
     virtual ~ERISieve();
 

--- a/psi4/src/psi4/libmints/sieve.h
+++ b/psi4/src/psi4/libmints/sieve.h
@@ -93,7 +93,7 @@ class BasisSet;
  *
  */
 
-class __attribute__((visibility("default"))) __attribute__((deprecated(
+class PSI_API __attribute__((deprecated(
     "ERISieve is deprecated in favor of TwoBodyAOInt, and "
     "will be fully be removed as soon as Psi4 v1.9 releases. "
 ))) ERISieve {

--- a/psi4/src/psi4/libmints/sieve.h
+++ b/psi4/src/psi4/libmints/sieve.h
@@ -179,6 +179,10 @@ class PSI_API ERISieve {
 
    public:
     /// Constructor, basis set and first sieve cutoff
+    PSI_DEPRECATED(
+        "ERISieve is deprecated in favor of TwoBodyAOInt, and "
+         "will be fully be removed as of Psi4 v1.9. "
+    )
     ERISieve(std::shared_ptr<BasisSet> primary, double sieve = 0.0, bool do_csam = false);
     /// Destructor, frees memory
     virtual ~ERISieve();
@@ -207,6 +211,10 @@ class PSI_API ERISieve {
     /// Is the shell quartet (MN|RS) significant according to sieve? (no restriction on MNRS order)
 
     // inline bool shell_significant(int M, int N, int R, int S) {
+    PSI_DEPRECATED(
+        "ERISieve is deprecated in favor of TwoBodyAOInt, and "
+         "will be fully be removed as of Psi4 v1.9. "
+    )
     bool shell_significant(int M, int N, int R, int S) {
         bool schwarz_bound =
             shell_pair_values_[N * nshell_ + M] * shell_pair_values_[R * nshell_ + S] >= sieve2_;


### PR DESCRIPTION
## Description
This PR is a companion to https://github.com/psi4/psi4/pull/2933. The goal of https://github.com/psi4/psi4/pull/2933 is to completely eliminate the `ERISieve` class, for reasons explained there. However, it turns out that eliminating `ERISieve` requires fiddling with the v2rdm_casscf plugin, as well, since it also uses `ERISieve`.

This PR is meant to be a deprecation of the `ERISieve` class that will show up in v1.8 in the meantime, in case `ERISieve` isn't fully removed by then.

## User API & Changelog headlines
- [X] Deprecates the `ERISieve` class.

## Dev notes & details
- [X] Fully deprecates the `ERISieve` class C++-side by tagging it with the deprecated attribute.
- [X] Deprecates the `ERISieve` class Python-side by creating helper functions for the Python-facing `ERISieve` functions that warn about deprecation.

## Questions
- [x] Is `PSI_DEPRECATED` the preferred mechanism by which to perform this deprecation?
- [X] Assuming the answer to the first question is "yes", are there any other functions in `ERISieve` that should be tagged? I chose specifically the user-facing functions.
- [x] I _loathe_ having to use a global variable for the Python-side helper functions. But, unbelievably, it is what I considered the best one I could think of. I would be very happy to hear out alternative suggestions.
- [ ] Using the `PSI_API` and `PSI_DEPRECATED` macros together to tag the `ERISieve` class cause the compiler to complain. On further exploration, replacing `PSI_DEPRECATED` with its textual definition seems to work fine. Is this an acceptable solution?

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge
