### PR TITLE
Fix #2976

### DIFF
--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -192,28 +192,16 @@ double DFMP2::compute_energy() {
         }
         throw PSIEXCEPTION("There are no occupied orbitals with alpha spin.");
     }
-    if (Cb_subset("AO", "ACTIVE_OCC")->colspi()[0] == 0) {
-        if (nalpha() == 1) {
-            variables_["MP2 SINGLES ENERGY"] = 0.0;
-            variables_["MP2 SAME-SPIN CORRELATION ENERGY"] = 0.0;
-            variables_["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = 0.0;
-            variables_["MP2 CORRELATION ENERGY"] = 0.0;
-            print_energies();
-            energy_ = variables_["MP2 TOTAL ENERGY"];
-            return variables_["MP2 TOTAL ENERGY"];
-        }
-        else {
-            throw PSIEXCEPTION("There are no occupied orbitals with beta spin.");
-        }
-    }
-    if (Ca_subset("AO", "ACTIVE_VIR")->colspi()[0] == 0) {
-        if (Cb_subset("AO", "ACTIVE_VIR")->colspi()[0] == 0) {
-            throw PSIEXCEPTION("There are no virtual orbitals with alpha or beta spin.");
-        }
-        throw PSIEXCEPTION("There are no virtual orbitals with alpha spin.");
-    }
-    if (Cb_subset("AO", "ACTIVE_VIR")->colspi()[0] == 0) {
-        throw PSIEXCEPTION("There are no virtual orbitals with beta spin.");
+    auto num_alpha_excit = std::min(Ca_subset("AO", "ACTIVE_OCC")->colspi()[0], Ca_subset("AO", "ACTIVE_OCC")->colspi()[0]);
+    auto num_beta_excit = std::min(Cb_subset("AO", "ACTIVE_OCC")->colspi()[0], Cb_subset("AO", "ACTIVE_OCC")->colspi()[0]);
+    if (num_alpha_excit + num_beta_excit < 2) {
+        variables_["MP2 SINGLES ENERGY"] = 0.0;
+        variables_["MP2 SAME-SPIN CORRELATION ENERGY"] = 0.0;
+        variables_["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = 0.0;
+        variables_["MP2 CORRELATION ENERGY"] = 0.0;
+        print_energies();
+        energy_ = variables_["MP2 TOTAL ENERGY"];
+        return variables_["MP2 TOTAL ENERGY"];
     }
     timer_on("DFMP2 Singles");
     form_singles();

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -186,14 +186,8 @@ void DFMP2::common_init() {
 }
 double DFMP2::compute_energy() {
     print_header();
-    if (Ca_subset("AO", "ACTIVE_OCC")->colspi()[0] == 0) {
-        if (Cb_subset("AO", "ACTIVE_OCC")->colspi()[0] == 0) {
-            throw PSIEXCEPTION("There are no occupied orbitals with alpha or beta spin.");
-        }
-        throw PSIEXCEPTION("There are no occupied orbitals with alpha spin.");
-    }
-    auto num_alpha_excit = std::min(Ca_subset("AO", "ACTIVE_OCC")->colspi()[0], Ca_subset("AO", "ACTIVE_OCC")->colspi()[0]);
-    auto num_beta_excit = std::min(Cb_subset("AO", "ACTIVE_OCC")->colspi()[0], Cb_subset("AO", "ACTIVE_OCC")->colspi()[0]);
+    auto num_alpha_excit = std::min(Ca_subset("AO", "ACTIVE_OCC")->colspi()[0], Ca_subset("AO", "ACTIVE_VIR")->colspi()[0]);
+    auto num_beta_excit = std::min(Cb_subset("AO", "ACTIVE_OCC")->colspi()[0], Cb_subset("AO", "ACTIVE_VIR")->colspi()[0]);
     if (num_alpha_excit + num_beta_excit < 2) {
         variables_["MP2 SINGLES ENERGY"] = 0.0;
         variables_["MP2 SAME-SPIN CORRELATION ENERGY"] = 0.0;

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -189,6 +189,7 @@ double DFMP2::compute_energy() {
     auto num_alpha_excit = std::min(Ca_subset("AO", "ACTIVE_OCC")->colspi()[0], Ca_subset("AO", "ACTIVE_VIR")->colspi()[0]);
     auto num_beta_excit = std::min(Cb_subset("AO", "ACTIVE_OCC")->colspi()[0], Cb_subset("AO", "ACTIVE_VIR")->colspi()[0]);
     if (num_alpha_excit + num_beta_excit < 2) {
+        outfile->Printf("  Warning: no MP2 calculation performed on system with alpha ACTIVE_OCC (%d), beta ACTIVE_OCC (%d), alpha ACTIVE_VIR (%d), beta ACTIVE_VIR (%d); returning 0.0 by definition.\n", Ca_subset("AO", "ACTIVE_OCC")->colspi()[0], Cb_subset("AO", "ACTIVE_OCC")->colspi()[0], Ca_subset("AO", "ACTIVE_VIR")->colspi()[0], Cb_subset("AO", "ACTIVE_VIR")->colspi()[0]);
         variables_["MP2 SINGLES ENERGY"] = 0.0;
         variables_["MP2 SAME-SPIN CORRELATION ENERGY"] = 0.0;
         variables_["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = 0.0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,7 +45,7 @@ foreach(test_name aediis-1
                   dct10 dct11 dct12 ao-dfcasscf-sp density-screen-1 density-screen-2 dfcasscf-sa-sp
                   dfcasscf-fzc-sp dfcasscf-sp dfccd1 dfccdl1 dfccd-grad1 dfccsd1 dfccsdl1 dfccsd-grad1
                   dfccsd-t-grad1
-                  dfccsdt1 dfccsdat1 dfmp2-1 dfmp2-2 dfmp2-3 dfmp2-4 dfmp2-fc dfmp2-freq1 dfmp2-freq2
+                  dfccsdt1 dfccsdat1 dfmp2-1 dfmp2-2 dfmp2-3 dfmp2-4 dfmp2-5 dfmp2-fc dfmp2-freq1 dfmp2-freq2
                   dfccsd-grad2 dfccsd-t-grad2 dfccsdat2 dfccsdt2
                   dfmp2-grad1 dfmp2-grad2 dfmp2-grad3 dfmp2-grad4 dfmp2-grad5 dfomp2-1 dfomp2-2 dfomp2-3
                   dfomp2-4 dfomp2-grad1 dfomp2-grad2 dfomp2-grad3 dfomp3-1 dfomp3-2

--- a/tests/dfmp2-5/CMakeLists.txt
+++ b/tests/dfmp2-5/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(dfmp2-5 "psi;df;dfmp2")

--- a/tests/dfmp2-5/input.dat
+++ b/tests/dfmp2-5/input.dat
@@ -1,0 +1,12 @@
+molecule {
+0 2
+Li
+}
+
+set basis def2-SVP
+set reference uhf
+set freeze_core True
+set scf_type df
+set mp2_type df
+
+energy('mp2')

--- a/tests/dfmp2-5/input.dat
+++ b/tests/dfmp2-5/input.dat
@@ -9,4 +9,6 @@ set freeze_core True
 set scf_type df
 set mp2_type df
 
-energy('mp2')
+wfn = energy('mp2', return_wfn=True)[1]
+
+compare_values(0.0, wfn.variable("MP2 CORRELATION ENERGY"), 7, "MP2 Correlation Energy") #TEST

--- a/tests/dfmp2-5/output.ref
+++ b/tests/dfmp2-5/output.ref
@@ -1,0 +1,353 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.9a1.dev7 
+
+                         Git: Rev {master} d179884 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Monday, 05 June 2023 01:26PM
+
+    Process ID: 22534
+    Host:       jonathons-mbp.wireless.emory.edu
+    PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+molecule {
+0 2
+Li
+}
+
+set basis def2-SVP
+set reference uhf
+set freeze_core True
+set scf_type df
+set mp2_type df
+
+energy('mp2')
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  5, 4, 3
+    Auxiliary basis highest AM E, G, H:  6, 5, 4
+    Onebody   basis highest AM E, G, H:  6, 5, 4
+    Solid Harmonics ordering:            gaussian
+
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Jun  5 13:26:32 2023
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry LI         line    35 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         LI           0.000000000000     0.000000000000     0.000000000000     7.016003436600
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 3
+  Nalpha       = 2
+  Nbeta        = 1
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is CORE.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 5
+    Number of basis functions: 9
+    Number of Cartesian functions: 9
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry LI         line    54 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. 
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (DEF2-SVP AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 17
+    Number of basis functions: 51
+    Number of Cartesian functions: 60
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.3551569221E-01.
+  Reciprocal condition number of the overlap matrix is 7.0278443887E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Core (One-Electron) Hamiltonian.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         3       3       1       1       1       0
+     B1g        0       0       0       0       0       0
+     B2g        0       0       0       0       0       0
+     B3g        0       0       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        2       2       0       0       0       0
+     B2u        2       2       0       0       0       0
+     B3u        2       2       1       0       0       1
+   -------------------------------------------------------
+    Total       9       9       2       1       1       1
+   -------------------------------------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter   1:    -7.04309415523453   -7.04309e+00   7.09382e-02 DIIS/ADIIS
+   @DF-UHF iter   2:    -7.31419887865640   -2.71105e-01   2.59065e-02 DIIS/ADIIS
+   @DF-UHF iter   3:    -7.34046409908635   -2.62652e-02   6.38497e-03 DIIS/ADIIS
+   @DF-UHF iter   4:    -7.34197619408693   -1.51210e-03   1.85372e-04 DIIS/ADIIS
+   @DF-UHF iter   5:    -7.34197716612027   -9.72033e-07   6.32423e-06 DIIS
+   @DF-UHF iter   6:    -7.34197716651249   -3.92223e-10   7.46255e-08 DIIS
+   @DF-UHF iter   7:    -7.34197716651257   -7.37188e-14   2.38600e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.717631523E-05
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500171763E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -2.461375     1B3u   -0.109138  
+
+    Alpha Virtual:                                                        
+
+       2Ag    -0.013018     3Ag     0.107187     1B2u    0.118774  
+       1B1u    0.118774     2B3u    0.691600     2B1u    0.710988  
+       2B2u    0.710988  
+
+    Beta Occupied:                                                        
+
+       1Ag    -2.457883  
+
+    Beta Virtual:                                                         
+
+       2Ag     0.020540     1B2u    0.134855     1B1u    0.134855  
+       3Ag     0.135807     1B3u    0.166953     2B1u    0.717104  
+       2B2u    0.717104     2B3u    0.741344  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     0,    0,    0,    0,    0,    0,    0,    1 ]
+    NA   [     1,    0,    0,    0,    0,    0,    0,    1 ]
+    NB   [     1,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UHF Final Energy:    -7.34197716651257
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -9.6555583825224609
+    Two-Electron Energy =                   2.3135812160098945
+    Total Energy =                         -7.3419771665125664
+
+  UHF NO Occupations:
+  HONO-1 :    1 Ag 1.9999914
+  HONO-0 :    1B3u 1.0000000
+  LUNO+0 :    2 Ag 0.0000086
+  LUNO+1 :    2B3u 0.0000000
+  LUNO+2 :    2B2u 0.0000000
+  LUNO+3 :    1B2u 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Jun  5 13:26:33 2023
+Module time:
+	user time   =       0.29 seconds =       0.00 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.29 seconds =       0.00 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on jonathons-mbp.wireless.emory.edu
+*** at Mon Jun  5 13:26:33 2023
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //               DFMP2               //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1 entry LI         line    53 file /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4/basis/def2-svp-ri.gbs 
+
+	 --------------------------------------------------------
+	                          DF-MP2                         
+	      2nd-Order Density-Fitted Moller-Plesset Theory     
+	              UMP2 Wavefunction,   1 Threads             
+	                                                         
+	        Rob Parrish, Justin Turney, Andy Simmonett,      
+	           Ed Hohenstein, and C. David Sherrill          
+	 --------------------------------------------------------
+
+	 --------------------------------------------------------
+	                 NBF =     9, NAUX =    25
+	 --------------------------------------------------------
+	   CLASS    FOCC     OCC    AOCC    AVIR     VIR    FVIR
+	   ALPHA       1       2       1       7       7       0
+	    BETA       1       1       0       8       8       0
+	 --------------------------------------------------------
+
+	-----------------------------------------------------------
+	 ==================> DF-MP2 Energies <==================== 
+	-----------------------------------------------------------
+	 Reference Energy          =      -7.3419771665125664 [Eh]
+	 Singles Energy            =       0.0000000000000000 [Eh]
+	 Same-Spin Energy          =       0.0000000000000000 [Eh]
+	 Opposite-Spin Energy      =       0.0000000000000000 [Eh]
+	 Correlation Energy        =       0.0000000000000000 [Eh]
+	 Total Energy              =      -7.3419771665125664 [Eh]
+	-----------------------------------------------------------
+	 ================> DF-SCS-MP2 Energies <================== 
+	-----------------------------------------------------------
+	 SCS Same-Spin Scale       =       0.3333333333333333 [-]
+	 SCS Opposite-Spin Scale   =       1.2000000000000000 [-]
+	 SCS Same-Spin Energy      =       0.0000000000000000 [Eh]
+	 SCS Opposite-Spin Energy  =       0.0000000000000000 [Eh]
+	 SCS Correlation Energy    =       0.0000000000000000 [Eh]
+	 SCS Total Energy          =      -7.3419771665125664 [Eh]
+	-----------------------------------------------------------
+
+
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Jun  5 13:26:33 2023
+Module time:
+	user time   =       0.04 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.33 seconds =       0.01 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+    Psi4 stopped on: Monday, 05 June 2023 01:26PM
+    Psi4 wall time for execution: 0:00:00.79
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dfmp2-5/output.ref
+++ b/tests/dfmp2-5/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.9a1.dev7 
+                               Psi4 1.9a1.dev10 
 
-                         Git: Rev {master} d179884 dirty
+                         Git: Rev {2976} 4df1735 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -31,9 +31,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 05 June 2023 01:26PM
+    Psi4 started on: Tuesday, 06 June 2023 11:44AM
 
-    Process ID: 22534
+    Process ID: 2880
     Host:       jonathons-mbp.wireless.emory.edu
     PSIDATADIR: /Users/jonathonmisiewicz/psi4/objdir/stage/share/psi4
     Memory:     500.0 MiB
@@ -53,7 +53,9 @@ set freeze_core True
 set scf_type df
 set mp2_type df
 
-energy('mp2')
+wfn = energy('mp2', return_wfn=True)[1]
+
+compare_values(0.0, wfn.variable("MP2 CORRELATION ENERGY"), 7, "MP2 Correlation Energy") #TEST
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
@@ -65,7 +67,7 @@ Scratch directory: /tmp/
     Solid Harmonics ordering:            gaussian
 
 *** tstart() called on jonathons-mbp.wireless.emory.edu
-*** at Mon Jun  5 13:26:32 2023
+*** at Tue Jun  6 11:44:22 2023
 
    => Loading Basis Set <=
 
@@ -186,10 +188,10 @@ Scratch directory: /tmp/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-UHF iter   1:    -7.04309415523453   -7.04309e+00   7.09382e-02 DIIS/ADIIS
-   @DF-UHF iter   2:    -7.31419887865640   -2.71105e-01   2.59065e-02 DIIS/ADIIS
-   @DF-UHF iter   3:    -7.34046409908635   -2.62652e-02   6.38497e-03 DIIS/ADIIS
-   @DF-UHF iter   4:    -7.34197619408693   -1.51210e-03   1.85372e-04 DIIS/ADIIS
+   @DF-UHF iter   1:    -7.04309415523453   -7.04309e+00   7.09382e-02 ADIIS/DIIS
+   @DF-UHF iter   2:    -7.31419887865640   -2.71105e-01   2.59065e-02 ADIIS/DIIS
+   @DF-UHF iter   3:    -7.34046409908635   -2.62652e-02   6.38497e-03 ADIIS/DIIS
+   @DF-UHF iter   4:    -7.34197619408693   -1.51210e-03   1.85372e-04 ADIIS/DIIS
    @DF-UHF iter   5:    -7.34197716612027   -9.72033e-07   6.32423e-06 DIIS
    @DF-UHF iter   6:    -7.34197716651249   -3.92223e-10   7.46255e-08 DIIS
    @DF-UHF iter   7:    -7.34197716651257   -7.37188e-14   2.38600e-09 DIIS
@@ -274,18 +276,18 @@ Properties computed using the SCF density matrix
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Jun  5 13:26:33 2023
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Tue Jun  6 11:44:23 2023
 Module time:
 	user time   =       0.29 seconds =       0.00 minutes
-	system time =       0.09 seconds =       0.00 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 Total time:
 	user time   =       0.29 seconds =       0.00 minutes
-	system time =       0.09 seconds =       0.00 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
 
 *** tstart() called on jonathons-mbp.wireless.emory.edu
-*** at Mon Jun  5 13:26:33 2023
+*** at Tue Jun  6 11:44:23 2023
 
 
   //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
@@ -316,6 +318,7 @@ Total time:
 	    BETA       1       1       0       8       8       0
 	 --------------------------------------------------------
 
+  Warning: no MP2 calculation performed on system with alpha ACTIVE_OCC (1), beta ACTIVE_OCC (0), alpha ACTIVE_VIR (7), beta ACTIVE_VIR (8); returning 0.0 by definition.
 	-----------------------------------------------------------
 	 ==================> DF-MP2 Energies <==================== 
 	-----------------------------------------------------------
@@ -337,17 +340,18 @@ Total time:
 	-----------------------------------------------------------
 
 
-*** tstop() called on jonathons-mbp.wireless.emory.edu at Mon Jun  5 13:26:33 2023
+*** tstop() called on jonathons-mbp.wireless.emory.edu at Tue Jun  6 11:44:23 2023
 Module time:
 	user time   =       0.04 seconds =       0.00 minutes
 	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
 	user time   =       0.33 seconds =       0.01 minutes
-	system time =       0.09 seconds =       0.00 minutes
+	system time =       0.10 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
+    MP2 Correlation Energy................................................................PASSED
 
-    Psi4 stopped on: Monday, 05 June 2023 01:26PM
-    Psi4 wall time for execution: 0:00:00.79
+    Psi4 stopped on: Tuesday, 06 June 2023 11:44AM
+    Psi4 wall time for execution: 0:00:00.96
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dfmp2-5/test_input.py
+++ b/tests/dfmp2-5/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("df;dfmp2")
+def test_dfmp2_5():
+    ctest_runner(__file__)
+


### PR DESCRIPTION
## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Fixes a crash when attempting DFMP2 on systems with too few electrons to support MP2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Massively simplified the DFMP2 validation logic

## Checklist
- [x] dfmp2 tests pass
- [x] Turned the bug report into a new test case. (Thanks for a clean one, Susi.)

## Status
- [x] Ready for review
- [x] Ready for merge
