### PR TITLE
Fix tests to reflect pyddx 0.4

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -230,7 +230,7 @@ jobs:
           - geometric
           - openfermion>=1.0
           - openfermionpsi4
-          - pyddx=0.3.0
+          - pyddx>=0.4
           - pymdi
           - qcengine
           - qcfractal

--- a/external/upstream/ddx/CMakeLists.txt
+++ b/external/upstream/ddx/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(${ENABLE_ddx})
     if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_ddx}))
         include(FindPythonModule)
-        find_python_module(pyddx ATLEAST 0.3.0 QUIET)
+        find_python_module(pyddx ATLEAST 0.4.0 QUIET)
     endif()
 
     if(${pyddx_FOUND})

--- a/psi4/driver/procrouting/solvent/ddx.py
+++ b/psi4/driver/procrouting/solvent/ddx.py
@@ -156,7 +156,7 @@ class DdxInterface:
     def __init__(self, molecule, options, basisset):
         # verify that the minimal version is used if pyddx is provided
         # from outside the Psi4 ecosystem
-        min_version = "0.3.0"
+        min_version = "0.4.0"
         if parse_version(pyddx.__version__) < parse_version(min_version):
             raise ModuleNotFoundError("pyddx version {} is required at least. "
                                       "Version {}"

--- a/tests/pytests/test_ddx.py
+++ b/tests/pytests/test_ddx.py
@@ -109,7 +109,7 @@ def _base_test_fock(fock_term, density_matrix, eps=1e-4, tol=1e-6):
        "dm": core.Matrix.from_array(0.6682326961201372 * np.ones((2, 2))),
        "ddx": {"model": "lpb", "solvent_epsilon": 80, "solvent_kappa": 1.5,
                "radii": [1.5873, 1.5873]},
-       "tol": 5e-6,
+       "tol": 3e-5,
    }, id='h2lpb'),
 ])
 def test_ddx_fock_build(inp):
@@ -289,7 +289,7 @@ def test_ddx_rhf_reference(inp):
         "geom": __geoms["nh3"],
         "basis": "cc-pvdz",
         "ddx": {"model": "lpb", "solvent": "water", "radii_set": "uff", "solvent_kappa": 0.11},
-        "ref": -56.19598597466339,
+        "ref": -56.1988043665621,
     }, id='nh3-lpb'),
 ])
 def test_ddx_rhf_consistency(inp):


### PR DESCRIPTION
Fixes #2940. Closes #2921

@mnottoli  Could you quickly give this a second pair of eyes to check what I'm doing [here when I'm lowering the tolerance](https://github.com/psi4/psi4/blob/6173fba2dc820bba05918f3dfa599550704de4f5/tests/pytests/test_ddx.py#L112) is reasonable --- I'm thinking this is the escaped charge problem for this small system. Maybe we should just remove the test alltogether?

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge
