### PR TITLE
CompositeJK Part 2.5: Update Reference Outputs

### DIFF
--- a/tests/linK-1/output.ref
+++ b/tests/linK-1/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.8a1.dev17 
+                               Psi4 1.8a1.dev68 
 
-                         Git: Rev {dpoole34/compositejk-pilot} e4f6b14 dirty
+                         Git: Rev {dpoole34/compositejk-pilot-ref} 78ba1c2 
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -31,11 +31,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Thursday, 08 December 2022 03:46PM
+    Psi4 started on: Monday, 08 May 2023 09:20AM
 
-    Process ID: 26439
+    Process ID: 816515
     Host:       ds6
-    PSIDATADIR: /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4
+    PSIDATADIR: /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -57,7 +57,7 @@ molecule mol {
 }
 
 set {
-    scf_type directdfj+link 
+    scf_type dfdirj+link
     df_scf_guess false
     basis aug-cc-pVDZ
     e_convergence 1.0e-10
@@ -76,15 +76,15 @@ compare(1, variable("SCF ITERATIONS") < 12.0, "LinK Incfock Efficient")
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:46:59 2022
+*** at Mon May  8 09:20:08 2023
 
    => Loading Basis Set <=
 
     Name: AUG-CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   254 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/aug-cc-pvdz.gbs 
-    atoms 2-3 entry H          line    40 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 1   entry O          line   254 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3 entry H          line    40 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/aug-cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -122,7 +122,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+LINK.
+  SCF Algorithm Type is DFDIRJ+LINK.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -146,25 +146,24 @@ Scratch directory: /scratch/dpoole34/
     Name: (AUG-CC-PVDZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   270 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    70 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 1   entry O          line   270 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+LINK 
-j_type_: DIRECTDFJ 
-k_type_: LINK 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              LINK
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:          Yes
     Screening Type:        DENSITY
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -271,19 +270,19 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:47:00 2022
+*** tstop() called on ds6 at Mon May  8 09:20:09 2023
 Module time:
-	user time   =       0.99 seconds =       0.02 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       0.91 seconds =       0.02 minutes
+	system time =       0.08 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.99 seconds =       0.02 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       0.91 seconds =       0.02 minutes
+	system time =       0.08 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
     HF Energy (Using LinK algo)...........................................................PASSED
     LinK Incfock Efficient................................................................PASSED
 
-    Psi4 stopped on: Thursday, 08 December 2022 03:47PM
-    Psi4 wall time for execution: 0:00:01.31
+    Psi4 stopped on: Monday, 08 May 2023 09:20AM
+    Psi4 wall time for execution: 0:00:01.17
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/linK-2/output.ref
+++ b/tests/linK-2/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.8a1.dev17 
+                               Psi4 1.8a1.dev68 
 
-                         Git: Rev {dpoole34/compositejk-pilot} e4f6b14 dirty
+                         Git: Rev {dpoole34/compositejk-pilot-ref} 78ba1c2 
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -31,11 +31,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Thursday, 08 December 2022 03:47PM
+    Psi4 started on: Monday, 08 May 2023 09:20AM
 
-    Process ID: 26460
+    Process ID: 816564
     Host:       ds6
-    PSIDATADIR: /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4
+    PSIDATADIR: /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -66,7 +66,7 @@ molecule mol {
 }
 
 set {
-    scf_type directdfj+link 
+    scf_type dfdirj+link
     df_scf_guess false
     basis cc-pVTZ
     e_convergence 1.0e-10
@@ -84,15 +84,15 @@ compare(1, variable("SCF ITERATIONS") < 13.0, "LinK Incfock Efficient")
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:47:10 2022
+*** at Mon May  8 09:20:22 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-6  entry C          line   186 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
-    atoms 7-12 entry H          line    23 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-6  entry C          line   186 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 7-12 entry H          line    23 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -139,7 +139,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+LINK.
+  SCF Algorithm Type is DFDIRJ+LINK.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -218,25 +218,24 @@ Scratch directory: /scratch/dpoole34/
     Name: (CC-PVTZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-6  entry C          line   125 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
-    atoms 7-12 entry H          line    51 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-6  entry C          line   125 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 7-12 entry H          line    51 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+LINK 
-j_type_: DIRECTDFJ 
-k_type_: LINK 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              LINK
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:                0
     Incremental Fock:          Yes
     Screening Type:        DENSITY
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -247,7 +246,7 @@ k_type_: LINK
   Cached 20.0% of DFT collocation blocks in 0.306 [GiB].
 
   Minimum eigenvalue in the overlap matrix is 3.7592595819E-05.
-  Reciprocal condition number of the overlap matrix is 4.6398212529E-06.
+  Reciprocal condition number of the overlap matrix is 4.6398212530E-06.
     Using symmetric orthogonalization.
 
   ==> Pre-Iterations <==
@@ -267,20 +266,20 @@ k_type_: LINK
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RKS iter SAD:  -231.83029426915795   -2.31830e+02   0.00000e+00 
-   @RKS iter   1:  -231.83555581126606   -5.26154e-03   3.65101e-03 ADIIS/DIIS
-   @RKS iter   2:  -231.53471074547025    3.00845e-01   4.63419e-03 ADIIS/DIIS/INCFOCK
-   @RKS iter   3:  -232.32939413751313   -7.94683e-01   3.59964e-04 ADIIS/DIIS/INCFOCK
-   @RKS iter   4:  -232.33321033193747   -3.81619e-03   7.46497e-05 DIIS/INCFOCK
-   @RKS iter   5:  -232.33338551709221   -1.75185e-04   7.55361e-06 DIIS/INCFOCK
-   @RKS iter   6:  -232.33338587751265   -3.60420e-07   6.94038e-06 DIIS
-   @RKS iter   7:  -232.33338777965491   -1.90214e-06   6.76768e-07 DIIS
-   @RKS iter   8:  -232.33338779468380   -1.50289e-08   3.09013e-07 DIIS
-   @RKS iter   9:  -232.33338779778938   -3.10558e-09   1.70372e-08 DIIS
-   @RKS iter  10:  -232.33338779779777   -8.38440e-12   6.56351e-09 DIIS
+   @RKS iter   1:  -231.83555581126677   -5.26154e-03   3.65101e-03 ADIIS/DIIS
+   @RKS iter   2:  -231.53471074547130    3.00845e-01   4.63419e-03 ADIIS/DIIS/INCFOCK
+   @RKS iter   3:  -232.32939413751362   -7.94683e-01   3.59964e-04 ADIIS/DIIS/INCFOCK
+   @RKS iter   4:  -232.33321033193775   -3.81619e-03   7.46497e-05 DIIS/INCFOCK
+   @RKS iter   5:  -232.33338551709267   -1.75185e-04   7.55361e-06 DIIS/INCFOCK
+   @RKS iter   6:  -232.33338587751268   -3.60420e-07   6.94038e-06 DIIS
+   @RKS iter   7:  -232.33338777965605   -1.90214e-06   6.76768e-07 DIIS
+   @RKS iter   8:  -232.33338779468338   -1.50273e-08   3.09013e-07 DIIS
+   @RKS iter   9:  -232.33338779778876   -3.10538e-09   1.70372e-08 DIIS
+   @RKS iter  10:  -232.33338779779734   -8.58336e-12   6.56351e-09 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @RKS iter  11:  -232.33338779779785   -8.52651e-14   1.36726e-09 DIIS
+   @RKS iter  11:  -232.33338779779697    3.69482e-13   1.36726e-09 DIIS
   Energy and wave function converged.
 
 
@@ -392,17 +391,17 @@ k_type_: LINK
     NA   [    21 ]
     NB   [    21 ]
 
-  @RKS Final Energy:  -232.33338779779785
+  @RKS Final Energy:  -232.33338779779697
 
    => Energetics <=
 
     Nuclear Repulsion Energy =            203.7109313602788916
-    One-Electron Energy =                -714.7993539993815375
-    Two-Electron Energy =                 306.9305826533805543
-    DFT Exchange-Correlation Energy =     -28.1755478120757310
+    One-Electron Energy =                -714.7993539993822196
+    Two-Electron Energy =                 306.9305826533820891
+    DFT Exchange-Correlation Energy =     -28.1755478120757381
     Empirical Dispersion Energy =           0.0000000000000000
     VV10 Nonlocal Energy =                  0.0000000000000000
-    Total Energy =                       -232.3333877977978261
+    Total Energy =                       -232.3333877977969735
 
 Computation Completed
 
@@ -421,24 +420,24 @@ Properties computed using the SCF density matrix
  L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
  Dipole X            :        147.6174493         -147.6125312            0.0049182
  Dipole Y            :         22.9056464          -22.9024868            0.0031596
- Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.0000000            0.0000000           -0.0000000
  Magnitude           :                                                    0.0058456
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:53:58 2022
+*** tstop() called on ds6 at Mon May  8 09:26:58 2023
 Module time:
-	user time   =     406.99 seconds =       6.78 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =        408 seconds =       6.80 minutes
+	user time   =     396.33 seconds =       6.61 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =        396 seconds =       6.60 minutes
 Total time:
-	user time   =     406.99 seconds =       6.78 minutes
-	system time =       0.24 seconds =       0.00 minutes
-	total time  =        408 seconds =       6.80 minutes
+	user time   =     396.33 seconds =       6.61 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =        396 seconds =       6.60 minutes
     B3LYP Energy (using LinK algo)........................................................PASSED
     LinK Incfock Efficient................................................................PASSED
 
-    Psi4 stopped on: Thursday, 08 December 2022 03:53PM
-    Psi4 wall time for execution: 0:06:48.13
+    Psi4 stopped on: Monday, 08 May 2023 09:26AM
+    Psi4 wall time for execution: 0:06:36.69
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/linK-3/output.ref
+++ b/tests/linK-3/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.8a1.dev17 
+                               Psi4 1.8a1.dev68 
 
-                         Git: Rev {dpoole34/compositejk-pilot} e4f6b14 dirty
+                         Git: Rev {dpoole34/compositejk-pilot-ref} 78ba1c2 
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -31,11 +31,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Thursday, 08 December 2022 03:54PM
+    Psi4 started on: Monday, 08 May 2023 09:31AM
 
-    Process ID: 26541
+    Process ID: 817499
     Host:       ds6
-    PSIDATADIR: /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4
+    PSIDATADIR: /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -68,7 +68,7 @@ molecule mol {
 
 set {
     reference uhf
-    scf_type directdfj+link 
+    scf_type dfdirj+link
     df_scf_guess false
     basis 6-31G*
     e_convergence 1.0e-10
@@ -91,15 +91,15 @@ compare(1, variable("SCF ITERATIONS") < 19.0, "ROHF LinK Incfock Efficient")
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:54:41 2022
+*** at Mon May  8 09:31:57 2023
 
    => Loading Basis Set <=
 
     Name: 6-31G*
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-6  entry C          line   111 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/6-31gs.gbs 
-    atoms 7-12 entry H          line    44 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/6-31gs.gbs 
+    atoms 1-6  entry C          line   111 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/6-31gs.gbs 
+    atoms 7-12 entry H          line    44 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/6-31gs.gbs 
 
 
          ---------------------------------------------------------
@@ -146,7 +146,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+LINK.
+  SCF Algorithm Type is DFDIRJ+LINK.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -170,25 +170,24 @@ Scratch directory: /scratch/dpoole34/
     Name: (6-31G* AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-6  entry C          line   121 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 7-12 entry H          line    51 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1-6  entry C          line   121 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 7-12 entry H          line    51 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+LINK 
-j_type_: DIRECTDFJ 
-k_type_: LINK 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              LINK
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:          Yes
     Screening Type:        DENSITY
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -217,26 +216,26 @@ k_type_: LINK
                         Total Energy        Delta E     RMS |[F,P]|
 
    @UHF iter SAD:  -229.97628349801798   -2.29976e+02   0.00000e+00 
-   @UHF iter   1:  -230.34049812990128   -3.64215e-01   2.84897e-03 DIIS/ADIIS
-   @UHF iter   2:  -230.40556115546840   -6.50630e-02   9.10573e-04 DIIS/ADIIS/INCFOCK
+   @UHF iter   1:  -230.34049812990119   -3.64215e-01   2.84897e-03 DIIS/ADIIS
+   @UHF iter   2:  -230.40556115546877   -6.50630e-02   9.10573e-04 DIIS/ADIIS/INCFOCK
    @UHF iter   3:  -230.41345636158763   -7.89521e-03   4.49251e-04 DIIS/ADIIS/INCFOCK
-   @UHF iter   4:  -230.41572974153320   -2.27338e-03   1.91643e-04 DIIS/ADIIS/INCFOCK
-   @UHF iter   5:  -230.41688607751922   -1.15634e-03   1.04622e-04 DIIS/ADIIS/INCFOCK
-   @UHF iter   6:  -230.41726728449041   -3.81207e-04   3.44251e-05 DIIS
-   @UHF iter   7:  -230.41729518028322   -2.78958e-05   8.95035e-06 DIIS/INCFOCK
-   @UHF iter   8:  -230.41729655766784   -1.37738e-06   3.00576e-06 DIIS
-   @UHF iter   9:  -230.41729673019302   -1.72525e-07   7.62041e-07 DIIS
-   @UHF iter  10:  -230.41729674144131   -1.12483e-08   3.40281e-07 DIIS
-   @UHF iter  11:  -230.41729674488266   -3.44136e-09   2.27475e-07 DIIS
-   @UHF iter  12:  -230.41729674660334   -1.72068e-09   1.91708e-07 DIIS
-   @UHF iter  13:  -230.41729674887165   -2.26831e-09   1.56673e-07 DIIS
-   @UHF iter  14:  -230.41729675274470   -3.87305e-09   6.68673e-08 DIIS
-   @UHF iter  15:  -230.41729675337797   -6.33264e-10   1.79330e-08 DIIS
-   @UHF iter  16:  -230.41729675339241   -1.44382e-11   6.35053e-09 DIIS
+   @UHF iter   4:  -230.41572974153326   -2.27338e-03   1.91643e-04 DIIS/ADIIS/INCFOCK
+   @UHF iter   5:  -230.41688607751891   -1.15634e-03   1.04622e-04 DIIS/ADIIS/INCFOCK
+   @UHF iter   6:  -230.41726728449024   -3.81207e-04   3.44251e-05 DIIS
+   @UHF iter   7:  -230.41729518028293   -2.78958e-05   8.95035e-06 DIIS/INCFOCK
+   @UHF iter   8:  -230.41729655766835   -1.37739e-06   3.00576e-06 DIIS
+   @UHF iter   9:  -230.41729673019270   -1.72524e-07   7.62041e-07 DIIS
+   @UHF iter  10:  -230.41729674144077   -1.12481e-08   3.40281e-07 DIIS
+   @UHF iter  11:  -230.41729674488272   -3.44195e-09   2.27475e-07 DIIS
+   @UHF iter  12:  -230.41729674660309   -1.72037e-09   1.91708e-07 DIIS
+   @UHF iter  13:  -230.41729674887114   -2.26805e-09   1.56673e-07 DIIS
+   @UHF iter  14:  -230.41729675274394   -3.87280e-09   6.68673e-08 DIIS
+   @UHF iter  15:  -230.41729675337768   -6.33747e-10   1.79330e-08 DIIS
+   @UHF iter  16:  -230.41729675339184   -1.41540e-11   6.35052e-09 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @UHF iter  17:  -230.41729675339326   -8.52651e-13   3.00872e-09 DIIS
+   @UHF iter  17:  -230.41729675339334   -1.50635e-12   3.00871e-09 DIIS
   Energy and wave function converged.
 
 
@@ -339,14 +338,14 @@ k_type_: LINK
     NA   [    21 ]
     NB   [    20 ]
 
-  @UHF Final Energy:  -230.41729675339326
+  @UHF Final Energy:  -230.41729675339334
 
    => Energetics <=
 
     Nuclear Repulsion Energy =            203.7109313602788916
-    One-Electron Energy =                -703.9941117519565523
-    Two-Electron Energy =                 269.8658836382844015
-    Total Energy =                       -230.4172967533932592
+    One-Electron Energy =                -703.9941117519526870
+    Two-Electron Energy =                 269.8658836382804793
+    Total Energy =                       -230.4172967533933161
 
   UHF NO Occupations:
   HONO-2 :   19  A 1.9835690
@@ -380,30 +379,30 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:55:20 2022
+*** tstop() called on ds6 at Mon May  8 09:32:33 2023
 Module time:
-	user time   =      38.10 seconds =       0.64 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =         39 seconds =       0.65 minutes
+	user time   =      35.81 seconds =       0.60 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =         36 seconds =       0.60 minutes
 Total time:
-	user time   =      38.10 seconds =       0.64 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =         39 seconds =       0.65 minutes
+	user time   =      35.81 seconds =       0.60 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =         36 seconds =       0.60 minutes
     UHF Energy (using LinK algo)..........................................................PASSED
     UHF LinK Incfock Efficient............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:55:20 2022
+*** at Mon May  8 09:32:33 2023
 
    => Loading Basis Set <=
 
     Name: 6-31G*
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-6  entry C          line   111 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/6-31gs.gbs 
-    atoms 7-12 entry H          line    44 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/6-31gs.gbs 
+    atoms 1-6  entry C          line   111 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/6-31gs.gbs 
+    atoms 7-12 entry H          line    44 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/6-31gs.gbs 
 
 
          ---------------------------------------------------------
@@ -450,7 +449,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+LINK.
+  SCF Algorithm Type is DFDIRJ+LINK.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -474,25 +473,24 @@ Scratch directory: /scratch/dpoole34/
     Name: (6-31G* AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-6  entry C          line   121 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 7-12 entry H          line    51 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 1-6  entry C          line   121 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 7-12 entry H          line    51 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+LINK 
-j_type_: DIRECTDFJ 
-k_type_: LINK 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              LINK
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:          Yes
     Screening Type:        DENSITY
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -521,20 +519,20 @@ k_type_: LINK
                         Total Energy        Delta E     RMS |[F,P]|
 
    @ROHF iter SAD:  -229.97628349801801   -2.29976e+02   0.00000e+00 
-   @ROHF iter   1:  -230.34049812990156   -3.64215e-01   1.97150e-03 DIIS
+   @ROHF iter   1:  -230.34049812990099   -3.64215e-01   1.97150e-03 DIIS
    @ROHF iter   2:  -230.39754842942534   -5.70503e-02   5.92347e-04 DIIS/INCFOCK
-   @ROHF iter   3:  -230.40213224295394   -4.58381e-03   2.54181e-04 DIIS/INCFOCK
-   @ROHF iter   4:  -230.40285594951087   -7.23707e-04   2.60662e-05 DIIS/INCFOCK
-   @ROHF iter   5:  -230.40286971684054   -1.37673e-05   1.09670e-05 DIIS/INCFOCK
-   @ROHF iter   6:  -230.40287161530756   -1.89847e-06   2.55354e-06 DIIS
-   @ROHF iter   7:  -230.40287183399215   -2.18685e-07   5.54114e-07 DIIS
-   @ROHF iter   8:  -230.40287184255357   -8.56141e-09   6.63256e-08 DIIS
-   @ROHF iter   9:  -230.40287184266970   -1.16131e-10   2.77789e-08 DIIS
-   @ROHF iter  10:  -230.40287184268720   -1.75078e-11   1.23581e-08 DIIS
+   @ROHF iter   3:  -230.40213224295314   -4.58381e-03   2.54181e-04 DIIS/INCFOCK
+   @ROHF iter   4:  -230.40285594951104   -7.23707e-04   2.60662e-05 DIIS/INCFOCK
+   @ROHF iter   5:  -230.40286971684026   -1.37673e-05   1.09670e-05 DIIS/INCFOCK
+   @ROHF iter   6:  -230.40287161530773   -1.89847e-06   2.55354e-06 DIIS
+   @ROHF iter   7:  -230.40287183399255   -2.18685e-07   5.54114e-07 DIIS
+   @ROHF iter   8:  -230.40287184255305   -8.56051e-09   6.63256e-08 DIIS
+   @ROHF iter   9:  -230.40287184266913   -1.16074e-10   2.77789e-08 DIIS
+   @ROHF iter  10:  -230.40287184268681   -1.76783e-11   1.23581e-08 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @ROHF iter  11:  -230.40287184269278   -5.57066e-12   3.69592e-09 DIIS
+   @ROHF iter  11:  -230.40287184269221   -5.40012e-12   3.69592e-09 DIIS
   Energy and wave function converged.
 
 
@@ -594,14 +592,14 @@ k_type_: LINK
     NA   [    21 ]
     NB   [    20 ]
 
-  @ROHF Final Energy:  -230.40287184269278
+  @ROHF Final Energy:  -230.40287184269221
 
    => Energetics <=
 
     Nuclear Repulsion Energy =            203.7109313602788916
-    One-Electron Energy =                -703.9664612139116571
-    Two-Electron Energy =                 269.8526580109399902
-    Total Energy =                       -230.4028718426927753
+    One-Electron Energy =                -703.9664612139101791
+    Two-Electron Energy =                 269.8526580109390807
+    Total Energy =                       -230.4028718426922069
 
 Computation Completed
 
@@ -625,19 +623,19 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:55:44 2022
+*** tstop() called on ds6 at Mon May  8 09:32:56 2023
 Module time:
-	user time   =      24.64 seconds =       0.41 minutes
+	user time   =      23.39 seconds =       0.39 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =         24 seconds =       0.40 minutes
+	total time  =         23 seconds =       0.38 minutes
 Total time:
-	user time   =      62.77 seconds =       1.05 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =         63 seconds =       1.05 minutes
+	user time   =      59.23 seconds =       0.99 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =         59 seconds =       0.98 minutes
     ROHF Energy (using LinK algo).........................................................PASSED
     ROHF LinK Incfock Efficient...........................................................PASSED
 
-    Psi4 stopped on: Thursday, 08 December 2022 03:55PM
-    Psi4 wall time for execution: 0:01:03.25
+    Psi4 stopped on: Monday, 08 May 2023 09:32AM
+    Psi4 wall time for execution: 0:00:59.55
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/scf5/output.ref
+++ b/tests/scf5/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.8a1.dev17 
+                               Psi4 1.8a1.dev68 
 
-                         Git: Rev {dpoole34/compositejk-pilot} e4f6b14 dirty
+                         Git: Rev {dpoole34/compositejk-pilot-ref} 78ba1c2 
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -31,11 +31,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Thursday, 08 December 2022 03:56PM
+    Psi4 started on: Monday, 08 May 2023 09:18AM
 
-    Process ID: 26703
+    Process ID: 816085
     Host:       ds6
-    PSIDATADIR: /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4
+    PSIDATADIR: /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -55,24 +55,24 @@ Eref = {
         "Canonical" : -149.58723684929720, #TEST
         "DF"        : -149.58715054487624, #TEST
         "Composite": {
-          "DirectDFJ+COSX"    : -149.58722317236171, #TEST
-          "DirectDFJ+LinK"    : -149.58726772171027  #TEST
+          "DFDirJ+COSX"    : -149.58722317236171, #TEST
+          "DFDirJ+LinK"    : -149.58726772171027  #TEST
         } 
     },
     "Triplet UHF": {
         "Canonical" : -149.67135517240553, #TEST
         "DF"        : -149.67125624291961, #TEST
         "Composite": {
-          "DirectDFJ+COSX"    : -149.67132922581225, #TEST
-          "DirectDFJ+LinK"    : -149.67137328005577  #TEST
+          "DFDirJ+COSX"    : -149.67132922581225, #TEST
+          "DFDirJ+LinK"    : -149.67137328005577  #TEST
         }
     },
     "Triplet ROHF": {
         "Canonical" : -149.65170765757173, #TEST
         "DF"        : -149.65160796208073, #TEST
         "Composite": {
-          "DirectDFJ+COSX"    : -149.65168894156605, #TEST
-          "DirectDFJ+LinK"    : -149.65172557470324  #TEST
+          "DFDirJ+COSX"    : -149.65168894156605, #TEST
+          "DFDirJ+LinK"    : -149.65172557470324  #TEST
         }
     }
 }
@@ -130,7 +130,7 @@ compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF RHF energy') #TEST
 
 for method in Eref["Singlet"]["Composite"].keys():
     set scf_type $method 
-    if method == "DirectDFJ+COSX": 
+    if method == "DFDirJ+COSX":
       set screening csam
     else:
       set screening density
@@ -164,7 +164,7 @@ compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF UHF energy') #TEST
 
 for method in Eref["Singlet"]["Composite"].keys():
     set scf_type $method 
-    if method == "DirectDFJ+COSX": 
+    if method == "DFDirJ+COSX":
       set screening csam
     else:
       set screening density
@@ -198,7 +198,7 @@ compare_values(Eref["Singlet"]["DF"], E, 6, 'Singlet MemDF CUHF energy') #TEST
 
 for method in Eref["Singlet"]["Composite"].keys():
     set scf_type $method 
-    if method == "DirectDFJ+COSX": 
+    if method == "DFDirJ+COSX":
       set screening csam
     else:
       set screening density
@@ -240,7 +240,7 @@ compare_values(Eref["Triplet UHF"]["DF"], E, 6, 'Triplet MemDF UHF energy') #TES
 
 for method in Eref["Triplet UHF"]["Composite"].keys():
     set scf_type $method 
-    if method == "DirectDFJ+COSX": 
+    if method == "DFDirJ+COSX":
       set screening csam
     else:
       set screening density
@@ -279,7 +279,7 @@ compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF ROHF energy') #T
 
 for method in Eref["Triplet ROHF"]["Composite"].keys():
     set scf_type $method 
-    if method == "DirectDFJ+COSX": 
+    if method == "DFDirJ+COSX":
       set screening csam
     else:
       set screening density
@@ -318,7 +318,7 @@ compare_values(Eref["Triplet ROHF"]["DF"], E, 6, 'Triplet MemDF CUHF energy') #T
 
 for method in Eref["Triplet ROHF"]["Composite"].keys():
     set scf_type $method 
-    if method == "DirectDFJ+COSX": 
+    if method == "DFDirJ+COSX":
       set screening csam
     else:
       set screening density
@@ -332,14 +332,14 @@ for method in Eref["Triplet ROHF"]["Composite"].keys():
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:27 2022
+*** at Mon May  8 09:18:32 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -538,28 +538,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:28 2022
+*** tstop() called on ds6 at Mon May  8 09:18:33 2023
 Module time:
-	user time   =       0.48 seconds =       0.01 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       0.50 seconds =       0.01 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.48 seconds =       0.01 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       0.50 seconds =       0.01 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
     Singlet PK RHF energy.................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:28 2022
+*** at Mon May  8 09:18:33 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -628,13 +628,14 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   Starting with a DF guess...
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -790,28 +791,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:29 2022
+*** tstop() called on ds6 at Mon May  8 09:18:34 2023
 Module time:
-	user time   =       0.80 seconds =       0.01 minutes
+	user time   =       0.77 seconds =       0.01 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       1.31 seconds =       0.02 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       1.29 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
     Singlet Direct RHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:29 2022
+*** at Mon May  8 09:18:34 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -992,28 +993,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:29 2022
+*** tstop() called on ds6 at Mon May  8 09:18:34 2023
 Module time:
-	user time   =       0.33 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.66 seconds =       0.03 minutes
-	system time =       0.06 seconds =       0.00 minutes
+	user time   =       1.71 seconds =       0.03 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
     Singlet Disk RHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:29 2022
+*** at Mon May  8 09:18:34 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -1082,7 +1083,7 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -1224,28 +1225,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:29 2022
+*** tstop() called on ds6 at Mon May  8 09:18:34 2023
 Module time:
-	user time   =       0.22 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.21 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.90 seconds =       0.03 minutes
-	system time =       0.07 seconds =       0.00 minutes
+	user time   =       1.95 seconds =       0.03 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
     Singlet DiskDF RHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:29 2022
+*** at Mon May  8 09:18:34 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -1314,11 +1315,12 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -1457,28 +1459,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:29 2022
+*** tstop() called on ds6 at Mon May  8 09:18:35 2023
 Module time:
-	user time   =       0.21 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.22 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.14 seconds =       0.04 minutes
-	system time =       0.07 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.19 seconds =       0.04 minutes
+	system time =       0.11 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
     Singlet MemDF RHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:29 2022
+*** at Mon May  8 09:18:35 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -1515,7 +1517,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+COSX.
+  SCF Algorithm Type is DFDIRJ+COSX.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -1547,24 +1549,23 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+COSX 
-j_type_: DIRECTDFJ 
-k_type_: COSX 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              COSX
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:           No
     Screening Type:           CSAM
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -1605,15 +1606,15 @@ k_type_: COSX
    @RHF iter SAD:  -149.27713328631933   -1.49277e+02   0.00000e+00 
    @RHF iter   1:  -149.56382697604778   -2.86694e-01   1.10975e-02 DIIS/ADIIS
    @RHF iter   2:  -149.58629558037484   -2.24686e-02   2.92559e-03 DIIS/ADIIS
-   @RHF iter   3:  -149.58760428588195   -1.30871e-03   6.47395e-04 DIIS/ADIIS
+   @RHF iter   3:  -149.58760428588198   -1.30871e-03   6.47395e-04 DIIS/ADIIS
    @RHF iter   4:  -149.58772283023291   -1.18544e-04   1.38075e-04 DIIS/ADIIS
-   @RHF iter   5:  -149.58772855372339   -5.72349e-06   1.83160e-05 DIIS
-   @RHF iter   6:  -149.58772885952462   -3.05801e-07   2.47041e-06 DIIS
-   @RHF iter   7:  -149.58772885956984   -4.52189e-11   2.44347e-07 DIIS
+   @RHF iter   5:  -149.58772855372317   -5.72349e-06   1.83160e-05 DIIS
+   @RHF iter   6:  -149.58772885952447   -3.05801e-07   2.47041e-06 DIIS
+   @RHF iter   7:  -149.58772885956975   -4.52758e-11   2.44347e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @RHF iter   8:  -149.58722317116360    5.05688e-04   9.91149e-04 DIIS/ADIIS
+   @RHF iter   8:  -149.58722317116377    5.05688e-04   9.91149e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -1655,14 +1656,14 @@ k_type_: COSX
     NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  @RHF Final Energy:  -149.58722317116360
+  @RHF Final Energy:  -149.58722317116377
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.8059033672358851
-    Two-Electron Energy =                  86.4301879389086025
-    Total Energy =                       -149.5872231711636289
+    One-Electron Energy =                -266.8059033672361693
+    Two-Electron Energy =                  86.4301879389087446
+    Total Energy =                       -149.5872231711637710
 
 Computation Completed
 
@@ -1686,28 +1687,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:32 2022
+*** tstop() called on ds6 at Mon May  8 09:18:37 2023
 Module time:
-	user time   =       2.66 seconds =       0.04 minutes
+	user time   =       2.48 seconds =       0.04 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          3 seconds =       0.05 minutes
+	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       4.83 seconds =       0.08 minutes
-	system time =       0.08 seconds =       0.00 minutes
+	user time   =       4.69 seconds =       0.08 minutes
+	system time =       0.12 seconds =       0.00 minutes
 	total time  =          5 seconds =       0.08 minutes
-    Singlet DirectDFJ+COSX RHF energy.....................................................PASSED
+    Singlet DFDirJ+COSX RHF energy........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:32 2022
+*** at Mon May  8 09:18:37 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -1744,7 +1745,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+LINK.
+  SCF Algorithm Type is DFDIRJ+LINK.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -1776,24 +1777,23 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+LINK 
-j_type_: DIRECTDFJ 
-k_type_: LINK 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              LINK
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:           No
     Screening Type:        DENSITY
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -1912,28 +1912,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:34 2022
+*** tstop() called on ds6 at Mon May  8 09:18:39 2023
 Module time:
-	user time   =       1.56 seconds =       0.03 minutes
+	user time   =       1.50 seconds =       0.03 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       6.41 seconds =       0.11 minutes
-	system time =       0.09 seconds =       0.00 minutes
+	user time   =       6.22 seconds =       0.10 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          7 seconds =       0.12 minutes
-    Singlet DirectDFJ+LinK RHF energy.....................................................PASSED
+    Singlet DFDirJ+LinK RHF energy........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:34 2022
+*** at Mon May  8 09:18:39 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -2176,28 +2176,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:34 2022
+*** tstop() called on ds6 at Mon May  8 09:18:39 2023
 Module time:
-	user time   =       0.42 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.43 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       6.86 seconds =       0.11 minutes
-	system time =       0.10 seconds =       0.00 minutes
+	user time   =       6.67 seconds =       0.11 minutes
+	system time =       0.15 seconds =       0.00 minutes
 	total time  =          7 seconds =       0.12 minutes
     Singlet PK UHF energy.................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:34 2022
+*** at Mon May  8 09:18:39 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -2266,13 +2266,14 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   Starting with a DF guess...
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -2472,28 +2473,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:35 2022
+*** tstop() called on ds6 at Mon May  8 09:18:40 2023
 Module time:
-	user time   =       0.91 seconds =       0.02 minutes
+	user time   =       0.88 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       7.79 seconds =       0.13 minutes
-	system time =       0.11 seconds =       0.00 minutes
+	user time   =       7.58 seconds =       0.13 minutes
+	system time =       0.16 seconds =       0.00 minutes
 	total time  =          8 seconds =       0.13 minutes
     Singlet Direct UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:35 2022
+*** at Mon May  8 09:18:40 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -2718,28 +2719,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:36 2022
+*** tstop() called on ds6 at Mon May  8 09:18:41 2023
 Module time:
-	user time   =       0.32 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       8.14 seconds =       0.14 minutes
-	system time =       0.12 seconds =       0.00 minutes
+	user time   =       7.99 seconds =       0.13 minutes
+	system time =       0.18 seconds =       0.00 minutes
 	total time  =          9 seconds =       0.15 minutes
     Singlet Disk UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:36 2022
+*** at Mon May  8 09:18:41 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -2808,7 +2809,7 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -2994,28 +2995,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:36 2022
+*** tstop() called on ds6 at Mon May  8 09:18:41 2023
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
+	user time   =       0.25 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.40 seconds =       0.14 minutes
-	system time =       0.13 seconds =       0.00 minutes
+	user time   =       8.26 seconds =       0.14 minutes
+	system time =       0.19 seconds =       0.00 minutes
 	total time  =          9 seconds =       0.15 minutes
     Singlet DiskDF UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:36 2022
+*** at Mon May  8 09:18:41 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -3084,11 +3085,12 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -3271,28 +3273,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:36 2022
+*** tstop() called on ds6 at Mon May  8 09:18:41 2023
 Module time:
 	user time   =       0.23 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       8.66 seconds =       0.14 minutes
-	system time =       0.13 seconds =       0.00 minutes
+	user time   =       8.52 seconds =       0.14 minutes
+	system time =       0.19 seconds =       0.00 minutes
 	total time  =          9 seconds =       0.15 minutes
     Singlet MemDF UHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:36 2022
+*** at Mon May  8 09:18:41 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -3329,7 +3331,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+COSX.
+  SCF Algorithm Type is DFDIRJ+COSX.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -3361,24 +3363,23 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+COSX 
-j_type_: DIRECTDFJ 
-k_type_: COSX 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              COSX
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:           No
     Screening Type:           CSAM
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -3418,24 +3419,24 @@ k_type_: COSX
 
    @UHF iter SAD:  -149.27713328631933   -1.49277e+02   0.00000e+00 
    @UHF iter   1:  -149.56382697604778   -2.86694e-01   1.10975e-02 DIIS/ADIIS
-   @UHF iter   2:  -149.58629558037470   -2.24686e-02   2.92559e-03 DIIS/ADIIS
-   @UHF iter   3:  -149.58760428588192   -1.30871e-03   6.47395e-04 DIIS/ADIIS
-   @UHF iter   4:  -149.58772283023299   -1.18544e-04   1.38075e-04 DIIS/ADIIS
-   @UHF iter   5:  -149.58772855372328   -5.72349e-06   1.83160e-05 DIIS
-   @UHF iter   6:  -149.58772885952459   -3.05801e-07   2.47041e-06 DIIS
-   @UHF iter   7:  -149.58772885956975   -4.51621e-11   2.44347e-07 DIIS
+   @UHF iter   2:  -149.58629558037484   -2.24686e-02   2.92559e-03 DIIS/ADIIS
+   @UHF iter   3:  -149.58760428588207   -1.30871e-03   6.47395e-04 DIIS/ADIIS
+   @UHF iter   4:  -149.58772283023285   -1.18544e-04   1.38075e-04 DIIS/ADIIS
+   @UHF iter   5:  -149.58772855372337   -5.72349e-06   1.83160e-05 DIIS
+   @UHF iter   6:  -149.58772885952450   -3.05801e-07   2.47041e-06 DIIS
+   @UHF iter   7:  -149.58772885956972   -4.52189e-11   2.44347e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @UHF iter   8:  -149.58722317116371    5.05688e-04   9.91149e-04 DIIS/ADIIS
+   @UHF iter   8:  -149.58722322604331    5.05634e-04   9.91148e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
   ==> Post-Iterations <==
 
-   @Spin Contamination Metric:  -8.881784197E-15
+   @Spin Contamination Metric:  -1.776356839E-14
    @S^2 Expected:                0.000000000E+00
-   @S^2 Observed:               -8.881784197E-15
+   @S^2 Observed:               -1.776356839E-14
    @S   Expected:                0.000000000E+00
    @S   Observed:                0.000000000E+00
 
@@ -3445,81 +3446,81 @@ k_type_: COSX
     Alpha Occupied:                                                       
 
        1Ag   -20.718186     1B1u  -20.716591     2Ag    -1.762756  
-       2B1u   -1.064574     1B2u   -0.812724     3Ag    -0.770577  
-       1B3u   -0.707523     1B3g   -0.420229  
+       2B1u   -1.064574     1B3u   -0.812724     3Ag    -0.770577  
+       1B2u   -0.707523     1B2g   -0.420229  
 
     Alpha Virtual:                                                        
 
-       1B2g    0.078702     3B1u    0.460336     2B3u    0.693920  
-       2B2u    0.696563     4Ag     0.713064     2B3g    0.825214  
-       2B2g    0.852636     5Ag     0.879262     4B1u    0.889111  
+       1B3g    0.078702     3B1u    0.460336     2B2u    0.693920  
+       2B3u    0.696563     4Ag     0.713064     2B2g    0.825214  
+       2B3g    0.852636     5Ag     0.879262     4B1u    0.889111  
        5B1u    1.413064     1B1g    1.442922     6Ag     1.443938  
-       3B3u    1.637673     3B2u    1.642235     6B1u    1.953272  
-       1Au     1.954322     7Ag     2.483527     3B2g    2.530348  
-       7B1u    2.536977     3B3g    2.548923     4B3u    3.927463  
-       4B2u    3.928699     8Ag     4.116806     4B2g    4.259266  
-       4B3g    4.274563     2B1g    4.934640     9Ag     4.966106  
-       5B3u    5.111788     8B1u    5.123534     5B2u    5.157197  
-       6B2u    5.264086     6B3u    5.272739    10Ag     5.546638  
-       5B3g    5.659533     5B2g    5.666050     9B1u    6.117812  
+       3B2u    1.637673     3B3u    1.642235     6B1u    1.953272  
+       1Au     1.954322     7Ag     2.483527     3B3g    2.530348  
+       7B1u    2.536977     3B2g    2.548923     4B2u    3.927463  
+       4B3u    3.928699     8Ag     4.116806     4B3g    4.259266  
+       4B2g    4.274563     2B1g    4.934640     9Ag     4.966106  
+       5B2u    5.111788     8B1u    5.123534     5B3u    5.157197  
+       6B3u    5.264086     6B2u    5.272739    10Ag     5.546638  
+       5B2g    5.659533     5B3g    5.666050     9B1u    6.117812  
        2Au     6.397139    10B1u    6.421963     3B1g    6.546782  
       11Ag     6.548540     3Au     6.775088    11B1u    6.791609  
-       6B2g    6.817736     6B3g    6.862237     7B3u    7.040086  
-       7B2u    7.090378    12B1u    7.574534    12Ag     7.686631  
-       7B2g    8.073746     7B3g    8.120090    13Ag     8.184818  
+       6B3g    6.817736     6B2g    6.862237     7B2u    7.040086  
+       7B3u    7.090378    12B1u    7.574534    12Ag     7.686631  
+       7B3g    8.073746     7B2g    8.120090    13Ag     8.184818  
       13B1u   15.899399  
 
     Beta Occupied:                                                        
 
        1Ag   -20.718186     1B1u  -20.716591     2Ag    -1.762756  
-       2B1u   -1.064574     1B2u   -0.812724     3Ag    -0.770577  
-       1B3u   -0.707523     1B3g   -0.420229  
+       2B1u   -1.064574     1B3u   -0.812724     3Ag    -0.770577  
+       1B2u   -0.707523     1B2g   -0.420229  
 
     Beta Virtual:                                                         
 
-       1B2g    0.078702     3B1u    0.460336     2B3u    0.693920  
-       2B2u    0.696563     4Ag     0.713064     2B3g    0.825214  
-       2B2g    0.852636     5Ag     0.879262     4B1u    0.889111  
+       1B3g    0.078702     3B1u    0.460336     2B2u    0.693920  
+       2B3u    0.696563     4Ag     0.713064     2B2g    0.825214  
+       2B3g    0.852636     5Ag     0.879262     4B1u    0.889111  
        5B1u    1.413064     1B1g    1.442922     6Ag     1.443938  
-       3B3u    1.637673     3B2u    1.642235     6B1u    1.953272  
-       1Au     1.954322     7Ag     2.483527     3B2g    2.530348  
-       7B1u    2.536977     3B3g    2.548923     4B3u    3.927463  
-       4B2u    3.928699     8Ag     4.116806     4B2g    4.259266  
-       4B3g    4.274563     2B1g    4.934640     9Ag     4.966106  
-       5B3u    5.111788     8B1u    5.123534     5B2u    5.157197  
-       6B2u    5.264086     6B3u    5.272739    10Ag     5.546638  
-       5B3g    5.659533     5B2g    5.666050     9B1u    6.117812  
+       3B2u    1.637673     3B3u    1.642235     6B1u    1.953272  
+       1Au     1.954322     7Ag     2.483527     3B3g    2.530348  
+       7B1u    2.536977     3B2g    2.548923     4B2u    3.927463  
+       4B3u    3.928699     8Ag     4.116806     4B3g    4.259266  
+       4B2g    4.274563     2B1g    4.934640     9Ag     4.966106  
+       5B2u    5.111788     8B1u    5.123534     5B3u    5.157197  
+       6B3u    5.264086     6B2u    5.272739    10Ag     5.546638  
+       5B2g    5.659533     5B3g    5.666050     9B1u    6.117812  
        2Au     6.397139    10B1u    6.421963     3B1g    6.546782  
       11Ag     6.548540     3Au     6.775088    11B1u    6.791609  
-       6B2g    6.817736     6B3g    6.862237     7B3u    7.040086  
-       7B2u    7.090378    12B1u    7.574534    12Ag     7.686631  
-       7B2g    8.073746     7B3g    8.120090    13Ag     8.184818  
+       6B3g    6.817736     6B2g    6.862237     7B2u    7.040086  
+       7B3u    7.090378    12B1u    7.574534    12Ag     7.686631  
+       7B3g    8.073746     7B2g    8.120090    13Ag     8.184818  
       13B1u   15.899399  
 
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
-    DOCC [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    DOCC [     3,    0,    1,    0,    0,    2,    1,    1 ]
     SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
-    NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
-    NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
+    NA   [     3,    0,    1,    0,    0,    2,    1,    1 ]
+    NB   [     3,    0,    1,    0,    0,    2,    1,    1 ]
 
-  @UHF Final Energy:  -149.58722317116371
+  @UHF Final Energy:  -149.58722322604331
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.8059033672361124
-    Two-Electron Energy =                  86.4301879389087446
-    Total Energy =                       -149.5872231711637141
+    One-Electron Energy =                -266.8059033672358851
+    Two-Electron Energy =                  86.4301878840289532
+    Total Energy =                       -149.5872232260432781
 
   UHF NO Occupations:
-  HONO-2 :    1B3g 2.0000000
+  HONO-2 :    2 Ag 2.0000000
   HONO-1 :    3 Ag 2.0000000
   HONO-0 :    1B2u 2.0000000
-  LUNO+0 :    2B2u 0.0000000
-  LUNO+1 :    3B1u 0.0000000
-  LUNO+2 :    4B1u 0.0000000
-  LUNO+3 :    2B3g 0.0000000
+  LUNO+0 :    3B1u 0.0000000
+  LUNO+1 :    2B2u 0.0000000
+  LUNO+2 :    3B2u 0.0000000
+  LUNO+3 :    4B1u 0.0000000
 
 
 Computation Completed
@@ -3544,28 +3545,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:39 2022
+*** tstop() called on ds6 at Mon May  8 09:18:44 2023
 Module time:
-	user time   =       2.75 seconds =       0.05 minutes
+	user time   =       2.61 seconds =       0.04 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      11.44 seconds =       0.19 minutes
-	system time =       0.14 seconds =       0.00 minutes
+	user time   =      11.16 seconds =       0.19 minutes
+	system time =       0.20 seconds =       0.00 minutes
 	total time  =         12 seconds =       0.20 minutes
-    Singlet DirectDFJ+COSX UHF energy.....................................................PASSED
+    Singlet DFDirJ+COSX UHF energy........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:39 2022
+*** at Mon May  8 09:18:44 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -3602,7 +3603,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+LINK.
+  SCF Algorithm Type is DFDIRJ+LINK.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -3634,24 +3635,23 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+LINK 
-j_type_: DIRECTDFJ 
-k_type_: LINK 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              LINK
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:           No
     Screening Type:        DENSITY
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -3814,28 +3814,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:41 2022
+*** tstop() called on ds6 at Mon May  8 09:18:45 2023
 Module time:
-	user time   =       1.64 seconds =       0.03 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       1.61 seconds =       0.03 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      13.11 seconds =       0.22 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =         14 seconds =       0.23 minutes
-    Singlet DirectDFJ+LinK UHF energy.....................................................PASSED
+	user time   =      12.79 seconds =       0.21 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =         13 seconds =       0.22 minutes
+    Singlet DFDirJ+LinK UHF energy........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:41 2022
+*** at Mon May  8 09:18:45 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -4066,28 +4066,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:41 2022
+*** tstop() called on ds6 at Mon May  8 09:18:46 2023
 Module time:
-	user time   =       0.42 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.43 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      13.56 seconds =       0.23 minutes
-	system time =       0.17 seconds =       0.00 minutes
+	user time   =      13.24 seconds =       0.22 minutes
+	system time =       0.25 seconds =       0.00 minutes
 	total time  =         14 seconds =       0.23 minutes
     Singlet PK CUHF energy................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:41 2022
+*** at Mon May  8 09:18:46 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -4156,13 +4156,14 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   Starting with a DF guess...
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -4350,28 +4351,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:42 2022
+*** tstop() called on ds6 at Mon May  8 09:18:47 2023
 Module time:
-	user time   =       0.90 seconds =       0.02 minutes
+	user time   =       0.89 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      14.48 seconds =       0.24 minutes
-	system time =       0.18 seconds =       0.00 minutes
+	user time   =      14.16 seconds =       0.24 minutes
+	system time =       0.26 seconds =       0.00 minutes
 	total time  =         15 seconds =       0.25 minutes
     Singlet Direct CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:42 2022
+*** at Mon May  8 09:18:47 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -4584,28 +4585,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:43 2022
+*** tstop() called on ds6 at Mon May  8 09:18:47 2023
 Module time:
-	user time   =       0.34 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.39 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      14.84 seconds =       0.25 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =         16 seconds =       0.27 minutes
+	user time   =      14.58 seconds =       0.24 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =         15 seconds =       0.25 minutes
     Singlet Disk CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:43 2022
+*** at Mon May  8 09:18:47 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -4674,7 +4675,7 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -4848,28 +4849,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:43 2022
+*** tstop() called on ds6 at Mon May  8 09:18:48 2023
 Module time:
-	user time   =       0.24 seconds =       0.00 minutes
+	user time   =       0.23 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      15.10 seconds =       0.25 minutes
-	system time =       0.20 seconds =       0.00 minutes
+	user time   =      14.84 seconds =       0.25 minutes
+	system time =       0.30 seconds =       0.01 minutes
 	total time  =         16 seconds =       0.27 minutes
     Singlet DiskDF CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:43 2022
+*** at Mon May  8 09:18:48 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -4938,11 +4939,12 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -5113,28 +5115,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:43 2022
+*** tstop() called on ds6 at Mon May  8 09:18:48 2023
 Module time:
-	user time   =       0.28 seconds =       0.00 minutes
+	user time   =       0.25 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      15.41 seconds =       0.26 minutes
-	system time =       0.20 seconds =       0.00 minutes
+	user time   =      15.12 seconds =       0.25 minutes
+	system time =       0.30 seconds =       0.01 minutes
 	total time  =         16 seconds =       0.27 minutes
     Singlet MemDF CUHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:43 2022
+*** at Mon May  8 09:18:48 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -5171,7 +5173,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+COSX.
+  SCF Algorithm Type is DFDIRJ+COSX.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -5203,24 +5205,23 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+COSX 
-j_type_: DIRECTDFJ 
-k_type_: COSX 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              COSX
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:           No
     Screening Type:           CSAM
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -5261,15 +5262,15 @@ k_type_: COSX
    @CUHF iter SAD:  -149.27713328631935   -1.49277e+02   0.00000e+00 
    @CUHF iter   1:  -149.56382697604778   -2.86694e-01   1.10975e-02 DIIS/ADIIS
    @CUHF iter   2:  -149.58629558037475   -2.24686e-02   2.92559e-03 DIIS/ADIIS
-   @CUHF iter   3:  -149.58760428588184   -1.30871e-03   6.47395e-04 DIIS/ADIIS
+   @CUHF iter   3:  -149.58760428588189   -1.30871e-03   6.47395e-04 DIIS/ADIIS
    @CUHF iter   4:  -149.58772283023282   -1.18544e-04   1.38075e-04 DIIS/ADIIS
-   @CUHF iter   5:  -149.58772855372334   -5.72349e-06   1.83160e-05 DIIS
-   @CUHF iter   6:  -149.58772885952450   -3.05801e-07   2.47041e-06 DIIS
-   @CUHF iter   7:  -149.58772885956984   -4.53326e-11   2.44347e-07 DIIS
+   @CUHF iter   5:  -149.58772855372339   -5.72349e-06   1.83160e-05 DIIS
+   @CUHF iter   6:  -149.58772885952456   -3.05801e-07   2.47041e-06 DIIS
+   @CUHF iter   7:  -149.58772885956969   -4.51337e-11   2.44347e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @CUHF iter   8:  -149.58722317116369    5.05688e-04   9.91149e-04 DIIS/ADIIS
+   @CUHF iter   8:  -149.58722317116377    5.05688e-04   9.91149e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -5343,14 +5344,14 @@ k_type_: COSX
     NA   [     3,    0,    0,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    1,    0,    2,    1,    1 ]
 
-  @CUHF Final Energy:  -149.58722317116369
+  @CUHF Final Energy:  -149.58722317116377
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.8059033672361693
-    Two-Electron Energy =                  86.4301879389088441
-    Total Energy =                       -149.5872231711636573
+    One-Electron Energy =                -266.8059033672364535
+    Two-Electron Energy =                  86.4301879389090288
+    Total Energy =                       -149.5872231711637710
 
 Computation Completed
 
@@ -5374,28 +5375,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:46 2022
+*** tstop() called on ds6 at Mon May  8 09:18:51 2023
 Module time:
-	user time   =       2.80 seconds =       0.05 minutes
+	user time   =       2.67 seconds =       0.04 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      18.24 seconds =       0.30 minutes
-	system time =       0.21 seconds =       0.00 minutes
+	user time   =      17.81 seconds =       0.30 minutes
+	system time =       0.31 seconds =       0.01 minutes
 	total time  =         19 seconds =       0.32 minutes
-    Singlet DirectDFJ+COSX CUHF energy....................................................PASSED
+    Singlet DFDirJ+COSX CUHF energy.......................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:46 2022
+*** at Mon May  8 09:18:51 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -5432,7 +5433,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+LINK.
+  SCF Algorithm Type is DFDIRJ+LINK.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -5464,24 +5465,23 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+LINK 
-j_type_: DIRECTDFJ 
-k_type_: LINK 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              LINK
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:           No
     Screening Type:        DENSITY
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -5632,28 +5632,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:48 2022
+*** tstop() called on ds6 at Mon May  8 09:18:52 2023
 Module time:
-	user time   =       1.64 seconds =       0.03 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       1.60 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      19.91 seconds =       0.33 minutes
-	system time =       0.22 seconds =       0.00 minutes
-	total time  =         21 seconds =       0.35 minutes
-    Singlet DirectDFJ+LinK CUHF energy....................................................PASSED
+	user time   =      19.44 seconds =       0.32 minutes
+	system time =       0.33 seconds =       0.01 minutes
+	total time  =         20 seconds =       0.33 minutes
+    Singlet DFDirJ+LinK CUHF energy.......................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:48 2022
+*** at Mon May  8 09:18:52 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -5903,28 +5903,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:48 2022
+*** tstop() called on ds6 at Mon May  8 09:18:53 2023
 Module time:
-	user time   =       0.37 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.43 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      20.31 seconds =       0.34 minutes
-	system time =       0.23 seconds =       0.00 minutes
+	user time   =      19.89 seconds =       0.33 minutes
+	system time =       0.36 seconds =       0.01 minutes
 	total time  =         21 seconds =       0.35 minutes
     Triplet PK UHF energy.................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:48 2022
+*** at Mon May  8 09:18:53 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -5993,13 +5993,14 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   Starting with a DF guess...
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -6205,28 +6206,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:49 2022
+*** tstop() called on ds6 at Mon May  8 09:18:54 2023
 Module time:
-	user time   =       0.67 seconds =       0.01 minutes
+	user time   =       0.66 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      21.01 seconds =       0.35 minutes
-	system time =       0.24 seconds =       0.00 minutes
+	user time   =      20.58 seconds =       0.34 minutes
+	system time =       0.37 seconds =       0.01 minutes
 	total time  =         22 seconds =       0.37 minutes
     Triplet Direct UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:49 2022
+*** at Mon May  8 09:18:54 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -6458,28 +6459,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:49 2022
+*** tstop() called on ds6 at Mon May  8 09:18:54 2023
 Module time:
-	user time   =       0.27 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      21.31 seconds =       0.36 minutes
-	system time =       0.26 seconds =       0.00 minutes
+	user time   =      20.97 seconds =       0.35 minutes
+	system time =       0.40 seconds =       0.01 minutes
 	total time  =         22 seconds =       0.37 minutes
     Triplet Disk UHF energy...............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:49 2022
+*** at Mon May  8 09:18:54 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -6548,7 +6549,7 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -6741,28 +6742,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:49 2022
+*** tstop() called on ds6 at Mon May  8 09:18:54 2023
 Module time:
 	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      21.52 seconds =       0.36 minutes
-	system time =       0.26 seconds =       0.00 minutes
+	user time   =      21.17 seconds =       0.35 minutes
+	system time =       0.41 seconds =       0.01 minutes
 	total time  =         22 seconds =       0.37 minutes
     Triplet DiskDF UHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:49 2022
+*** at Mon May  8 09:18:54 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -6831,11 +6832,12 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -7025,28 +7027,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:50 2022
+*** tstop() called on ds6 at Mon May  8 09:18:55 2023
 Module time:
-	user time   =       0.19 seconds =       0.00 minutes
+	user time   =       0.16 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      21.74 seconds =       0.36 minutes
-	system time =       0.27 seconds =       0.00 minutes
+	user time   =      21.36 seconds =       0.36 minutes
+	system time =       0.42 seconds =       0.01 minutes
 	total time  =         23 seconds =       0.38 minutes
     Triplet MemDF UHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:50 2022
+*** at Mon May  8 09:18:55 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -7083,7 +7085,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+COSX.
+  SCF Algorithm Type is DFDIRJ+COSX.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -7115,24 +7117,23 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+COSX 
-j_type_: DIRECTDFJ 
-k_type_: COSX 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              COSX
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:           No
     Screening Type:           CSAM
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -7178,18 +7179,18 @@ k_type_: COSX
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
    @UHF iter   1:  -131.02266731942422   -1.31023e+02   3.53990e-01 ADIIS
-   @UHF iter   2:  -140.14034734140540   -9.11768e+00   1.85365e-01 ADIIS
-   @UHF iter   3:  -149.07920849522236   -8.93886e+00   6.20863e-02 DIIS/ADIIS
-   @UHF iter   4:  -149.65391531645002   -5.74707e-01   1.05356e-02 DIIS/ADIIS
-   @UHF iter   5:  -149.67061947228331   -1.67042e-02   1.87593e-03 DIIS/ADIIS
-   @UHF iter   6:  -149.67160507761122   -9.85605e-04   4.33948e-04 DIIS/ADIIS
-   @UHF iter   7:  -149.67166177628388   -5.66987e-05   6.80300e-05 DIIS
-   @UHF iter   8:  -149.67166378928812   -2.01300e-06   9.42637e-06 DIIS
-   @UHF iter   9:  -149.67166383531969   -4.60316e-08   8.91526e-07 DIIS
+   @UHF iter   2:  -140.14034734140543   -9.11768e+00   1.85365e-01 ADIIS
+   @UHF iter   3:  -149.07920849522247   -8.93886e+00   6.20863e-02 DIIS/ADIIS
+   @UHF iter   4:  -149.65391531645000   -5.74707e-01   1.05356e-02 DIIS/ADIIS
+   @UHF iter   5:  -149.67061947228319   -1.67042e-02   1.87593e-03 DIIS/ADIIS
+   @UHF iter   6:  -149.67160507761133   -9.85605e-04   4.33948e-04 DIIS/ADIIS
+   @UHF iter   7:  -149.67166177628397   -5.66987e-05   6.80300e-05 DIIS
+   @UHF iter   8:  -149.67166378928820   -2.01300e-06   9.42637e-06 DIIS
+   @UHF iter   9:  -149.67166383531966   -4.60315e-08   8.91526e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @UHF iter  10:  -149.67132922569741    3.34610e-04   9.51899e-04 DIIS/ADIIS
+   @UHF iter  10:  -149.67132922569743    3.34610e-04   9.51899e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -7264,14 +7265,14 @@ k_type_: COSX
     NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  @UHF Final Energy:  -149.67132922569741
+  @UHF Final Energy:  -149.67132922569743
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.9129345756498424
-    Two-Electron Energy =                  86.4531130927887830
-    Total Energy =                       -149.6713292256974057
+    One-Electron Energy =                -266.9129345756501266
+    Two-Electron Energy =                  86.4531130927890388
+    Total Energy =                       -149.6713292256974341
 
   UHF NO Occupations:
   HONO-2 :    1B2u 1.9937328
@@ -7305,28 +7306,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:53 2022
+*** tstop() called on ds6 at Mon May  8 09:18:58 2023
 Module time:
-	user time   =       3.02 seconds =       0.05 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.81 seconds =       0.05 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      24.79 seconds =       0.41 minutes
-	system time =       0.28 seconds =       0.00 minutes
+	user time   =      24.20 seconds =       0.40 minutes
+	system time =       0.44 seconds =       0.01 minutes
 	total time  =         26 seconds =       0.43 minutes
-    Triplet DirectDFJ+COSX UHF energy.....................................................PASSED
+    Triplet DFDirJ+COSX UHF energy........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:53 2022
+*** at Mon May  8 09:18:58 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -7363,7 +7364,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+LINK.
+  SCF Algorithm Type is DFDIRJ+LINK.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -7395,24 +7396,23 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+LINK 
-j_type_: DIRECTDFJ 
-k_type_: LINK 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              LINK
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:           No
     Screening Type:        DENSITY
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -7582,28 +7582,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:55 2022
+*** tstop() called on ds6 at Mon May  8 09:18:59 2023
 Module time:
-	user time   =       1.86 seconds =       0.03 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       1.80 seconds =       0.03 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      26.68 seconds =       0.44 minutes
-	system time =       0.28 seconds =       0.00 minutes
-	total time  =         28 seconds =       0.47 minutes
-    Triplet DirectDFJ+LinK UHF energy.....................................................PASSED
+	user time   =      26.02 seconds =       0.43 minutes
+	system time =       0.46 seconds =       0.01 minutes
+	total time  =         27 seconds =       0.45 minutes
+    Triplet DFDirJ+LinK UHF energy........................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:55 2022
+*** at Mon May  8 09:18:59 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -7814,28 +7814,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:55 2022
+*** tstop() called on ds6 at Mon May  8 09:19:00 2023
 Module time:
-	user time   =       0.36 seconds =       0.01 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.37 seconds =       0.01 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      27.07 seconds =       0.45 minutes
-	system time =       0.29 seconds =       0.00 minutes
+	user time   =      26.41 seconds =       0.44 minutes
+	system time =       0.47 seconds =       0.01 minutes
 	total time  =         28 seconds =       0.47 minutes
     Triplet PK ROHF energy................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:55 2022
+*** at Mon May  8 09:19:00 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -7904,13 +7904,14 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   Starting with a DF guess...
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -8077,28 +8078,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:56 2022
+*** tstop() called on ds6 at Mon May  8 09:19:00 2023
 Module time:
-	user time   =       0.68 seconds =       0.01 minutes
-	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.65 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      27.77 seconds =       0.46 minutes
-	system time =       0.30 seconds =       0.01 minutes
-	total time  =         29 seconds =       0.48 minutes
+	user time   =      27.08 seconds =       0.45 minutes
+	system time =       0.48 seconds =       0.01 minutes
+	total time  =         28 seconds =       0.47 minutes
     Triplet Direct ROHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:56 2022
+*** at Mon May  8 09:19:01 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -8291,28 +8292,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:56 2022
+*** tstop() called on ds6 at Mon May  8 09:19:01 2023
 Module time:
-	user time   =       0.27 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.30 seconds =       0.01 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      28.06 seconds =       0.47 minutes
-	system time =       0.31 seconds =       0.01 minutes
+	user time   =      27.40 seconds =       0.46 minutes
+	system time =       0.50 seconds =       0.01 minutes
 	total time  =         29 seconds =       0.48 minutes
     Triplet Disk ROHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:56 2022
+*** at Mon May  8 09:19:01 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -8381,7 +8382,7 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -8535,28 +8536,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:56 2022
+*** tstop() called on ds6 at Mon May  8 09:19:01 2023
 Module time:
-	user time   =       0.15 seconds =       0.00 minutes
+	user time   =       0.14 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      28.24 seconds =       0.47 minutes
-	system time =       0.32 seconds =       0.01 minutes
+	user time   =      27.57 seconds =       0.46 minutes
+	system time =       0.51 seconds =       0.01 minutes
 	total time  =         29 seconds =       0.48 minutes
     Triplet DiskDF ROHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:56 2022
+*** at Mon May  8 09:19:01 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -8625,11 +8626,12 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -8780,28 +8782,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:56:57 2022
+*** tstop() called on ds6 at Mon May  8 09:19:01 2023
 Module time:
-	user time   =       0.17 seconds =       0.00 minutes
+	user time   =       0.16 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      28.44 seconds =       0.47 minutes
-	system time =       0.32 seconds =       0.01 minutes
-	total time  =         30 seconds =       0.50 minutes
+	user time   =      27.76 seconds =       0.46 minutes
+	system time =       0.51 seconds =       0.01 minutes
+	total time  =         29 seconds =       0.48 minutes
     Triplet MemDF ROHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:56:57 2022
+*** at Mon May  8 09:19:01 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -8838,7 +8840,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+COSX.
+  SCF Algorithm Type is DFDIRJ+COSX.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -8870,24 +8872,23 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+COSX 
-j_type_: DIRECTDFJ 
-k_type_: COSX 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              COSX
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:           No
     Screening Type:           CSAM
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -8934,17 +8935,17 @@ k_type_: COSX
 
    @ROHF iter   1:  -131.02266731942385   -1.31023e+02   2.71851e-01 DIIS
    @ROHF iter   2:  -139.64070004271142   -8.61803e+00   1.37369e-01 DIIS
-   @ROHF iter   3:  -148.99660951088305   -9.35591e+00   5.06619e-02 DIIS
+   @ROHF iter   3:  -148.99660951088308   -9.35591e+00   5.06619e-02 DIIS
    @ROHF iter   4:  -149.63963700749702   -6.43027e-01   6.07525e-03 DIIS
-   @ROHF iter   5:  -149.65187157255193   -1.22346e-02   4.84799e-04 DIIS
-   @ROHF iter   6:  -149.65198834090882   -1.16768e-04   1.12106e-04 DIIS
-   @ROHF iter   7:  -149.65199670359937   -8.36269e-06   1.71152e-05 DIIS
-   @ROHF iter   8:  -149.65199683539876   -1.31799e-07   2.91717e-06 DIIS
-   @ROHF iter   9:  -149.65199681028324    2.51155e-08   3.52335e-07 DIIS
+   @ROHF iter   5:  -149.65187157255204   -1.22346e-02   4.84799e-04 DIIS
+   @ROHF iter   6:  -149.65198834090884   -1.16768e-04   1.12106e-04 DIIS
+   @ROHF iter   7:  -149.65199670359951   -8.36269e-06   1.71152e-05 DIIS
+   @ROHF iter   8:  -149.65199683539862   -1.31799e-07   2.91717e-06 DIIS
+   @ROHF iter   9:  -149.65199681028344    2.51152e-08   3.52335e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @ROHF iter  10:  -149.65168894022727    3.07870e-04   6.55828e-04 DIIS
+   @ROHF iter  10:  -149.65168894022716    3.07870e-04   6.55828e-04 DIIS
   Energy and wave function converged.
 
 
@@ -8990,14 +8991,14 @@ k_type_: COSX
     NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  @ROHF Final Energy:  -149.65168894022727
+  @ROHF Final Energy:  -149.65168894022716
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.9107678299204736
-    Two-Electron Energy =                  86.4705866325295460
-    Total Energy =                       -149.6516889402272739
+    One-Electron Energy =                -266.9107678299206441
+    Two-Electron Energy =                  86.4705866325298302
+    Total Energy =                       -149.6516889402271602
 
 Computation Completed
 
@@ -9021,28 +9022,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:57:00 2022
+*** tstop() called on ds6 at Mon May  8 09:19:04 2023
 Module time:
-	user time   =       2.96 seconds =       0.05 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       2.76 seconds =       0.05 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      31.43 seconds =       0.52 minutes
-	system time =       0.33 seconds =       0.01 minutes
-	total time  =         33 seconds =       0.55 minutes
-    Triplet DirectDFJ+COSX ROHF energy....................................................PASSED
+	user time   =      30.54 seconds =       0.51 minutes
+	system time =       0.51 seconds =       0.01 minutes
+	total time  =         32 seconds =       0.53 minutes
+    Triplet DFDirJ+COSX ROHF energy.......................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:57:00 2022
+*** at Mon May  8 09:19:04 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -9079,7 +9080,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+LINK.
+  SCF Algorithm Type is DFDIRJ+LINK.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -9111,24 +9112,23 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+LINK 
-j_type_: DIRECTDFJ 
-k_type_: LINK 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              LINK
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:           No
     Screening Type:        DENSITY
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -9259,28 +9259,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:57:02 2022
+*** tstop() called on ds6 at Mon May  8 09:19:06 2023
 Module time:
-	user time   =       1.86 seconds =       0.03 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	user time   =       1.76 seconds =       0.03 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      33.31 seconds =       0.56 minutes
-	system time =       0.33 seconds =       0.01 minutes
-	total time  =         35 seconds =       0.58 minutes
-    Triplet DirectDFJ+LinK ROHF energy....................................................PASSED
+	user time   =      32.32 seconds =       0.54 minutes
+	system time =       0.52 seconds =       0.01 minutes
+	total time  =         34 seconds =       0.57 minutes
+    Triplet DFDirJ+LinK ROHF energy.......................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:57:02 2022
+*** at Mon May  8 09:19:06 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -9518,28 +9518,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:57:02 2022
+*** tstop() called on ds6 at Mon May  8 09:19:06 2023
 Module time:
-	user time   =       0.37 seconds =       0.01 minutes
+	user time   =       0.35 seconds =       0.01 minutes
 	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      33.70 seconds =       0.56 minutes
-	system time =       0.35 seconds =       0.01 minutes
-	total time  =         35 seconds =       0.58 minutes
+	user time   =      32.70 seconds =       0.55 minutes
+	system time =       0.54 seconds =       0.01 minutes
+	total time  =         34 seconds =       0.57 minutes
     Triplet PK CUHF energy................................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:57:02 2022
+*** at Mon May  8 09:19:06 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -9608,13 +9608,14 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   Starting with a DF guess...
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -9808,28 +9809,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:57:03 2022
+*** tstop() called on ds6 at Mon May  8 09:19:07 2023
 Module time:
-	user time   =       0.66 seconds =       0.01 minutes
+	user time   =       0.65 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      34.39 seconds =       0.57 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =         36 seconds =       0.60 minutes
+	user time   =      33.39 seconds =       0.56 minutes
+	system time =       0.56 seconds =       0.01 minutes
+	total time  =         35 seconds =       0.58 minutes
     Triplet Direct CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:57:03 2022
+*** at Mon May  8 09:19:07 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -10049,28 +10050,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:57:03 2022
+*** tstop() called on ds6 at Mon May  8 09:19:07 2023
 Module time:
-	user time   =       0.29 seconds =       0.00 minutes
+	user time   =       0.32 seconds =       0.01 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      34.71 seconds =       0.58 minutes
-	system time =       0.37 seconds =       0.01 minutes
-	total time  =         36 seconds =       0.60 minutes
+	user time   =      33.74 seconds =       0.56 minutes
+	system time =       0.57 seconds =       0.01 minutes
+	total time  =         35 seconds =       0.58 minutes
     Triplet Disk CUHF energy..............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:57:03 2022
+*** at Mon May  8 09:19:08 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -10139,7 +10140,7 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -10320,28 +10321,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:57:03 2022
+*** tstop() called on ds6 at Mon May  8 09:19:08 2023
 Module time:
 	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.00 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      34.92 seconds =       0.58 minutes
-	system time =       0.38 seconds =       0.01 minutes
+	user time   =      33.96 seconds =       0.57 minutes
+	system time =       0.59 seconds =       0.01 minutes
 	total time  =         36 seconds =       0.60 minutes
     Triplet DiskDF CUHF energy............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:57:03 2022
+*** at Mon May  8 09:19:08 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -10410,11 +10411,12 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
   ==> Integral Setup <==
 
-  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. Using in-core AOs.
+  DFHelper Memory: AOs need 0.005 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
 
   ==> MemDFJK: Density-Fitted J/K Matrices <==
 
@@ -10592,28 +10594,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:57:04 2022
+*** tstop() called on ds6 at Mon May  8 09:19:08 2023
 Module time:
 	user time   =       0.18 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =      35.13 seconds =       0.59 minutes
-	system time =       0.39 seconds =       0.01 minutes
-	total time  =         37 seconds =       0.62 minutes
+	user time   =      34.16 seconds =       0.57 minutes
+	system time =       0.60 seconds =       0.01 minutes
+	total time  =         36 seconds =       0.60 minutes
     Triplet MemDF CUHF energy.............................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:57:04 2022
+*** at Mon May  8 09:19:08 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -10650,7 +10652,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+COSX.
+  SCF Algorithm Type is DFDIRJ+COSX.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -10682,24 +10684,23 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+COSX 
-j_type_: DIRECTDFJ 
-k_type_: COSX 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              COSX
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:           No
     Screening Type:           CSAM
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -10746,17 +10747,17 @@ k_type_: COSX
 
    @CUHF iter   1:  -131.02266731942410   -1.31023e+02   3.53890e-01 ADIIS
    @CUHF iter   2:  -140.10621696114637   -9.08355e+00   1.85157e-01 ADIIS
-   @CUHF iter   3:  -149.07283195574368   -8.96661e+00   6.18535e-02 DIIS/ADIIS
-   @CUHF iter   4:  -149.63845093676028   -5.65619e-01   1.00842e-02 DIIS/ADIIS
+   @CUHF iter   3:  -149.07283195574365   -8.96661e+00   6.18535e-02 DIIS/ADIIS
+   @CUHF iter   4:  -149.63845093676022   -5.65619e-01   1.00842e-02 DIIS/ADIIS
    @CUHF iter   5:  -149.65151108189110   -1.30601e-02   1.51377e-03 DIIS/ADIIS
-   @CUHF iter   6:  -149.65197130478217   -4.60223e-04   2.18032e-04 DIIS/ADIIS
+   @CUHF iter   6:  -149.65197130478231   -4.60223e-04   2.18032e-04 DIIS/ADIIS
    @CUHF iter   7:  -149.65199790962754   -2.66048e-05   1.85204e-05 DIIS
-   @CUHF iter   8:  -149.65199703995134    8.69676e-07   2.10529e-06 DIIS
-   @CUHF iter   9:  -149.65199679272942    2.47222e-07   3.47492e-07 DIIS
+   @CUHF iter   8:  -149.65199703995128    8.69676e-07   2.10529e-06 DIIS
+   @CUHF iter   9:  -149.65199679272934    2.47222e-07   3.47492e-07 DIIS
   Energy and wave function converged with early screening.
   Performing final iteration with tighter screening.
 
-   @CUHF iter  10:  -149.65168894016250    3.07853e-04   9.18132e-04 DIIS/ADIIS
+   @CUHF iter  10:  -149.65168894016264    3.07853e-04   9.18132e-04 DIIS/ADIIS
   Energy and wave function converged.
 
 
@@ -10829,14 +10830,14 @@ k_type_: COSX
     NA   [     3,    0,    1,    1,    0,    2,    1,    1 ]
     NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
 
-  @CUHF Final Energy:  -149.65168894016250
+  @CUHF Final Energy:  -149.65168894016264
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             30.7884922571636537
-    One-Electron Energy =                -266.9107736954305210
-    Two-Electron Energy =                  86.4705924981043665
-    Total Energy =                       -149.6516889401625008
+    One-Electron Energy =                -266.9107736954304642
+    Two-Electron Energy =                  86.4705924981041676
+    Total Energy =                       -149.6516889401626429
 
 Computation Completed
 
@@ -10860,28 +10861,28 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:57:07 2022
+*** tstop() called on ds6 at Mon May  8 09:19:11 2023
 Module time:
-	user time   =       3.01 seconds =       0.05 minutes
+	user time   =       2.79 seconds =       0.05 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =      38.16 seconds =       0.64 minutes
-	system time =       0.39 seconds =       0.01 minutes
-	total time  =         40 seconds =       0.67 minutes
-    Triplet DirectDFJ+COSX CUHF energy....................................................PASSED
+	user time   =      36.98 seconds =       0.62 minutes
+	system time =       0.60 seconds =       0.01 minutes
+	total time  =         39 seconds =       0.65 minutes
+    Triplet DFDirJ+COSX CUHF energy.......................................................PASSED
 
 Scratch directory: /scratch/dpoole34/
 
 *** tstart() called on ds6
-*** at Thu Dec  8 15:57:07 2022
+*** at Mon May  8 09:19:11 2023
 
    => Loading Basis Set <=
 
     Name: CC-PVTZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 1-2 entry O          line   262 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz.gbs 
 
 
          ---------------------------------------------------------
@@ -10918,7 +10919,7 @@ Scratch directory: /scratch/dpoole34/
 
   ==> Algorithm <==
 
-  SCF Algorithm Type is DIRECTDFJ+LINK.
+  SCF Algorithm Type is DFDIRJ+LINK.
   DIIS enabled.
   MOM disabled.
   Fractional occupation disabled.
@@ -10950,24 +10951,23 @@ Scratch directory: /scratch/dpoole34/
     Name: CC-PVTZ-JKFIT
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
+    atoms 1-2 entry O          line   229 file /theoryfs2/ds/dpoole34/Documents/Codes/psi4-compositejk-pilot-ref/psi4-install/share/psi4/basis/cc-pvtz-jkfit.gbs 
 
-jk_type: DIRECTDFJ+LINK 
-j_type_: DIRECTDFJ 
-k_type_: LINK 
   ==> Integral Setup <==
 
   ==> CompositeJK: Mix-and-Match J+K Algorithm Combos <==
 
     J tasked:                  Yes
+    J algorithm:            DFDIRJ
     K tasked:                  Yes
+    K algorithm:              LINK
     wK tasked:                  No
     Integrals threads:           1
     Memory [MiB]:              375
     Incremental Fock:           No
     Screening Type:        DENSITY
 
-  ==> DirectDFJ: Integral-Direct Density-Fitted J <==
+  ==> DF-DirJ: Integral-Direct Density-Fitted J <==
 
     J Screening Cutoff:      1E-12
 
@@ -11125,18 +11125,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on ds6 at Thu Dec  8 15:57:09 2022
+*** tstop() called on ds6 at Mon May  8 09:19:13 2023
 Module time:
-	user time   =       1.87 seconds =       0.03 minutes
+	user time   =       1.79 seconds =       0.03 minutes
 	system time =       0.01 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =      40.06 seconds =       0.67 minutes
-	system time =       0.40 seconds =       0.01 minutes
-	total time  =         42 seconds =       0.70 minutes
-    Triplet DirectDFJ+LinK CUHF energy....................................................PASSED
+	user time   =      38.80 seconds =       0.65 minutes
+	system time =       0.61 seconds =       0.01 minutes
+	total time  =         41 seconds =       0.68 minutes
+    Triplet DFDirJ+LinK CUHF energy.......................................................PASSED
 
-    Psi4 stopped on: Thursday, 08 December 2022 03:57PM
-    Psi4 wall time for execution: 0:00:41.59
+    Psi4 stopped on: Monday, 08 May 2023 09:19AM
+    Psi4 wall time for execution: 0:00:40.59
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
A small, simple companion to https://github.com/psi4/psi4/pull/2833. This updates to the reference output files for the tests that use CompositeJK methods (linK-1, linK-2, linK-3, and scf5), especially notable since the current reference files use `DIRECTDFJ` for composite `SCF_TYPE` methods instead of the current `DFDIRJ`.

## User API & Changelog headlines
N/A

## Dev notes & details
- [X] Regenerate the reference output files for the tests linK-1, linK-2, linK-3, and scf5.

## Questions
N/A

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [X] Ready for merge
