### PR TITLE
Renovate Dimension object

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -319,8 +319,8 @@ void export_mints(py::module& m) {
     typedef void (Vector::*vector_three)(double alpha, double beta, const Vector &other);
 
     py::class_<Dimension>(m, "Dimension", "Initializes and defines Dimension Objects")
-        .def(py::init<const size_t>())
-        .def(py::init<const size_t, const std::string&>())
+        .def(py::init<size_t>())
+        .def(py::init<size_t, const std::string&>())
         .def(py::init<const std::vector<int>&>())
         .def("print_out", &Dimension::print, "Print out the dimension object to the output file")
         .def("init", &Dimension::init, "Re-initializes the dimension object")

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -319,7 +319,7 @@ void export_mints(py::module& m) {
     typedef void (Vector::*vector_three)(double alpha, double beta, const Vector &other);
 
     py::class_<Dimension>(m, "Dimension", "Initializes and defines Dimension Objects")
-        .def(py::init<>())
+        .def(py::init<const size_t>())
         .def(py::init<const size_t, const std::string&>())
         .def(py::init<const std::vector<int>&>())
         .def("print_out", &Dimension::print, "Print out the dimension object to the output file")

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -319,8 +319,8 @@ void export_mints(py::module& m) {
     typedef void (Vector::*vector_three)(double alpha, double beta, const Vector &other);
 
     py::class_<Dimension>(m, "Dimension", "Initializes and defines Dimension Objects")
-        .def(py::init<int>())
-        .def(py::init<int, const std::string&>())
+        .def(py::init<>())
+        .def(py::init<const size_t, const std::string&>())
         .def(py::init<const std::vector<int>&>())
         .def("print_out", &Dimension::print, "Print out the dimension object to the output file")
         .def("init", &Dimension::init, "Re-initializes the dimension object")

--- a/psi4/src/psi4/libmints/dimension.cc
+++ b/psi4/src/psi4/libmints/dimension.cc
@@ -61,8 +61,7 @@ void Dimension::print() const {
 }
 
 Dimension& Dimension::operator=(const int* other) {
-    std::copy(other, other + n(), blocks_);
-
+    std::copy(other, other + n(), blocks_.begin());
     return *this;
 }
 

--- a/psi4/src/psi4/libmints/dimension.cc
+++ b/psi4/src/psi4/libmints/dimension.cc
@@ -61,14 +61,14 @@ void Dimension::print() const {
 }
 
 Dimension& Dimension::operator=(const int* other) {
-    for (int i = 0, maxi = n(); i < maxi; ++i) blocks_[i] = other[i];
+    for (size_t i = 0, maxi = n(); i < maxi; ++i) blocks_[i] = other[i];
 
     return *this;
 }
 
 Dimension& Dimension::operator+=(const Dimension& b) {
     if (n() == b.n()) {
-        for (int i = 0, maxi = n(); i < maxi; ++i) blocks_[i] += b.blocks_[i];
+        for (size_t i = 0, maxi = n(); i < maxi; ++i) blocks_[i] += b.blocks_[i];
     } else {
         std::string msg = "Dimension operator+=: adding operators of different size (" + std::to_string(n()) + " and " +
                           std::to_string(b.n()) + ")";
@@ -80,7 +80,7 @@ Dimension& Dimension::operator+=(const Dimension& b) {
 
 Dimension& Dimension::operator-=(const Dimension& b) {
     if (n() == b.n()) {
-        for (int i = 0, maxi = n(); i < maxi; ++i) blocks_[i] -= b.blocks_[i];
+        for (size_t i = 0, maxi = n(); i < maxi; ++i) blocks_[i] -= b.blocks_[i];
     } else {
         std::string msg = "Dimension operator-=: subtracting operators of different size (" + std::to_string(n()) +
                           " and " + std::to_string(b.n()) + ")";
@@ -96,7 +96,7 @@ PSI_API bool operator!=(const Dimension& a, const Dimension& b) { return !operat
 PSI_API Dimension operator+(const Dimension& a, const Dimension& b) {
     Dimension result = a;
     if (a.n() == b.n()) {
-        for (int i = 0, maxi = a.n(); i < maxi; ++i) result[i] += b[i];
+        for (size_t i = 0, maxi = a.n(); i < maxi; ++i) result[i] += b[i];
     } else {
         std::string msg = "Dimension operator+: adding operators of different size (" + std::to_string(a.n()) +
                           " and " + std::to_string(b.n()) + ")";
@@ -109,7 +109,7 @@ PSI_API Dimension operator+(const Dimension& a, const Dimension& b) {
 PSI_API Dimension operator-(const Dimension& a, const Dimension& b) {
     Dimension result = a;
     if (a.n() == b.n()) {
-        for (int i = 0, maxi = a.n(); i < maxi; ++i) result[i] -= b[i];
+        for (size_t i = 0, maxi = a.n(); i < maxi; ++i) result[i] -= b[i];
     } else {
         std::string msg = "Dimension operator-: subtracting operators of different size (" + std::to_string(a.n()) +
                           " and " + std::to_string(b.n()) + ")";
@@ -140,7 +140,7 @@ bool Slice::validate_slice() {
     }
 
     // Check that begin[h] >= 0 and end[h] >= begin[h]
-    for (int h = 0, max_h = begin_.n(); h < max_h; h++) {
+    for (size_t h = 0, max_h = begin_.n(); h < max_h; h++) {
         if (begin_[h] < 0) {
             valid = false;
             msg = "Invalid Slice: element " + std::to_string(h) + " of begin Dimension object is less than zero (" +

--- a/psi4/src/psi4/libmints/dimension.cc
+++ b/psi4/src/psi4/libmints/dimension.cc
@@ -40,11 +40,11 @@ namespace psi {
 
 Dimension::Dimension() : name_("(empty)") {}
 
-Dimension::Dimension(int n, const std::string& name) : name_(name), blocks_(n, 0) {}
+Dimension::Dimension(const size_t n, const std::string& name) : name_(name), blocks_(n, 0) {}
 
 Dimension::Dimension(const std::vector<int>& v) : blocks_(v) {}
 
-void Dimension::init(int n, const std::string& name) {
+void Dimension::init(const size_t n, const std::string& name) {
     name_ = name;
     blocks_.assign(n, 0);
 }

--- a/psi4/src/psi4/libmints/dimension.cc
+++ b/psi4/src/psi4/libmints/dimension.cc
@@ -61,7 +61,7 @@ void Dimension::print() const {
 }
 
 Dimension& Dimension::operator=(const int* other) {
-    for (size_t i = 0, maxi = n(); i < maxi; ++i) blocks_[i] = other[i];
+    std::copy(other, other + n(), blocks_);
 
     return *this;
 }

--- a/psi4/src/psi4/libmints/dimension.cc
+++ b/psi4/src/psi4/libmints/dimension.cc
@@ -50,7 +50,7 @@ int Dimension::sum() const { return std::accumulate(blocks_.begin(), blocks_.end
 int Dimension::max() const { return *(std::max_element(blocks_.begin(), blocks_.end())); }
 
 void Dimension::zero() { std::fill(blocks_.begin(), blocks_.end(), 0); }
-void Dimension::fill(int v) { std::fill(blocks_.begin(), blocks_.end(), v); }
+void Dimension::fill(const int v) { std::fill(blocks_.begin(), blocks_.end(), v); }
 
 void Dimension::print() const {
     outfile->Printf("  %s (n = %d): ", name_.c_str(), n());

--- a/psi4/src/psi4/libmints/dimension.cc
+++ b/psi4/src/psi4/libmints/dimension.cc
@@ -37,11 +37,8 @@
 #include "psi4/libpsi4util/exception.h"
 
 namespace psi {
-
 Dimension::Dimension() : name_("(empty)") {}
-
 Dimension::Dimension(const size_t n, const std::string& name) : name_(name), blocks_(n, 0) {}
-
 Dimension::Dimension(const std::vector<int>& v) : blocks_(v) {}
 
 void Dimension::init(const size_t n, const std::string& name) {
@@ -50,11 +47,9 @@ void Dimension::init(const size_t n, const std::string& name) {
 }
 
 int Dimension::sum() const { return std::accumulate(blocks_.begin(), blocks_.end(), 0); }
-
 int Dimension::max() const { return *(std::max_element(blocks_.begin(), blocks_.end())); }
 
 void Dimension::zero() { std::fill(blocks_.begin(), blocks_.end(), 0); }
-
 void Dimension::fill(int v) { std::fill(blocks_.begin(), blocks_.end(), v); }
 
 void Dimension::print() const {
@@ -96,7 +91,6 @@ Dimension& Dimension::operator-=(const Dimension& b) {
 }
 
 PSI_API bool operator==(const Dimension& a, const Dimension& b) { return (a.blocks_ == b.blocks_); }
-
 PSI_API bool operator!=(const Dimension& a, const Dimension& b) { return !operator==(a, b); }
 
 PSI_API Dimension operator+(const Dimension& a, const Dimension& b) {
@@ -125,7 +119,6 @@ PSI_API Dimension operator-(const Dimension& a, const Dimension& b) {
 }
 
 Slice::Slice(const Dimension& begin, const Dimension& end) : begin_(begin), end_(end) { validate_slice(); }
-
 Slice::Slice(const Slice& other) : begin_(other.begin()), end_(other.end()) { validate_slice(); }
 
 Slice& Slice::operator+=(const Dimension& increment) {

--- a/psi4/src/psi4/libmints/dimension.cc
+++ b/psi4/src/psi4/libmints/dimension.cc
@@ -38,10 +38,10 @@
 
 namespace psi {
 Dimension::Dimension() : name_("(empty)") {}
-Dimension::Dimension(const size_t n, const std::string& name) : name_(name), blocks_(n, 0) {}
+Dimension::Dimension(const size_t n, const std::string& name/* = ""*/) : name_(name), blocks_(n, 0) {}
 Dimension::Dimension(const std::vector<int>& v) : blocks_(v) {}
 
-void Dimension::init(const size_t n, const std::string& name) {
+void Dimension::init(const size_t n, const std::string& name/* = ""*/) {
     name_ = name;
     blocks_.assign(n, 0);
 }

--- a/psi4/src/psi4/libmints/dimension.cc
+++ b/psi4/src/psi4/libmints/dimension.cc
@@ -38,10 +38,10 @@
 
 namespace psi {
 Dimension::Dimension() : name_("(empty)") {}
-Dimension::Dimension(const size_t n, const std::string& name/* = ""*/) : name_(name), blocks_(n, 0) {}
+Dimension::Dimension(size_t n, const std::string& name/* = ""*/) : name_(name), blocks_(n, 0) {}
 Dimension::Dimension(const std::vector<int>& v) : blocks_(v) {}
 
-void Dimension::init(const size_t n, const std::string& name/* = ""*/) {
+void Dimension::init(size_t n, const std::string& name/* = ""*/) {
     name_ = name;
     blocks_.assign(n, 0);
 }
@@ -50,7 +50,7 @@ int Dimension::sum() const { return std::accumulate(blocks_.begin(), blocks_.end
 int Dimension::max() const { return *(std::max_element(blocks_.begin(), blocks_.end())); }
 
 void Dimension::zero() { std::fill(blocks_.begin(), blocks_.end(), 0); }
-void Dimension::fill(const int v) { std::fill(blocks_.begin(), blocks_.end(), v); }
+void Dimension::fill(int v) { std::fill(blocks_.begin(), blocks_.end(), v); }
 
 void Dimension::print() const {
     outfile->Printf("  %s (n = %d): ", name_.c_str(), n());

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -37,6 +37,8 @@
 
 namespace psi {
 
+/// @brief Dimension object
+/// \ingroup MINTS
 class PSI_API Dimension {
    private:
     std::string name_;

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -57,6 +57,9 @@ class PSI_API Dimension {
     Dimension(const std::vector<int>& other);
 
     /// @brief Assignment operator, this one can be very dangerous
+    PSI_DEPRECATED(
+        "The assignment operator for psi::Dimension is being deprecated. Unless someone speaks up, 1.8 will be the "
+        "last release to have it.")
     Dimension& operator=(const int* other);
 
     Dimension& operator+=(const Dimension& b);

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -84,7 +84,7 @@ class PSI_API Dimension {
 
     /// @brief Access a block number at a partcular index. Not bounds-checked.
     const int& operator[](const size_t i) const { return blocks_[i]; }
-    
+
     /// @brief Access a block number at a partcular index. Not bounds-checked.
     const std::vector<int>& blocks() const { return blocks_; }
 
@@ -100,21 +100,23 @@ class PSI_API Dimension {
         "last release to have them.")
     operator const int*() const { return blocks_.data(); }
 
-    /// Return the sum of constituent dimensions
+    /// @brief Return the sum of constituent dimensions (block numbers)
     int sum() const;
+
+    /// @brief Return the maximum of constituent dimensions (block numbers)
     int max() const;
 
-    /// Zero all the elements
+    /// @brief Zero all the dimensions (block numbers)
     void zero();
 
-    /// Fill all elements in blocks_ with given value
-    void fill(int v);
+    /// @brief Fill all elements in blocks_ with given value
+    void fill(const int v);
 
     void print() const;
 
     // Only used for python
     const int& get(const size_t i) const { return blocks_[i]; }
-    void set(const size_t i, int val) { blocks_[i] = val; }
+    void set(const size_t i, const int val) { blocks_[i] = val; }
 
     PSI_API friend bool operator==(const Dimension& a, const Dimension& b);
     PSI_API friend bool operator!=(const Dimension& a, const Dimension& b);

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -81,12 +81,23 @@ class PSI_API Dimension {
 
     /// @brief Access a block number at a partcular index. Not bounds-checked.
     int& operator[](const size_t i) { return blocks_[i]; }
+
+    /// @brief Access a block number at a partcular index. Not bounds-checked.
     const int& operator[](const size_t i) const { return blocks_[i]; }
+    
+    /// @brief Access a block number at a partcular index. Not bounds-checked.
     const std::vector<int>& blocks() const { return blocks_; }
 
-    /// Casting operator to int*
+    /// @brief Casting operator to int*
+    PSI_DEPRECATED(
+        "Cast-to-pointer operators for psi::Dimension are being deprecated. Unless someone speaks up, 1.8 will be the "
+        "last release to have them.")
     operator int*() { return blocks_.data(); }
-    /// Casting operator to const int*
+
+    /// @brief Casting operator to const int*
+    PSI_DEPRECATED(
+        "Cast-to-pointer operators for psi::Dimension are being deprecated. Unless someone speaks up, 1.8 will be the "
+        "last release to have them.")
     operator const int*() const { return blocks_.data(); }
 
     /// Return the sum of constituent dimensions

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -71,7 +71,7 @@ class PSI_API Dimension {
     void init(const size_t n, const std::string& name = "");
 
     /// @brief Return the rank (number of block numbers)
-    int n() const { return static_cast<int>(blocks_.size()); }
+    int n() const { return blocks_.size(); }
 
     /// @brief Return the name of the Dimension object
     const std::string& name() const { return name_; }

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -43,29 +43,40 @@ class PSI_API Dimension {
     std::vector<int> blocks_;
 
    public:
+    /// @brief Constructs an empty Dimension object, with the name initialized to "(empty)"
     Dimension();
+
+    /// @brief Constructs a Dimension object with a specified number of block numbers and optionally a name. If no name
+    /// is given it will be a zero-length string.
+    /// @param n : number of blocks
+    /// @param name : (optional) name associated with this Dimension object
     Dimension(int n, const std::string& name = "");
+
+    /// @brief Constructs a Dimension object from an std::vector<int> object, leaving the name a zero-length string.
+    /// @param other : object to copy the block numbers from
     Dimension(const std::vector<int>& other);
 
-    /// Assignment operator, this one can be very dangerous
+    /// @brief Assignment operator, this one can be very dangerous
     Dimension& operator=(const int* other);
 
     Dimension& operator+=(const Dimension& b);
     Dimension& operator-=(const Dimension& b);
 
-    /// Re-initializes the object
+    /// @brief Re-initializes the object. If no name is given it will be a zero-length string.
+    /// @param n : number of blocks
+    /// @param name : (optional) name associated with this Dimension object
     void init(int n, const std::string& name = "");
 
-    /// Return the rank
+    /// @brief Return the rank (number of block numbers)
     int n() const { return static_cast<int>(blocks_.size()); }
 
-    /// Return the name of the dimension
+    /// @brief Return the name of the Dimension object
     const std::string& name() const { return name_; }
 
-    /// Set the name of the dimension
+    /// @brief Set the name of the Dimension object
     void set_name(const std::string& name) { name_ = name; }
 
-    /// Blocks access
+    /// @brief Access a block number at a partcular index. Not bounds-checked.
     int& operator[](int i) { return blocks_[i]; }
     const int& operator[](int i) const { return blocks_[i]; }
     const std::vector<int>& blocks() const { return blocks_; }

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -50,7 +50,7 @@ class PSI_API Dimension {
     /// is given it will be a zero-length string.
     /// @param n : number of blocks
     /// @param name : (optional) name associated with this Dimension object
-    Dimension(int n, const std::string& name = "");
+    Dimension(const size_t n, const std::string& name = "");
 
     /// @brief Constructs a Dimension object from an std::vector<int> object, leaving the name a zero-length string.
     /// @param other : object to copy the block numbers from
@@ -68,7 +68,7 @@ class PSI_API Dimension {
     /// @brief Re-initializes the object. If no name is given it will be a zero-length string.
     /// @param n : number of blocks
     /// @param name : (optional) name associated with this Dimension object
-    void init(int n, const std::string& name = "");
+    void init(const size_t n, const std::string& name = "");
 
     /// @brief Return the rank (number of block numbers)
     int n() const { return static_cast<int>(blocks_.size()); }
@@ -80,8 +80,8 @@ class PSI_API Dimension {
     void set_name(const std::string& name) { name_ = name; }
 
     /// @brief Access a block number at a partcular index. Not bounds-checked.
-    int& operator[](int i) { return blocks_[i]; }
-    const int& operator[](int i) const { return blocks_[i]; }
+    int& operator[](const size_t i) { return blocks_[i]; }
+    const int& operator[](const size_t i) const { return blocks_[i]; }
     const std::vector<int>& blocks() const { return blocks_; }
 
     /// Casting operator to int*
@@ -102,8 +102,8 @@ class PSI_API Dimension {
     void print() const;
 
     // Only used for python
-    const int& get(int i) const { return blocks_[i]; }
-    void set(int i, int val) { blocks_[i] = val; }
+    const int& get(const size_t i) const { return blocks_[i]; }
+    void set(const size_t i, int val) { blocks_[i] = val; }
 
     PSI_API friend bool operator==(const Dimension& a, const Dimension& b);
     PSI_API friend bool operator!=(const Dimension& a, const Dimension& b);

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -60,7 +60,7 @@ class PSI_API Dimension {
 
     /// @brief Assignment operator, this one can be very dangerous
     PSI_DEPRECATED(
-        "The assignment operator for psi::Dimension is being deprecated. Unless someone speaks up, 1.9 may be the "
+        "The assignment operator for psi::Dimension is being deprecated. Unless someone speaks up, 1.10 may be the "
         "last release to have it.")
     Dimension& operator=(const int* other);
 
@@ -92,13 +92,13 @@ class PSI_API Dimension {
 
     /// @brief Casting operator to int*
     PSI_DEPRECATED(
-        "Cast-to-pointer operators for psi::Dimension are being deprecated. Unless someone speaks up, 1.9 may be the "
+        "Cast-to-pointer operators for psi::Dimension are being deprecated. Unless someone speaks up, 1.10 may be the "
         "last release to have them.")
     operator int*() { return blocks_.data(); }
 
     /// @brief Casting operator to const int*
     PSI_DEPRECATED(
-        "Cast-to-pointer operators for psi::Dimension are being deprecated. Unless someone speaks up, 1.9 may be the "
+        "Cast-to-pointer operators for psi::Dimension are being deprecated. Unless someone speaks up, 1.10 may be the "
         "last release to have them.")
     operator const int*() const { return blocks_.data(); }
 

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -60,7 +60,7 @@ class PSI_API Dimension {
 
     /// @brief Assignment operator, this one can be very dangerous
     PSI_DEPRECATED(
-        "The assignment operator for psi::Dimension is being deprecated. Unless someone speaks up, 1.8 will be the "
+        "The assignment operator for psi::Dimension is being deprecated. Unless someone speaks up, 1.9 may be the "
         "last release to have it.")
     Dimension& operator=(const int* other);
 
@@ -92,13 +92,13 @@ class PSI_API Dimension {
 
     /// @brief Casting operator to int*
     PSI_DEPRECATED(
-        "Cast-to-pointer operators for psi::Dimension are being deprecated. Unless someone speaks up, 1.8 will be the "
+        "Cast-to-pointer operators for psi::Dimension are being deprecated. Unless someone speaks up, 1.9 may be the "
         "last release to have them.")
     operator int*() { return blocks_.data(); }
 
     /// @brief Casting operator to const int*
     PSI_DEPRECATED(
-        "Cast-to-pointer operators for psi::Dimension are being deprecated. Unless someone speaks up, 1.8 will be the "
+        "Cast-to-pointer operators for psi::Dimension are being deprecated. Unless someone speaks up, 1.9 may be the "
         "last release to have them.")
     operator const int*() const { return blocks_.data(); }
 

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -73,7 +73,7 @@ class PSI_API Dimension {
     void init(const size_t n, const std::string& name = "");
 
     /// @brief Return the rank (number of block numbers)
-    int n() const { return blocks_.size(); }
+    size_t n() const { return blocks_.size(); }
 
     /// @brief Return the name of the Dimension object
     const std::string& name() const { return name_; }
@@ -87,7 +87,7 @@ class PSI_API Dimension {
     /// @brief Access a block number at a partcular index. Not bounds-checked.
     const int& operator[](const size_t i) const { return blocks_[i]; }
 
-    /// @brief Access a block number at a partcular index. Not bounds-checked.
+    /// @brief Get a const reference to the std::vector storing the block numbers inside the Dimension object.
     const std::vector<int>& blocks() const { return blocks_; }
 
     /// @brief Casting operator to int*

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -52,7 +52,7 @@ class PSI_API Dimension {
     /// is given it will be a zero-length string.
     /// @param n : number of blocks
     /// @param name : (optional) name associated with this Dimension object
-    Dimension(const size_t n, const std::string& name = "");
+    Dimension(size_t n, const std::string& name = "");
 
     /// @brief Constructs a Dimension object from an std::vector<int> object, leaving the name a zero-length string.
     /// @param other : object to copy the block numbers from
@@ -70,7 +70,7 @@ class PSI_API Dimension {
     /// @brief Re-initializes the object. If no name is given it will be a zero-length string.
     /// @param n : number of blocks
     /// @param name : (optional) name associated with this Dimension object
-    void init(const size_t n, const std::string& name = "");
+    void init(size_t n, const std::string& name = "");
 
     /// @brief Return the rank (number of block numbers)
     size_t n() const { return blocks_.size(); }
@@ -82,10 +82,10 @@ class PSI_API Dimension {
     void set_name(const std::string& name) { name_ = name; }
 
     /// @brief Access a block number at a partcular index. Not bounds-checked.
-    int& operator[](const size_t i) { return blocks_[i]; }
+    int& operator[](size_t i) { return blocks_[i]; }
 
     /// @brief Access a block number at a partcular index. Not bounds-checked.
-    const int& operator[](const size_t i) const { return blocks_[i]; }
+    const int& operator[](size_t i) const { return blocks_[i]; }
 
     /// @brief Get a const reference to the std::vector storing the block numbers inside the Dimension object.
     const std::vector<int>& blocks() const { return blocks_; }
@@ -112,13 +112,13 @@ class PSI_API Dimension {
     void zero();
 
     /// @brief Fill all elements in blocks_ with given value
-    void fill(const int v);
+    void fill(int v);
 
     void print() const;
 
     // Only used for python
-    const int& get(const size_t i) const { return blocks_[i]; }
-    void set(const size_t i, const int val) { blocks_[i] = val; }
+    const int& get(size_t i) const { return blocks_[i]; }
+    void set(size_t i, int val) { blocks_[i] = val; }
 
     PSI_API friend bool operator==(const Dimension& a, const Dimension& b);
     PSI_API friend bool operator!=(const Dimension& a, const Dimension& b);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR aims to improve the Dimension object in various ways, by adding machine-readable (for eg. VSCode) docstrings, adding const to arguments, replacing `int` with `size_t` to match `std::vector::operator[](std::size_t)` and cautiously deprecating member functions that deal with pointers.

Not only are pointers more error-prone, they are currently involved in some strange interaction between `Dimension` and `Matrix` objects, resulting in awkward roundabout initialization/construction that I hope to untangle before Psi4 1.11? (1.11, or maybe 1.12?).
Please let me know if you feel the three deprecations in this PR would be too disruptive or otherwise undesirable, this PR is very much a "request for comments".

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] API change: The custom assignment operator for `Dimension` objects (`Dimension& operator=(const int*)`) is being deprecated. Unless someone speaks up, 1.10 may be the last release to have it.
- [x] API change: Cast-to-pointer operators for `Dimension` objects (`operator int*()` and `operator const int*() const`) are being deprecated. Unless someone speaks up, 1.10 may be the last release to have them.
- [x] Minor API change: Several constructors and member functions of `Dimension` are now using `size_t` instead of `int` for indexing:
−`Dimension::Dimension(int, const std::string&)` is now `Dimension::Dimension(size_t, const std::string&)`
−`void Dimension::init(int, const std::string&)` is now `void Dimension::init(size_t, const std::string&)`
−`int Dimension::n() const` is now `size_t Dimension::n() const`
−`int& Dimension::operator[](int)` is now `int& Dimension::operator[](size_t)`
−`const int& Dimension::operator[](int) const` is now `const int& Dimension::operator[](size_t) const`
−`const int& Dimension::get(int) const` is now `const int& Dimension::get(size_t) const`
−`void Dimension::set(int, int)` is now `void Dimension::set(size_t, int)`

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Machine-readable docstrings have been added to `dimension.h` to improve suggestions offered by IDEs like VSCode
- [x] `size_t` is now used instead of `int` when dealing with array indexing. Python bindings have been updated to reflect the change in constructor arguments.
- [x] Local variables have been made `const` where possible
- [x] Deprecation notices have been added to `Dimension& operator=(int*)`, `operator int*()` and `operator const int*() const`

## Checklist
- [x] No new features
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
