### PR TITLE
Add Comprehensive JK Build+Screening Testing

### DIFF
--- a/tests/pytests/test_comprehensive_jk_screening.py
+++ b/tests/pytests/test_comprehensive_jk_screening.py
@@ -63,8 +63,8 @@ def test_comprehensive_jk_screening(scf_type, scf_subtype, screening):
     should_error_out = should_error_out or (scf_type in Eref["Singlet"]["Composite"].keys() and screening == "NONE")
     #== .. DFDIRJ+LINK with SCREENING=SCHWARZ or CSAM... ==#
     should_error_out = should_error_out or (scf_type == "DFDIRJ+LINK" and screening in [ "SCHWARZ", "CSAM" ])
-    #== .. and DISK_DF, DIRECT, or Yoshimine PK with SCREENING=NONE ==# 
-    should_error_out = should_error_out or (scf_type == "PK" and scf_subtype == "YOSHIMINE_OUT_OF_CORE" and screening == "NONE")
+    #== .. and DISK_DF, DIRECT, or PK with SCREENING=NONE ==#
+    should_error_out = should_error_out or (scf_type == "PK" and screening == "NONE")
     should_error_out = should_error_out or (scf_type == "DISK_DF" and screening == "NONE")
     should_error_out = should_error_out or (scf_type == "DIRECT" and screening == "NONE")
   

--- a/tests/pytests/test_comprehensive_jk_screening.py
+++ b/tests/pytests/test_comprehensive_jk_screening.py
@@ -5,7 +5,10 @@ from utils import compare, compare_integers, compare_values
 
 pytestmark = [pytest.mark.psi, pytest.mark.api] 
 
-def test_comprehensive_jk_screening():
+@pytest.mark.parametrize("scf_type", [ "PK", "DIRECT", "OUT_OF_CORE", "DISK_DF", "MEM_DF", "DFDIRJ+LINK", "DFDIRJ+COSX" ])
+@pytest.mark.parametrize("scf_subtype", [ "AUTO", "INCORE", "OUT_OF_CORE", "YOSHIMINE_OUT_OF_CORE", "REORDER_OUT_OF_CORE" ])
+@pytest.mark.parametrize("screening", [ "SCHWARZ", "DENSITY", "CSAM", "NONE" ])
+def test_comprehensive_jk_screening(scf_type, scf_subtype, screening):
     """Checks the energy values computed by different JK methods using different
     screening types. The differences in energies should be insignificant.""" 
 
@@ -32,90 +35,68 @@ def test_comprehensive_jk_screening():
     
     psi4.geometry(singlet_o2)
     
-    #=== define core options ==#
+    #=== define options ==#
     psi4.set_options({
+        "scf_type": scf_type,
+        "scf_subtype": scf_subtype,
+        "screening": screening, 
         "df_scf_guess": False,
         "basis": "cc-pvtz",
         "df_basis_scf": "cc-pvtz-jkfit",
         "print": 2,
     })
-    
-    #== define various scf params to combine test ==#
-    scf_params = {
-        "SCF_TYPE": [ "PK", "DIRECT", "OUT_OF_CORE", "DISK_DF", "MEM_DF", "DFDIRJ+LINK", "DFDIRJ+COSX" ],
-        
-        "SCF_SUBTYPE": [ "AUTO", "INCORE", "OUT_OF_CORE", "YOSHIMINE_OUT_OF_CORE", "REORDER_OUT_OF_CORE" ],
-        
-        "SCREENING": [ "SCHWARZ", "DENSITY", "CSAM", "NONE" ],
-    }
-   
-    #== create scf test combos from above params ==# 
-    keyword_option_pairs = []
-    for keyword, options in scf_params.items():
-        keyword_option_pairs.append([ (keyword, x) for x in options ])
-    
-    keyword_option_combos = itertools.product(*keyword_option_pairs)
-
-    #== loop over and test scf combinations ==#
-    for keyword_option_combo in keyword_option_combos:
-        for keyword_option_pair in keyword_option_combo:
-            psi4.set_options({keyword_option_pair[0]: keyword_option_pair[1]})
  
-        scf_type = psi4.core.get_global_option("SCF_TYPE")
-        scf_subtype = psi4.core.get_global_option("SCF_SUBTYPE")
-        screening = psi4.core.get_global_option("SCREENING")
+    #== skip redundant option combinations based on type/subtype combination ==#   
+    if scf_type not in [ "PK", "DISK_DF", "MEM_DF"] and scf_subtype != "AUTO":
+        pytest.skip(f'Singlet {scf_type}({scf_subtype})+{screening}  skipped: redundant test') 
+    elif scf_type in [ "DISK_DF", "MEM_DF"] and scf_subtype in [ "YOSHIMINE_OUT_OF_CORE", "REORDER_OUT_OF_CORE" ]:
+        pytest.skip(f'Singlet {scf_type}({scf_subtype})+{screening}  skipped: redundant test') 
+
+    #== certain combinations of SCF_TYPE and SCREENING should throw an exception by design ==#
+    should_throw = False
+    #== specifically, non-integral-direct methods and DFDirJ+COSX with SCREENING = DENSITY ==# 
+    should_throw = should_throw or (scf_type not in [ "DIRECT", "DFDIRJ+LINK" ] and screening == "DENSITY")
+
+    #== other combinations error out badly and need to be fixed; skip them here ==#
+    should_error_out = False
+    #== this includes Composite methods with SCREENING=NONE... ==#
+    should_error_out = should_error_out or (scf_type in Eref["Singlet"]["Composite"].keys() and screening == "NONE")
+    #== .. DFDIRJ+LINK with SCREENING=SCHWARZ or CSAM... ==#
+    should_error_out = should_error_out or (scf_type == "DFDIRJ+LINK" and screening in [ "SCHWARZ", "CSAM" ])
+    #== .. and DISK_DF, DIRECT, or Yoshimine PK with SCREENING=NONE ==# 
+    should_error_out = should_error_out or (scf_type == "PK" and scf_subtype == "YOSHIMINE_OUT_OF_CORE" and screening == "NONE")
+    should_error_out = should_error_out or (scf_type == "DISK_DF" and screening == "NONE")
+    should_error_out = should_error_out or (scf_type == "DIRECT" and screening == "NONE")
+  
+    E = 0.0 
     
-        #== skip redundant option combinations based on type/subtype combination ==#   
-        if scf_type not in [ "PK", "DISK_DF", "MEM_DF"] and scf_subtype != "AUTO":
-            continue
-        elif scf_type in [ "DISK_DF", "MEM_DF"] and scf_subtype in [ "YOSHIMINE_OUT_OF_CORE", "REORDER_OUT_OF_CORE" ]:
-            continue
+    #== check that should_error_out and should_throw are not simultaneously true, for better testing ==# 
+    if should_error_out and should_throw:
+        raise Exception(f'Duplicate checks on {scf_type}({scf_subtype})+{screening}!')
+    #== skip if current option combo is expected to break ==#
+    elif should_error_out and not should_throw:
+        pytest.skip(f'Singlet {scf_type}({scf_subtype})+{screening}  skipped: will error out') 
 
-        #== certain combinations of SCF_TYPE and SCREENING should throw an exception by design ==#
-        should_throw = False
-        #== specifically, non-integral-direct methods and DFDirJ+COSX with SCREENING = DENSITY ==# 
-        should_throw = should_throw or (scf_type not in [ "DIRECT", "DFDIRJ+LINK" ] and screening == "DENSITY")
-
-        #== other combinations error out badly and need to be fixed; skip them here ==#
-        should_error_out = False
-        #== this includes Composite methods with SCREENING=NONE... ==#
-        should_error_out = should_error_out or (scf_type in Eref["Singlet"]["Composite"].keys() and screening == "NONE")
-        #== .. DFDIRJ+LINK with SCREENING=SCHWARZ or CSAM... ==#
-        should_error_out = should_error_out or (scf_type == "DFDIRJ+LINK" and screening in [ "SCHWARZ", "CSAM" ])
-        #== .. and DISK_DF, DIRECT, or Yoshimine PK with SCREENING=NONE ==# 
-        should_error_out = should_error_out or (scf_type == "PK" and scf_subtype == "YOSHIMINE_OUT_OF_CORE" and screening == "NONE")
-        should_error_out = should_error_out or (scf_type == "DISK_DF" and screening == "NONE")
-        should_error_out = should_error_out or (scf_type == "DIRECT" and screening == "NONE")
-      
-        E = 0.0 
-        
-        #== check that should_error_out and should_throw are not simultaneously true, for better testing ==# 
-        if should_error_out and should_throw:
-            raise Exception(f'Duplicate checks on {scf_type}({scf_subtype})+{screening}!')
-        #== skip if current option combo is expected to break ==#
-        elif should_error_out and not should_throw:
-            continue
- 
-        #== if expected, test if current option combo throws exception ==# 
-        if not should_error_out and should_throw:
-            with pytest.raises(Exception) as e_info:
-                E = psi4.energy('scf')
-
-            # we keep this line just for printout purposes; should always pass if done correctly
-            assert compare_values(0.0, E, 6, f'Singlet {scf_type}({scf_subtype})+{screening}  throws exception') #TEST
-
-        #== otherwise, test if current option combo gives right answer ==#
-        else: 
+    #== if expected, test if current option combo throws exception ==# 
+    if not should_error_out and should_throw:
+        with pytest.raises(Exception) as e_info:
             E = psi4.energy('scf')
-      
-            E_ref = 0.0
-            if scf_type in [ "DIRECT", "PK", "OUT_OF_CORE" ]:
-                E_ref = Eref["Singlet"]["Canonical"] 
-            elif scf_type in [ "MEM_DF", "DISK_DF" ]:
-                E_ref = Eref["Singlet"]["DF"]
-            elif scf_type in Eref["Singlet"]["Composite"].keys(): 
-                E_ref = Eref["Singlet"]["Composite"][scf_type]
-            else:
-                raise Exception("Invalid JK method used!") 
 
-            assert compare_values(E_ref, E, 6, f'Singlet {scf_type}({scf_subtype})+{screening}  RHF energy') #TEST
+        # we keep this line just for printout purposes; should always pass if done correctly
+        assert compare_values(0.0, E, 6, f'Singlet {scf_type}({scf_subtype})+{screening}  throws exception') #TEST
+
+    #== otherwise, test if current option combo gives right answer ==#
+    else: 
+        E = psi4.energy('scf')
+  
+        E_ref = 0.0
+        if scf_type in [ "DIRECT", "PK", "OUT_OF_CORE" ]:
+            E_ref = Eref["Singlet"]["Canonical"] 
+        elif scf_type in [ "MEM_DF", "DISK_DF" ]:
+            E_ref = Eref["Singlet"]["DF"]
+        elif scf_type in Eref["Singlet"]["Composite"].keys(): 
+            E_ref = Eref["Singlet"]["Composite"][scf_type]
+        else:
+            raise Exception("Invalid JK method used!") 
+
+        assert compare_values(E_ref, E, 6, f'Singlet {scf_type}({scf_subtype})+{screening}  RHF energy') #TEST

--- a/tests/pytests/test_comprehensive_jk_screening.py
+++ b/tests/pytests/test_comprehensive_jk_screening.py
@@ -47,7 +47,7 @@ def test_comprehensive_jk_screening(scf_type, scf_subtype, screening):
     })
  
     #== skip redundant option combinations based on type/subtype combination ==#   
-    if scf_type not in [ "PK", "DISK_DF", "MEM_DF"] and scf_subtype != "AUTO":
+    if scf_type not in [ "PK", "DISK_DF", "MEM_DF"] and scf_subtype == "AUTO":
         pytest.skip(f'Singlet {scf_type}({scf_subtype})+{screening}  skipped: redundant test') 
     elif scf_type in [ "DISK_DF", "MEM_DF"] and scf_subtype in [ "YOSHIMINE_OUT_OF_CORE", "REORDER_OUT_OF_CORE" ]:
         pytest.skip(f'Singlet {scf_type}({scf_subtype})+{screening}  skipped: redundant test') 

--- a/tests/pytests/test_comprehensive_jk_screening.py
+++ b/tests/pytests/test_comprehensive_jk_screening.py
@@ -47,7 +47,7 @@ def test_comprehensive_jk_screening(scf_type, scf_subtype, screening):
     })
  
     #== skip redundant option combinations based on type/subtype combination ==#   
-    if scf_type not in [ "PK", "DISK_DF", "MEM_DF"] and scf_subtype == "AUTO":
+    if scf_type not in [ "PK", "DISK_DF", "MEM_DF"] and scf_subtype != "AUTO":
         pytest.skip(f'Singlet {scf_type}({scf_subtype})+{screening}  skipped: redundant test') 
     elif scf_type in [ "DISK_DF", "MEM_DF"] and scf_subtype in [ "YOSHIMINE_OUT_OF_CORE", "REORDER_OUT_OF_CORE" ]:
         pytest.skip(f'Singlet {scf_type}({scf_subtype})+{screening}  skipped: redundant test') 

--- a/tests/pytests/test_comprehensive_jk_screening.py
+++ b/tests/pytests/test_comprehensive_jk_screening.py
@@ -83,7 +83,7 @@ def test_comprehensive_jk_screening(scf_type, scf_subtype, screening):
             E = psi4.energy('scf')
 
         # we keep this line just for printout purposes; should always pass if done correctly
-        assert compare_values(0.0, E, 6, f'Singlet {scf_type}({scf_subtype})+{screening}  throws exception')
+        assert compare(type(e_info), pytest.ExceptionInfo, f'Singlet {scf_type}({scf_subtype})+{screening}  throws exception')
 
     #== otherwise, test if current option combo gives right answer ==#
     else: 

--- a/tests/pytests/test_comprehensive_jk_screening.py
+++ b/tests/pytests/test_comprehensive_jk_screening.py
@@ -78,7 +78,7 @@ def test_comprehensive_jk_screening(scf_type, scf_subtype, screening):
         pytest.skip(f'Singlet {scf_type}({scf_subtype})+{screening}  skipped: will error out') 
 
     #== if expected, test if current option combo throws exception ==# 
-    if not should_error_out and should_throw:
+    elif not should_error_out and should_throw:
         with pytest.raises(Exception) as e_info:
             E = psi4.energy('scf')
 

--- a/tests/pytests/test_comprehensive_jk_screening.py
+++ b/tests/pytests/test_comprehensive_jk_screening.py
@@ -14,13 +14,13 @@ def test_comprehensive_jk_screening(scf_type, scf_subtype, screening):
 
     #== define reference energies ==#
     Eref = {  
-        "Nuclear"       :   30.7884922572,     #TEST
+        "Nuclear"       :   30.7884922572,
         "Singlet": {
-            "Canonical" : -149.58723684929720, #TEST
-            "DF"        : -149.58715054487624, #TEST
+            "Canonical" : -149.58723684929720,
+            "DF"        : -149.58715054487624,
             "Composite": {
-              "DFDIRJ+COSX"    : -149.58722317236171, #TEST
-              "DFDIRJ+LINK"    : -149.58726772171027  #TEST
+              "DFDIRJ+COSX"    : -149.58722317236171,
+              "DFDIRJ+LINK"    : -149.58726772171027
             } 
         }
     }
@@ -83,7 +83,7 @@ def test_comprehensive_jk_screening(scf_type, scf_subtype, screening):
             E = psi4.energy('scf')
 
         # we keep this line just for printout purposes; should always pass if done correctly
-        assert compare_values(0.0, E, 6, f'Singlet {scf_type}({scf_subtype})+{screening}  throws exception') #TEST
+        assert compare_values(0.0, E, 6, f'Singlet {scf_type}({scf_subtype})+{screening}  throws exception')
 
     #== otherwise, test if current option combo gives right answer ==#
     else: 
@@ -99,4 +99,4 @@ def test_comprehensive_jk_screening(scf_type, scf_subtype, screening):
         else:
             raise Exception("Invalid JK method used!") 
 
-        assert compare_values(E_ref, E, 6, f'Singlet {scf_type}({scf_subtype})+{screening}  RHF energy') #TEST
+        assert compare_values(E_ref, E, 6, f'Singlet {scf_type}({scf_subtype})+{screening}  RHF energy')

--- a/tests/pytests/test_comprehensive_jk_screening.py
+++ b/tests/pytests/test_comprehensive_jk_screening.py
@@ -49,6 +49,8 @@ def test_comprehensive_jk_screening(scf_type, scf_subtype, screening):
     #== skip redundant option combinations based on type/subtype combination ==#   
     if scf_type not in [ "PK", "DISK_DF", "MEM_DF"] and scf_subtype != "AUTO":
         pytest.skip(f'Singlet {scf_type}({scf_subtype})+{screening}  skipped: redundant test') 
+    elif scf_type in [ "PK", "DISK_DF", "MEM_DF"] and scf_subtype == "AUTO":
+        pytest.skip(f'Singlet {scf_type}({scf_subtype})+{screening}  skipped: redundant test') 
     elif scf_type in [ "DISK_DF", "MEM_DF"] and scf_subtype in [ "YOSHIMINE_OUT_OF_CORE", "REORDER_OUT_OF_CORE" ]:
         pytest.skip(f'Singlet {scf_type}({scf_subtype})+{screening}  skipped: redundant test') 
 

--- a/tests/pytests/test_comprehensive_jk_screening.py
+++ b/tests/pytests/test_comprehensive_jk_screening.py
@@ -1,0 +1,121 @@
+import pytest
+import psi4
+import itertools
+from utils import compare, compare_integers, compare_values
+
+pytestmark = [pytest.mark.psi, pytest.mark.api] 
+
+def test_comprehensive_jk_screening():
+    """Checks the energy values computed by different JK methods using different
+    screening types. The differences in energies should be insignificant.""" 
+
+    #== define reference energies ==#
+    Eref = {  
+        "Nuclear"       :   30.7884922572,     #TEST
+        "Singlet": {
+            "Canonical" : -149.58723684929720, #TEST
+            "DF"        : -149.58715054487624, #TEST
+            "Composite": {
+              "DFDIRJ+COSX"    : -149.58722317236171, #TEST
+              "DFDIRJ+LINK"    : -149.58726772171027  #TEST
+            } 
+        }
+    }
+    
+    #== define molecule ==#
+    singlet_o2 = """ 
+        0 1
+        O
+        O 1 1.1
+        units    angstrom
+    """
+    
+    psi4.geometry(singlet_o2)
+    
+    #=== define core options ==#
+    psi4.set_options({
+        "df_scf_guess": False,
+        "basis": "cc-pvtz",
+        "df_basis_scf": "cc-pvtz-jkfit",
+        "print": 2,
+    })
+    
+    #== define various scf params to combine test ==#
+    scf_params = {
+        "SCF_TYPE": [ "PK", "DIRECT", "OUT_OF_CORE", "DISK_DF", "MEM_DF", "DFDIRJ+LINK", "DFDIRJ+COSX" ],
+        
+        "SCF_SUBTYPE": [ "AUTO", "INCORE", "OUT_OF_CORE", "YOSHIMINE_OUT_OF_CORE", "REORDER_OUT_OF_CORE" ],
+        
+        "SCREENING": [ "SCHWARZ", "DENSITY", "CSAM", "NONE" ],
+    }
+   
+    #== create scf test combos from above params ==# 
+    keyword_option_pairs = []
+    for keyword, options in scf_params.items():
+        keyword_option_pairs.append([ (keyword, x) for x in options ])
+    
+    keyword_option_combos = itertools.product(*keyword_option_pairs)
+
+    #== loop over and test scf combinations ==#
+    for keyword_option_combo in keyword_option_combos:
+        for keyword_option_pair in keyword_option_combo:
+            psi4.set_options({keyword_option_pair[0]: keyword_option_pair[1]})
+ 
+        scf_type = psi4.core.get_global_option("SCF_TYPE")
+        scf_subtype = psi4.core.get_global_option("SCF_SUBTYPE")
+        screening = psi4.core.get_global_option("SCREENING")
+    
+        #== skip redundant option combinations based on type/subtype combination ==#   
+        if scf_type not in [ "PK", "DISK_DF", "MEM_DF"] and scf_subtype != "AUTO":
+            continue
+        elif scf_type in [ "DISK_DF", "MEM_DF"] and scf_subtype in [ "YOSHIMINE_OUT_OF_CORE", "REORDER_OUT_OF_CORE" ]:
+            continue
+
+        #== certain combinations of SCF_TYPE and SCREENING should throw an exception by design ==#
+        should_throw = False
+        #== specifically, non-integral-direct methods and DFDirJ+COSX with SCREENING = DENSITY ==# 
+        should_throw = should_throw or (scf_type not in [ "DIRECT", "DFDIRJ+LINK" ] and screening == "DENSITY")
+
+        #== other combinations error out badly and need to be fixed; skip them here ==#
+        should_error_out = False
+        #== this includes Composite methods with SCREENING=NONE... ==#
+        should_error_out = should_error_out or (scf_type in Eref["Singlet"]["Composite"].keys() and screening == "NONE")
+        #== .. DFDIRJ+LINK with SCREENING=SCHWARZ or CSAM... ==#
+        should_error_out = should_error_out or (scf_type == "DFDIRJ+LINK" and screening in [ "SCHWARZ", "CSAM" ])
+        #== .. and DISK_DF, DIRECT, or Yoshimine PK with SCREENING=NONE ==# 
+        should_error_out = should_error_out or (scf_type == "PK" and scf_subtype == "YOSHIMINE_OUT_OF_CORE" and screening == "NONE")
+        should_error_out = should_error_out or (scf_type == "DISK_DF" and screening == "NONE")
+        should_error_out = should_error_out or (scf_type == "DIRECT" and screening == "NONE")
+      
+        E = 0.0 
+        
+        #== check that should_error_out and should_throw are not simultaneously true, for better testing ==# 
+        if should_error_out and should_throw:
+            raise Exception(f'Duplicate checks on {scf_type}({scf_subtype})+{screening}!')
+        #== skip if current option combo is expected to break ==#
+        elif should_error_out and not should_throw:
+            continue
+ 
+        #== if expected, test if current option combo throws exception ==# 
+        if not should_error_out and should_throw:
+            with pytest.raises(Exception) as e_info:
+                E = psi4.energy('scf')
+
+            # we keep this line just for printout purposes; should always pass if done correctly
+            assert compare_values(0.0, E, 6, f'Singlet {scf_type}({scf_subtype})+{screening}  throws exception') #TEST
+
+        #== otherwise, test if current option combo gives right answer ==#
+        else: 
+            E = psi4.energy('scf')
+      
+            E_ref = 0.0
+            if scf_type in [ "DIRECT", "PK", "OUT_OF_CORE" ]:
+                E_ref = Eref["Singlet"]["Canonical"] 
+            elif scf_type in [ "MEM_DF", "DISK_DF" ]:
+                E_ref = Eref["Singlet"]["DF"]
+            elif scf_type in Eref["Singlet"]["Composite"].keys(): 
+                E_ref = Eref["Singlet"]["Composite"][scf_type]
+            else:
+                raise Exception("Invalid JK method used!") 
+
+            assert compare_values(E_ref, E, 6, f'Singlet {scf_type}({scf_subtype})+{screening}  RHF energy') #TEST

