### PR TITLE
More SCF Convergence Control for COSX Final Grid

### DIFF
--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -829,12 +829,15 @@ Both the accuracy of the COSX algorithm and also the computational
 cost are directly determined by the size of the integration grid, so selection
 of the grid is important. This COSX implementation uses two separate grids.
 By default, the SCF algorithm is first converged on a smaller grid, followed by a
-final SCF iteration on a larger grid. This results in numerical errors comparable to
+number of SCF iterations up to a maximum value (controlled by the |scf__cosx_maxiter_final| keyword)
+on a larger grid. By default, |scf__cosx_maxiter_final| is set to 1, a single
+SCF iteration, which results in numerical errors comparable to
 performing the entire SCF on the expensive larger grid at a computational cost
-much closer to the smaller grid. If desired, the SCF algorithm can also converge
-on the larger COSX grid by setting the |scf__cosx_full_scf| keyword to ``TRUE``, useful
-for the study of wavefunction properties such as gradients. The size of the initial grid
-is controlled by the keywords |scf__cosx_radial_points_initial| and |scf__cosx_spherical_points_initial|.
+much closer to the smaller grid. Setting |scf__cosx_maxiter_final| to 0 disables the
+larger grid entirely. Setting |scf__cosx_maxiter_final| to a negative number allows
+for the SCF to fully converge on the larger grid, useful for the study of wavefunction
+properties such as gradients. The size of the initial grid is controlled by the keywords
+|scf__cosx_radial_points_initial| and |scf__cosx_spherical_points_initial|.
 The final grid is controlled by |scf__cosx_radial_points_final| and
 |scf__cosx_spherical_points_final|. The defaults for both grids aim to balance
 cost and accuracy.

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -828,11 +828,13 @@ DFT quadrature grids, which are described in :ref:`sec:dft`.
 Both the accuracy of the COSX algorithm and also the computational
 cost are directly determined by the size of the integration grid, so selection
 of the grid is important. This COSX implementation uses two separate grids.
-The SCF algorithm is first converged on a smaller grid, followed by a final SCF
-iteration on a larger grid. This results in numerical errors comparable to
+By default, the SCF algorithm is first converged on a smaller grid, followed by a
+final SCF iteration on a larger grid. This results in numerical errors comparable to
 performing the entire SCF on the expensive larger grid at a computational cost
-much closer to the smaller grid. The size of the initial grid is controlled by the
-keywords |scf__cosx_radial_points_initial| and |scf__cosx_spherical_points_initial|.
+much closer to the smaller grid. If desired, the SCF algorithm can also converge
+on the larger COSX grid by setting the |scf__cosx_full_scf| keyword to ``TRUE``, useful
+for the study of wavefunction properties such as gradients. The size of the initial grid
+is controlled by the keywords |scf__cosx_radial_points_initial| and |scf__cosx_spherical_points_initial|.
 The final grid is controlled by |scf__cosx_radial_points_final| and
 |scf__cosx_spherical_points_final|. The defaults for both grids aim to balance
 cost and accuracy.

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -834,7 +834,7 @@ on a larger grid. By default, |scf__cosx_maxiter_final| is set to 1, a single
 SCF iteration, which results in numerical errors comparable to
 performing the entire SCF on the expensive larger grid at a computational cost
 much closer to the smaller grid. Setting |scf__cosx_maxiter_final| to 0 disables the
-larger grid entirely. Setting |scf__cosx_maxiter_final| to a negative number allows
+larger grid entirely. Setting |scf__cosx_maxiter_final| to -1 allows
 for the SCF to fully converge on the larger grid, useful for the study of wavefunction
 properties such as gradients. The size of the initial grid is controlled by the keywords
 |scf__cosx_radial_points_initial| and |scf__cosx_spherical_points_initial|.

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -270,6 +270,8 @@ def scf_iterate(self, e_conv=None, d_conv=None):
 
     # does the JK algorithm use severe screening approximations for early SCF iterations?
     early_screening = self.jk().get_early_screening()
+    # does the JK algorithm fully converge after early screening is disabled? 
+    early_screening_full_scf = core.get_option('SCF', 'COSX_FULL_SCF') 
 
     # has early_screening changed from True to False?
     early_screening_disabled = False
@@ -497,7 +499,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
             continue
 
         # this is the first iteration after early screening was turned off
-        if early_screening_disabled:
+        if early_screening_disabled and not early_screening_full_scf:
             break
 
         # Call any postiteration callbacks
@@ -518,7 +520,10 @@ def scf_iterate(self, e_conv=None, d_conv=None):
                     self.jk().clear_D_prev()
 
                 core.print_out("  Energy and wave function converged with early screening.\n")
-                core.print_out("  Performing final iteration with tighter screening.\n\n")
+                if early_screening_full_scf:
+                    core.print_out("  Continuing SCF iterations with tighter screening.\n\n")
+                else:
+                    core.print_out("  Performing final iteration with tighter screening.\n\n")
             else:
                 break
 

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -270,7 +270,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
 
     # does the JK algorithm use severe screening approximations for early SCF iterations?
     early_screening = self.jk().get_early_screening()
-    # does the JK algorithm fully converge after early screening is disabled? 
+    # does the SCF fully converge after early screening is disabled? 
     early_screening_full_scf = core.get_option('SCF', 'COSX_FULL_SCF') 
 
     # has early_screening changed from True to False?

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -273,6 +273,9 @@ def scf_iterate(self, e_conv=None, d_conv=None):
     # maximum number of scf iterations to run after early screening is disabled
     scf_maxiter_post_screening = core.get_option('SCF', 'COSX_MAXITER_FINAL')
 
+    if scf_maxiter_post_screening < -1:
+        raise ValidationError('COSX_MAXITER_FINAL ({}) must be -1 or above. If you wish to attempt full SCF converge on the final COSX grid, set COSX_MAXITER_FINAL to -1.'.format(scf_maxiter_post_screening))
+
     # has early_screening changed from True to False?
     early_screening_disabled = False
 

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -279,7 +279,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
     # SCF iterations!
     SCFE_old = 0.0
     Dnorm = 0.0
-    scf_iter_post_screening = 0 
+    scf_iter_post_screening = 0
     while True:
         self.iteration_ += 1
 
@@ -500,10 +500,10 @@ def scf_iterate(self, e_conv=None, d_conv=None):
             continue
 
         # have we completed our post-early screening SCF iterations? 
-        if early_screening_disabled: 
+        if early_screening_disabled:
             scf_iter_post_screening += 1
             if scf_iter_post_screening >= scf_maxiter_post_screening and scf_maxiter_post_screening > 0:
-                break 
+                break
 
         # Call any postiteration callbacks
         if not ((self.iteration_ == 0) and self.sad_) and _converged(Ediff, Dnorm, e_conv=e_conv, d_conv=d_conv):

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -182,7 +182,6 @@ void CompositeJK::common_init() {
     density_screening_ = options_.get_str("SCREENING") == "DENSITY";
     set_cutoff(options_.get_double("INTS_TOLERANCE"));
     early_screening_ = k_type_ == "COSX" ? true : false;
-    //early_screening_ = true; 
     
     // pre-construct per-thread TwoBodyAOInt objects for computing 3- and 4-index ERIs
     timer_on("CompositeJK: ERI Computers");

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -182,7 +182,7 @@ void CompositeJK::common_init() {
     density_screening_ = options_.get_str("SCREENING") == "DENSITY";
     set_cutoff(options_.get_double("INTS_TOLERANCE"));
     early_screening_ = k_type_ == "COSX" ? true : false;
-    
+
     // pre-construct per-thread TwoBodyAOInt objects for computing 3- and 4-index ERIs
     timer_on("CompositeJK: ERI Computers");
     

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -181,8 +181,9 @@ void CompositeJK::common_init() {
     // other options
     density_screening_ = options_.get_str("SCREENING") == "DENSITY";
     set_cutoff(options_.get_double("INTS_TOLERANCE"));
-    early_screening_ = true;
-
+    early_screening_ = k_type_ == "COSX" ? true : false;
+    //early_screening_ = true; 
+    
     // pre-construct per-thread TwoBodyAOInt objects for computing 3- and 4-index ERIs
     timer_on("CompositeJK: ERI Computers");
     

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1681,8 +1681,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_int("COSX_RADIAL_POINTS_FINAL", 35);
         /*- Screening criteria for integrals and intermediates in COSX -*/
         options.add_double("COSX_INTS_TOLERANCE", 1.0E-11);
-        /*- Fully converge SCF on larger (i.e., final) grid? -*/ 
-        options.add_bool("COSX_FULL_SCF", false);
+        /*- Maximum number of SCF iterations to run on on larger (i.e., final) COSX grid -*/
+        options.add_int("COSX_MAXITER_FINAL", 1);
         /*- Screening criteria for shell-pair densities in COSX !expert -*/
         options.add_double("COSX_DENSITY_TOLERANCE", 1.0E-10);
         /*- Screening criteria for basis function values on COSX grids !expert -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1684,7 +1684,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- Controls SCF iteration behavior for the larger (i.e., final) COSX grid.
         -1 fully converges the SCF on the final grid if possible, ending early if |scf__maxiter| total SCF iterations are reached (failure).
         0 disables the final COSX grid entirely.
-        n runs up to n iterations on the final COSX grid, ending early if SCF convergence is reached or MAXITER total SCF iterations are performed. -*/
+        n runs up to n iterations on the final COSX grid, ending early if SCF convergence is reached (success) or if |scf__maxiter| total SCF iterations are reached (failure). -*/
         options.add_int("COSX_MAXITER_FINAL", 1);
         /*- Screening criteria for shell-pair densities in COSX !expert -*/
         options.add_double("COSX_DENSITY_TOLERANCE", 1.0E-10);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1681,7 +1681,10 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_int("COSX_RADIAL_POINTS_FINAL", 35);
         /*- Screening criteria for integrals and intermediates in COSX -*/
         options.add_double("COSX_INTS_TOLERANCE", 1.0E-11);
-        /*- Maximum number of SCF iterations to run on on larger (i.e., final) COSX grid -*/
+        /*- Controls SCF iteration behavior for the larger (i.e., final) COSX grid.
+        -1 fully converges the SCF on the final grid if possible, ending early if MAXITER total SCF iterations are performed.
+        0 disables the final COSX grid entirely.
+        n runs up to n iterations on the final COSX grid, ending early if SCF convergence is reached or MAXITER total SCF iterations are performed. -*/
         options.add_int("COSX_MAXITER_FINAL", 1);
         /*- Screening criteria for shell-pair densities in COSX !expert -*/
         options.add_double("COSX_DENSITY_TOLERANCE", 1.0E-10);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1682,7 +1682,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- Screening criteria for integrals and intermediates in COSX -*/
         options.add_double("COSX_INTS_TOLERANCE", 1.0E-11);
         /*- Controls SCF iteration behavior for the larger (i.e., final) COSX grid.
-        -1 fully converges the SCF on the final grid if possible, ending early if MAXITER total SCF iterations are performed.
+        -1 fully converges the SCF on the final grid if possible, ending early if |scf__maxiter| total SCF iterations are reached (failure).
         0 disables the final COSX grid entirely.
         n runs up to n iterations on the final COSX grid, ending early if SCF convergence is reached or MAXITER total SCF iterations are performed. -*/
         options.add_int("COSX_MAXITER_FINAL", 1);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1692,7 +1692,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
                         "ROBUST TREUTLER NONE FLAT P_GAUSSIAN D_GAUSSIAN P_SLATER D_SLATER LOG_GAUSSIAN LOG_SLATER NONE");
         /*- Do reduce numerical COSX errors with overlap fitting? !expert -*/
         options.add_bool("COSX_OVERLAP_FITTING", true);
- 
+
         /*- SUBSECTION SAD Guess Algorithm -*/
 
         /*- The amount of SAD information to print to the output !expert -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1681,6 +1681,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_int("COSX_RADIAL_POINTS_FINAL", 35);
         /*- Screening criteria for integrals and intermediates in COSX -*/
         options.add_double("COSX_INTS_TOLERANCE", 1.0E-11);
+        /*- Fully converge SCF on larger (i.e., final) grid? -*/ 
+        options.add_bool("COSX_FULL_SCF", false);
         /*- Screening criteria for shell-pair densities in COSX !expert -*/
         options.add_double("COSX_DENSITY_TOLERANCE", 1.0E-10);
         /*- Screening criteria for basis function values on COSX grids !expert -*/
@@ -1690,7 +1692,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
                         "ROBUST TREUTLER NONE FLAT P_GAUSSIAN D_GAUSSIAN P_SLATER D_SLATER LOG_GAUSSIAN LOG_SLATER NONE");
         /*- Do reduce numerical COSX errors with overlap fitting? !expert -*/
         options.add_bool("COSX_OVERLAP_FITTING", true);
-
+ 
         /*- SUBSECTION SAD Guess Algorithm -*/
 
         /*- The amount of SAD information to print to the output !expert -*/


### PR DESCRIPTION
## Description
Currently, COSX in Psi4 uses a two-grid scheme to complete the SCF - the SCF is first converged on a smaller grid, and then a single iteration is performed on a larger grid, a scheme proposed by Neese. This scheme works quite well for energies; but since the SCF isn't converged on the larger grid, it may not be as ideal if wavefunction properties (e.g., gradients) are desired.

This PR fixes that by adding a new keyword, `COSX_MAXITER_FINAL`, an integer that determines the maximum number of SCF iterations to run on the final COSX grid. By default, this keyword is set to 1, mimicking the current behavior of the code. A more detailed description of behavior can be broken down as follows:

- If `COSX_MAXITER_FINAL` < 0; the SCF will attempt to fully converge on the final COSX grid (within the constraints provided by `MAXITER`, of course).
- If `COSX_MAXITER_FINAL` == 0; the SCF will not run on the final grid at all, effectively turning the COSX algorithm into a single-grid implementation.
- If `COSX_MAXITER_FINAL` > 0; the SCF will run on the final grid for a maximum number of iterations specified by the keyword. 
    - If the SCF converges on the final grid before the iteration count specified by `COSX_MAXITER_FINAL`, the SCF will exit upon convergence.
    - If the iteration count specified by `COSX_MAXITER_FINAL` is reached before the SCF is converged on the final grid, the SCF will exit, treated as a success.
    - If the `MAXITER` SCF iteration limit is hit before the `COSX_MAXITER_FINAL` limit is reached, the calculation will fail.

Also of note, this PR changes CompositeJK so that early_screening is disabled for LinK-based composite methods. Practically, this means that LinK-based methods do not run the extra post-early-screening SCF iteration that is present in COSX-based methods.

## User API & Changelog headlines
- [X] Adds a new keyword, `COSX_MAXITER_FINAL`, for controlling the maximum number of SCF iterations to run on the final COSX grid.

## Dev notes & details
- [X] Adds a new keyword, `COSX_MAXITER_FINAL`, for controlling the maximum number of SCF iterations to run on the final COSX grid. The keyword can be used to run a preset number of SCF iterations or fully converge the SCF on the final grid, or to skip the final grid entirely.
- [X] Changes the early screening feature so that it is only turned on for COSX-based composite methods.

## Questions
- [x] N/A

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge
