### PR TITLE
modernize paths and bugfixes

### DIFF
--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -6,6 +6,7 @@
 # * Remove ``if(NOT PY_${module})`` so runs each time, also remove module caps
 # * Module name, not path in fphsa
 # * Added version handling via parse_version call
+# * Switched PYTHON -> Python
 
 #.rst:
 #

--- a/external/upstream/CMakeLists.txt
+++ b/external/upstream/CMakeLists.txt
@@ -26,3 +26,7 @@ foreach(dir
   )
   add_subdirectory(${dir})
 endforeach()
+
+# for rare case where resolved ${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR} isn't nested, make libdir. may yet be empty
+file(TO_NATIVE_PATH "${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" _plain_libdir)
+file(MAKE_DIRECTORY ${_plain_libdir})

--- a/psi4/__init__.py
+++ b/psi4/__init__.py
@@ -27,28 +27,42 @@
 #
 
 
-# Figure out psidatadir: envvar trumps staged/installed
+# Figure out paths
+# * in figuring out psidatadir: envvar trumps staged/installed
+# * some full paths are computed here using the prefix, but all outputs are relative to __file__, so relocatability preserved
+# * note that all path entities are directories except for "executable" that is a file
 import os
-psi4_module_loc = os.path.dirname(os.path.abspath(__file__))
-pymod = os.path.normpath(os.path.sep.join(['@PYMOD_INSTALL_LIBDIR@', '@CMAKE_INSTALL_LIBDIR@', 'psi4']))
-if pymod.startswith(os.path.sep + os.path.sep):
-    pymod = pymod[1:]
-pymod_dir_step = os.path.sep.join(['..'] * pymod.count(os.path.sep))
-data_dir = os.path.sep.join([psi4_module_loc, pymod_dir_step, '@CMAKE_INSTALL_DATADIR@', 'psi4'])
-executable = os.path.abspath(os.path.sep.join([psi4_module_loc, pymod_dir_step, '@CMAKE_INSTALL_BINDIR@', 'psi4']))
 from pathlib import Path
-if not Path(executable).exists():
-    # Win conda recipe moves psi4 executable unknown to CMake
-    executable = str((Path(psi4_module_loc) / ".." / ".." / ".." / "Scripts" / "psi4.exe").resolve())
+psi4_module_loc = Path(__file__).resolve().parent
 
+prefix = Path("@CMAKE_INSTALL_PREFIX@".replace("\\", "/"))
+cmake_install_bindir = "@CMAKE_INSTALL_BINDIR@".replace("\\", "/")
+cmake_install_datadir = "@CMAKE_INSTALL_DATADIR@".replace("\\", "/")
+cmake_install_libdir = "@CMAKE_INSTALL_LIBDIR@".replace("\\", "/")
+pymod_install_libdir = "@PYMOD_INSTALL_LIBDIR@".lstrip("/")
+full_pymod = (prefix / cmake_install_libdir / pymod_install_libdir / "psi4").resolve()
+full_data = prefix / cmake_install_datadir / "psi4"
+full_bin = prefix / cmake_install_bindir
+rel_data = os.path.relpath(full_data, start=full_pymod)
+rel_bin = os.path.relpath(full_bin, start=full_pymod)
+
+executable = psi4_module_loc.joinpath(rel_bin, "psi4")
+executable_exe = (Path("/opt/anaconda1anaconda2anaconda3") / "Scripts" / "psi4.exe").resolve(strict=False)
+if executable_exe.exists():
+    # Win conda-build generates this unbeknownst to CMake
+    executable = executable_exe
+executable = str(executable.resolve())
+
+data_dir = psi4_module_loc.joinpath(rel_data)
 if "PSIDATADIR" in os.environ.keys():
