### PR TITLE
sanitize molecule names for dfhelper

### DIFF
--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -103,8 +103,10 @@ void DFHelper::AO_filename_maker(size_t i) {
 
 std::string DFHelper::start_filename(std::string start) {
     std::string name = PSIOManager::shared_object()->get_default_path();
+    std::string safe_mol = primary_->molecule()->name();
+    safe_mol.erase(std::remove(safe_mol.begin(), safe_mol.end(), '/'), safe_mol.end());
     name += start + "." + std::to_string(SYSTEM_GETPID());
-    name += "." + primary_->molecule()->name() + ".";
+    name += "." + safe_mol + ".";
     name += std::to_string(rand()) + "." + ".dat";
     return name;
 }

--- a/tests/pytests/test_misc.py
+++ b/tests/pytests/test_misc.py
@@ -99,6 +99,16 @@ def test_parse_cotton_irreps_error(inp):
     assert 'not valid for point group' in str(e.value)
 
 
+def test_slash_in_molecule_name_plus_dfhelper():
+    mymol = psi4.core.Molecule.from_arrays(geom=[0, 0, 0, 2, 0, 0], elem=["h", "h"], name="h2/mol")
+
+    # segfaults if any DF (that is, following line commented). runs if DF suppressed (following line active)
+    #psi4.set_options({"scf_type": "pk", "df_basis_guess": "false"})
+
+    ene = psi4.energy("b3lyp/cc-pvtz", molecule=mymol)
+    assert compare_values(-1.00125358, ene, 5, 'weird mol name ok as file')
+
+
 # <<<  TODO Deprecated! Delete in Psi4 v1.5  >>>
 
 @uusing("networkx")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] While not recommended to use a `/` character in your molecule labels, if you do, at least now it won't segfault if density fitting is involved. Thanks to @bennybp for the bug report.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Error can be triggered with below. Shows up in `DFHelper::put_tensor()`

```
import psi4

mymol = psi4.Molecule.from_arrays(geom=[0, 0, 0, 2, 0, 0], elem=["h", "h"], name="h2/mol")

# segfaults if any DF (that is, following line commented). runs if DF suppressed (following line active)
#psi4.set_options({"scf_type": "pk", "df_basis_guess": "false"})

ene = psi4.energy("b3lyp/cc-pvtz", molecule=mymol)
print(ene)
```

## Checklist
- [x] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
