### PR TITLE
Fix #2875: remove cached `nmo_` var

### DIFF
--- a/psi4/src/psi4/cc/ccenergy/form_df_ints.cc
+++ b/psi4/src/psi4/cc/ccenergy/form_df_ints.cc
@@ -55,7 +55,7 @@ void CCEnergyWavefunction::form_df_ints(Options &options, int **cachelist, int *
      */
     std::shared_ptr<BasisSet> dfBasis = get_basisset("DF_BASIS_CC");
     int nocc = doccpi().sum();
-    int nvir = nmo_ - nocc;
+    int nvir = Wavefunction::nmo() - nocc;
     int nbf = basisset_->nbf();
     int nbf2 = nbf * nbf;
     SharedMatrix Ca = Ca_subset("AO");

--- a/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
@@ -65,7 +65,7 @@ void CCEnergyWavefunction::get_moinfo() {
     psio_address next;
 
     moinfo_.nirreps = nirrep_;
-    moinfo_.nmo = nmo_;
+    moinfo_.nmo = Wavefunction::nmo();
     moinfo_.nso = nso_;
     moinfo_.nao = basisset_->nao();
     moinfo_.labels = molecule_->irrep_labels();

--- a/psi4/src/psi4/dct/dct_gradient_RHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_RHF.cc
@@ -368,18 +368,18 @@ void DCTSolver::compute_ewdm_odc_RHF() {
     auto a_opdm = Matrix("MO basis OPDM (Alpha)", nirrep_, nmopi_, nmopi_);
 
     const int *alpha_corr_to_pitzer = _ints->alpha_corr_to_pitzer();
-    auto *alpha_pitzer_to_corr = new int[nmo_];
-    ::memset(alpha_pitzer_to_corr, '\0', nmo_ * sizeof(int));
+    auto *alpha_pitzer_to_corr = new int[Wavefunction::nmo()];
+    ::memset(alpha_pitzer_to_corr, '\0', Wavefunction::nmo() * sizeof(int));
 
-    for (int n = 0; n < nmo_; ++n) {
+    for (int n = 0; n < Wavefunction::nmo(); ++n) {
         alpha_pitzer_to_corr[alpha_corr_to_pitzer[n]] = n;
     }
 
     const int *beta_corr_to_pitzer = _ints->beta_corr_to_pitzer();
-    auto *beta_pitzer_to_corr = new int[nmo_];
-    ::memset(beta_pitzer_to_corr, '\0', nmo_ * sizeof(int));
+    auto *beta_pitzer_to_corr = new int[Wavefunction::nmo()];
+    ::memset(beta_pitzer_to_corr, '\0', Wavefunction::nmo() * sizeof(int));
 
-    for (int n = 0; n < nmo_; ++n) {
+    for (int n = 0; n < Wavefunction::nmo(); ++n) {
         beta_pitzer_to_corr[beta_corr_to_pitzer[n]] = n;
     }
 

--- a/psi4/src/psi4/dct/dct_gradient_UHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_UHF.cc
@@ -3554,18 +3554,18 @@ void DCTSolver::compute_ewdm_dc() {
     Matrix bW("Energy-weighted density matrix (Beta)", nirrep_, nmopi_, nmopi_);
 
     const int *alpha_corr_to_pitzer = _ints->alpha_corr_to_pitzer();
-    auto *alpha_pitzer_to_corr = new int[nmo_];
-    ::memset(alpha_pitzer_to_corr, '\0', nmo_ * sizeof(int));
+    auto *alpha_pitzer_to_corr = new int[Wavefunction::nmo()];
+    ::memset(alpha_pitzer_to_corr, '\0', Wavefunction::nmo() * sizeof(int));
 
-    for (int n = 0; n < nmo_; ++n) {
+    for (int n = 0; n < Wavefunction::nmo(); ++n) {
         alpha_pitzer_to_corr[alpha_corr_to_pitzer[n]] = n;
     }
 
     const int *beta_corr_to_pitzer = _ints->beta_corr_to_pitzer();
-    auto *beta_pitzer_to_corr = new int[nmo_];
-    ::memset(beta_pitzer_to_corr, '\0', nmo_ * sizeof(int));
+    auto *beta_pitzer_to_corr = new int[Wavefunction::nmo()];
+    ::memset(beta_pitzer_to_corr, '\0', Wavefunction::nmo() * sizeof(int));
 
-    for (int n = 0; n < nmo_; ++n) {
+    for (int n = 0; n < Wavefunction::nmo(); ++n) {
         beta_pitzer_to_corr[beta_corr_to_pitzer[n]] = n;
     }
 
@@ -4437,18 +4437,18 @@ void DCTSolver::compute_ewdm_odc() {
     auto b_opdm = std::make_shared<Matrix>("MO basis OPDM (Beta)", nirrep_, nmopi_, nmopi_);
 
     const int *alpha_corr_to_pitzer = _ints->alpha_corr_to_pitzer();
-    auto *alpha_pitzer_to_corr = new int[nmo_];
-    ::memset(alpha_pitzer_to_corr, '\0', nmo_ * sizeof(int));
+    auto *alpha_pitzer_to_corr = new int[Wavefunction::nmo()];
+    ::memset(alpha_pitzer_to_corr, '\0', Wavefunction::nmo() * sizeof(int));
 
-    for (int n = 0; n < nmo_; ++n) {
+    for (int n = 0; n < Wavefunction::nmo(); ++n) {
         alpha_pitzer_to_corr[alpha_corr_to_pitzer[n]] = n;
     }
 
     const int *beta_corr_to_pitzer = _ints->beta_corr_to_pitzer();
-    auto *beta_pitzer_to_corr = new int[nmo_];
-    ::memset(beta_pitzer_to_corr, '\0', nmo_ * sizeof(int));
+    auto *beta_pitzer_to_corr = new int[Wavefunction::nmo()];
+    ::memset(beta_pitzer_to_corr, '\0', Wavefunction::nmo() * sizeof(int));
 
-    for (int n = 0; n < nmo_; ++n) {
+    for (int n = 0; n < Wavefunction::nmo(); ++n) {
         beta_pitzer_to_corr[beta_corr_to_pitzer[n]] = n;
     }
 

--- a/psi4/src/psi4/dct/dct_memory.cc
+++ b/psi4/src/psi4/dct/dct_memory.cc
@@ -49,7 +49,6 @@ namespace dct {
 void DCTSolver::init() {
     nso_ = reference_wavefunction_->nso();
     nirrep_ = reference_wavefunction_->nirrep();
-    nmo_ = reference_wavefunction_->nmo();
     enuc_ = reference_wavefunction_->molecule()->nuclear_repulsion_energy(
         reference_wavefunction_->get_dipole_field_strength());
     scf_energy_ = reference_wavefunction_->energy();
@@ -68,14 +67,12 @@ void DCTSolver::init() {
     nbvir_ = nbvirpi_.sum();
 
     auto zero = Dimension(nirrep_);
-    slices_ = {
-        {"SO",  Slice(zero, nsopi_)},
-        {"MO",  Slice(zero, nmopi_)},
-        {"ACTIVE_OCC_A",  Slice(frzcpi_, nalphapi_)},
-        {"ACTIVE_OCC_B",  Slice(frzcpi_, nbetapi_)},
-        {"ACTIVE_VIR_A",  Slice(nalphapi_, nalphapi_ + navirpi_)},
-        {"ACTIVE_VIR_B",  Slice(nbetapi_, nbetapi_ + nbvirpi_)}
-    };
+    slices_ = {{"SO", Slice(zero, nsopi_)},
+               {"MO", Slice(zero, nmopi_)},
+               {"ACTIVE_OCC_A", Slice(frzcpi_, nalphapi_)},
+               {"ACTIVE_OCC_B", Slice(frzcpi_, nbetapi_)},
+               {"ACTIVE_VIR_A", Slice(nalphapi_, nalphapi_ + navirpi_)},
+               {"ACTIVE_VIR_B", Slice(nbetapi_, nbetapi_ + nbvirpi_)}};
 
     aocc_c_ = std::make_shared<Matrix>("Alpha Occupied MO Coefficients", nirrep_, nsopi_, naoccpi_);
     bocc_c_ = std::make_shared<Matrix>("Beta Occupied MO Coefficients", nirrep_, nsopi_, nboccpi_);

--- a/psi4/src/psi4/dct/dct_tau_RHF.cc
+++ b/psi4/src/psi4/dct/dct_tau_RHF.cc
@@ -282,10 +282,10 @@ void DCTSolver::print_opdm_RHF() {
         if (count % 4 == 3 && i != nalpha_) outfile->Printf("\n\t\t");
     }
     outfile->Printf("\n\n\t\tVirtual orbitals\n\t\t");
-    for (int i = nalpha_, count = 0; i < nmo_; ++i, ++count) {
+    for (int i = nalpha_, count = 0; i < Wavefunction::nmo(); ++i, ++count) {
         int irrep = aPairs[i].second;
         outfile->Printf("%4d%-4s%11.4f  ", ++aIrrepCount[irrep], irrepLabels[irrep].c_str(), 2 * aPairs[i].first);
-        if (count % 4 == 3 && i != nmo_) outfile->Printf("\n\t\t");
+        if (count % 4 == 3 && i != Wavefunction::nmo()) outfile->Printf("\n\t\t");
     }
     outfile->Printf("\n\n");
 }

--- a/psi4/src/psi4/dct/dct_tau_UHF.cc
+++ b/psi4/src/psi4/dct/dct_tau_UHF.cc
@@ -679,16 +679,16 @@ void DCTSolver::print_opdm() {
         if (count % 4 == 3 && i != nbeta_) outfile->Printf("\n\t\t");
     }
     outfile->Printf("\n\n\t\tAlpha virtual orbitals\n\t\t");
-    for (int i = nalpha_, count = 0; i < nmo_; ++i, ++count) {
+    for (int i = nalpha_, count = 0; i < Wavefunction::nmo(); ++i, ++count) {
         int irrep = aPairs[i].second;
         outfile->Printf("%4d%-4s%11.4f  ", ++aIrrepCount[irrep], irrepLabels[irrep].c_str(), aPairs[i].first);
-        if (count % 4 == 3 && i != nmo_) outfile->Printf("\n\t\t");
+        if (count % 4 == 3 && i != Wavefunction::nmo()) outfile->Printf("\n\t\t");
     }
     outfile->Printf("\n\n\t\tBeta virtual orbitals\n\t\t");
-    for (int i = nbeta_, count = 0; i < nmo_; ++i, ++count) {
+    for (int i = nbeta_, count = 0; i < Wavefunction::nmo(); ++i, ++count) {
         int irrep = bPairs[i].second;
         outfile->Printf("%4d%-4s%11.4f  ", ++bIrrepCount[irrep], irrepLabels[irrep].c_str(), bPairs[i].first);
-        if (count % 4 == 3 && i != nmo_) outfile->Printf("\n\t\t");
+        if (count % 4 == 3 && i != Wavefunction::nmo()) outfile->Printf("\n\t\t");
     }
     outfile->Printf("\n\n");
 }

--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -423,7 +423,7 @@ void CIWavefunction::transform_mcscf_ints_ao(bool approx_only) {
     }
 
     int nact = CalcInfo_->num_ci_orbs;
-    int nrot = nmo_ - CalcInfo_->num_fzc_orbs - CalcInfo_->num_fzv_orbs;
+    int nrot = Wavefunction::nmo() - CalcInfo_->num_fzc_orbs - CalcInfo_->num_fzv_orbs;
 
     // Transform from the SO to the AO basis for the C matrix.
     // just transfroms the C_{mu_ao i} -> C_{mu_so i}

--- a/psi4/src/psi4/dfocc/dfgrad.cc
+++ b/psi4/src/psi4/dfocc/dfgrad.cc
@@ -48,7 +48,7 @@ void DFOCC::dfgrad() {
     tstart();
     tpdm_tilde();
     back_trans();
-    auto W = std::make_shared<Matrix>("AO-basis Energy-Weighted OPDM", nmo_, nmo_);
+    auto W = std::make_shared<Matrix>("AO-basis Energy-Weighted OPDM", Wavefunction::nmo(), Wavefunction::nmo());
     GFao->to_shared_matrix(W);
     Lagrangian_ = W;
 }  // end dfgrad

--- a/psi4/src/psi4/dfocc/dfocc.cc
+++ b/psi4/src/psi4/dfocc/dfocc.cc
@@ -547,7 +547,7 @@ void DFOCC::common_malloc() {
 
     if (reference_ == "RESTRICTED") {
         // Memory allocation
-        HmoA = std::make_shared<Tensor2d>("MO-basis alpha one-electron ints", nmo_, nmo_);
+        HmoA = std::make_shared<Tensor2d>("MO-basis alpha one-electron ints", Wavefunction::nmo(), Wavefunction::nmo());
         FijA = std::make_shared<Tensor2d>("Fint <I|J>", naoccA, naoccA);
         FabA = std::make_shared<Tensor2d>("Fint <A|B>", navirA, navirA);
         HooA = std::make_shared<Tensor2d>("OEI <O|O>", noccA, noccA);
@@ -564,20 +564,20 @@ void DFOCC::common_malloc() {
             GabA = std::make_shared<Tensor2d>("G Intermediate <A|B>", navirA, navirA);
             G1c_oo = std::make_shared<Tensor2d>("Correlation OPDM <O|O>", noccA, noccA);
             G1c_vv = std::make_shared<Tensor2d>("Correlation OPDM <V|V>", nvirA, nvirA);
-            G1 = std::make_shared<Tensor2d>("MO-basis OPDM", nmo_, nmo_);
+            G1 = std::make_shared<Tensor2d>("MO-basis OPDM", Wavefunction::nmo(), Wavefunction::nmo());
             G1ao = std::make_shared<Tensor2d>("AO-basis OPDM", nso_, nso_);
-            G1c = std::make_shared<Tensor2d>("MO-basis correlation OPDM", nmo_, nmo_);
-            GF = std::make_shared<Tensor2d>("MO-basis GFM", nmo_, nmo_);
+            G1c = std::make_shared<Tensor2d>("MO-basis correlation OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            GF = std::make_shared<Tensor2d>("MO-basis GFM", Wavefunction::nmo(), Wavefunction::nmo());
             GFao = std::make_shared<Tensor2d>("AO-basis GFM", nso_, nso_);
             GFoo = std::make_shared<Tensor2d>("MO-basis GFM <O|O>", noccA, noccA);
             GFvo = std::make_shared<Tensor2d>("MO-basis GFM <V|O>", nvirA, noccA);
             GFov = std::make_shared<Tensor2d>("MO-basis GFM <O|V>", noccA, nvirA);
             GFvv = std::make_shared<Tensor2d>("MO-basis GFM <V|V>", nvirA, nvirA);
             GFtvv = std::make_shared<Tensor2d>("MO-basis Complementary GFM <V|V>", nvirA, nvirA);
-            WorbA = std::make_shared<Tensor2d>("MO-basis alpha MO gradient", nmo_, nmo_);
-            UorbA = std::make_shared<Tensor2d>("Alpha MO rotation matrix", nmo_, nmo_);
-            KorbA = std::make_shared<Tensor2d>("Alpha K MO rotation parameters matrix", nmo_, nmo_);
-            KsqrA = std::make_shared<Tensor2d>("Alpha K^2 MO rotation parameters matrix", nmo_, nmo_);
+            WorbA = std::make_shared<Tensor2d>("MO-basis alpha MO gradient", Wavefunction::nmo(), Wavefunction::nmo());
+            UorbA = std::make_shared<Tensor2d>("Alpha MO rotation matrix", Wavefunction::nmo(), Wavefunction::nmo());
+            KorbA = std::make_shared<Tensor2d>("Alpha K MO rotation parameters matrix", Wavefunction::nmo(), Wavefunction::nmo());
+            KsqrA = std::make_shared<Tensor2d>("Alpha K^2 MO rotation parameters matrix", Wavefunction::nmo(), Wavefunction::nmo());
             AvoA = std::make_shared<Tensor2d>("Diagonal MO Hessian <V|O>", nvirA, noccA);
             if (orb_opt_ == "FALSE") {
                 WvoA = std::make_shared<Tensor2d>("Effective MO gradient <V|O>", nvirA, noccA);
@@ -588,8 +588,8 @@ void DFOCC::common_malloc() {
 
     else if (reference_ == "UNRESTRICTED") {
         // Memory allocation
-        HmoA = std::make_shared<Tensor2d>("MO-basis alpha one-electron ints", nmo_, nmo_);
-        HmoB = std::make_shared<Tensor2d>("MO-basis beta one-electron ints", nmo_, nmo_);
+        HmoA = std::make_shared<Tensor2d>("MO-basis alpha one-electron ints", Wavefunction::nmo(), Wavefunction::nmo());
+        HmoB = std::make_shared<Tensor2d>("MO-basis beta one-electron ints", Wavefunction::nmo(), Wavefunction::nmo());
         FijA = std::make_shared<Tensor2d>("Fint <I|J>", naoccA, naoccA);
         FijB = std::make_shared<Tensor2d>("Fint <i|j>", naoccB, naoccB);
         FabA = std::make_shared<Tensor2d>("Fint <A|B>", navirA, navirA);
@@ -617,13 +617,13 @@ void DFOCC::common_malloc() {
             G1c_ooB = std::make_shared<Tensor2d>("Correlation OPDM <o|o>", noccB, noccB);
             G1c_vvA = std::make_shared<Tensor2d>("Correlation OPDM <V|V>", nvirA, nvirA);
             G1c_vvB = std::make_shared<Tensor2d>("Correlation OPDM <v|v>", nvirB, nvirB);
-            G1cA = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", nmo_, nmo_);
-            G1cB = std::make_shared<Tensor2d>("MO-basis beta correlation OPDM", nmo_, nmo_);
-            G1A = std::make_shared<Tensor2d>("MO-basis alpha OPDM", nmo_, nmo_);
-            G1B = std::make_shared<Tensor2d>("MO-basis beta OPDM", nmo_, nmo_);
+            G1cA = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1cB = std::make_shared<Tensor2d>("MO-basis beta correlation OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1A = std::make_shared<Tensor2d>("MO-basis alpha OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1B = std::make_shared<Tensor2d>("MO-basis beta OPDM", Wavefunction::nmo(), Wavefunction::nmo());
             G1ao = std::make_shared<Tensor2d>("AO-basis OPDM", nso_, nso_);
-            GFA = std::make_shared<Tensor2d>("MO-basis alpha GFM", nmo_, nmo_);
-            GFB = std::make_shared<Tensor2d>("MO-basis beta GFM", nmo_, nmo_);
+            GFA = std::make_shared<Tensor2d>("MO-basis alpha GFM", Wavefunction::nmo(), Wavefunction::nmo());
+            GFB = std::make_shared<Tensor2d>("MO-basis beta GFM", Wavefunction::nmo(), Wavefunction::nmo());
             GFao = std::make_shared<Tensor2d>("AO-basis GFM", nso_, nso_);
             GFooA = std::make_shared<Tensor2d>("MO-basis GFM <O|O>", noccA, noccA);
             GFooB = std::make_shared<Tensor2d>("MO-basis GFM <o|o>", noccB, noccB);
@@ -635,14 +635,14 @@ void DFOCC::common_malloc() {
             GFvvB = std::make_shared<Tensor2d>("MO-basis GFM <v|v>", nvirB, nvirB);
             GFtvvA = std::make_shared<Tensor2d>("MO-basis Complementary GFM <V|V>", nvirA, nvirA);
             GFtvvB = std::make_shared<Tensor2d>("MO-basis Complementary GFM <v|v>", nvirB, nvirB);
-            WorbA = std::make_shared<Tensor2d>("MO-basis alpha MO gradient", nmo_, nmo_);
-            WorbB = std::make_shared<Tensor2d>("MO-basis beta MO gradient", nmo_, nmo_);
-            UorbA = std::make_shared<Tensor2d>("Alpha MO rotation matrix", nmo_, nmo_);
-            UorbB = std::make_shared<Tensor2d>("Beta MO rotation matrix", nmo_, nmo_);
-            KorbA = std::make_shared<Tensor2d>("Alpha K MO rotation parameters matrix", nmo_, nmo_);
-            KorbB = std::make_shared<Tensor2d>("Beta K MO rotation parameters matrix", nmo_, nmo_);
-            KsqrA = std::make_shared<Tensor2d>("Alpha K^2 MO rotation parameters matrix", nmo_, nmo_);
-            KsqrB = std::make_shared<Tensor2d>("Beta K^2 MO rotation parameters matrix", nmo_, nmo_);
+            WorbA = std::make_shared<Tensor2d>("MO-basis alpha MO gradient", Wavefunction::nmo(), Wavefunction::nmo());
+            WorbB = std::make_shared<Tensor2d>("MO-basis beta MO gradient", Wavefunction::nmo(), Wavefunction::nmo());
+            UorbA = std::make_shared<Tensor2d>("Alpha MO rotation matrix", Wavefunction::nmo(), Wavefunction::nmo());
+            UorbB = std::make_shared<Tensor2d>("Beta MO rotation matrix", Wavefunction::nmo(), Wavefunction::nmo());
+            KorbA = std::make_shared<Tensor2d>("Alpha K MO rotation parameters matrix", Wavefunction::nmo(), Wavefunction::nmo());
+            KorbB = std::make_shared<Tensor2d>("Beta K MO rotation parameters matrix", Wavefunction::nmo(), Wavefunction::nmo());
+            KsqrA = std::make_shared<Tensor2d>("Alpha K^2 MO rotation parameters matrix", Wavefunction::nmo(), Wavefunction::nmo());
+            KsqrB = std::make_shared<Tensor2d>("Beta K^2 MO rotation parameters matrix", Wavefunction::nmo(), Wavefunction::nmo());
             AvoA = std::make_shared<Tensor2d>("Diagonal MO Hessian <V|O>", nvirA, noccA);
             AvoB = std::make_shared<Tensor2d>("Diagonal MO Hessian <v|o>", nvirB, noccB);
             if (orb_opt_ == "FALSE") {

--- a/psi4/src/psi4/dfocc/get_moinfo.cc
+++ b/psi4/src/psi4/dfocc/get_moinfo.cc
@@ -55,7 +55,6 @@ void DFOCC::get_moinfo() {
         // Read in mo info
         nso_ = reference_wavefunction_->nso();
         nirrep_ = reference_wavefunction_->nirrep();
-        nmo_ = reference_wavefunction_->nmo();
         nmopi_ = reference_wavefunction_->nmopi();
         nsopi_ = reference_wavefunction_->nsopi();
         frzcpi_ = reference_wavefunction_->frzcpi();
@@ -77,19 +76,19 @@ void DFOCC::get_moinfo() {
         nfrzc = frzcpi_[0];
         nfrzv = frzvpi_[0];
         noccA = nalphapi_.sum();
-        nvirA = nmo_ - noccA;         // Number of virtual orbitals
-        naoccA = noccA - nfrzc;       // Number of active occupied orbitals
-        navirA = nvirA - nfrzv;       // Number of active virtual orbitals
-        nocc2AA = noccA * noccA;      // Number of all OCC-OCC pairs
-        nvir2AA = nvirA * nvirA;      // Number of all VIR-VIR pairs
-        naocc2AA = naoccA * naoccA;   // Number of active OCC-OCC pairs
-        navir2AA = navirA * navirA;   // Number of active VIR-VIR pairs
-        navoAA = naoccA * navirA;     // Number of active OCC-VIR pairs
-        nvoAA = noccA * nvirA;        // Number of all OCC-VIR pairs
-        namo = nmo_ - nfrzc - nfrzv;  // Number of active  orbitals
-        npop = nmo_ - nfrzv;          // Number of populated orbitals
+        nvirA = Wavefunction::nmo() - noccA;         // Number of virtual orbitals
+        naoccA = noccA - nfrzc;                      // Number of active occupied orbitals
+        navirA = nvirA - nfrzv;                      // Number of active virtual orbitals
+        nocc2AA = noccA * noccA;                     // Number of all OCC-OCC pairs
+        nvir2AA = nvirA * nvirA;                     // Number of all VIR-VIR pairs
+        naocc2AA = naoccA * naoccA;                  // Number of active OCC-OCC pairs
+        navir2AA = navirA * navirA;                  // Number of active VIR-VIR pairs
+        navoAA = naoccA * navirA;                    // Number of active OCC-VIR pairs
+        nvoAA = noccA * nvirA;                       // Number of all OCC-VIR pairs
+        namo = Wavefunction::nmo() - nfrzc - nfrzv;  // Number of active  orbitals
+        npop = Wavefunction::nmo() - nfrzv;          // Number of populated orbitals
         ntri_so = 0.5 * nso_ * (nso_ + 1);
-        ntri = 0.5 * nmo_ * (nmo_ + 1);
+        ntri = 0.5 * Wavefunction::nmo() * (Wavefunction::nmo() + 1);
         dimtei = 0.5 * ntri * (ntri + 1);
         nso2_ = nso_ * nso_;
         ntri_ijAA = 0.5 * naoccA * (naoccA + 1);
@@ -100,11 +99,11 @@ void DFOCC::get_moinfo() {
         /********************************************************************************************/
         // Read orbital energies
         epsilon_a_ = reference_wavefunction_->epsilon_a();
-        eps_orbA = std::make_shared<Tensor1d>("epsilon <P|Q>", nmo_);
-        for (int p = 0; p < nmo_; ++p) eps_orbA->set(p, epsilon_a_->get(0, p));
+        eps_orbA = std::make_shared<Tensor1d>("epsilon <P|Q>", Wavefunction::nmo());
+        for (int p = 0; p < Wavefunction::nmo(); ++p) eps_orbA->set(p, epsilon_a_->get(0, p));
 
         // Build Initial fock matrix
-        FockA = std::make_shared<Tensor2d>("MO-basis alpha Fock matrix", nmo_, nmo_);
+        FockA = std::make_shared<Tensor2d>("MO-basis alpha Fock matrix", Wavefunction::nmo(), Wavefunction::nmo());
         for (int i = 0; i < noccA; ++i) FockA->set(i, i, epsilon_a_->get(0, i));
         for (int a = 0; a < nvirA; ++a) FockA->set(a + noccA, a + noccA, epsilon_a_->get(0, a + noccA));
         if (print_ > 2) FockA->print();
@@ -135,10 +134,10 @@ void DFOCC::get_moinfo() {
 
         // Read orbital coefficients from reference_wavefunction
         Ca_ = reference_wavefunction_->Ca()->clone();
-        CmoA = std::make_shared<Tensor2d>("Alpha MO Coefficients", nso_, nmo_);
+        CmoA = std::make_shared<Tensor2d>("Alpha MO Coefficients", nso_, Wavefunction::nmo());
         CmoA->set(Ca_);
         if (orb_opt_ == "TRUE" || qchf_ == "TRUE") {
-            Cmo_refA = std::make_shared<Tensor2d>("Alpha Reference MO Coefficients", nso_, nmo_);
+            Cmo_refA = std::make_shared<Tensor2d>("Alpha Reference MO Coefficients", nso_, Wavefunction::nmo());
             Cmo_refA->copy(CmoA);
         }
         if (print_ > 2) CmoA->print();
@@ -159,7 +158,6 @@ void DFOCC::get_moinfo() {
         // Read in mo info
         nso_ = reference_wavefunction_->nso();
         nirrep_ = reference_wavefunction_->nirrep();
-        nmo_ = reference_wavefunction_->nmo();
         nmopi_ = reference_wavefunction_->nmopi();
         nsopi_ = reference_wavefunction_->nsopi();
         frzcpi_ = reference_wavefunction_->frzcpi();
@@ -182,36 +180,36 @@ void DFOCC::get_moinfo() {
         nfrzv = frzvpi_[0];
         noccA = nalphapi_.sum();
         noccB = nbetapi_.sum();
-        nvirA = nmo_ - noccA;         // Number of virtual orbitals
-        nvirB = nmo_ - noccB;         // Number of virtual orbitals
-        naoccA = noccA - nfrzc;       // Number of active occupied orbitals
-        naoccB = noccB - nfrzc;       // Number of active occupied orbitals
-        navirA = nvirA - nfrzv;       // Number of active virtual orbitals
-        navirB = nvirB - nfrzv;       // Number of active virtual orbitals
-        nocc2AA = noccA * noccA;      // Number of all OCC-OCC pairs
-        nocc2AB = noccA * noccB;      // Number of all OCC-OCC pairs
-        nocc2BB = noccB * noccB;      // Number of all OCC-OCC pairs
-        nvir2AA = nvirA * nvirA;      // Number of all VIR-VIR pairs
-        nvir2AB = nvirA * nvirB;      // Number of all VIR-VIR pairs
-        nvir2BB = nvirB * nvirB;      // Number of all VIR-VIR pairs
-        naocc2AA = naoccA * naoccA;   // Number of active OCC-OCC pairs
-        naocc2AB = naoccA * naoccB;   // Number of active OCC-OCC pairs
-        naocc2BB = naoccB * naoccB;   // Number of active OCC-OCC pairs
-        navir2AA = navirA * navirA;   // Number of active VIR-VIR pairs
-        navir2AB = navirA * navirB;   // Number of active VIR-VIR pairs
-        navir2BB = navirB * navirB;   // Number of active VIR-VIR pairs
-        navoAA = naoccA * navirA;     // Number of active OCC-VIR pairs
-        navoBA = naoccA * navirB;     // Number of active OCC-VIR pairs
-        navoAB = naoccB * navirA;     // Number of active OCC-VIR pairs
-        navoBB = naoccB * navirB;     // Number of active OCC-VIR pairs
-        nvoAA = noccA * nvirA;        // Number of all OCC-VIR pairs
-        nvoBA = noccA * nvirB;        // Number of all OCC-VIR pairs
-        nvoAB = noccB * nvirA;        // Number of all OCC-VIR pairs
-        nvoBB = noccB * nvirB;        // Number of all OCC-VIR pairs
-        namo = nmo_ - nfrzc - nfrzv;  // Number of active  orbitals
-        npop = nmo_ - nfrzv;          // Number of populated orbitals
+        nvirA = Wavefunction::nmo() - noccA;         // Number of virtual orbitals
+        nvirB = Wavefunction::nmo() - noccB;         // Number of virtual orbitals
+        naoccA = noccA - nfrzc;                      // Number of active occupied orbitals
+        naoccB = noccB - nfrzc;                      // Number of active occupied orbitals
+        navirA = nvirA - nfrzv;                      // Number of active virtual orbitals
+        navirB = nvirB - nfrzv;                      // Number of active virtual orbitals
+        nocc2AA = noccA * noccA;                     // Number of all OCC-OCC pairs
+        nocc2AB = noccA * noccB;                     // Number of all OCC-OCC pairs
+        nocc2BB = noccB * noccB;                     // Number of all OCC-OCC pairs
+        nvir2AA = nvirA * nvirA;                     // Number of all VIR-VIR pairs
+        nvir2AB = nvirA * nvirB;                     // Number of all VIR-VIR pairs
+        nvir2BB = nvirB * nvirB;                     // Number of all VIR-VIR pairs
+        naocc2AA = naoccA * naoccA;                  // Number of active OCC-OCC pairs
+        naocc2AB = naoccA * naoccB;                  // Number of active OCC-OCC pairs
+        naocc2BB = naoccB * naoccB;                  // Number of active OCC-OCC pairs
+        navir2AA = navirA * navirA;                  // Number of active VIR-VIR pairs
+        navir2AB = navirA * navirB;                  // Number of active VIR-VIR pairs
+        navir2BB = navirB * navirB;                  // Number of active VIR-VIR pairs
+        navoAA = naoccA * navirA;                    // Number of active OCC-VIR pairs
+        navoBA = naoccA * navirB;                    // Number of active OCC-VIR pairs
+        navoAB = naoccB * navirA;                    // Number of active OCC-VIR pairs
+        navoBB = naoccB * navirB;                    // Number of active OCC-VIR pairs
+        nvoAA = noccA * nvirA;                       // Number of all OCC-VIR pairs
+        nvoBA = noccA * nvirB;                       // Number of all OCC-VIR pairs
+        nvoAB = noccB * nvirA;                       // Number of all OCC-VIR pairs
+        nvoBB = noccB * nvirB;                       // Number of all OCC-VIR pairs
+        namo = Wavefunction::nmo() - nfrzc - nfrzv;  // Number of active  orbitals
+        npop = Wavefunction::nmo() - nfrzv;          // Number of populated orbitals
         ntri_so = 0.5 * nso_ * (nso_ + 1);
-        ntri = 0.5 * nmo_ * (nmo_ + 1);
+        ntri = 0.5 * Wavefunction::nmo() * (Wavefunction::nmo() + 1);
         dimtei = 0.5 * ntri * (ntri + 1);
         nso2_ = nso_ * nso_;
         ntri_ijAA = 0.5 * naoccA * (naoccA + 1);
@@ -221,20 +219,16 @@ void DFOCC::get_moinfo() {
 
         if (naoccA == 0 && naoccB == 0) {
             throw PSIEXCEPTION("There are no occupied orbitals with alpha or beta spin.");
-        }
-        else if (naoccA == 0) {
+        } else if (naoccA == 0) {
             throw PSIEXCEPTION("There are no occupied orbitals with alpha spin.");
-        }
-        else if (naoccB == 0) {
+        } else if (naoccB == 0) {
             throw PSIEXCEPTION("There are no occupied orbitals with beta spin.");
         }
         if (navirA == 0 && navirB == 0) {
             throw PSIEXCEPTION("There are no virtual orbitals with alpha or beta spin.");
-        }
-        else if (navirA == 0) {
+        } else if (navirA == 0) {
             throw PSIEXCEPTION("There are no virtual orbitals with alpha spin.");
-        }
-        else if (navirB == 0) {
+        } else if (navirB == 0) {
             throw PSIEXCEPTION("There are no virtual orbitals with beta spin.");
         }
 
@@ -261,18 +255,18 @@ void DFOCC::get_moinfo() {
         // Read orbital energies
         epsilon_a_ = reference_wavefunction_->epsilon_a();
         epsilon_b_ = reference_wavefunction_->epsilon_b();
-        eps_orbA = std::make_shared<Tensor1d>("epsilon <P|Q>", nmo_);
-        eps_orbB = std::make_shared<Tensor1d>("epsilon <p|q>", nmo_);
-        for (int p = 0; p < nmo_; ++p) eps_orbA->set(p, epsilon_a_->get(0, p));
-        for (int p = 0; p < nmo_; ++p) eps_orbB->set(p, epsilon_b_->get(0, p));
+        eps_orbA = std::make_shared<Tensor1d>("epsilon <P|Q>", Wavefunction::nmo());
+        eps_orbB = std::make_shared<Tensor1d>("epsilon <p|q>", Wavefunction::nmo());
+        for (int p = 0; p < Wavefunction::nmo(); ++p) eps_orbA->set(p, epsilon_a_->get(0, p));
+        for (int p = 0; p < Wavefunction::nmo(); ++p) eps_orbB->set(p, epsilon_b_->get(0, p));
 
         // Build Initial fock matrix
-        FockA = std::make_shared<Tensor2d>("MO-basis alpha Fock matrix", nmo_, nmo_);
+        FockA = std::make_shared<Tensor2d>("MO-basis alpha Fock matrix", Wavefunction::nmo(), Wavefunction::nmo());
         for (int i = 0; i < noccA; ++i) FockA->set(i, i, epsilon_a_->get(0, i));
         for (int a = 0; a < nvirA; ++a) FockA->set(a + noccA, a + noccA, epsilon_a_->get(0, a + noccA));
         if (print_ > 2) FockA->print();
 
-        FockB = std::make_shared<Tensor2d>("MO-basis beta Fock matrix", nmo_, nmo_);
+        FockB = std::make_shared<Tensor2d>("MO-basis beta Fock matrix", Wavefunction::nmo(), Wavefunction::nmo());
         for (int i = 0; i < noccB; ++i) FockB->set(i, i, epsilon_b_->get(0, i));
         for (int a = 0; a < nvirB; ++a) FockB->set(a + noccB, a + noccB, epsilon_b_->get(0, a + noccB));
         if (print_ > 2) FockB->print();
@@ -316,16 +310,16 @@ void DFOCC::get_moinfo() {
 
         // Read orbital coefficients from reference_wavefunction
         Ca_ = reference_wavefunction_->Ca()->clone();
-        CmoA = std::make_shared<Tensor2d>("Alpha MO Coefficients", nso_, nmo_);
+        CmoA = std::make_shared<Tensor2d>("Alpha MO Coefficients", nso_, Wavefunction::nmo());
         CmoA->set(Ca_);
         if (print_ > 2) CmoA->print();
 
         Cb_ = reference_wavefunction_->Cb()->clone();
-        CmoB = std::make_shared<Tensor2d>("Beta MO Coefficients", nso_, nmo_);
+        CmoB = std::make_shared<Tensor2d>("Beta MO Coefficients", nso_, Wavefunction::nmo());
         CmoB->set(Cb_);
         if (orb_opt_ == "TRUE" || qchf_ == "TRUE") {
-            Cmo_refA = std::make_shared<Tensor2d>("Alpha Reference MO Coefficients", nso_, nmo_);
-            Cmo_refB = std::make_shared<Tensor2d>("Beta Reference MO Coefficients", nso_, nmo_);
+            Cmo_refA = std::make_shared<Tensor2d>("Alpha Reference MO Coefficients", nso_, Wavefunction::nmo());
+            Cmo_refB = std::make_shared<Tensor2d>("Beta Reference MO Coefficients", nso_, Wavefunction::nmo());
             Cmo_refA->copy(CmoA);
             Cmo_refB->copy(CmoB);
         }

--- a/psi4/src/psi4/dfocc/manager.cc
+++ b/psi4/src/psi4/dfocc/manager.cc
@@ -930,10 +930,10 @@ void DFOCC::ccsd_manager() {
             G1c_vvA = std::make_shared<Tensor2d>("Correlation OPDM <V|V>", nvirA, nvirA);
             G1c_vvB = std::make_shared<Tensor2d>("Correlation OPDM <v|v>", nvirB, nvirB);
 
-            G1cA = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", nmo_, nmo_);
-            G1cB = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", nmo_, nmo_);
-            G1A = std::make_shared<Tensor2d>("MO-basis alpha OPDM", nmo_, nmo_);
-            G1B = std::make_shared<Tensor2d>("MO-basis beta OPDM", nmo_, nmo_);
+            G1cA = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1cB = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1A = std::make_shared<Tensor2d>("MO-basis alpha OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1B = std::make_shared<Tensor2d>("MO-basis beta OPDM", Wavefunction::nmo(), Wavefunction::nmo());
 
             ccsd_opdm();
             uccsd_tpdm();
@@ -1406,10 +1406,10 @@ void DFOCC::ccsd_t_manager() {
             G1c_vvA = std::make_shared<Tensor2d>("Correlation OPDM <V|V>", nvirA, nvirA);
             G1c_vvB = std::make_shared<Tensor2d>("Correlation OPDM <v|v>", nvirB, nvirB);
 
-            G1cA = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", nmo_, nmo_);
-            G1cB = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", nmo_, nmo_);
-            G1A = std::make_shared<Tensor2d>("MO-basis alpha OPDM", nmo_, nmo_);
-            G1B = std::make_shared<Tensor2d>("MO-basis beta OPDM", nmo_, nmo_);
+            G1cA = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1cB = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1A = std::make_shared<Tensor2d>("MO-basis alpha OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1B = std::make_shared<Tensor2d>("MO-basis beta OPDM", Wavefunction::nmo(), Wavefunction::nmo());
 
             ccsd_opdm();
             uccsd_tpdm();

--- a/psi4/src/psi4/dfocc/manager_cd.cc
+++ b/psi4/src/psi4/dfocc/manager_cd.cc
@@ -695,10 +695,10 @@ void DFOCC::ccsd_manager_cd() {
             G1c_vvA = std::make_shared<Tensor2d>("Correlation OPDM <V|V>", nvirA, nvirA);
             G1c_vvB = std::make_shared<Tensor2d>("Correlation OPDM <v|v>", nvirB, nvirB);
 
-            G1cA = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", nmo_, nmo_);
-            G1cB = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", nmo_, nmo_);
-            G1A = std::make_shared<Tensor2d>("MO-basis alpha OPDM", nmo_, nmo_);
-            G1B = std::make_shared<Tensor2d>("MO-basis beta OPDM", nmo_, nmo_);
+            G1cA = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1cB = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1A = std::make_shared<Tensor2d>("MO-basis alpha OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1B = std::make_shared<Tensor2d>("MO-basis beta OPDM", Wavefunction::nmo(), Wavefunction::nmo());
 
             ccsd_opdm();
             uccsd_tpdm();
@@ -1164,10 +1164,10 @@ void DFOCC::ccsd_t_manager_cd() {
             G1c_vvA = std::make_shared<Tensor2d>("Correlation OPDM <V|V>", nvirA, nvirA);
             G1c_vvB = std::make_shared<Tensor2d>("Correlation OPDM <v|v>", nvirB, nvirB);
 
-            G1cA = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", nmo_, nmo_);
-            G1cB = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", nmo_, nmo_);
-            G1A = std::make_shared<Tensor2d>("MO-basis alpha OPDM", nmo_, nmo_);
-            G1B = std::make_shared<Tensor2d>("MO-basis beta OPDM", nmo_, nmo_);
+            G1cA = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1cB = std::make_shared<Tensor2d>("MO-basis alpha correlation OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1A = std::make_shared<Tensor2d>("MO-basis alpha OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            G1B = std::make_shared<Tensor2d>("MO-basis beta OPDM", Wavefunction::nmo(), Wavefunction::nmo());
 
             ccsd_opdm();
             uccsd_tpdm();

--- a/psi4/src/psi4/dfocc/occ_iterations.cc
+++ b/psi4/src/psi4/dfocc/occ_iterations.cc
@@ -430,24 +430,24 @@ void DFOCC::save_mo_to_wfn() {
 
     // Save MOs to wfn_; We cannot semicanonicalize them, as we'd need to do the same to all MO-basis quantities
     if (reference_ == "RESTRICTED") {
-        SharedMatrix Ca = std::make_shared<Matrix>("Alpha MO Coefficients", nso_, nmo_);
+        SharedMatrix Ca = std::make_shared<Matrix>("Alpha MO Coefficients", nso_, Wavefunction::nmo());
         CmoA->to_shared_matrix(Ca);
         Ca_->copy(Ca);
 
         if (options_.get_str("MOLDEN_WRITE") == "TRUE") {
             // Diagonalize OPDM to obtain NOs
-            SharedMatrix aevecs(new Matrix("Eigenvectors (Alpha)", nmo_, nmo_));
-            SharedVector aevals(new Vector("Eigenvalues (Alpha)", nmo_));
+            SharedMatrix aevecs(new Matrix("Eigenvectors (Alpha)", Wavefunction::nmo(), Wavefunction::nmo()));
+            SharedVector aevals(new Vector("Eigenvalues (Alpha)", Wavefunction::nmo()));
 
             // Diagonaliz OPDM
-            auto a_opdm = std::make_shared<Matrix>("Alpha OPDM", nmo_, nmo_);
+            auto a_opdm = std::make_shared<Matrix>("Alpha OPDM", Wavefunction::nmo(), Wavefunction::nmo());
             G1->to_shared_matrix(a_opdm);
             // scale by 1/2 because MoldenWrite expect only alpha part
             a_opdm->scale(0.5);
             a_opdm->diagonalize(aevecs, aevals, descending);
 
             // Form transformation matrix from AO to NO
-            SharedMatrix aAONO(new Matrix("NOs (Alpha)", nso_, nmo_));
+            SharedMatrix aAONO(new Matrix("NOs (Alpha)", nso_, Wavefunction::nmo()));
             aAONO->gemm(false, false, 1.0, Ca, aevecs, 0.0);
 
             // Write to MOLDEN file
@@ -455,7 +455,7 @@ void DFOCC::save_mo_to_wfn() {
             std::string filename = get_writer_file_prefix(molecule_->name()) + "_dfocc.molden";
 
             // For now use zeros instead of energies, and NO occupation numbers as occupation numbers
-            SharedVector dummy_a(new Vector("Dummy Vector Alpha", nmo_));
+            SharedVector dummy_a(new Vector("Dummy Vector Alpha", Wavefunction::nmo()));
             for (int i = 0; i < naoccA; ++i) eps_orbA->set(i + nfrzc, eigooA->get(i));
             for (int a = 0; a < navirA; ++a) eps_orbA->set(a + noccA, eigvvA->get(a));
             eps_orbA->to_shared_vector(dummy_a);
@@ -472,8 +472,8 @@ void DFOCC::save_mo_to_wfn() {
     }
 
     else if (reference_ == "UNRESTRICTED") {
-        SharedMatrix Ca = std::make_shared<Matrix>("Alpha MO Coefficients", nso_, nmo_);
-        SharedMatrix Cb = std::make_shared<Matrix>("Beta MO Coefficients", nso_, nmo_);
+        SharedMatrix Ca = std::make_shared<Matrix>("Alpha MO Coefficients", nso_, Wavefunction::nmo());
+        SharedMatrix Cb = std::make_shared<Matrix>("Beta MO Coefficients", nso_, Wavefunction::nmo());
         CmoA->to_shared_matrix(Ca);
         CmoB->to_shared_matrix(Cb);
 
@@ -482,22 +482,22 @@ void DFOCC::save_mo_to_wfn() {
 
         if (options_.get_str("MOLDEN_WRITE") == "TRUE") {
             // Diagonalize OPDM to obtain NOs
-            SharedMatrix aevecs(new Matrix("Eigenvectors (Alpha)", nmo_, nmo_));
-            SharedMatrix bevecs(new Matrix("Eigenvectors (Beta)", nmo_, nmo_));
-            SharedVector aevals(new Vector("Eigenvalues (Alpha)", nmo_));
-            SharedVector bevals(new Vector("Eigenvalues (Beta)", nmo_));
+            SharedMatrix aevecs(new Matrix("Eigenvectors (Alpha)", Wavefunction::nmo(), Wavefunction::nmo()));
+            SharedMatrix bevecs(new Matrix("Eigenvectors (Beta)", Wavefunction::nmo(), Wavefunction::nmo()));
+            SharedVector aevals(new Vector("Eigenvalues (Alpha)", Wavefunction::nmo()));
+            SharedVector bevals(new Vector("Eigenvalues (Beta)", Wavefunction::nmo()));
 
             // Diagonaliz OPDM
-            SharedMatrix a_opdm = std::make_shared<Matrix>("Alpha OPDM", nmo_, nmo_);
-            SharedMatrix b_opdm = std::make_shared<Matrix>("Alpha OPDM", nmo_, nmo_);
+            SharedMatrix a_opdm = std::make_shared<Matrix>("Alpha OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+            SharedMatrix b_opdm = std::make_shared<Matrix>("Alpha OPDM", Wavefunction::nmo(), Wavefunction::nmo());
             G1A->to_shared_matrix(a_opdm);
             G1B->to_shared_matrix(b_opdm);
             a_opdm->diagonalize(aevecs, aevals, descending);
             b_opdm->diagonalize(bevecs, bevals, descending);
 
             // Form transformation matrix from AO to NO
-            SharedMatrix aAONO(new Matrix("NOs (Alpha)", nso_, nmo_));
-            SharedMatrix bAONO(new Matrix("NOs (Beta)", nso_, nmo_));
+            SharedMatrix aAONO(new Matrix("NOs (Alpha)", nso_, Wavefunction::nmo()));
+            SharedMatrix bAONO(new Matrix("NOs (Beta)", nso_, Wavefunction::nmo()));
             aAONO->gemm(false, false, 1.0, Ca, aevecs, 0.0);
             bAONO->gemm(false, false, 1.0, Cb, bevecs, 0.0);
 
@@ -506,8 +506,8 @@ void DFOCC::save_mo_to_wfn() {
             std::string filename = get_writer_file_prefix(molecule_->name()) + "_dfocc.molden";
 
             // For now use zeros instead of energies, and NO occupation numbers as occupation numbers
-            SharedVector dummy_a(new Vector("Dummy Vector Alpha", nmo_));
-            SharedVector dummy_b(new Vector("Dummy Vector Beta", nmo_));
+            SharedVector dummy_a(new Vector("Dummy Vector Alpha", Wavefunction::nmo()));
+            SharedVector dummy_b(new Vector("Dummy Vector Beta", Wavefunction::nmo()));
             for (int i = 0; i < naoccA; ++i) eps_orbA->set(i + nfrzc, eigooA->get(i));
             for (int a = 0; a < navirA; ++a) eps_orbA->set(a + noccA, eigvvA->get(a));
             for (int i = 0; i < naoccB; ++i) eps_orbB->set(i + nfrzc, eigooB->get(i));

--- a/psi4/src/psi4/dfocc/pair_index.cc
+++ b/psi4/src/psi4/dfocc/pair_index.cc
@@ -287,7 +287,7 @@ int DFOCC::so_pair_idx(int i, int j) {
 //   mo_pair_idx (unpacked)
 //====================================
 int DFOCC::mo_pair_idx(int i, int j) {
-    int value = j + (i * nmo_);
+    int value = j + (i * Wavefunction::nmo());
     return value;
 }
 

--- a/psi4/src/psi4/dfocc/prepare4grad.cc
+++ b/psi4/src/psi4/dfocc/prepare4grad.cc
@@ -956,8 +956,8 @@ void DFOCC::effective_pdm_gfm() {
 }  // end effective_pdm_gfm
 
 void DFOCC::set_opdm() {
-    auto Da = std::make_shared<Matrix>("MO-basis alpha OPDM", nmo_, nmo_);
-    auto Db = std::make_shared<Matrix>("MO-basis beta OPDM", nmo_, nmo_);
+    auto Da = std::make_shared<Matrix>("MO-basis alpha OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+    auto Db = std::make_shared<Matrix>("MO-basis beta OPDM", Wavefunction::nmo(), Wavefunction::nmo());
     if (reference_ == "RESTRICTED") {
         G1->to_shared_matrix(Da);
         Da->scale(0.5);

--- a/psi4/src/psi4/dfocc/properties.cc
+++ b/psi4/src/psi4/dfocc/properties.cc
@@ -48,8 +48,8 @@ void DFOCC::oeprop() {
     // is, CD gradient tech available in the literature but none in Psi4, even for CD-HF.)
     // This should wait until after the current dfocc push. - JPM 08/2022
 
-    auto Da_ = std::make_shared<Matrix>("MO-basis alpha OPDM", nmo_, nmo_);
-    auto Db_ = std::make_shared<Matrix>("MO-basis beta OPDM", nmo_, nmo_);
+    auto Da_ = std::make_shared<Matrix>("MO-basis alpha OPDM", Wavefunction::nmo(), Wavefunction::nmo());
+    auto Db_ = std::make_shared<Matrix>("MO-basis beta OPDM", Wavefunction::nmo(), Wavefunction::nmo());
     if (reference_ == "RESTRICTED") {
         G1->to_shared_matrix(Da_);
         Da_->scale(0.5);
@@ -90,7 +90,7 @@ void DFOCC::ekt_ip() {
     if (reference_ == "RESTRICTED") {
 
         // Call EKT
-        auto ektA = std::make_shared<Ektip>("Alpha EKT", noccA, nmo_, GF, G1, 1.0, 0.5);
+        auto ektA = std::make_shared<Ektip>("Alpha EKT", noccA, Wavefunction::nmo(), GF, G1, 1.0, 0.5);
 
         // Print IPs
         outfile->Printf("\n\tEKT Ionization Potentials (Alpha Spin Case) \n");

--- a/psi4/src/psi4/dfocc/qchf.cc
+++ b/psi4/src/psi4/dfocc/qchf.cc
@@ -434,7 +434,7 @@ void DFOCC::gwh() {
     SharedTensor2d Fso = std::make_shared<Tensor2d>("SO-basis Fock Matrix", nso_, nso_);
     SharedTensor2d Fsop = std::make_shared<Tensor2d>("SO-basis Fock' Matrix", nso_, nso_);
     SharedTensor2d Smhalf = std::make_shared<Tensor2d>("S^-1/2", nso_, nso_);
-    SharedTensor2d Cmop = std::make_shared<Tensor2d>("C' matrix", nso_, nmo_);
+    SharedTensor2d Cmop = std::make_shared<Tensor2d>("C' matrix", nso_, Wavefunction::nmo());
     SharedTensor2d Uso = std::make_shared<Tensor2d>("SO-basis U", nso_, nso_);
     SharedTensor2d temp = std::make_shared<Tensor2d>("Temp", nso_, nso_);
     SharedTensor1d e_orb = std::make_shared<Tensor1d>("epsilon <n|n>", nso_);
@@ -488,8 +488,8 @@ void DFOCC::gwh() {
 //          Canonic
 //=======================================================
 void DFOCC::canonic() {
-    SharedTensor2d UeigA = std::make_shared<Tensor2d>("UooA", nmo_, nmo_);
-    SharedTensor1d eigA = std::make_shared<Tensor1d>("epsilon <A|A>", nmo_);
+    SharedTensor2d UeigA = std::make_shared<Tensor2d>("UooA", Wavefunction::nmo(), Wavefunction::nmo());
+    SharedTensor1d eigA = std::make_shared<Tensor1d>("epsilon <A|A>", Wavefunction::nmo());
 
     // Diagonalize Fock
     FockA->diagonalize(UeigA, eigA, cutoff);
@@ -499,7 +499,7 @@ void DFOCC::canonic() {
     UorbA->copy(UeigA);
 
     // Get new MOs
-    SharedTensor2d Ca_new = std::make_shared<Tensor2d>("New alpha MO coefficients", nso_, nmo_);
+    SharedTensor2d Ca_new = std::make_shared<Tensor2d>("New alpha MO coefficients", nso_, Wavefunction::nmo());
     Ca_new->gemm(false, false, CmoA, UorbA, 1.0, 0.0);
     CmoA->copy(Ca_new);
     Ca_new.reset();
@@ -512,8 +512,8 @@ void DFOCC::canonic() {
     //========================= UHF REFERENCE ==================================================
     //==========================================================================================
     if (reference_ == "UNRESTRICTED") {
-        SharedTensor2d UeigB = std::make_shared<Tensor2d>("UeigB", nmo_, nmo_);
-        SharedTensor1d eigB = std::make_shared<Tensor1d>("epsilon <a|a>", nmo_);
+        SharedTensor2d UeigB = std::make_shared<Tensor2d>("UeigB", Wavefunction::nmo(), Wavefunction::nmo());
+        SharedTensor1d eigB = std::make_shared<Tensor1d>("epsilon <a|a>", Wavefunction::nmo());
 
         // Diagonalize Fock
         FockB->diagonalize(UeigB, eigB, cutoff);
@@ -523,7 +523,7 @@ void DFOCC::canonic() {
         UorbB->copy(UeigB);
 
         // Get new MOs
-        SharedTensor2d Cb_new = std::make_shared<Tensor2d>("New beta MO coefficients", nso_, nmo_);
+        SharedTensor2d Cb_new = std::make_shared<Tensor2d>("New beta MO coefficients", nso_, Wavefunction::nmo());
         Cb_new->gemm(false, false, CmoB, UorbB, 1.0, 0.0);
         CmoB->copy(Cb_new);
         Cb_new.reset();

--- a/psi4/src/psi4/dfocc/s2_response.cc
+++ b/psi4/src/psi4/dfocc/s2_response.cc
@@ -47,9 +47,9 @@ void DFOCC::s2_response() {
     //=========================
     // Read AO basis SO
     //=========================
-    SharedTensor2d SmoAB = std::make_shared<Tensor2d>("MO-basis Alpha-Beta Overlap Ints", nmo_, nmo_);
-    SharedTensor2d SmoBA = std::make_shared<Tensor2d>("MO-basis Beta-Alpha Overlap Ints", nmo_, nmo_);
-    SharedTensor2d temp = std::make_shared<Tensor2d>("Temp", nso_, nmo_);
+    SharedTensor2d SmoAB = std::make_shared<Tensor2d>("MO-basis Alpha-Beta Overlap Ints", Wavefunction::nmo(), Wavefunction::nmo());
+    SharedTensor2d SmoBA = std::make_shared<Tensor2d>("MO-basis Beta-Alpha Overlap Ints", Wavefunction::nmo(), Wavefunction::nmo());
+    SharedTensor2d temp = std::make_shared<Tensor2d>("Temp", nso_, Wavefunction::nmo());
 
     // AB
     temp->gemm(false, false, Sso, CmoB, 1.0, 0.0);
@@ -155,9 +155,9 @@ void DFOCC::s2_lagrangian() {
     //=========================
     // Read AO basis SO
     //=========================
-    SharedTensor2d SmoAB = std::make_shared<Tensor2d>("MO-basis Alpha-Beta Overlap Ints", nmo_, nmo_);
-    SharedTensor2d SmoBA = std::make_shared<Tensor2d>("MO-basis Beta-Alpha Overlap Ints", nmo_, nmo_);
-    SharedTensor2d temp = std::make_shared<Tensor2d>("Temp", nso_, nmo_);
+    SharedTensor2d SmoAB = std::make_shared<Tensor2d>("MO-basis Alpha-Beta Overlap Ints", Wavefunction::nmo(), Wavefunction::nmo());
+    SharedTensor2d SmoBA = std::make_shared<Tensor2d>("MO-basis Beta-Alpha Overlap Ints", Wavefunction::nmo(), Wavefunction::nmo());
+    SharedTensor2d temp = std::make_shared<Tensor2d>("Temp", nso_, Wavefunction::nmo());
 
     // AB
     temp->gemm(false, false, Sso, CmoB, 1.0, 0.0);

--- a/psi4/src/psi4/dfocc/semi_canonic.cc
+++ b/psi4/src/psi4/dfocc/semi_canonic.cc
@@ -113,7 +113,7 @@ void DFOCC::semi_canonic() {
     }
 
     // Get new MOs
-    SharedTensor2d Ca_new = std::make_shared<Tensor2d>("New alpha MO coefficients", nso_, nmo_);
+    SharedTensor2d Ca_new = std::make_shared<Tensor2d>("New alpha MO coefficients", nso_, Wavefunction::nmo());
     Ca_new->gemm(false, false, CmoA, UorbA, 1.0, 0.0);
     CmoA->copy(Ca_new);
     Ca_new.reset();
@@ -205,7 +205,7 @@ void DFOCC::semi_canonic() {
         }
 
         // Get new MOs
-        SharedTensor2d Cb_new = std::make_shared<Tensor2d>("New beta MO coefficients", nso_, nmo_);
+        SharedTensor2d Cb_new = std::make_shared<Tensor2d>("New beta MO coefficients", nso_, Wavefunction::nmo());
         Cb_new->gemm(false, false, CmoB, UorbB, 1.0, 0.0);
         CmoB->copy(Cb_new);
         Cb_new.reset();

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -164,8 +164,7 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
 
     /// Total number of SOs
     int nso_;
-    /// Total number of MOs
-    int nmo_;
+
     /// Number of irreps
     int nirrep_;
 
@@ -401,8 +400,8 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     FieldType get_dipole_perturbation_type() const;
 
     /**
-     * @brief Expert specialized use only. Sets the number of doubly and singly occupied orbitals per irrep. Results in an
-     * inconsistent Wavefunction object for SCF purposes, so caution is advised.
+     * @brief Expert specialized use only. Sets the number of doubly and singly occupied orbitals per irrep. Results in
+     * an inconsistent Wavefunction object for SCF purposes, so caution is advised.
      * @param doccpi the new list of doubly occupied orbitals per irrep
      */
     void force_occpi(const Dimension& input_doccpi, const Dimension& input_soccpi);
@@ -419,12 +418,13 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Returns the number of SOs
     int nso() const { return nso_; }
     /// Returns the number of MOs
-    int nmo() const { return nmo_; }
+    int nmo() const { return nmopi_.sum(); }
     /// Returns the number of irreps
     int nirrep() const { return nirrep_; }
     /// Returns the energy
     PSI_DEPRECATED(
-        "Using `Wavefunction.reference_energy` instead of `Wavefunction.energy` is deprecated, and as soon as 1.4 it will "
+        "Using `Wavefunction.reference_energy` instead of `Wavefunction.energy` is deprecated, and as soon as 1.4 it "
+        "will "
         "stop working")
     double reference_energy() const { return energy_; }
     double energy() const { return energy_; }
@@ -692,27 +692,33 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     std::map<std::string, std::shared_ptr<ExternalPotential>> potential_variables();
 
     PSI_DEPRECATED(
-        "Using `Wavefunction.get_variable` instead of `Wavefunction.scalar_variable` is deprecated, and as soon as 1.4 it will "
+        "Using `Wavefunction.get_variable` instead of `Wavefunction.scalar_variable` is deprecated, and as soon as 1.4 "
+        "it will "
         "stop working")
     double get_variable(const std::string& key);
     PSI_DEPRECATED(
-        "Using `Wavefunction.set_variable` instead of `Wavefunction.set_scalar_variable` is deprecated, and as soon as 1.4 it "
+        "Using `Wavefunction.set_variable` instead of `Wavefunction.set_scalar_variable` is deprecated, and as soon as "
+        "1.4 it "
         "will stop working")
     void set_variable(const std::string& key, double value);
     PSI_DEPRECATED(
-        "Using `Wavefunction.variables` instead of `Wavefunction.scalar_variables` is deprecated, and as soon as 1.4 it will "
+        "Using `Wavefunction.variables` instead of `Wavefunction.scalar_variables` is deprecated, and as soon as 1.4 "
+        "it will "
         "stop working")
     std::map<std::string, double> variables();
     PSI_DEPRECATED(
-        "Using `Wavefunction.get_array` instead of `Wavefunction.array_variable` is deprecated, and as soon as 1.4 it will "
+        "Using `Wavefunction.get_array` instead of `Wavefunction.array_variable` is deprecated, and as soon as 1.4 it "
+        "will "
         "stop working")
     SharedMatrix get_array(const std::string& key);
     PSI_DEPRECATED(
-        "Using `Wavefunction.set_array` instead of `Wavefunction.set_array_variable` is deprecated, and as soon as 1.4 it will "
+        "Using `Wavefunction.set_array` instead of `Wavefunction.set_array_variable` is deprecated, and as soon as 1.4 "
+        "it will "
         "stop working")
     void set_array(const std::string& key, SharedMatrix value);
     PSI_DEPRECATED(
-        "Using `Wavefunction.arrays` instead of `Wavefunction.array_variables` is deprecated, and as soon as 1.4 it will stop "
+        "Using `Wavefunction.arrays` instead of `Wavefunction.array_variables` is deprecated, and as soon as 1.4 it "
+        "will stop "
         "working")
     std::map<std::string, SharedMatrix> arrays();
 
@@ -729,7 +735,6 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// SOME way to let it get/set.
     /// Vector of density matrices
     std::map<std::string, SharedMatrix> density_map_;
-
 };
 
 }  // namespace psi

--- a/psi4/src/psi4/libsapt_solver/sapt0.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt0.cc
@@ -180,12 +180,12 @@ void SAPT0::print_header() {
         outfile->Printf("    NSO        = %9d\n", nso_);
         outfile->Printf("    NSO A      = %9zu\n", nsoA_);
         outfile->Printf("    NSO B      = %9zu\n", nsoB_);
-        outfile->Printf("    NMO        = %9d\n", nmo_);
+        outfile->Printf("    NMO        = %9d\n", Wavefunction::nmo());
         outfile->Printf("    NMO A      = %9zu\n", nmoA_);
         outfile->Printf("    NMO B      = %9zu\n", nmoB_);
     } else {
         outfile->Printf("    NSO        = %9d\n", nso_);
-        outfile->Printf("    NMO        = %9d\n", nmo_);
+        outfile->Printf("    NMO        = %9d\n", Wavefunction::nmo());
     }
     if (elst_basis_) {
         outfile->Printf("    NRI        = %9d\n", ribasis_->nbf());
@@ -698,8 +698,8 @@ void SAPT0::df_integrals() {
     double **B_p_RB = block_matrix(Plength, noccB_ * nvirA_);
 
     double **munu_temp = block_matrix(nthreads, nso_ * nso_);
-    double **Inu_temp = block_matrix(nthreads, nmo_ * nso_);
-    double **IJ_temp = block_matrix(nthreads, nmo_ * nmo_);
+    double **Inu_temp = block_matrix(nthreads, Wavefunction::nmo() * nso_);
+    double **IJ_temp = block_matrix(nthreads, Wavefunction::nmo() * Wavefunction::nmo());
 
     next_DF_AO = PSIO_ZERO;
     psio_address next_DF_AA = PSIO_ZERO;
@@ -1187,8 +1187,8 @@ void SAPT0::df_integrals_aio() {
     B_p_RB[1] = block_matrix(Plength, noccB_ * nvirA_);
 
     double **munu_temp = block_matrix(nthreads, nso_ * nso_);
-    double **Inu_temp = block_matrix(nthreads, nmo_ * nso_);
-    double **IJ_temp = block_matrix(nthreads, nmo_ * nmo_);
+    double **Inu_temp = block_matrix(nthreads, Wavefunction::nmo() * nso_);
+    double **IJ_temp = block_matrix(nthreads, Wavefunction::nmo() * Wavefunction::nmo());
 
     next_DF_AO = PSIO_ZERO;
     psio_address next_DF_AA = PSIO_ZERO;

--- a/psi4/src/psi4/libsapt_solver/sapt2.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt2.cc
@@ -192,12 +192,12 @@ void SAPT2::print_header() {
         outfile->Printf("    NSO        = %9d\n", nso_);
         outfile->Printf("    NSO A      = %9zu\n", nsoA_);
         outfile->Printf("    NSO B      = %9zu\n", nsoB_);
-        outfile->Printf("    NMO        = %9d\n", nmo_);
+        outfile->Printf("    NMO        = %9d\n", Wavefunction::nmo());
         outfile->Printf("    NMO A      = %9zu\n", nmoA_);
         outfile->Printf("    NMO B      = %9zu\n", nmoB_);
     } else {
         outfile->Printf("    NSO        = %9d\n", nso_);
-        outfile->Printf("    NMO        = %9d\n", nmo_);
+        outfile->Printf("    NMO        = %9d\n", Wavefunction::nmo());
     }
     outfile->Printf("    NRI        = %9zu\n", ndf_);
     outfile->Printf("    NOCC A     = %9zu\n", noccA_);

--- a/psi4/src/psi4/libsapt_solver/sapt2p.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt2p.cc
@@ -152,12 +152,12 @@ void SAPT2p::print_header() {
         outfile->Printf("    NSO        = %9d\n", nso_);
         outfile->Printf("    NSO A      = %9zu\n", nsoA_);
         outfile->Printf("    NSO B      = %9zu\n", nsoB_);
-        outfile->Printf("    NMO        = %9d\n", nmo_);
+        outfile->Printf("    NMO        = %9d\n", Wavefunction::nmo());
         outfile->Printf("    NMO A      = %9zu\n", nmoA_);
         outfile->Printf("    NMO B      = %9zu\n", nmoB_);
     } else {
         outfile->Printf("    NSO        = %9d\n", nso_);
-        outfile->Printf("    NMO        = %9d\n", nmo_);
+        outfile->Printf("    NMO        = %9d\n", Wavefunction::nmo());
     }
     outfile->Printf("    NRI        = %9zu\n", ndf_);
     outfile->Printf("    NOCC A     = %9zu\n", noccA_);

--- a/psi4/src/psi4/libsapt_solver/sapt2p3.cc
+++ b/psi4/src/psi4/libsapt_solver/sapt2p3.cc
@@ -178,12 +178,12 @@ void SAPT2p3::print_header() {
         outfile->Printf("    NSO        = %9d\n", nso_);
         outfile->Printf("    NSO A      = %9zu\n", nsoA_);
         outfile->Printf("    NSO B      = %9zu\n", nsoB_);
-        outfile->Printf("    NMO        = %9d\n", nmo_);
+        outfile->Printf("    NMO        = %9d\n", Wavefunction::nmo());
         outfile->Printf("    NMO A      = %9zu\n", nmoA_);
         outfile->Printf("    NMO B      = %9zu\n", nmoB_);
     } else {
         outfile->Printf("    NSO        = %9d\n", nso_);
-        outfile->Printf("    NMO        = %9d\n", nmo_);
+        outfile->Printf("    NMO        = %9d\n", Wavefunction::nmo());
     }
     outfile->Printf("    NRI        = %9zu\n", ndf_);
     outfile->Printf("    NOCC A     = %9zu\n", noccA_);

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -743,7 +743,6 @@ void HF::form_Shalf() {
 
         // Update nmo_
         nmopi_ = X_->colspi();
-        nmo_ = nmopi_.sum();
     }
 
     // Double check occupation vectors

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -393,7 +393,7 @@ std::vector<SharedMatrix> RHF::onel_Hx(std::vector<SharedMatrix> x_vec) {
     SharedMatrix F, Co, Cv;
     for (size_t i = 0; i < x_vec.size(); i++) {
         if (c1_input_[i]) {
-            if ((x_vec[i]->rowspi()[0] != nalpha_) || (x_vec[i]->colspi()[0] != (nmo_ - nalpha_))) {
+            if ((x_vec[i]->rowspi()[0] != nalpha_) || (x_vec[i]->colspi()[0] != (Wavefunction::nmo() - nalpha_))) {
                 throw PSIEXCEPTION("SCF::onel_Hx incoming rotation matrices must have shape (occ x vir).");
             }
             F = F_ao;
@@ -461,7 +461,7 @@ std::vector<SharedMatrix> RHF::twoel_Hx_full(std::vector<SharedMatrix> x_vec, bo
     SharedMatrix Co, Cv;
     for (size_t i = 0; i < x_vec.size(); i++) {
         if (c1_input_[i]) {
-            if ((x_vec[i]->rowspi()[0] != nalpha_) || (x_vec[i]->colspi()[0] != (nmo_ - nalpha_))) {
+            if ((x_vec[i]->rowspi()[0] != nalpha_) || (x_vec[i]->colspi()[0] != (Wavefunction::nmo() - nalpha_))) {
                 throw PSIEXCEPTION("SCF::twoel_Hx incoming rotation matrices must have shape (occ x vir).");
             }
             Co = Cocc_ao;
@@ -637,13 +637,13 @@ std::vector<SharedMatrix> RHF::cphf_solve(std::vector<SharedMatrix> x_vec, doubl
         auto Cocc_ao = Ca_subset("AO", "ALL");
         auto F_ao = matrix_subset_helper(Fa_, Ca_, "AO", "Fock");
         auto IFock_ao = linalg::triplet(Cocc_ao, F_ao, Cocc_ao, true, false, false);
-        Precon_ao = std::make_shared<Matrix>("Precon", nalpha_, nmo_ - nalpha_);
+        Precon_ao = std::make_shared<Matrix>("Precon", nalpha_, Wavefunction::nmo() - nalpha_);
 
         auto denomp = Precon_ao->pointer()[0];
         auto fp = IFock_ao->pointer();
 
         for (size_t i = 0, target = 0; i < nalpha_; i++) {
-            for (size_t a = nalpha_; a < nmo_; a++) {
+            for (size_t a = nalpha_; a < Wavefunction::nmo(); a++) {
                 denomp[target++] = -fp[i][i] + fp[a][a];
             }
         }

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -788,13 +788,13 @@ std::vector<SharedMatrix> UHF::cphf_solve(std::vector<SharedMatrix> x_vec, doubl
         auto Fb_ao = matrix_subset_helper(Fb_, Cb_, "AO", "Fock");
         auto IFock_ao_a = linalg::triplet(Caocc_ao, Fa_ao, Caocc_ao, true, false, false);
         auto IFock_ao_b = linalg::triplet(Cbocc_ao, Fb_ao, Cbocc_ao, true, false, false);
-        Precon_ao_a = std::make_shared<Matrix>("Precon", nalpha_, nmo_ - nalpha_);
-        Precon_ao_b = std::make_shared<Matrix>("Precon", nbeta_, nmo_ - nbeta_);
+        Precon_ao_a = std::make_shared<Matrix>("Precon", nalpha_, Wavefunction::nmo() - nalpha_);
+        Precon_ao_b = std::make_shared<Matrix>("Precon", nbeta_, Wavefunction::nmo() - nbeta_);
 
         auto denom_ap = Precon_ao_a->pointer()[0];
         auto f_ap = IFock_ao_a->pointer();
         for (size_t i = 0, target = 0; i < nalpha_; i++) {
-            for (size_t a = nalpha_; a < nmo_; a++) {
+            for (size_t a = nalpha_; a < Wavefunction::nmo(); a++) {
                 denom_ap[target++] = -f_ap[i][i] + f_ap[a][a];
             }
         }
@@ -802,7 +802,7 @@ std::vector<SharedMatrix> UHF::cphf_solve(std::vector<SharedMatrix> x_vec, doubl
         auto denom_bp = Precon_ao_b->pointer()[0];
         auto f_bp = IFock_ao_b->pointer();
         for (size_t i = 0, target = 0; i < nbeta_; i++) {
-            for (size_t a = nbeta_; a < nmo_; a++) {
+            for (size_t a = nbeta_; a < Wavefunction::nmo(); a++) {
                 denom_bp[target++] = -f_bp[i][i] + f_bp[a][a];
             }
         }
@@ -1106,7 +1106,7 @@ void UHF::compute_nos() {
     // Print the NOONs -- code ripped off from OEProp::compute_no_occupations()
     int max_num;
     if (options_.get_str("PRINT_NOONS") == "ALL")
-        max_num = nmo_;
+        max_num = Wavefunction::nmo();
     else
         max_num = to_integer(options_.get_str("PRINT_NOONS"));
 

--- a/psi4/src/psi4/mcscf/scf_save_info.cc
+++ b/psi4/src/psi4/mcscf/scf_save_info.cc
@@ -49,7 +49,6 @@ namespace mcscf {
 
 void SCF::save_info() {
     // No projection of MOs, just yet
-    nmo_ = nso_;
 
     // figure out how many frozen orbitals per irrep
     int nfrzc = basisset_->n_frozen_core();

--- a/psi4/src/psi4/occ/coord_grad.cc
+++ b/psi4/src/psi4/occ/coord_grad.cc
@@ -87,10 +87,10 @@ void OCCWave::dump_pdms() {
         psio_->open(PSIF_OCC_DENSITY, PSIO_OPEN_OLD);
 
         const int *alpha_corr_to_pitzer = ints->alpha_corr_to_pitzer();
-        auto *alpha_pitzer_to_corr = new int[nmo_];
-        memset(alpha_pitzer_to_corr, 0, nmo_ * sizeof(int));
+        auto *alpha_pitzer_to_corr = new int[Wavefunction::nmo()];
+        memset(alpha_pitzer_to_corr, 0, Wavefunction::nmo() * sizeof(int));
 
-        for (int n = 0; n < nmo_; ++n) {
+        for (int n = 0; n < Wavefunction::nmo(); ++n) {
             alpha_pitzer_to_corr[alpha_corr_to_pitzer[n]] = n;
         }
 
@@ -248,18 +248,18 @@ void OCCWave::dump_pdms() {
         psio_->open(PSIF_OCC_DENSITY, PSIO_OPEN_OLD);
 
         const int *alpha_corr_to_pitzer = ints->alpha_corr_to_pitzer();
-        auto *alpha_pitzer_to_corr = new int[nmo_];
-        memset(alpha_pitzer_to_corr, 0, nmo_ * sizeof(int));
+        auto *alpha_pitzer_to_corr = new int[Wavefunction::nmo()];
+        memset(alpha_pitzer_to_corr, 0, Wavefunction::nmo() * sizeof(int));
 
-        for (int n = 0; n < nmo_; ++n) {
+        for (int n = 0; n < Wavefunction::nmo(); ++n) {
             alpha_pitzer_to_corr[alpha_corr_to_pitzer[n]] = n;
         }
 
         const int *beta_corr_to_pitzer = ints->beta_corr_to_pitzer();
-        auto *beta_pitzer_to_corr = new int[nmo_];
-        memset(beta_pitzer_to_corr, 0, nmo_ * sizeof(int));
+        auto *beta_pitzer_to_corr = new int[Wavefunction::nmo()];
+        memset(beta_pitzer_to_corr, 0, Wavefunction::nmo() * sizeof(int));
 
-        for (int n = 0; n < nmo_; ++n) {
+        for (int n = 0; n < Wavefunction::nmo(); ++n) {
             beta_pitzer_to_corr[beta_corr_to_pitzer[n]] = n;
         }
 

--- a/psi4/src/psi4/occ/ekt_ea.cc
+++ b/psi4/src/psi4/occ/ekt_ea.cc
@@ -204,9 +204,9 @@ void OCCWave::ekt_ea() {
     if (reference_ == "RESTRICTED") ps_vecA.scale(0.5);
 
     // Sort pole strength
-    Array1d evals_A("Alpha ORB C1", nmo_);
-    Array1d ps_vec2A("Sorted Pole strength", nmo_);
-    Array1i irrep_A("IrrepA", nmo_);
+    Array1d evals_A("Alpha ORB C1", Wavefunction::nmo());
+    Array1d ps_vec2A("Sorted Pole strength", Wavefunction::nmo());
+    Array1i irrep_A("IrrepA", Wavefunction::nmo());
     evals_A.zero();
     ps_vec2A.zero();
     irrep_A.zero();
@@ -223,8 +223,8 @@ void OCCWave::ekt_ea() {
     }
 
     // Sort to descending order
-    for (int i = 0; i < nmo_; ++i) {
-        for (int j = nmo_ - 1; j > i; --j) {
+    for (int i = 0; i < Wavefunction::nmo(); ++i) {
+        for (int j = Wavefunction::nmo() - 1; j > i; --j) {
             if (ps_vec2A.get(j - 1) < ps_vec2A.get(j)) {
                 double dum = evals_A.get(j - 1);
                 evals_A.set(j - 1, evals_A.get(j));
@@ -301,7 +301,7 @@ void OCCWave::ekt_ea() {
         outfile->Printf("\tState    Symmetry   -EA (a.u.)       EA (eV)        Pole Strength \n");
         outfile->Printf("\t------------------------------------------------------------------- \n");
 
-        for (int i = 0; i < nmo_; ++i) {
+        for (int i = 0; i < Wavefunction::nmo(); ++i) {
             int h = irrep_A.get(i);
             outfile->Printf("\t%3d %10s %15.6f %15.6f %15.6f \n", i + 1, ct.gamma(h).symbol(), evals_A.get(i),
                             -evals_A.get(i) * pc_hartree2ev, ps_vec2A.get(i));
@@ -381,9 +381,9 @@ void OCCWave::ekt_ea() {
         }
 
         // Sort pole strength
-        Array1d evals_B("Alpha ORB C1", nmo_);
-        Array1d ps_vec2B("Sorted Pole strength", nmo_);
-        Array1i irrep_B("IrrepB", nmo_);
+        Array1d evals_B("Alpha ORB C1", Wavefunction::nmo());
+        Array1d ps_vec2B("Sorted Pole strength", Wavefunction::nmo());
+        Array1i irrep_B("IrrepB", Wavefunction::nmo());
         evals_B.zero();
         ps_vec2B.zero();
         irrep_B.zero();
@@ -400,8 +400,8 @@ void OCCWave::ekt_ea() {
         }
 
         // Sort to descending order
-        for (int i = 0; i < nmo_; ++i) {
-            for (int j = nmo_ - 1; j > i; --j) {
+        for (int i = 0; i < Wavefunction::nmo(); ++i) {
+            for (int j = Wavefunction::nmo() - 1; j > i; --j) {
                 if (ps_vec2B.get(j - 1) < ps_vec2B.get(j)) {
                     double dum = evals_B.get(j - 1);
                     evals_B.set(j - 1, evals_B.get(j));
@@ -474,7 +474,7 @@ void OCCWave::ekt_ea() {
             outfile->Printf("\tState    Symmetry   -EA (a.u.)       EA (eV)        Pole Strength \n");
             outfile->Printf("\t------------------------------------------------------------------- \n");
 
-            for (int i = 0; i < nmo_; ++i) {
+            for (int i = 0; i < Wavefunction::nmo(); ++i) {
                 int h = irrep_B.get(i);
                 outfile->Printf("\t%3d %10s %15.6f %15.6f %15.6f \n", i + 1, ct.gamma(h).symbol(), evals_B.get(i),
                                 -evals_B.get(i) * pc_hartree2ev, ps_vec2B.get(i));

--- a/psi4/src/psi4/occ/ekt_ip.cc
+++ b/psi4/src/psi4/occ/ekt_ip.cc
@@ -148,9 +148,9 @@ void OCCWave::ekt_ip() {
     if (reference_ == "RESTRICTED") ps_vecA.scale(0.5);
 
     // Sort pole strength
-    Array1d evals_A("Alpha ORB C1", nmo_);
-    Array1d ps_vec2A("Sorted Pole strength", nmo_);
-    Array1i irrep_A("IrrepA", nmo_);
+    Array1d evals_A("Alpha ORB C1", Wavefunction::nmo());
+    Array1d ps_vec2A("Sorted Pole strength", Wavefunction::nmo());
+    Array1i irrep_A("IrrepA", Wavefunction::nmo());
     evals_A.zero();
     ps_vec2A.zero();
     irrep_A.zero();
@@ -167,8 +167,8 @@ void OCCWave::ekt_ip() {
     }
 
     // Sort to descending order
-    for (int i = 0; i < nmo_; ++i) {
-        for (int j = nmo_ - 1; j > i; --j) {
+    for (int i = 0; i < Wavefunction::nmo(); ++i) {
+        for (int j = Wavefunction::nmo() - 1; j > i; --j) {
             if (ps_vec2A.get(j - 1) < ps_vec2A.get(j)) {
                 double dum = evals_A.get(j - 1);
                 evals_A.set(j - 1, evals_A.get(j));
@@ -245,7 +245,7 @@ void OCCWave::ekt_ip() {
         outfile->Printf("\tState    Symmetry   -IP (a.u.)       IP (eV)        Pole Strength \n");
         outfile->Printf("\t------------------------------------------------------------------- \n");
 
-        for (int i = 0; i < nmo_; ++i) {
+        for (int i = 0; i < Wavefunction::nmo(); ++i) {
             int h = irrep_A.get(i);
             outfile->Printf("\t%3d %10s %15.6f %15.6f %15.6f \n", i + 1, ct.gamma(h).symbol(), evals_A.get(i),
                             -evals_A.get(i) * pc_hartree2ev, ps_vec2A.get(i));
@@ -360,9 +360,9 @@ void OCCWave::ekt_ip() {
         }
 
         // Sort pole strength
-        Array1d evals_B("Alpha ORB C1", nmo_);
-        Array1d ps_vec2B("Sorted Pole strength", nmo_);
-        Array1i irrep_B("IrrepB", nmo_);
+        Array1d evals_B("Alpha ORB C1", Wavefunction::nmo());
+        Array1d ps_vec2B("Sorted Pole strength", Wavefunction::nmo());
+        Array1i irrep_B("IrrepB", Wavefunction::nmo());
         evals_B.zero();
         ps_vec2B.zero();
         irrep_B.zero();
@@ -379,8 +379,8 @@ void OCCWave::ekt_ip() {
         }
 
         // Sort to descending order
-        for (int i = 0; i < nmo_; ++i) {
-            for (int j = nmo_ - 1; j > i; --j) {
+        for (int i = 0; i < Wavefunction::nmo(); ++i) {
+            for (int j = Wavefunction::nmo() - 1; j > i; --j) {
                 if (ps_vec2B.get(j - 1) < ps_vec2B.get(j)) {
                     double dum = evals_B.get(j - 1);
                     evals_B.set(j - 1, evals_B.get(j));
@@ -453,7 +453,7 @@ void OCCWave::ekt_ip() {
             outfile->Printf("\tState    Symmetry   -IP (a.u.)       IP (eV)        Pole Strength \n");
             outfile->Printf("\t------------------------------------------------------------------- \n");
 
-            for (int i = 0; i < nmo_; ++i) {
+            for (int i = 0; i < Wavefunction::nmo(); ++i) {
                 int h = irrep_B.get(i);
                 outfile->Printf("\t%3d %10s %15.6f %15.6f %15.6f \n", i + 1, ct.gamma(h).symbol(), evals_B.get(i),
                                 -evals_B.get(i) * pc_hartree2ev, ps_vec2B.get(i));

--- a/psi4/src/psi4/occ/get_moinfo.cc
+++ b/psi4/src/psi4/occ/get_moinfo.cc
@@ -56,7 +56,6 @@ void OCCWave::get_moinfo() {
         // Read in mo info
         nso_ = reference_wavefunction_->nso();
         nirrep_ = reference_wavefunction_->nirrep();
-        nmo_ = reference_wavefunction_->nmo();
         nmopi_ = reference_wavefunction_->nmopi();
         nsopi_ = reference_wavefunction_->nsopi();
         frzcpi_ = reference_wavefunction_->frzcpi();
@@ -91,8 +90,8 @@ void OCCWave::get_moinfo() {
         // epsilon_a_ = SharedVector(reference_wavefunction_->epsilon_a());
 
         /* Build mosym arrays */
-        mosym = new int[nmo_];
-        memset(mosym, 0, sizeof(int) * nmo_);
+        mosym = new int[Wavefunction::nmo()];
+        memset(mosym, 0, sizeof(int) * Wavefunction::nmo());
         for (int h = 0, q = 0; h < nirrep_; h++) {
             for (int p = 0; p < nmopi_[h]; p++) {
                 mosym[q++] = h;
@@ -101,7 +100,7 @@ void OCCWave::get_moinfo() {
 
         /* Build sosym arrays */
         sosym = new int[nso_];
-        memset(sosym, 0, sizeof(int) * nmo_);
+        memset(sosym, 0, sizeof(int) * Wavefunction::nmo());
         for (int h = 0, q = 0; h < nirrep_; h++) {
             for (int p = 0; p < nsopi_[h]; p++) {
                 sosym[q++] = h;
@@ -118,25 +117,25 @@ void OCCWave::get_moinfo() {
             PitzerOffset[h] = PitzerOffset[h - 1] + nmopi_[h - 1];
         }
 
-        nvoA = nmo_ - nooA;            // Number of virtual orbitals
-        nacooA = nooA - nfrzc;         // Number of active occupied orbitals
-        nacso = nmo_ - nfrzc - nfrzv;  // Number of active  orbitals
-        nacvoA = nvoA - nfrzv;         // Number of active virtual orbitals
-        npop = nmo_ - nfrzv;           // Number of populated orbitals
+        nvoA = Wavefunction::nmo() - nooA;            // Number of virtual orbitals
+        nacooA = nooA - nfrzc;                        // Number of active occupied orbitals
+        nacso = Wavefunction::nmo() - nfrzc - nfrzv;  // Number of active  orbitals
+        nacvoA = nvoA - nfrzv;                        // Number of active virtual orbitals
+        npop = Wavefunction::nmo() - nfrzv;           // Number of populated orbitals
 
         ntri_so = 0.5 * nso_ * (nso_ + 1);
-        ntri = 0.5 * nmo_ * (nmo_ + 1);
+        ntri = 0.5 * Wavefunction::nmo() * (Wavefunction::nmo() + 1);
         dimtei = 0.5 * ntri * (ntri + 1);
 
         /********************************************************************************************/
         /************************** pitzer2symblk ***************************************************/
         /********************************************************************************************/
-        pitzer2symirrep = new int[nmo_];
-        pitzer2symblk = new int[nmo_];
+        pitzer2symirrep = new int[Wavefunction::nmo()];
+        pitzer2symblk = new int[Wavefunction::nmo()];
         occ2symblkA = new int[nooA];
         virt2symblkA = new int[nvoA];
-        memset(pitzer2symirrep, 0, sizeof(int) * nmo_);
-        memset(pitzer2symblk, 0, sizeof(int) * nmo_);
+        memset(pitzer2symirrep, 0, sizeof(int) * Wavefunction::nmo());
+        memset(pitzer2symblk, 0, sizeof(int) * Wavefunction::nmo());
         memset(occ2symblkA, 0, sizeof(int) * nooA);
         memset(virt2symblkA, 0, sizeof(int) * nvoA);
 
@@ -177,7 +176,7 @@ void OCCWave::get_moinfo() {
 
         // print
         if (print_ > 1) {
-            for (int p = 0; p < nmo_; p++) {
+            for (int p = 0; p < Wavefunction::nmo(); p++) {
                 outfile->Printf(" p, pitzer2symblk[p]: %2d %2d \n", p, pitzer2symblk[p]);
             }
             outfile->Printf("\n");
@@ -186,25 +185,25 @@ void OCCWave::get_moinfo() {
         /********************************************************************************************/
         /************************** qt2pitzer *******************************************************/
         /********************************************************************************************/
-        qt2pitzerA = new int[nmo_];
-        pitzer2qtA = new int[nmo_];
-        memset(qt2pitzerA, 0, sizeof(int) * nmo_);
-        memset(pitzer2qtA, 0, sizeof(int) * nmo_);
+        qt2pitzerA = new int[Wavefunction::nmo()];
+        pitzer2qtA = new int[Wavefunction::nmo()];
+        memset(qt2pitzerA, 0, sizeof(int) * Wavefunction::nmo());
+        memset(pitzer2qtA, 0, sizeof(int) * Wavefunction::nmo());
 
         reorder_qt(doccpi(), soccpi(), frzcpi_, frzvpi_, pitzer2qtA, nmopi_, nirrep_);
-        for (int p = 0; p < nmo_; p++) {
+        for (int p = 0; p < Wavefunction::nmo(); p++) {
             int pa = pitzer2qtA[p];
             qt2pitzerA[pa] = p;
         }
 
         // print
         if (print_ > 1) {
-            for (int p = 0; p < nmo_; p++) {
+            for (int p = 0; p < Wavefunction::nmo(); p++) {
                 outfile->Printf(" p, pitzer2qtA[p]: %2d %2d \n", p, pitzer2qtA[p]);
             }
             outfile->Printf("\n");
 
-            for (int p = 0; p < nmo_; p++) {
+            for (int p = 0; p < Wavefunction::nmo(); p++) {
                 outfile->Printf(" p, qt2pitzerA[p]: %2d %2d \n", p, qt2pitzerA[p]);
             }
             outfile->Printf("\n");
@@ -337,13 +336,13 @@ void OCCWave::get_moinfo() {
         if (read_mo_coeff == "TRUE") {
             outfile->Printf("\n\tReading MO coefficients in pitzer order from the external file CmoA.psi...\n");
 
-            double **C_pitzerA = block_matrix(nso_, nmo_);
-            memset(C_pitzerA[0], 0, sizeof(double) * nso_ * nmo_);
+            double **C_pitzerA = block_matrix(nso_, Wavefunction::nmo());
+            memset(C_pitzerA[0], 0, sizeof(double) * nso_ * Wavefunction::nmo());
 
             // read binary data
             std::ifstream InFile1;
             InFile1.open("CmoA.psi", std::ios::in | std::ios::binary);
-            InFile1.read((char *)C_pitzerA[0], sizeof(double) * nso_ * nmo_);
+            InFile1.read((char *)C_pitzerA[0], sizeof(double) * nso_ * Wavefunction::nmo());
             InFile1.close();
 
             // set C_scf
@@ -369,7 +368,6 @@ void OCCWave::get_moinfo() {
         // Read in mo info
         nso_ = reference_wavefunction_->nso();
         nirrep_ = reference_wavefunction_->nirrep();
-        nmo_ = reference_wavefunction_->nmo();
         nmopi_ = reference_wavefunction_->nmopi();
         nsopi_ = reference_wavefunction_->nsopi();
         frzcpi_ = reference_wavefunction_->frzcpi();
@@ -408,8 +406,8 @@ void OCCWave::get_moinfo() {
         epsilon_b_ = reference_wavefunction_->epsilon_b();
 
         /* Build mosym arrays */
-        mosym = new int[nmo_];
-        memset(mosym, 0, sizeof(int) * nmo_);
+        mosym = new int[Wavefunction::nmo()];
+        memset(mosym, 0, sizeof(int) * Wavefunction::nmo());
         for (int h = 0, q = 0; h < nirrep_; h++) {
             for (int p = 0; p < nmopi_[h]; p++) {
                 mosym[q++] = h;
@@ -418,7 +416,7 @@ void OCCWave::get_moinfo() {
 
         /* Build sosym arrays */
         sosym = new int[nso_];
-        memset(sosym, 0, sizeof(int) * nmo_);
+        memset(sosym, 0, sizeof(int) * Wavefunction::nmo());
         for (int h = 0, q = 0; h < nirrep_; h++) {
             for (int p = 0; p < nsopi_[h]; p++) {
                 sosym[q++] = h;
@@ -436,30 +434,30 @@ void OCCWave::get_moinfo() {
             PitzerOffset[h] = PitzerOffset[h - 1] + nmopi_[h - 1];
         }
 
-        nvoA = nmo_ - nooA;            // Number of virtual orbitals
-        nvoB = nmo_ - nooB;            // Number of virtual orbitals
-        nacooA = nooA - nfrzc;         // Number of active occupied orbitals
-        nacooB = nooB - nfrzc;         // Number of active occupied orbitals
-        nacso = nmo_ - nfrzc - nfrzv;  // Number of active  orbitals
-        nacvoA = nvoA - nfrzv;         // Number of active virtual orbitals
-        nacvoB = nvoB - nfrzv;         // Number of active virtual orbitals
-        npop = nmo_ - nfrzv;           // Number of populated orbitals
+        nvoA = Wavefunction::nmo() - nooA;            // Number of virtual orbitals
+        nvoB = Wavefunction::nmo() - nooB;            // Number of virtual orbitals
+        nacooA = nooA - nfrzc;                        // Number of active occupied orbitals
+        nacooB = nooB - nfrzc;                        // Number of active occupied orbitals
+        nacso = Wavefunction::nmo() - nfrzc - nfrzv;  // Number of active  orbitals
+        nacvoA = nvoA - nfrzv;                        // Number of active virtual orbitals
+        nacvoB = nvoB - nfrzv;                        // Number of active virtual orbitals
+        npop = Wavefunction::nmo() - nfrzv;           // Number of populated orbitals
 
         ntri_so = 0.5 * nso_ * (nso_ + 1);
-        ntri = 0.5 * nmo_ * (nmo_ + 1);
+        ntri = 0.5 * Wavefunction::nmo() * (Wavefunction::nmo() + 1);
         dimtei = 0.5 * ntri * (ntri + 1);
 
         /********************************************************************************************/
         /************************** pitzer2symblk ***************************************************/
         /********************************************************************************************/
-        pitzer2symirrep = new int[nmo_];
-        pitzer2symblk = new int[nmo_];
+        pitzer2symirrep = new int[Wavefunction::nmo()];
+        pitzer2symblk = new int[Wavefunction::nmo()];
         occ2symblkA = new int[nooA];
         occ2symblkB = new int[nooB];
         virt2symblkA = new int[nvoA];
         virt2symblkB = new int[nvoB];
-        memset(pitzer2symirrep, 0, sizeof(int) * nmo_);
-        memset(pitzer2symblk, 0, sizeof(int) * nmo_);
+        memset(pitzer2symirrep, 0, sizeof(int) * Wavefunction::nmo());
+        memset(pitzer2symblk, 0, sizeof(int) * Wavefunction::nmo());
         memset(occ2symblkA, 0, sizeof(int) * nooA);
         memset(occ2symblkB, 0, sizeof(int) * nooB);
         memset(virt2symblkA, 0, sizeof(int) * nvoA);
@@ -524,7 +522,7 @@ void OCCWave::get_moinfo() {
 
         // print
         if (print_ > 1) {
-            for (int p = 0; p < nmo_; p++) {
+            for (int p = 0; p < Wavefunction::nmo(); p++) {
                 outfile->Printf(" p, pitzer2symblk[p]: %2d %2d \n", p, pitzer2symblk[p]);
             }
             outfile->Printf("\n");
@@ -533,16 +531,16 @@ void OCCWave::get_moinfo() {
         /********************************************************************************************/
         /************************** qt2pitzer *******************************************************/
         /********************************************************************************************/
-        qt2pitzerA = new int[nmo_];
-        pitzer2qtA = new int[nmo_];
-        qt2pitzerB = new int[nmo_];
-        pitzer2qtB = new int[nmo_];
-        memset(qt2pitzerA, 0, sizeof(int) * nmo_);
-        memset(pitzer2qtA, 0, sizeof(int) * nmo_);
-        memset(qt2pitzerB, 0, sizeof(int) * nmo_);
-        memset(pitzer2qtB, 0, sizeof(int) * nmo_);
+        qt2pitzerA = new int[Wavefunction::nmo()];
+        pitzer2qtA = new int[Wavefunction::nmo()];
+        qt2pitzerB = new int[Wavefunction::nmo()];
+        pitzer2qtB = new int[Wavefunction::nmo()];
+        memset(qt2pitzerA, 0, sizeof(int) * Wavefunction::nmo());
+        memset(pitzer2qtA, 0, sizeof(int) * Wavefunction::nmo());
+        memset(qt2pitzerB, 0, sizeof(int) * Wavefunction::nmo());
+        memset(pitzer2qtB, 0, sizeof(int) * Wavefunction::nmo());
         reorder_qt_uhf(doccpi(), soccpi(), frzcpi_, frzvpi_, pitzer2qtA, pitzer2qtB, nmopi_, nirrep_);
-        for (int p = 0; p < nmo_; p++) {
+        for (int p = 0; p < Wavefunction::nmo(); p++) {
             int pa = pitzer2qtA[p];
             int pb = pitzer2qtB[p];
             qt2pitzerA[pa] = p;
@@ -551,22 +549,22 @@ void OCCWave::get_moinfo() {
 
         // print
         if (print_ > 1) {
-            for (int p = 0; p < nmo_; p++) {
+            for (int p = 0; p < Wavefunction::nmo(); p++) {
                 outfile->Printf(" p, pitzer2qtA[p]: %2d %2d \n", p, pitzer2qtA[p]);
             }
             outfile->Printf("\n");
 
-            for (int p = 0; p < nmo_; p++) {
+            for (int p = 0; p < Wavefunction::nmo(); p++) {
                 outfile->Printf(" p, pitzer2qtB[p]: %2d %2d \n", p, pitzer2qtB[p]);
             }
             outfile->Printf("\n");
 
-            for (int p = 0; p < nmo_; p++) {
+            for (int p = 0; p < Wavefunction::nmo(); p++) {
                 outfile->Printf(" p, qt2pitzerA[p]: %2d %2d \n", p, qt2pitzerA[p]);
             }
             outfile->Printf("\n");
 
-            for (int p = 0; p < nmo_; p++) {
+            for (int p = 0; p < Wavefunction::nmo(); p++) {
                 outfile->Printf(" p, qt2pitzerB[p]: %2d %2d \n", p, qt2pitzerB[p]);
             }
             outfile->Printf("\n");
@@ -643,21 +641,21 @@ void OCCWave::get_moinfo() {
             outfile->Printf(
                 "\n\tReading MO coefficients in pitzer order from external files CmoA.psi and CmoB.psi...\n");
 
-            double **C_pitzerA = block_matrix(nso_, nmo_);
-            double **C_pitzerB = block_matrix(nso_, nmo_);
-            memset(C_pitzerA[0], 0, sizeof(double) * nso_ * nmo_);
-            memset(C_pitzerB[0], 0, sizeof(double) * nso_ * nmo_);
+            double **C_pitzerA = block_matrix(nso_, Wavefunction::nmo());
+            double **C_pitzerB = block_matrix(nso_, Wavefunction::nmo());
+            memset(C_pitzerA[0], 0, sizeof(double) * nso_ * Wavefunction::nmo());
+            memset(C_pitzerB[0], 0, sizeof(double) * nso_ * Wavefunction::nmo());
 
             // read binary data
             std::ifstream InFile1;
             InFile1.open("CmoA.psi", std::ios::in | std::ios::binary);
-            InFile1.read((char *)C_pitzerA[0], sizeof(double) * nso_ * nmo_);
+            InFile1.read((char *)C_pitzerA[0], sizeof(double) * nso_ * Wavefunction::nmo());
             InFile1.close();
 
             // read binary data
             std::ifstream InFile2;
             InFile2.open("CmoB.psi", std::ios::in | std::ios::binary);
-            InFile2.read((char *)C_pitzerB[0], sizeof(double) * nso_ * nmo_);
+            InFile2.read((char *)C_pitzerB[0], sizeof(double) * nso_ * Wavefunction::nmo());
             InFile2.close();
 
             // set C_scf
@@ -691,5 +689,5 @@ void OCCWave::get_moinfo() {
     Hso = SharedMatrix(Tso->clone());
     Hso->add(Vso);
 }
-}
-}  // End Namespaces
+}  // namespace occwave
+}  // namespace psi

--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -454,8 +454,8 @@ double OCCWave::compute_energy() {
     if (write_mo_coeff == "TRUE") {
         outfile->Printf("\n\tWriting MO coefficients in pitzer order to external file CmoA.psi...\n");
 
-        double **C_pitzerA = block_matrix(nso_, nmo_);
-        memset(C_pitzerA[0], 0, sizeof(double) * nso_ * nmo_);
+        double **C_pitzerA = block_matrix(nso_, Wavefunction::nmo());
+        memset(C_pitzerA[0], 0, sizeof(double) * nso_ * Wavefunction::nmo());
 
         // set C_pitzer
         C_pitzerA = Ca_->to_block_matrix();
@@ -463,15 +463,15 @@ double OCCWave::compute_energy() {
         // write binary data
         std::ofstream OutFile1;
         OutFile1.open("CmoA.psi", std::ios::out | std::ios::binary);
-        OutFile1.write((char *)C_pitzerA[0], sizeof(double) * nso_ * nmo_);
+        OutFile1.write((char *)C_pitzerA[0], sizeof(double) * nso_ * Wavefunction::nmo());
         OutFile1.close();
         free_block(C_pitzerA);
 
         if (reference_ == "UNRESTRICTED") {
             outfile->Printf("\n\tWriting MO coefficients in pitzer order to external file CmoB.psi...\n");
 
-            double **C_pitzerB = block_matrix(nso_, nmo_);
-            memset(C_pitzerB[0], 0, sizeof(double) * nso_ * nmo_);
+            double **C_pitzerB = block_matrix(nso_, Wavefunction::nmo());
+            memset(C_pitzerB[0], 0, sizeof(double) * nso_ * Wavefunction::nmo());
 
             // set C_pitzer
             C_pitzerB = Cb_->to_block_matrix();
@@ -479,7 +479,7 @@ double OCCWave::compute_energy() {
             // write binary data
             std::ofstream OutFile2;
             OutFile2.open("CmoB.psi", std::ios::out | std::ios::binary);
-            OutFile2.write((char *)C_pitzerB[0], sizeof(double) * nso_ * nmo_);
+            OutFile2.write((char *)C_pitzerB[0], sizeof(double) * nso_ * Wavefunction::nmo());
             OutFile2.close();
             free_block(C_pitzerB);
         }

--- a/psi4/src/psi4/scfgrad/response.cc
+++ b/psi4/src/psi4/scfgrad/response.cc
@@ -2183,9 +2183,9 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response() {
     auto ao_dipole = mints.ao_dipole();
     auto Ca = Ca_subset("AO");
     auto Caocc = Ca_subset("AO", "OCC");
-    Matrix mu_x("mu X", nmo_, nocc);
-    Matrix mu_y("mu Y", nmo_, nocc);
-    Matrix mu_z("mu Z", nmo_, nocc);
+    Matrix mu_x("mu X", Wavefunction::nmo(), nocc);
+    Matrix mu_y("mu Y", Wavefunction::nmo(), nocc);
+    Matrix mu_z("mu Z", Wavefunction::nmo(), nocc);
     mu_x.transform(Ca, ao_dipole[0], Caocc);
     mu_y.transform(Ca, ao_dipole[1], Caocc);
     mu_z.transform(Ca, ao_dipole[2], Caocc);
@@ -4707,12 +4707,12 @@ void USCFDeriv::dipole_derivatives(std::shared_ptr<Matrix> C1,
 
     MintsHelper mints(basisset_);
     auto ao_dipole = mints.ao_dipole();
-    Matrix mu1_x("mu X", nmo_, n1occ);
-    Matrix mu1_y("mu Y", nmo_, n1occ);
-    Matrix mu1_z("mu Z", nmo_, n1occ);
-    Matrix mu2_x("mu X", nmo_, n2occ);
-    Matrix mu2_y("mu Y", nmo_, n2occ);
-    Matrix mu2_z("mu Z", nmo_, n2occ);
+    Matrix mu1_x("mu X", Wavefunction::nmo(), n1occ);
+    Matrix mu1_y("mu Y", Wavefunction::nmo(), n1occ);
+    Matrix mu1_z("mu Z", Wavefunction::nmo(), n1occ);
+    Matrix mu2_x("mu X", Wavefunction::nmo(), n2occ);
+    Matrix mu2_y("mu Y", Wavefunction::nmo(), n2occ);
+    Matrix mu2_z("mu Z", Wavefunction::nmo(), n2occ);
     mu1_x.transform(C1, ao_dipole[0], C1occ);
     mu1_y.transform(C1, ao_dipole[1], C1occ);
     mu1_z.transform(C1, ao_dipole[2], C1occ);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Refactored code in the WaveFunction class as per #2875

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] No changes to user experience

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Removed `nmo_` cache variable in favor of `nmopi_.sum()` to keep things in sync
- [ ] Refactored code to reflect removal of variable

## Questions
- [ ] Best ways to test this change?

## Checklist
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge

#2875