### PR TITLE
Begone, ERISieve (Kind of)!

### DIFF
--- a/external/downstream/v2rdm_casscf/CMakeLists.txt
+++ b/external/downstream/v2rdm_casscf/CMakeLists.txt
@@ -16,7 +16,7 @@ if(${ENABLE_v2rdm_casscf})
 
         ExternalProject_Add(v2rdm_casscf_external
             DEPENDS psi4-core
-            URL https://github.com/loriab/v2rdm_casscf/archive/dfdaae7.tar.gz
+            URL https://github.com/loriab/v2rdm_casscf/archive/aa7d6a1.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -1565,7 +1565,7 @@ def _core_erisieve_build(
     Previously constructed a Psi4 ERISieve object from an input basis set, with an optional cutoff threshold for
     ERI screening and an optional input to enable CSAM screening (over Schwarz screening).
 
-    However, the ERISieve class has been removed from Psi4 as of v1.9. So, the function now throws with an UpgradeHelper
+    However, as the ERISieve class was removed from Psi4 in v1.9, the function now throws with an UpgradeHelper
     exception, and lets the user know to use TwoBodyAOInt instead.
 
     Parameters

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -1562,7 +1562,7 @@ def _core_erisieve_build(
         do_csam: bool = False
     ) -> core.ERISieve:
     """
-    Previously constructed a Psi4 ERISieve object from an input basis set, with an optional cutoff threshold for
+    This function previously constructed a Psi4 ERISieve object from an input basis set, with an optional cutoff threshold for
     ERI screening and an optional input to enable CSAM screening (over Schwarz screening).
 
     However, as the ERISieve class was removed from Psi4 in v1.9, the function now throws with an UpgradeHelper

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -1562,8 +1562,11 @@ def _core_erisieve_build(
         do_csam: bool = False
     ) -> core.ERISieve:
     """
-    Constructs a Psi4 ERISieve object from an input basis set, with an optional cutoff threshold for
+    Previously constructed a Psi4 ERISieve object from an input basis set, with an optional cutoff threshold for
     ERI screening and an optional input to enable CSAM screening (over Schwarz screening).
+
+    However, the ERISieve class has been removed from Psi4 as of v1.9. So, the function now throws with an UpgradeHelper
+    exception, and lets the user know to use TwoBodyAOInt instead. 
 
     Parameters
     ----------
@@ -1574,7 +1577,7 @@ def _core_erisieve_build(
     do_csam
         Use CSAM screening? If True, CSAM screening is used; else, Schwarz screening is used. By default,
         Schwarz screening is utilized.
-
+    
     Returns
     -------
     ERISieve
@@ -1585,12 +1588,7 @@ def _core_erisieve_build(
     >>> sieve = psi4.core.ERISieve.build(bas, cutoff, csam)
     """
 
-    warnings.warn(
-        "`ERISieve` is deprecated in favor of `TwoBodyAOInt`, and will be removed as soon as Psi4 v1.9 is released.\n",
-        category=FutureWarning,
-        stacklevel=2)
-
-    return core.ERISieve(orbital_basis, cutoff, do_csam)
+    raise UpgradeHelper("ERISieve", "TwoBodyAOInt", 1.8, " The ERISieve class has been removed and replaced with the TwoBodyAOInt class. ERISieve.build(orbital_basis, cutoff, do_csam) can be replaced with the command sequence factory = psi4.core.IntegralFactory(basis); factory.eri(0).")
 
 
 core.ERISieve.build = _core_erisieve_build

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -1566,7 +1566,7 @@ def _core_erisieve_build(
     ERI screening and an optional input to enable CSAM screening (over Schwarz screening).
 
     However, the ERISieve class has been removed from Psi4 as of v1.9. So, the function now throws with an UpgradeHelper
-    exception, and lets the user know to use TwoBodyAOInt instead. 
+    exception, and lets the user know to use TwoBodyAOInt instead.
 
     Parameters
     ----------
@@ -1577,7 +1577,7 @@ def _core_erisieve_build(
     do_csam
         Use CSAM screening? If True, CSAM screening is used; else, Schwarz screening is used. By default,
         Schwarz screening is utilized.
-    
+
     Returns
     -------
     ERISieve

--- a/psi4/src/psi4/libfock/PK_workers.cc
+++ b/psi4/src/psi4/libfock/PK_workers.cc
@@ -352,8 +352,8 @@ void PKWorker::first_quartet(size_t i) {
     bufidx_ = i;
     offset_ = bufidx_ * buf_size_;
     initialize_task();
-    #pragma omp critical
-    outfile->Printf("thread %d, offset is %lu and max_idx is %lu\n",omp_get_thread_num(),offset_,max_idx_);
+    // DEBUG    #pragma omp critical
+    // DEBUG    outfile->Printf("thread %d, offset is %lu and max_idx is %lu\n",omp_get_thread_num(),offset_,max_idx_);
     // DEBUG    std::cout << "thread" << omp_get_thread_num() << ", offset is " << offset_ << " and max_idx is " <<
     // max_idx_ << std::endl;
     shells_left_ = false;
@@ -383,7 +383,7 @@ bool PKWorker::is_shell_relevant() {
     // indices are too high ?
 
     if (low_ijkl > max_idx_ && low_ikjl > max_idx_ && low_iljk > max_idx_) {
-        outfile->Printf("Rejecting1 shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
+        // DEBUG        outfile->Printf("Rejecting1 shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
         return false;
     }
 
@@ -407,7 +407,7 @@ bool PKWorker::is_shell_relevant() {
     // indices are too low ?
 
     if (hi_ijkl < offset_ && hi_ikjl < offset_ && hi_iljk < offset_) {
-        outfile->Printf("Rejecting2 shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
+        // DEBUG        outfile->Printf("Accepting shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
         return false;
     }
 
@@ -429,12 +429,11 @@ bool PKWorker::is_shell_relevant() {
 
         if (bJ || bK1 || bK2) {
             // This shell should be computed by the present thread.
-            outfile->Printf("Accepting shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
+            //outfile->Printf("Accepting shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
             return true;
         }
     }
-
-    outfile->Printf("Rejecting shell3 <%d %d|%d %d>\n",P_,Q_,R_,S_);
+    // DEBUG    outfile->Printf("Rejecting shell3 <%d %d|%d %d>\n",P_,Q_,R_,S_);
     return false;
 }
 

--- a/psi4/src/psi4/libfock/PK_workers.cc
+++ b/psi4/src/psi4/libfock/PK_workers.cc
@@ -407,7 +407,7 @@ bool PKWorker::is_shell_relevant() {
     // indices are too low ?
 
     if (hi_ijkl < offset_ && hi_ikjl < offset_ && hi_iljk < offset_) {
-        // DEBUG        outfile->Printf("Accepting shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
+        // DEBUG        outfile->Printf("Rejecting2 shell <%d %d|%d %d>\n",P_,Q_,R_,S_);        
         return false;
     }
 
@@ -429,7 +429,7 @@ bool PKWorker::is_shell_relevant() {
 
         if (bJ || bK1 || bK2) {
             // This shell should be computed by the present thread.
-            //outfile->Printf("Accepting shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
+            // DEBUG        outfile->Printf("Accepting shell <%d %d|%d %d>\n",P_,Q_,R_,S_);            
             return true;
         }
     }

--- a/psi4/src/psi4/libfock/PK_workers.cc
+++ b/psi4/src/psi4/libfock/PK_workers.cc
@@ -407,7 +407,7 @@ bool PKWorker::is_shell_relevant() {
     // indices are too low ?
 
     if (hi_ijkl < offset_ && hi_ikjl < offset_ && hi_iljk < offset_) {
-        // DEBUG        outfile->Printf("Rejecting2 shell <%d %d|%d %d>\n",P_,Q_,R_,S_);        
+        // DEBUG        outfile->Printf("Rejecting2 shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
         return false;
     }
 
@@ -429,7 +429,7 @@ bool PKWorker::is_shell_relevant() {
 
         if (bJ || bK1 || bK2) {
             // This shell should be computed by the present thread.
-            // DEBUG        outfile->Printf("Accepting shell <%d %d|%d %d>\n",P_,Q_,R_,S_);            
+            // DEBUG        outfile->Printf("Accepting shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
             return true;
         }
     }

--- a/psi4/src/psi4/libfock/PK_workers.cc
+++ b/psi4/src/psi4/libfock/PK_workers.cc
@@ -39,10 +39,10 @@ namespace psi {
 
 namespace pk {
 
-AOShellSieveIterator::AOShellSieveIterator(std::shared_ptr<BasisSet> prim, SharedSieve sieve_input)
-    : shell_pairs_(sieve_input->shell_pairs()) {
+AOShellSieveIterator::AOShellSieveIterator(std::shared_ptr<BasisSet> prim, SharedSieve eri_input)
+    : shell_pairs_(eri_input->shell_pairs()) {
     bs_ = prim;
-    sieve_ = sieve_input;
+    eri_ = eri_input;
     npairs_ = shell_pairs_.size();
     PQ_ = 0;
     RS_ = 0;
@@ -60,7 +60,7 @@ void AOShellSieveIterator::first() {
     PQ_ = 0;
     RS_ = 0;
     populate_indices();
-    while (!sieve_->shell_significant(P_, Q_, R_, S_)) {
+    while (!eri_->shell_significant(P_, Q_, R_, S_)) {
         // We do not use a function to increment so we can directly
         // return when needed
         ++RS_;
@@ -87,7 +87,7 @@ void AOShellSieveIterator::next() {
         }
     }
     populate_indices();
-    while (!sieve_->shell_significant(P_, Q_, R_, S_)) {
+    while (!eri_->shell_significant(P_, Q_, R_, S_)) {
         // We do not use a function to increment so we can directly
         // return when needed
         ++RS_;
@@ -104,13 +104,13 @@ void AOShellSieveIterator::next() {
 }
 
 AOFctSieveIterator AOShellSieveIterator::integrals_iterator() {
-    return AOFctSieveIterator(bs_->shell(P_), bs_->shell(Q_), bs_->shell(R_), bs_->shell(S_), sieve_);
+    return AOFctSieveIterator(bs_->shell(P_), bs_->shell(Q_), bs_->shell(R_), bs_->shell(S_), eri_);
 }
 
 AOFctSieveIterator::AOFctSieveIterator(const GaussianShell &s1, const GaussianShell &s2, const GaussianShell &s3,
-                                       const GaussianShell &s4, std::shared_ptr<TwoBodyAOInt> siev)
+                                       const GaussianShell &s4, std::shared_ptr<TwoBodyAOInt> eri)
     : usi_(s1), usj_(s2), usk_(s3), usl_(s4) {
-    sieve_ = siev;
+    eri_ = eri;
     done_ = false;
 
     ni_ = usi_.nfunction();
@@ -278,16 +278,16 @@ void AOFctSieveIterator::first() {
     lrel_ = 0;
     populate_indices();
     // find a significant ij
-    while (!sieve_->function_pair_significant(i_, j_)) {
+    while (!eri_->function_pair_significant(i_, j_)) {
         increment_bra();
         if (done_) return;
     }
     // find a significant integral
-    while (!sieve_->function_significant(i_, j_, k_, l_)) {
+    while (!eri_->function_significant(i_, j_, k_, l_)) {
         increment_ket();
         if (done_) return;
         // If ij changes, find next significant pair
-        while (!sieve_->function_pair_significant(i_, j_)) {
+        while (!eri_->function_pair_significant(i_, j_)) {
             increment_bra();
             if (done_) return;
         }
@@ -299,16 +299,16 @@ void AOFctSieveIterator::first() {
 void AOFctSieveIterator::next() {
     increment_ket();
     if (done_) return;
-    while (!sieve_->function_pair_significant(i_, j_)) {
+    while (!eri_->function_pair_significant(i_, j_)) {
         increment_bra();
         if (done_) return;
     }
     // find a significant integral
-    while (!sieve_->function_significant(i_, j_, k_, l_)) {
+    while (!eri_->function_significant(i_, j_, k_, l_)) {
         increment_ket();
         if (done_) return;
         // If ij changes, find next significant pair
-        while (!sieve_->function_pair_significant(i_, j_)) {
+        while (!eri_->function_pair_significant(i_, j_)) {
             increment_bra();
             if (done_) return;
         }
@@ -317,10 +317,10 @@ void AOFctSieveIterator::next() {
     reorder_inds();
 }
 
-PKWorker::PKWorker(std::shared_ptr<BasisSet> primary, SharedSieve sieve, std::shared_ptr<AIOHandler> AIO,
+PKWorker::PKWorker(std::shared_ptr<BasisSet> primary, SharedSieve eri, std::shared_ptr<AIOHandler> AIO,
                    int target_file, size_t buf_size) {
     AIO_ = AIO;
-    sieve_ = sieve;
+    eri_ = eri;
     target_file_ = target_file;
     primary_ = primary;
     buf_size_ = buf_size;
@@ -348,7 +348,7 @@ char *PKWorker::get_label_wK(const int batch) {
 }
 
 void PKWorker::first_quartet(size_t i) {
-    shelliter_ = std::unique_ptr<AOShellSieveIterator>(new AOShellSieveIterator(primary_, sieve_));
+    shelliter_ = std::unique_ptr<AOShellSieveIterator>(new AOShellSieveIterator(primary_, eri_));
     bufidx_ = i;
     offset_ = bufidx_ * buf_size_;
     initialize_task();
@@ -455,9 +455,9 @@ void PKWorker::next_quartet() {
     shells_left_ = shell_found;
 }
 
-PKWrkrReord::PKWrkrReord(std::shared_ptr<BasisSet> primary, SharedSieve sieve, std::shared_ptr<AIOHandler> AIO,
+PKWrkrReord::PKWrkrReord(std::shared_ptr<BasisSet> primary, SharedSieve eri, std::shared_ptr<AIOHandler> AIO,
                          int target_file, size_t buffer_size, size_t nbuffer)
-    : PKWorker(primary, sieve, AIO, target_file, buffer_size) {
+    : PKWorker(primary, eri, AIO, target_file, buffer_size) {
     set_nbuf(nbuffer);
     buf_ = 0;
 
@@ -734,9 +734,9 @@ void PKWrkrReord::write_wK(std::vector<size_t> min_ind, std::vector<size_t> max_
     ::memset((void *)wK_bufs_[buf_], '\0', buf_size() * sizeof(double));
 }
 
-PKWrkrInCore::PKWrkrInCore(std::shared_ptr<BasisSet> primary, SharedSieve sieve, size_t buf_size, size_t lastbuf,
+PKWrkrInCore::PKWrkrInCore(std::shared_ptr<BasisSet> primary, SharedSieve eri, size_t buf_size, size_t lastbuf,
                            double *Jbuf, double *Kbuf, double *wKbuf, int nworkers)
-    : PKWorker(primary, sieve, std::shared_ptr<AIOHandler>(), 0, buf_size) {
+    : PKWorker(primary, eri, std::shared_ptr<AIOHandler>(), 0, buf_size) {
     nworkers_ = nworkers;
     last_buf_ = lastbuf;
     J_buf0_ = Jbuf;
@@ -845,10 +845,10 @@ void PKWrkrInCore::finalize_ints_wK(size_t pk_pairs) {
     }
 }
 
-PKWrkrIWL::PKWrkrIWL(std::shared_ptr<BasisSet> primary, SharedSieve sieve, std::shared_ptr<AIOHandler> AIOp,
+PKWrkrIWL::PKWrkrIWL(std::shared_ptr<BasisSet> primary, SharedSieve eri, std::shared_ptr<AIOHandler> AIOp,
                      int targetfile, int K_file, size_t buf_size, std::vector<int> &bufforpq,
                      std::shared_ptr<std::vector<size_t>> pos)
-    : PKWorker(primary, sieve, AIOp, targetfile, buf_size) {
+    : PKWorker(primary, eri, AIOp, targetfile, buf_size) {
     K_file_ = K_file;
     buf_for_pq_ = bufforpq;
     size_t lastpq = buf_for_pq_.size() - 1;

--- a/psi4/src/psi4/libfock/PK_workers.cc
+++ b/psi4/src/psi4/libfock/PK_workers.cc
@@ -29,7 +29,6 @@
 #include "psi4/libmints/integral.h"
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/gshell.h"
-#include "psi4/libmints/sieve.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libpsio/aiohandler.h"
@@ -109,7 +108,7 @@ AOFctSieveIterator AOShellSieveIterator::integrals_iterator() {
 }
 
 AOFctSieveIterator::AOFctSieveIterator(const GaussianShell &s1, const GaussianShell &s2, const GaussianShell &s3,
-                                       const GaussianShell &s4, std::shared_ptr<ERISieve> siev)
+                                       const GaussianShell &s4, std::shared_ptr<TwoBodyAOInt> siev)
     : usi_(s1), usj_(s2), usk_(s3), usl_(s4) {
     sieve_ = siev;
     done_ = false;
@@ -353,8 +352,8 @@ void PKWorker::first_quartet(size_t i) {
     bufidx_ = i;
     offset_ = bufidx_ * buf_size_;
     initialize_task();
-    // DEBUG    #pragma omp critical
-    // DEBUG    outfile->Printf("thread %d, offset is %lu and max_idx is %lu\n",omp_get_thread_num(),offset_,max_idx_);
+    #pragma omp critical
+    outfile->Printf("thread %d, offset is %lu and max_idx is %lu\n",omp_get_thread_num(),offset_,max_idx_);
     // DEBUG    std::cout << "thread" << omp_get_thread_num() << ", offset is " << offset_ << " and max_idx is " <<
     // max_idx_ << std::endl;
     shells_left_ = false;
@@ -384,7 +383,7 @@ bool PKWorker::is_shell_relevant() {
     // indices are too high ?
 
     if (low_ijkl > max_idx_ && low_ikjl > max_idx_ && low_iljk > max_idx_) {
-        // DEBUG        outfile->Printf("Rejecting1 shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
+        outfile->Printf("Rejecting1 shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
         return false;
     }
 
@@ -408,7 +407,7 @@ bool PKWorker::is_shell_relevant() {
     // indices are too low ?
 
     if (hi_ijkl < offset_ && hi_ikjl < offset_ && hi_iljk < offset_) {
-        // DEBUG        outfile->Printf("Rejecting2 shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
+        outfile->Printf("Rejecting2 shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
         return false;
     }
 
@@ -430,12 +429,12 @@ bool PKWorker::is_shell_relevant() {
 
         if (bJ || bK1 || bK2) {
             // This shell should be computed by the present thread.
-            // DEBUG        outfile->Printf("Accepting shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
+            outfile->Printf("Accepting shell <%d %d|%d %d>\n",P_,Q_,R_,S_);
             return true;
         }
     }
 
-    // DEBUG    outfile->Printf("Rejecting shell3 <%d %d|%d %d>\n",P_,Q_,R_,S_);
+    outfile->Printf("Rejecting shell3 <%d %d|%d %d>\n",P_,Q_,R_,S_);
     return false;
 }
 

--- a/psi4/src/psi4/libfock/PK_workers.cc
+++ b/psi4/src/psi4/libfock/PK_workers.cc
@@ -39,7 +39,7 @@ namespace psi {
 
 namespace pk {
 
-AOShellSieveIterator::AOShellSieveIterator(std::shared_ptr<BasisSet> prim, SharedSieve eri_input)
+AOShellSieveIterator::AOShellSieveIterator(std::shared_ptr<BasisSet> prim, SharedInt eri_input)
     : shell_pairs_(eri_input->shell_pairs()) {
     bs_ = prim;
     eri_ = eri_input;
@@ -317,7 +317,7 @@ void AOFctSieveIterator::next() {
     reorder_inds();
 }
 
-PKWorker::PKWorker(std::shared_ptr<BasisSet> primary, SharedSieve eri, std::shared_ptr<AIOHandler> AIO,
+PKWorker::PKWorker(std::shared_ptr<BasisSet> primary, SharedInt eri, std::shared_ptr<AIOHandler> AIO,
                    int target_file, size_t buf_size) {
     AIO_ = AIO;
     eri_ = eri;
@@ -455,7 +455,7 @@ void PKWorker::next_quartet() {
     shells_left_ = shell_found;
 }
 
-PKWrkrReord::PKWrkrReord(std::shared_ptr<BasisSet> primary, SharedSieve eri, std::shared_ptr<AIOHandler> AIO,
+PKWrkrReord::PKWrkrReord(std::shared_ptr<BasisSet> primary, SharedInt eri, std::shared_ptr<AIOHandler> AIO,
                          int target_file, size_t buffer_size, size_t nbuffer)
     : PKWorker(primary, eri, AIO, target_file, buffer_size) {
     set_nbuf(nbuffer);
@@ -734,7 +734,7 @@ void PKWrkrReord::write_wK(std::vector<size_t> min_ind, std::vector<size_t> max_
     ::memset((void *)wK_bufs_[buf_], '\0', buf_size() * sizeof(double));
 }
 
-PKWrkrInCore::PKWrkrInCore(std::shared_ptr<BasisSet> primary, SharedSieve eri, size_t buf_size, size_t lastbuf,
+PKWrkrInCore::PKWrkrInCore(std::shared_ptr<BasisSet> primary, SharedInt eri, size_t buf_size, size_t lastbuf,
                            double *Jbuf, double *Kbuf, double *wKbuf, int nworkers)
     : PKWorker(primary, eri, std::shared_ptr<AIOHandler>(), 0, buf_size) {
     nworkers_ = nworkers;
@@ -845,7 +845,7 @@ void PKWrkrInCore::finalize_ints_wK(size_t pk_pairs) {
     }
 }
 
-PKWrkrIWL::PKWrkrIWL(std::shared_ptr<BasisSet> primary, SharedSieve eri, std::shared_ptr<AIOHandler> AIOp,
+PKWrkrIWL::PKWrkrIWL(std::shared_ptr<BasisSet> primary, SharedInt eri, std::shared_ptr<AIOHandler> AIOp,
                      int targetfile, int K_file, size_t buf_size, std::vector<int> &bufforpq,
                      std::shared_ptr<std::vector<size_t>> pos)
     : PKWorker(primary, eri, AIOp, targetfile, buf_size) {

--- a/psi4/src/psi4/libfock/PK_workers.h
+++ b/psi4/src/psi4/libfock/PK_workers.h
@@ -59,7 +59,7 @@ class AOShellSieveIterator;
 class AOFctSieveIterator;
 
 typedef std::unique_ptr<AOShellSieveIterator> UniqueAOShellIt;
-typedef std::shared_ptr<TwoBodyAOInt> SharedSieve;
+typedef std::shared_ptr<TwoBodyAOInt> SharedInt;
 
 /** AOShellSieveIterator provides an iterator over significant shell
  * quartets using a TwoBodyAOInt object.
@@ -70,7 +70,7 @@ class AOShellSieveIterator {
     // Basis set
     std::shared_ptr<BasisSet> bs_;
     // Sieve object
-    SharedSieve eri_;
+    SharedInt eri_;
     // Vector of significant shell pairs
     const std::vector<std::pair<int, int>>& shell_pairs_;
     // Number of shell pairs
@@ -87,7 +87,7 @@ class AOShellSieveIterator {
 
    public:
     /// Constructor
-    AOShellSieveIterator(std::shared_ptr<BasisSet> prim, SharedSieve eri_input);
+    AOShellSieveIterator(std::shared_ptr<BasisSet> prim, SharedInt eri_input);
 
     /// Iterator functions
     void first();
@@ -221,7 +221,7 @@ class PKWorker {
     /// Current basis set
     std::shared_ptr<BasisSet> primary_;
     /// Current sieve
-    SharedSieve eri_;
+    SharedInt eri_;
     /// Are we doing wK?
     bool do_wK_;
 
@@ -265,7 +265,7 @@ class PKWorker {
 
    public:
     /// Constructor for PKWorker
-    PKWorker(std::shared_ptr<BasisSet> primary, SharedSieve eri, std::shared_ptr<AIOHandler> AIO, int target_file,
+    PKWorker(std::shared_ptr<BasisSet> primary, SharedInt eri, std::shared_ptr<AIOHandler> AIO, int target_file,
              size_t buf_size);
     /// Destructor for PKWorker, does nothing
     virtual ~PKWorker() {}
@@ -395,7 +395,7 @@ class PKWrkrReord : public PKWorker {
 
    public:
     /// Constructor
-    PKWrkrReord(std::shared_ptr<BasisSet> primary, SharedSieve eri, std::shared_ptr<AIOHandler> AIO, int target_file,
+    PKWrkrReord(std::shared_ptr<BasisSet> primary, SharedInt eri, std::shared_ptr<AIOHandler> AIO, int target_file,
                 size_t buffer_size, size_t nbuffer);
     /// Destructor
     ~PKWrkrReord() override;
@@ -443,7 +443,7 @@ class PKWrkrInCore : public PKWorker {
     void initialize_task() override;
 
    public:
-    PKWrkrInCore(std::shared_ptr<BasisSet> primary, SharedSieve eri, size_t buf_size, size_t lastbuf, double* Jbuf,
+    PKWrkrInCore(std::shared_ptr<BasisSet> primary, SharedInt eri, size_t buf_size, size_t lastbuf, double* Jbuf,
                  double* Kbuf, double* wKbuf, int nworkers);
 
     /// Filling values in the relevant part of the buffer
@@ -487,7 +487,7 @@ class PKWrkrIWL : public PKWorker {
 
    public:
     /// Constructor
-    PKWrkrIWL(std::shared_ptr<BasisSet> primary, SharedSieve eri, std::shared_ptr<AIOHandler> AIOp, int targetfile,
+    PKWrkrIWL(std::shared_ptr<BasisSet> primary, SharedInt eri, std::shared_ptr<AIOHandler> AIOp, int targetfile,
               int K_file, size_t buf_size, std::vector<int>& bufforpq, std::shared_ptr<std::vector<size_t>> pos);
     /// Destructor
     ~PKWrkrIWL() override;

--- a/psi4/src/psi4/libfock/PK_workers.h
+++ b/psi4/src/psi4/libfock/PK_workers.h
@@ -70,7 +70,7 @@ class AOShellSieveIterator {
     // Basis set
     std::shared_ptr<BasisSet> bs_;
     // Sieve object
-    SharedSieve sieve_;
+    SharedSieve eri_;
     // Vector of significant shell pairs
     const std::vector<std::pair<int, int>>& shell_pairs_;
     // Number of shell pairs
@@ -87,7 +87,7 @@ class AOShellSieveIterator {
 
    public:
     /// Constructor
-    AOShellSieveIterator(std::shared_ptr<BasisSet> prim, SharedSieve sieve_input);
+    AOShellSieveIterator(std::shared_ptr<BasisSet> prim, SharedSieve eri_input);
 
     /// Iterator functions
     void first();
@@ -111,7 +111,7 @@ class AOShellSieveIterator {
 class AOFctSieveIterator {
    private:
     // Sieve
-    std::shared_ptr<TwoBodyAOInt> sieve_;
+    std::shared_ptr<TwoBodyAOInt> eri_;
     // Integral indices
     int i_, j_, k_, l_;
     // Relative integral indices within shells
@@ -221,7 +221,7 @@ class PKWorker {
     /// Current basis set
     std::shared_ptr<BasisSet> primary_;
     /// Current sieve
-    SharedSieve sieve_;
+    SharedSieve eri_;
     /// Are we doing wK?
     bool do_wK_;
 
@@ -265,7 +265,7 @@ class PKWorker {
 
    public:
     /// Constructor for PKWorker
-    PKWorker(std::shared_ptr<BasisSet> primary, SharedSieve sieve, std::shared_ptr<AIOHandler> AIO, int target_file,
+    PKWorker(std::shared_ptr<BasisSet> primary, SharedSieve eri, std::shared_ptr<AIOHandler> AIO, int target_file,
              size_t buf_size);
     /// Destructor for PKWorker, does nothing
     virtual ~PKWorker() {}
@@ -395,7 +395,7 @@ class PKWrkrReord : public PKWorker {
 
    public:
     /// Constructor
-    PKWrkrReord(std::shared_ptr<BasisSet> primary, SharedSieve sieve, std::shared_ptr<AIOHandler> AIO, int target_file,
+    PKWrkrReord(std::shared_ptr<BasisSet> primary, SharedSieve eri, std::shared_ptr<AIOHandler> AIO, int target_file,
                 size_t buffer_size, size_t nbuffer);
     /// Destructor
     ~PKWrkrReord() override;
@@ -443,7 +443,7 @@ class PKWrkrInCore : public PKWorker {
     void initialize_task() override;
 
    public:
-    PKWrkrInCore(std::shared_ptr<BasisSet> primary, SharedSieve sieve, size_t buf_size, size_t lastbuf, double* Jbuf,
+    PKWrkrInCore(std::shared_ptr<BasisSet> primary, SharedSieve eri, size_t buf_size, size_t lastbuf, double* Jbuf,
                  double* Kbuf, double* wKbuf, int nworkers);
 
     /// Filling values in the relevant part of the buffer
@@ -487,7 +487,7 @@ class PKWrkrIWL : public PKWorker {
 
    public:
     /// Constructor
-    PKWrkrIWL(std::shared_ptr<BasisSet> primary, SharedSieve sieve, std::shared_ptr<AIOHandler> AIOp, int targetfile,
+    PKWrkrIWL(std::shared_ptr<BasisSet> primary, SharedSieve eri, std::shared_ptr<AIOHandler> AIOp, int targetfile,
               int K_file, size_t buf_size, std::vector<int>& bufforpq, std::shared_ptr<std::vector<size_t>> pos);
     /// Destructor
     ~PKWrkrIWL() override;

--- a/psi4/src/psi4/libfock/PK_workers.h
+++ b/psi4/src/psi4/libfock/PK_workers.h
@@ -48,7 +48,7 @@
 namespace psi {
 
 class AIOHandler;
-class ERISieve;
+class TwoBodyAOInt;
 class BasisSet;
 class GaussianShell;
 
@@ -59,10 +59,10 @@ class AOShellSieveIterator;
 class AOFctSieveIterator;
 
 typedef std::unique_ptr<AOShellSieveIterator> UniqueAOShellIt;
-typedef std::shared_ptr<ERISieve> SharedSieve;
+typedef std::shared_ptr<TwoBodyAOInt> SharedSieve;
 
 /** AOShellSieveIterator provides an iterator over significant shell
- * quartets using an ERISieve object.
+ * quartets using a TwoBodyAOInt object.
  */
 
 class AOShellSieveIterator {
@@ -105,13 +105,13 @@ class AOShellSieveIterator {
 };
 
 /** AOFctSieveIterator: provides an iterator over significant functions for
- * a specific shell quartet, using an ERISieve object.
+ * a specific shell quartet, using a TwoBodyAOInt object.
  */
 
 class AOFctSieveIterator {
    private:
     // Sieve
-    std::shared_ptr<ERISieve> sieve_;
+    std::shared_ptr<TwoBodyAOInt> sieve_;
     // Integral indices
     int i_, j_, k_, l_;
     // Relative integral indices within shells
@@ -145,7 +145,7 @@ class AOFctSieveIterator {
    public:
     /// Constructor
     AOFctSieveIterator(const GaussianShell& s1, const GaussianShell& s2, const GaussianShell& s3,
-                       const GaussianShell& s4, std::shared_ptr<ERISieve> siev);
+                       const GaussianShell& s4, std::shared_ptr<TwoBodyAOInt> siev);
 
     /// Iterator functions
     void first();

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -276,14 +276,14 @@ void PKManager::compute_integrals(bool wK) {
                     std::swap(Q, S);
                 }
                 // DEBUG#    pragma omp critical
-                // DEBUG            outfile->Printf("Computing shell <%d %d|%d %d>\n",P,Q,R,S);        
+                // DEBUG            outfile->Printf("Computing shell <%d %d|%d %d>\n",P,Q,R,S);
                 tb[thread]->compute_shell(P, Q, R, S);
                 integrals_buffering(tb[thread]->buffer(), P, Q, R, S);
                 // DEBUG#pragma omp critical
                 // DEBUG              {
                 // DEBUG                outfile->Printf("After buffering\n");
                 // DEBUG                debug_wrt();
-                // DEBUG              }                
+                // DEBUG              }
                 ++nshqu;
             }
         } else {  // Computing range-separated integrals
@@ -1084,7 +1084,7 @@ void PKMgrYoshimine::compute_integrals(bool wK) {
         }
     }
 
-    // Loop over significant shell pairs from TwoBodyAOInt 
+    // Loop over significant shell pairs from TwoBodyAOInt
     const auto& sh_pairs = tb[0]->shell_pairs();
     size_t npairs = sh_pairs.size();
     // We avoid having one more branch in the loop by moving it outside

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -190,7 +190,7 @@ PKManager::PKManager(std::shared_ptr<BasisSet> primary, size_t memory, Options& 
     ntasks_ = 0;
 
     auto factory = std::make_shared<IntegralFactory>(primary_, primary_, primary_, primary_);
-    sieve_ = std::shared_ptr<TwoBodyAOInt>(factory->eri());
+    eri_ = std::shared_ptr<TwoBodyAOInt>(factory->eri());
 
     if (memory_ < pk_pairs_) {
         throw PSIEXCEPTION("Not enough memory for PK algorithm\n");
@@ -887,7 +887,7 @@ void PKMgrReorder::allocate_buffers() {
     // Ok, now we have the size of a buffer and how many buffers
     // we want for each thread. We can allocate IO buffers.
     for (int i = 0; i < nthreads(); ++i) {
-        fill_buffer(std::make_shared<PKWrkrReord>(primary(), sieve(), AIO(), pk_file(), buf_size, buf_per_thread));
+        fill_buffer(std::make_shared<PKWrkrReord>(primary(), eri(), AIO(), pk_file(), buf_size, buf_per_thread));
     }
 }
 
@@ -1024,7 +1024,7 @@ void PKMgrYoshimine::allocate_buffers() {
     // Ok, now we have the size of a buffer and how many buffers
     // we want for each thread. We can allocate IO buffers.
     for (int i = 0; i < nthreads(); ++i) {
-        fill_buffer(std::make_shared<PKWrkrIWL>(primary(), sieve(), AIO(), iwl_file_J_, iwl_file_K_, ints_per_buf_,
+        fill_buffer(std::make_shared<PKWrkrIWL>(primary(), eri(), AIO(), iwl_file_J_, iwl_file_K_, ints_per_buf_,
                                                 batch_for_pq(), current_pos));
     }
 }
@@ -1505,7 +1505,7 @@ void PKMgrInCore::allocate_buffers() {
 
     for (size_t i = 0; i < nthreads(); ++i) {
         // DEBUG        outfile->Printf("start is %lu\n",start);
-        SharedPKWrkr buf = std::make_shared<PKWrkrInCore>(primary(), sieve(), buffer_size, lastbuf, J_ints_.get(),
+        SharedPKWrkr buf = std::make_shared<PKWrkrInCore>(primary(), eri(), buffer_size, lastbuf, J_ints_.get(),
                                                           K_ints_.get(), wK_ints_.get(), nthreads());
         fill_buffer(buf);
         set_ntasks(nthreads());

--- a/psi4/src/psi4/libfock/PKmanagers.cc
+++ b/psi4/src/psi4/libfock/PKmanagers.cc
@@ -256,7 +256,7 @@ void PKManager::compute_integrals(bool wK) {
         thread = omp_get_thread_num();
 #endif
         SharedPKWrkr buf = get_buffer();
-        outfile->Printf("Starting task %d\n", i);
+        // DEBUG        outfile->Printf("Starting task %d\n", i);
         if (!wK) {  // Computing usual integrals
             for (buf->first_quartet(i); buf->more_work(); buf->next_quartet()) {
                 size_t P = buf->P();
@@ -275,12 +275,15 @@ void PKManager::compute_integrals(bool wK) {
                     std::swap(P, R);
                     std::swap(Q, S);
                 }
-                #pragma omp critical
-                outfile->Printf("Computing shell <%d %d|%d %d>\n",P,Q,R,S);
+                // DEBUG#    pragma omp critical
+                // DEBUG            outfile->Printf("Computing shell <%d %d|%d %d>\n",P,Q,R,S);        
                 tb[thread]->compute_shell(P, Q, R, S);
                 integrals_buffering(tb[thread]->buffer(), P, Q, R, S);
-                #pragma omp critical
-                outfile->Printf("After buffering\n");
+                // DEBUG#pragma omp critical
+                // DEBUG              {
+                // DEBUG                outfile->Printf("After buffering\n");
+                // DEBUG                debug_wrt();
+                // DEBUG              }                
                 ++nshqu;
             }
         } else {  // Computing range-separated integrals

--- a/psi4/src/psi4/libfock/PKmanagers.h
+++ b/psi4/src/psi4/libfock/PKmanagers.h
@@ -110,7 +110,7 @@ class PKManager {
     double omega_;
 
     /// Sieving object for the integrals
-    std::shared_ptr<TwoBodyAOInt> sieve_;
+    std::shared_ptr<TwoBodyAOInt> eri_;
     /// Size of triangular list of PK pairs
     size_t pk_pairs_;
     /// Total size of the four-index triangular PK
@@ -153,7 +153,7 @@ class PKManager {
     double cutoff() const { return cutoff_; }
     int nthreads() const { return nthreads_; }
     int nbf() const { return nbf_; }
-    std::shared_ptr<TwoBodyAOInt> sieve() const { return sieve_; }
+    std::shared_ptr<TwoBodyAOInt> eri() const { return eri_; }
     size_t pk_pairs() const { return pk_pairs_; }
     size_t pk_size() const { return pk_size_; }
     size_t ntasks() const { return ntasks_; }

--- a/psi4/src/psi4/libfock/PKmanagers.h
+++ b/psi4/src/psi4/libfock/PKmanagers.h
@@ -38,9 +38,9 @@ namespace psi {
 
 // Forward declarations for Psi4
 class Options;
-class ERISieve;
 class AIOHandler;
 class BasisSet;
+class TwoBodyAOInt;
 
 namespace pk {
 
@@ -95,9 +95,9 @@ class PKManager {
     Options& options_;
     /// Integral cutoff to apply
     double cutoff_;
-    /// CSAM Screening (defaults to false)
-    bool do_csam_;
+    /// Basis set
     std::shared_ptr<BasisSet> primary_;
+    /// Number of threads
     int nthreads_;
     /// Number of basis functions
     int nbf_;
@@ -110,7 +110,7 @@ class PKManager {
     double omega_;
 
     /// Sieving object for the integrals
-    std::shared_ptr<ERISieve> sieve_;
+    std::shared_ptr<TwoBodyAOInt> sieve_;
     /// Size of triangular list of PK pairs
     size_t pk_pairs_;
     /// Total size of the four-index triangular PK
@@ -153,7 +153,7 @@ class PKManager {
     double cutoff() const { return cutoff_; }
     int nthreads() const { return nthreads_; }
     int nbf() const { return nbf_; }
-    std::shared_ptr<ERISieve> sieve() const { return sieve_; }
+    std::shared_ptr<TwoBodyAOInt> sieve() const { return sieve_; }
     size_t pk_pairs() const { return pk_pairs_; }
     size_t pk_size() const { return pk_size_; }
     size_t ntasks() const { return ntasks_; }

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -44,7 +44,6 @@ namespace psi {
 class MinimalInterface;
 class BasisSet;
 class Matrix;
-class ERISieve;
 class TwoBodyAOInt;
 class Options;
 class PSIO;
@@ -734,7 +733,7 @@ class PSI_API DirectJK : public JK {
     /// Number of threads for DF integrals TODO: DF_INTS_NUM_THREADS
     int df_ints_num_threads_;
     /// ERI Sieve
-    std::shared_ptr<ERISieve> sieve_;
+    std::shared_ptr<TwoBodyAOInt> sieve_;
 
     /// Options object
     Options& options_;

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -733,7 +733,7 @@ class PSI_API DirectJK : public JK {
     /// Number of threads for DF integrals TODO: DF_INTS_NUM_THREADS
     int df_ints_num_threads_;
     /// ERI Sieve
-    std::shared_ptr<TwoBodyAOInt> sieve_;
+    std::shared_ptr<TwoBodyAOInt> eri_;
 
     /// Options object
     Options& options_;

--- a/psi4/src/psi4/libmints/sieve.cc
+++ b/psi4/src/psi4/libmints/sieve.cc
@@ -34,6 +34,7 @@
 #include "psi4/libmints/integral.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
+#include "psi4/libpsi4util/exception.h"
 
 #include <cfloat>
 
@@ -46,22 +47,7 @@ ERISieve::ERISieve(std::shared_ptr<BasisSet> primary, double sieve, bool do_csam
 ERISieve::~ERISieve() {}
 
 void ERISieve::common_init() {
-    // if sieve_ is 0, then erfc_inv is infinite
-    // the boost function just throws an error in this case
-    // if (sieve_ > 0.0) {
-    //    throw FeatureNotImplemented("libmints: sieve.cc", "replacement for boost::math::erfc_inv()", __FILE__,
-    //    __LINE__); erfc_thresh_ = boost::math::erfc_inv(sieve_);
-    //} else
-    //    erfc_thresh_ = DBL_MAX;
-
-    Options &options = Process::environment.options;
-    do_qqr_ = false;  // Code below for QQR was/is utterly broken.
-
-    debug_ = 0;
-
-    integrals();
-    if (do_csam_) csam_integrals();
-    set_sieve(sieve_);
+    throw PSIEXCEPTION("Using `ERISieve` instead of `TwoBodyAOInt` is obsolete as of 1.8. The ERISieve class has been removed and replaced with the TwoBodyAOInt class. ERISieve(primary, sieve, do_csam) can be replaced with the command sequence IntegralFactory factory(primary, primary, primary, primary); auto eri_computer = std::shared_ptr<TwoBodyAOInt>(factory.eri());");
 }
 
 void ERISieve::set_sieve(double sieve) {

--- a/psi4/src/psi4/libmints/twobody.h
+++ b/psi4/src/psi4/libmints/twobody.h
@@ -216,7 +216,7 @@ class PSI_API TwoBodyAOInt {
         return shell_pair_values_[N * nshell_ + M] * shell_pair_values_[R * nshell_ + S];
     }
     /// Is the function pair (mn| ever significant according to sieve (no restriction on mn order)
-    inline bool function_pair_significant(int m, int n) {
+    inline bool function_pair_significant(const int m, const int n) {
         return function_pair_values_[m * nbf_ + n] * max_integral_ >= screening_threshold_squared_;
     }
     /// Is the integral (mn|rs) significant according to sieve? (no restriction on mnrs order)

--- a/psi4/src/psi4/libmints/twobody.h
+++ b/psi4/src/psi4/libmints/twobody.h
@@ -220,7 +220,7 @@ class PSI_API TwoBodyAOInt {
         return function_pair_values_[m * nbf_ + n] * max_integral_ >= screening_threshold_squared_;
     }
     /// Is the integral (mn|rs) significant according to sieve? (no restriction on mnrs order)
-    inline bool function_significant(int m, int n, int r, int s) {
+    inline bool function_significant(const int m, const int n, const int r, const int s) {
         return function_pair_values_[m * nbf_ + n] * function_pair_values_[r * nbf_ + s] >= screening_threshold_squared_;
     }
     /// Return max(PQ|PQ)

--- a/psi4/src/psi4/libmints/twobody.h
+++ b/psi4/src/psi4/libmints/twobody.h
@@ -215,6 +215,14 @@ class PSI_API TwoBodyAOInt {
      inline double shell_ceiling2(int M, int N, int R, int S) {
         return shell_pair_values_[N * nshell_ + M] * shell_pair_values_[R * nshell_ + S];
     }
+    /// Is the function pair (mn| ever significant according to sieve (no restriction on mn order)
+    inline bool function_pair_significant(int m, int n) {
+        return function_pair_values_[m * nbf_ + n] * max_integral_ >= screening_threshold_squared_;
+    }
+    /// Is the integral (mn|rs) significant according to sieve? (no restriction on mnrs order)
+    inline bool function_significant(int m, int n, int r, int s) {
+        return function_pair_values_[m * nbf_ + n] * function_pair_values_[r * nbf_ + s] >= screening_threshold_squared_;
+    }
     /// Return max(PQ|PQ)
     double max_integral() const { return max_integral_; }
     /// Square of ceiling of integral (mn|rs)


### PR DESCRIPTION
## Description
This PR is a reimplementation of https://github.com/psi4/psi4/pull/2933; but instead of entirely deleting the `ERISieve` class, it makes `ERISieve` inaccessible for use through the following:

- Using `core.ERISieve.build` now throws an `UpgradeHelper` exception when called, as compared to the previous behavior of giving a warning.
- Calling the `ERISieve` constructor C++-side now throws an exception, with the same message as the UpgradeHelper would give.

Aside from that, this PR does the same things as https://github.com/psi4/psi4/pull/2933. `ERISieve` is replaced with `TwoBodyAOInt` in all use cases, with adjustments as necessary. Additionally, the new version of v2rdm_casscf is used, which also uses `TwoBodyAOInt` instead of `ERISieve`.

## User API & Changelog headlines
- [X] Calling `core.ERISieve.build` Py-side, or constructing an `ERISieve` object C++-side, now throws an exception. The removed functionalities, specifically `shell_significant`, can be accessed via the construction of a TwoBodyAOInt object.

## Dev notes & details
- [X] The `ERISieve` class in libmints has been made inaccessible, now throwing exceptions when constructed (with an UpgradeHelper Py-side, and a PSIEXCEPTION C++-side).
- [X] Functionalities in `ERISieve` that were not in `TwoBodyAOInt` and were required in the code, were added to `TwoBodyAOInt`.
- [X] The PKJK files have been adjusted as necessary to support the use of `TwoBodyAOInt`.

## TODO
- [X] Remove ERISieve from all other external plugins (currently focusing on v2rdm_casscf).

## Questions
- N/A

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge