### PR TITLE
Fix #1989

### DIFF
--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -544,10 +544,12 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
      * @param C matrix in the SO basis to use for transforms to MO basis
      * @param basis the symmetry basis to use
      *  AO, SO, MO, CartAO
+     * @param MO_as_overlap whether the AO-to-MO transformation requires the overlap.
+     *   Only used when MO basis requested.
      * @return the matrix M in the desired basis
      **/
     SharedMatrix matrix_subset_helper(SharedMatrix M, SharedMatrix C, const std::string& basis,
-                                      const std::string matrix_basename) const;
+                                      const std::string matrix_basename, bool MO_as_overlap = true) const;
 
     /**
      * Return the alpha orbital eigenvalues in the desired basis

--- a/tests/pytests/test_wfn.py
+++ b/tests/pytests/test_wfn.py
@@ -1,0 +1,24 @@
+import pytest
+
+import numpy as np
+import psi4
+
+from utils import compare_arrays
+
+pytestmark = [pytest.mark.psi, pytest.mark.api]
+
+def test_export_ao_elec_dip_deriv():
+    h2o = psi4.geometry("""
+        O
+        H 1 1.0
+        H 1 1.0 2 101.5
+    """)
+
+    rhf_e, wfn = psi4.energy('SCF/cc-pVDZ', molecule=h2o, return_wfn=True)
+
+    F_diagonals = []
+    for h in wfn.epsilon_a().nph:
+        F_diagonals.append(np.diag(h))
+    F_expected = psi4.core.Matrix.from_array(F_diagonals)
+    assert psi4.compare_matrices(wfn.Fa_subset("MO"), F_expected, 8, "Alpha Fock Matrix")  # TEST
+    assert psi4.compare_matrices(wfn.Fb_subset("MO"), F_expected, 8, "Beta Fock Matrix")  # TEST

--- a/tests/pytests/test_wfn.py
+++ b/tests/pytests/test_wfn.py
@@ -5,7 +5,7 @@ import psi4
 
 from utils import compare_arrays
 
-pytestmark = [pytest.mark.psi, pytest.mark.api]
+pytestmark = [pytest.mark.psi, pytest.mark.api, pytest.mark.quick]
 
 def test_fock_subset_mo():
     h2o = psi4.geometry("""
@@ -20,5 +20,5 @@ def test_fock_subset_mo():
     for h in wfn.epsilon_a().nph:
         F_diagonals.append(np.diag(h))
     F_expected = psi4.core.Matrix.from_array(F_diagonals)
-    assert psi4.compare_matrices(wfn.Fa_subset("MO"), F_expected, 8, "Alpha Fock Matrix")  # TEST
-    assert psi4.compare_matrices(wfn.Fb_subset("MO"), F_expected, 8, "Beta Fock Matrix")  # TEST
+    assert psi4.compare_matrices(F_expected, wfn.Fa_subset("MO"), 8, "Alpha Fock Matrix")
+    assert psi4.compare_matrices(F_expected, wfn.Fb_subset("MO"), 8, "Beta Fock Matrix")

--- a/tests/pytests/test_wfn.py
+++ b/tests/pytests/test_wfn.py
@@ -7,7 +7,7 @@ from utils import compare_arrays
 
 pytestmark = [pytest.mark.psi, pytest.mark.api]
 
-def test_export_ao_elec_dip_deriv():
+def test_fock_subset_mo():
     h2o = psi4.geometry("""
         O
         H 1 1.0


### PR DESCRIPTION
## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] `wfn.Fa_subset` and `wfn.Fb_subset` now return the correct matrices in the MO basis

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] The matrix helper signature is a little uglier now, sadly.

## Checklist
- [x] Tests added for Fa and Fb in MO basis
- [x] Quick tests and new test pass

## Status
- [x] Ready for review
- [x] Ready for merge