--- a/tests/pytests/test_comprehensive_jk_screening.py
+++ b/tests/pytests/test_comprehensive_jk_screening.py
@@ -73,9 +73,9 @@ def test_comprehensive_jk_screening(scf_type, scf_subtype, screening):
     #== check that should_error_out and should_throw are not simultaneously true, for better testing ==# 
     if should_error_out and should_throw:
         raise Exception(f'Duplicate checks on {scf_type}({scf_subtype})+{screening}!')
-    #== skip if current option combo is expected to break ==#
+    #== xfail if current option combo is expected to break ==#
     elif should_error_out and not should_throw:
-        pytest.skip(f'Singlet {scf_type}({scf_subtype})+{screening}  skipped: will error out') 
+        pytest.xfail(f'Singlet {scf_type}({scf_subtype})+{screening}  xfailed: will error out')
 
     #== if expected, test if current option combo throws exception ==# 
     elif not should_error_out and should_throw:


### PR DESCRIPTION
## Description
This PR is designed to enable testing of a wide variety of combinations of `SCF_TYPE`, `SCF_SUBTYPE`, and `SCREENING` keywords available in Psi4. Of the currently-available JK tests, scf5 covers a wide variety of build methods, but only at a single screening type per method (density or csam, depending on the method). Meanwhile, `test_erisieve.py`, after the updates introduced in https://github.com/psi4/psi4/pull/2973, tests a wide variety of screening types, but with limited testing in conjunction with different JK builds (the only tests that don't use the Python interface of `TwoBodyAOInt` directly, use `SCF_TYPE=DIRECT` or `DF` as the JK method for screening comparisons). This leaves a lot of untested JK build+screening combos, which may be potentially broken and uncaught by the CI as a result. As a matter of fact, such cases actually do exist in the code currently (e.g., CompositeJK methods + no screening).

This PR adds a new pytest module, `test_comprehensive_jk_screening.py`. It is effectively an expanded version of the scf5 test module, testing one of the scf5 systems (singlet oxygen) with the same basis set, but also including different screening methods and algorithmic subtypes available in Psi4. Screening is assumed to have an insignificant impact on energy within the tolerance used, so all screening types for a given method use the same reference energy. Some combinations of method and screening type throw an exception by design; this is accounted for in the test by testing that such combinations do indeed throw an exception as expected. Other combinations of method and algorithm are broken at the moment and error out; these are simply skipped for now. They are all logged in the same spot, and can and will be addressed in future PRs.

## User API & Changelog headlines
- [X] N/A

## Dev notes & details
- [X] Adds a new pytest module to Psi4, `test_comprehensive_jk_screening.py` , to test different combinations of JK build algorithms and ERI screening methods.

## Questions
- [x] Would the test in `test_comprehensive_jk_screening.py` be better placed in `test_erisieve.py`? I placed the test in the former because I considered it large enough to warrant not having the quick pytest mark, but I'm ambivalent about where the test goes between those two test modules.

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge