### PR TITLE
Fix #2985: Symmetry OEINTS

### DIFF
--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -618,7 +618,7 @@ SharedMatrix MintsHelper::ao_overlap(std::shared_ptr<BasisSet> bs1, std::shared_
         ints_vec.push_back(std::shared_ptr<OneBodyAOInt>(factory.ao_overlap()));
     }
     auto overlap_mat = std::make_shared<Matrix>(PSIF_AO_S, bs1->nbf(), bs2->nbf());
-    one_body_ao_computer(ints_vec, overlap_mat, false);
+    one_body_ao_computer(ints_vec, overlap_mat, bs1 == bs2);
     return overlap_mat;
 }
 
@@ -650,7 +650,7 @@ SharedMatrix MintsHelper::ao_kinetic(std::shared_ptr<BasisSet> bs1, std::shared_
         ints_vec.push_back(std::shared_ptr<OneBodyAOInt>(factory.ao_kinetic()));
     }
     auto kinetic_mat = std::make_shared<Matrix>("AO-basis Kinetic Ints", bs1->nbf(), bs2->nbf());
-    one_body_ao_computer(ints_vec, kinetic_mat, false);
+    one_body_ao_computer(ints_vec, kinetic_mat, bs1 == bs2);
     return kinetic_mat;
 }
 
@@ -683,7 +683,7 @@ SharedMatrix MintsHelper::ao_potential(std::shared_ptr<BasisSet> bs1, std::share
         ints_vec.push_back(std::shared_ptr<OneBodyAOInt>(factory.ao_potential()));
     }
     auto potential_mat = std::make_shared<Matrix>("AO-basis Potential Ints", bs1->nbf(), bs2->nbf());
-    one_body_ao_computer(ints_vec, potential_mat, false);
+    one_body_ao_computer(ints_vec, potential_mat, bs1 == bs2);
     return potential_mat;
 }
 
@@ -705,7 +705,7 @@ SharedMatrix MintsHelper::ao_ecp(std::shared_ptr<BasisSet> bs1, std::shared_ptr<
         ints_vec.push_back(std::shared_ptr<OneBodyAOInt>(factory.ao_ecp()));
     }
     auto ecp_mat = std::make_shared<Matrix>("AO-basis ECP Ints", bs1->nbf(), bs2->nbf());
-    one_body_ao_computer(ints_vec, ecp_mat, false);
+    one_body_ao_computer(ints_vec, ecp_mat, bs1 == bs2);
     return ecp_mat;
 }
 #endif

--- a/tests/pytests/test_mints.py
+++ b/tests/pytests/test_mints.py
@@ -7,7 +7,7 @@ from utils import compare_arrays
 
 pytestmark = [pytest.mark.psi, pytest.mark.api]
 
-def test_overlap():
+def test_overlap_obs():
     h2o = psi4.geometry("""
         O
         H 1 1.0
@@ -15,14 +15,38 @@ def test_overlap():
         symmetry c1
     """)
 
-    rhf_e, wfn = psi4.energy('SCF/cc-pVDZ', molecule=h2o, return_wfn=True)
+    psi4.set_options({'basis': 'aug-cc-pvdz'})
 
+    conv = psi4.core.BasisSet.build(h2o,'BASIS', psi4.core.get_global_option('BASIS'))
+
+    wfn = psi4.core.Wavefunction.build(h2o, psi4.core.get_global_option('BASIS'))
     mints = psi4.core.MintsHelper(wfn.basisset())
 
     case1 = mints.ao_overlap()
     case2 = mints.ao_overlap(wfn.basisset(), wfn.basisset())
 
     assert psi4.compare_matrices(case1, case2, 10, "OVERLAP_TEST")  # TEST
+
+def test_overlap_aux():
+    h2o = psi4.geometry("""
+        O
+        H 1 1.0
+        H 1 1.0 2 101.5
+        symmetry c1
+    """)
+
+    psi4.set_options({'basis': 'aug-cc-pvdz',
+                      'df_basis_mp2':'aug-cc-pvdz-ri'})
+
+    conv = psi4.core.BasisSet.build(h2o,'BASIS', psi4.core.get_global_option('BASIS'))
+    aux = psi4.core.BasisSet.build(h2o,'DF_BASIS_MP2',"", "RIFIT", psi4.core.get_global_option('DF_BASIS_MP2'))
+
+    wfn = psi4.core.Wavefunction.build(h2o, psi4.core.get_global_option('BASIS'))
+    mints = psi4.core.MintsHelper(wfn.basisset())
+
+    tr = mints.ao_overlap(aux, aux).trace()
+
+    assert psi4.compare_values(118, tr, 12, 'Test that diagonal elements of AO Overlap are 1.0')  # TEST
 
 def test_export_ao_elec_dip_deriv():
     h2o = psi4.geometry("""

--- a/tests/pytests/test_mints.py
+++ b/tests/pytests/test_mints.py
@@ -7,6 +7,23 @@ from utils import compare_arrays
 
 pytestmark = [pytest.mark.psi, pytest.mark.api]
 
+def test_overlap():
+    h2o = psi4.geometry("""
+        O
+        H 1 1.0
+        H 1 1.0 2 101.5
+        symmetry c1
+    """)
+
+    rhf_e, wfn = psi4.energy('SCF/cc-pVDZ', molecule=h2o, return_wfn=True)
+
+    mints = psi4.core.MintsHelper(wfn.basisset())
+
+    case1 = mints.ao_overlap()
+    case2 = mints.ao_overlap(wfn.basisset(), wfn.basisset())
+
+    assert psi4.compare_matrices(case1, case2, 10, "OVERLAP_TEST")  # TEST
+
 def test_export_ao_elec_dip_deriv():
     h2o = psi4.geometry("""
         O


### PR DESCRIPTION
## Description
Quick fix to symmetry in one-electron integral calls in MintsHelper. Closes #2985 

## Dev notes & details
- [X] Changes the bool to `one_body_ao_computer` to check if the provided basis sets are the same in `mintshelper.cc`

## Questions
- [X] N/A

## Checklist
- [X] Adds a test for the one-electron overlap integrals in `test_mints.py`
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge
