### PR TITLE
Adds user option for ScreeningType::None

### DIFF
--- a/psi4/src/psi4/libmints/twobody.cc
+++ b/psi4/src/psi4/libmints/twobody.cc
@@ -78,10 +78,12 @@ TwoBodyAOInt::TwoBodyAOInt(const IntegralFactory *intsfactory, int deriv)
         screening_type_ = ScreeningType::CSAM;
     else if (screentype == "DENSITY")
         screening_type_ = ScreeningType::Density;
+    else if (screentype == "NONE")
+        screening_type_ = ScreeningType::None;
     else
         throw PSIEXCEPTION("Unknown screening type " + screentype + " in TwoBodyAOInt()");
     
-    if (screening_threshold_ == 0.0) screening_type_ = ScreeningType::None;
+    if (screening_threshold_ == 0.0) screening_type_ = ScreeningType::Schwarz;
 
 }
 
@@ -247,7 +249,7 @@ void TwoBodyAOInt::setup_sieve() {
             break;
         case ScreeningType::None:   
             sieve_impl_ = [=](int M, int N, int R, int S) { return this->shell_significant_none(M, N, R, S); };
-            break;
+            return;
         default:
             throw PSIEXCEPTION("Unimplemented screening type in TwoBodyAOInt::setup_sieve()");
     }

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -212,7 +212,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     options.add_bool("MOLDEN_WITH_VIRTUAL", true);
 
     /*- The type of screening used when computing two-electron integrals. -*/
-    options.add_str("SCREENING", "CSAM", "SCHWARZ CSAM DENSITY");
+    options.add_str("SCREENING", "CSAM", "SCHWARZ CSAM DENSITY NONE");
 
     // CDS-TODO: We should go through and check that the user hasn't done
     // something silly like specify frozen_docc in DETCI but not in TRANSQT.


### PR DESCRIPTION
## Description
Add ScreeningType::None as a user option and sets ScreeningType::Schwarz as the default. This should allow use of mixed basis set types to be used in integrals as well.

## User API & Changelog headlines
N/A

## Dev notes & details
- [X] Breaks out of setup_sieve() in twobody.cc before exception can be thrown
- [X] Adds "NONE" to list of options in read_options.cc

## Checklist
- [X] Tests added for any new features
- [X] All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge
