### PR TITLE
temp pin adcc

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -221,7 +221,7 @@ jobs:
           - python=${{ matrix.cfg.python-version }}
           - toml
             # qc opt'l
-          - adcc
+          - adcc=0.15.14
           - basis_set_exchange
           - cppe
           - dftd3-python
@@ -230,7 +230,7 @@ jobs:
           - geometric
           - openfermion>=1.0
           - openfermionpsi4
-          - pyddx=0.3.0
+          - pyddx=0.3.*
           - pymdi
           - qcengine
           - qcfractal


### PR DESCRIPTION
## Description
At the moment, psi4 + adcc 0.15.14 is passing but 0.15.16 is not. @maxscheurer suspects a bugfix in adcc that the psi4 ref data needs to be updated to reflect. Pinning this for now so other PRs don't need to be held up.

## Status
- [x] Ready for review
- [ ] Ready for merge