-    data_dir = os.path.expanduser(os.environ["PSIDATADIR"])
-elif "CMAKE_INSTALL_DATADIR" in data_dir:
-    data_dir = os.path.sep.join([os.path.abspath(os.path.dirname(__file__)), "share", "psi4"])
+    data_dir = Path(os.path.expanduser(os.environ["PSIDATADIR"]))
+elif "CMAKE_INSTALL_DATADIR" in str(data_dir):
+    data_dir = Path(os.path.sep.join([os.path.abspath(os.path.dirname(__file__)), "share", "psi4"]))
 
-data_dir = os.path.abspath(data_dir)
-if not os.path.isdir(data_dir):
-    raise KeyError(f"Unable to read the Psi4 Python folder - check the PSIDATADIR environmental variable - current value is {data_dir}")
+data_dir = data_dir.resolve(strict=False)
+if not data_dir.is_dir():
+    raise KeyError(f"Unable to read the Psi4 Python folder - check the PSIDATADIR environmental variable - current value is {str(data_dir)}")
+data_dir = str(data_dir)
 
 # Init core
 from . import core
@@ -63,7 +77,8 @@ if "PSI_SCRATCH" in os.environ.keys():
     core.IOManager.shared_object().set_default_path(envvar_scratch)
 
 core.set_datadir(data_dir)
-del psi4_module_loc, pymod, pymod_dir_step, data_dir
+del cmake_install_bindir, cmake_install_datadir, cmake_install_libdir, pymod_install_libdir
+del psi4_module_loc, prefix, full_pymod, full_data, full_bin, rel_data, rel_bin, data_dir, executable_exe
 
 # Cleanup core at exit
 import atexit

--- a/psi4/psi4.bat
+++ b/psi4/psi4.bat
@@ -26,4 +26,8 @@
 :: @END LICENSE
 ::
 
+:: Interpretation: when this batch file is called, call the Python interpreter on the "psi4" script
+::  alongside (postpend "psi4" script name to drive and path "~dp" of full path to called batch file "%0")
+::  and pass on any arguments ("%*"): `python this_bat_file_parent_dir/psi4 [other args]`
+
 @Python_EXECUTABLE@ %~dp0psi4 %*

--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -65,7 +65,7 @@ parser.add_argument("--psiapi-path", action='store_true',
                     help="""Generates a bash command to source correct Python """
                          """interpreter and path for ``python -c "import psi4"``""")
 parser.add_argument("--module", action='store_true',
-                    help="""Generates the path to PsiAPI loading.""")
+                    help="""Generates the path to PsiAPI loading. That is, the following file exists: `psi4 --module`/psi4/__init__.py . Also, adding `psi4 --module` to PYTHONPATH allows "import psi4".""")
 parser.add_argument("-v", "--verbose", action='store_true', help="Prints Psithon to Python translation.")
 parser.add_argument("--inplace", action='store_true',
                     help="Runs Psi4 from the source directory. !Warning! expert option.")
@@ -78,7 +78,7 @@ parser.add_argument("--qcschema", "--schema", action='store_true',
 parser.add_argument("--json", action='store_true',
                     help="Runs a JSON input file. !Warning! depcrated option in 1.4, use --qcschema instead.")
 parser.add_argument("-t", "--test", nargs='?', const='smoke', default=None,
-                    help="Runs pytest tests. If `pytest-xdist` installed, parallel with `--nthread`.")
+                    help="Runs pytest tests (requires pytest installed). If `pytest-xdist` installed, parallel with `--nthread`.")
 parser.add_argument("--mdi", default=None,
                     help="Sets MDI configuration options")
 parser.add_argument("--loglevel", default=20,
@@ -112,11 +112,36 @@ Generates a CMake command for building a plugin against this Psi4 installation.
 args, unknown = parser.parse_known_args()
 args = args.__dict__  # Namespace object seems silly
 
-# Figure out pythonpath
-cmake_install_prefix = os.path.normpath(os.path.dirname(os.path.abspath(__file__)) + os.path.sep + '..')
-lib_dir = os.path.sep.join([cmake_install_prefix, "@CMAKE_INSTALL_LIBDIR@", "@PYMOD_INSTALL_LIBDIR@"])
+# Figure out paths
+# * some full paths are computed here using the prefix, but all outputs are relative to __file__, so relocatability preserved
+# * note that all path entities are directories except for "executable" that is a file
+executable = Path(__file__).resolve()
+psi4_exe_loc = executable.parent
+
+prefix = Path("@CMAKE_INSTALL_PREFIX@".replace("\\", "/"))
+cmake_install_bindir = "@CMAKE_INSTALL_BINDIR@".replace("\\", "/")
+cmake_install_datadir = "@CMAKE_INSTALL_DATADIR@".replace("\\", "/")
+cmake_install_libdir = "@CMAKE_INSTALL_LIBDIR@".replace("\\", "/")
+pymod_install_libdir = "@PYMOD_INSTALL_LIBDIR@".lstrip("/")
+psi4_install_cmakedir = "@psi4_INSTALL_CMAKEDIR@".replace("\\", "/")
+full_pymod = (prefix / cmake_install_libdir / pymod_install_libdir / "psi4").resolve()
+full_data = prefix / cmake_install_datadir / "psi4"
+full_bin = prefix / cmake_install_bindir
+full_cmake = prefix / psi4_install_cmakedir
+rel_pymod = os.path.relpath(full_pymod, start=full_bin)
+rel_data = os.path.relpath(full_data, start=full_bin)
+rel_cmake = os.path.relpath(full_cmake, start=full_bin)
+
+data_dir = psi4_exe_loc.joinpath(rel_data).resolve()
+psi4_module_loc = psi4_exe_loc.joinpath(rel_pymod).resolve()
+cmake_dir = psi4_exe_loc.joinpath(rel_cmake).resolve()
+cmake_install_prefix = os.path.commonpath([data_dir, psi4_module_loc, psi4_exe_loc, cmake_dir])
+lib_dir = str(psi4_module_loc.parent)
+bin_dir = str(psi4_exe_loc)
+share_cmake_dir = str(cmake_dir)
 
 if args["inplace"]:
+    # not tested after pathlib adjustments
     if "CMAKE_INSTALL_LIBDIR" not in lib_dir:
         raise ImportError("Cannot run inplace from an installed directory.")
 
@@ -153,8 +178,6 @@ if (args["output"] is None) and (args["qcschema"] is False):
 
 # Plugin compile line
 if args['plugin_compile']:
-    share_cmake_dir = os.path.sep.join([cmake_install_prefix, 'share', 'cmake', 'psi4'])
-
     plugincachealongside = os.path.isfile(share_cmake_dir + os.path.sep + 'psi4PluginCache.cmake')
     if plugincachealongside:
         print(f"""cmake -C {share_cmake_dir}/psi4PluginCache.cmake -DCMAKE_PREFIX_PATH={cmake_install_prefix} .""")
@@ -164,8 +187,8 @@ if args['plugin_compile']:
 
 if args['psiapi_path']:
     pyexe_dir = os.path.dirname("@Python_EXECUTABLE@")
-    bin_dir = Path(cmake_install_prefix) / 'bin'
     print(f"""export PATH={pyexe_dir}:$PATH  # python interpreter\nexport PATH={bin_dir}:$PATH  # psi4 executable\nexport PYTHONPATH={lib_dir}:$PYTHONPATH  # psi4 pymodule""")
+    # TODO Py not quite right on conda Windows and Psi include %PREFIX$. but maybe not appropriate for Win anyways
     sys.exit()
 
 if args["module"]:

--- a/psi4/share/psi4/scripts/ixyz2database.py
+++ b/psi4/share/psi4/scripts/ixyz2database.py
@@ -443,7 +443,7 @@ final += """
        *  Make sure the Psi4 driver can find your new database.
           M %s.py into INSTALLED_DIRECTORY/share/psi4/databases .
           Alternatively, add the directory containing %s.py into PYTHONPATH .
-""" % (dbse, dbse, dbse)
+""" % (dbse, dbse)
 
 final += """
    **  To enhance the functionality/documentation of your database, do the following:

--- a/psi4/versioner.py
+++ b/psi4/versioner.py
@@ -43,14 +43,18 @@ def collect_version_input_from_fallback(meta_file='metadata.py'):
     """
     cwd = os.path.dirname(os.path.abspath(__file__))
     res = dict(re.findall(r"__version_([a-z_]+)\s*=\s*'([^']+)'", open(cwd + '/' + meta_file).read()))
-    res.pop('_')
+    res.pop('_', None)
     return res
 
 
-def is_git_repo(cwd='./', dot_git_qualifies=False, no_git_cmd_result=False):
+def is_git_repo(cwd='./', dot_git_qualifies=False, no_git_cmd_result=False, extraneous_toplevel_patterns=None):
     """Returns boolean as to whether *cwd* is under git control. When no ``git``
     command available in environment, *no_git_cmd_result* returned. If within
     the .git directory of a git repository, *dot_git_qualifies* returned.
+    For rare circumstances when one might be under git control but not in the
+    target software repo that's providing versionable tags (e.g., conda-forge
+    staged-recipes Linux), string patterns in the *extraneous_toplevel_patterns*
+    list will return False.
 
     """
     command = 'git rev-parse --is-inside-work-tree'
@@ -72,7 +76,21 @@ def is_git_repo(cwd='./', dot_git_qualifies=False, no_git_cmd_result=False):
 
     if out.strip() == 'true':
         # in a git repo and not within .git dir
-        return True
+
+        if extraneous_toplevel_patterns:
+            command = 'git rev-parse --show-toplevel'
+            process = subprocess.Popen(command.split(),
+                                       stderr=subprocess.PIPE,
+                                       stdout=subprocess.PIPE,
+                                       cwd=cwd,
+                                       universal_newlines=True)
+            (out, err) = process.communicate()
+            for ptn in extraneous_toplevel_patterns:
+                if ptn in out.strip():
+                    return False
+            return True
+        else:
+            return True
 
     if out.strip() == 'false':
         # in a git repo in .git dir
@@ -120,7 +138,7 @@ def collect_version_input_from_git():
                                universal_newlines=True)
     (out, err) = process.communicate()
 
-    res['is_clean'] = False if str(out).rstrip() else True
+    res['is_clean'] = not str(out).rstrip()
 
     command = 'git rev-parse --abbrev-ref HEAD'  # returns HEAD when detached
     process = subprocess.Popen(command.split(),
@@ -165,7 +183,7 @@ def reconcile_and_compute_version_output(quiet=False):
         sys.exit()
 
     cwd = os.path.dirname(os.path.abspath(__file__))
-    if is_git_repo(cwd=cwd):
+    if is_git_repo(cwd=cwd, extraneous_toplevel_patterns=["staged-recipes", "feedstock_root"]):
         res.update(collect_version_input_from_git())
 
         # establish the default response


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
~Note: this isn't going to pass until after #2946~

## Dev notes & details
- [x] We had the odd situation where the install directories (GNUInstallDirs) were pretty flexible. But it wasn't quite flexible enough for the usual Windows install layout (see https://github.com/psi4/psi4/blob/master/conda/win/meta.yaml#L32-L41). And if you got those all in the right place, the paths computation in `run_psi4.py` (-> `bin/psi4`) and `psi4/__init__.py` wasn't quite as flexible as GNUInstallDirs allowed. So I modernized the lot with pathlib and hopefully systemitized it a bit, too.
- [x] There's a weird case on linux c-f where we're in a git repo, but it's not the psi git repo. Thus versioning is much confused. The versioner can now escape from that case and version as if tarball.

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)
- [x] works for lin, mac, win conda-builds

## Status
- [x] Ready for review
- [x] Ready for merge
