### PR TITLE
Add ao_f12g12() and ao_double_commutator() for a quadruplet of bases

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1521,7 +1521,9 @@ void export_mints(py::module& m) {
         .def("ao_f12_squared", normal_f12(&MintsHelper::ao_f12_squared), "AO F12 squared integrals", "corr"_a)
         .def("ao_f12_squared", normal_f122(&MintsHelper::ao_f12_squared), "AO F12 squared integrals", "corr"_a, "bs1"_a,
              "bs2"_a, "bs3"_a, "bs4"_a)
-        .def("ao_f12g12", &MintsHelper::ao_f12g12, "AO F12G12 integrals", "corr"_a)
+        .def("ao_f12g12", normal_f12(&MintsHelper::ao_f12g12), "AO F12G12 integrals", "corr"_a)
+        .def("ao_f12g12", normal_f122(&MintsHelper::ao_f12g12), "AO F12G12 integrals", "corr"_a, "bs1"_a,
+             "bs2"_a, "bs3"_a, "bs4"_a)
         .def("ao_f12_double_commutator", &MintsHelper::ao_f12_double_commutator, "AO F12 double commutator integrals",
              "corr"_a)
 	.def("f12_cgtg", &MintsHelper::f12_cgtg, "F12 Fitted Slater Correlation Factor", "exponent"_a = 1.0)

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1524,8 +1524,10 @@ void export_mints(py::module& m) {
         .def("ao_f12g12", normal_f12(&MintsHelper::ao_f12g12), "AO F12G12 integrals", "corr"_a)
         .def("ao_f12g12", normal_f122(&MintsHelper::ao_f12g12), "AO F12G12 integrals", "corr"_a, "bs1"_a,
              "bs2"_a, "bs3"_a, "bs4"_a)
-        .def("ao_f12_double_commutator", &MintsHelper::ao_f12_double_commutator, "AO F12 double commutator integrals",
+        .def("ao_f12_double_commutator", normal_f12(&MintsHelper::ao_f12_double_commutator), "AO F12 double commutator integrals",
              "corr"_a)
+        .def("ao_f12_double_commutator", normal_f122(&MintsHelper::ao_f12_double_commutator), "AO F12 double commutator integrals", "corr"_a, "bs1"_a,
+             "bs2"_a, "bs3"_a, "bs4"_a)
 	.def("f12_cgtg", &MintsHelper::f12_cgtg, "F12 Fitted Slater Correlation Factor", "exponent"_a = 1.0)
         .def("ao_3coverlap", normal_eri(&MintsHelper::ao_3coverlap), "3 Center overlap integrals")
         .def("ao_3coverlap", normal_3c(&MintsHelper::ao_3coverlap), "3 Center overlap integrals", "bs1"_a, "bs2"_a,

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -995,6 +995,14 @@ SharedMatrix MintsHelper::ao_f12g12(std::vector<std::pair<double, double>> exp_c
     return ao_helper("AO F12G12 Tensor", ints);
 }
 
+SharedMatrix MintsHelper::ao_f12g12(std::vector<std::pair<double, double>> exp_coeff,
+                                    std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2,
+                                    std::shared_ptr<BasisSet> bs3, std::shared_ptr<BasisSet> bs4) {
+    IntegralFactory intf(bs1, bs2, bs3, bs4);
+    std::shared_ptr<TwoBodyAOInt> ints(intf.f12g12(exp_coeff));
+    return ao_helper("AO F12G12 Tensor", ints);
+}
+
 SharedMatrix MintsHelper::ao_f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff) {
     std::shared_ptr<TwoBodyAOInt> ints(integral_->f12_double_commutator(exp_coeff));
     return ao_helper("AO F12 Double Commutator Tensor", ints);

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -1008,6 +1008,14 @@ SharedMatrix MintsHelper::ao_f12_double_commutator(std::vector<std::pair<double,
     return ao_helper("AO F12 Double Commutator Tensor", ints);
 }
 
+SharedMatrix MintsHelper::ao_f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff,
+                                         std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2,
+                                         std::shared_ptr<BasisSet> bs3, std::shared_ptr<BasisSet> bs4) {
+    IntegralFactory intf(bs1, bs2, bs3, bs4);
+    std::shared_ptr<TwoBodyAOInt> ints(intf.f12_double_commutator(exp_coeff));
+    return ao_helper("AO F12 Double Commutator Tensor", ints);
+}
+
 SharedMatrix MintsHelper::mo_erf_eri(double omega, SharedMatrix C1, SharedMatrix C2, SharedMatrix C3, SharedMatrix C4) {
     SharedMatrix mo_ints = mo_eri_helper(ao_erf_eri(omega), C1, C2, C3, C4);
     mo_ints->set_name("MO ERF ERI Tensor");

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -235,6 +235,8 @@ class PSI_API MintsHelper {
                                 std::shared_ptr<BasisSet> bs4);
     /// AO F12G12 Integrals
     SharedMatrix ao_f12g12(std::vector<std::pair<double, double>> exp_coeff);
+    SharedMatrix ao_f12g12(std::vector<std::pair<double, double>> exp_coeff, std::shared_ptr<BasisSet> bs1,
+                        std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3, std::shared_ptr<BasisSet> bs4);
     /// AO F12 double commutator Integrals
     SharedMatrix ao_f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff);
     /// F12 Fitted Slater Correlation Factor

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -239,6 +239,8 @@ class PSI_API MintsHelper {
                         std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3, std::shared_ptr<BasisSet> bs4);
     /// AO F12 double commutator Integrals
     SharedMatrix ao_f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff);
+    SharedMatrix ao_f12_double_commutator(std::vector<std::pair<double, double>> exp_coeff, std::shared_ptr<BasisSet> bs1,
+                        std::shared_ptr<BasisSet> bs2, std::shared_ptr<BasisSet> bs3, std::shared_ptr<BasisSet> bs4);
     /// F12 Fitted Slater Correlation Factor
     std::vector<std::pair<double, double>> f12_cgtg(double exponent = 1.0);
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
A small addition needed for an F12 code to work Python-side. Adds the ability to call
```
ao_f12g12(exp_coeff, Basis1, Basis2, Basis3, Basis4)
ao_double_commutator(exp_coeff, Basis1, Basis2, Basis3, Basis4)
```
with an arbitrary combination of 4 bases (some combinations require `SCREENING == 'NONE'` - see #2973). The other kinds of F12 integrals, e.g. `ao_f12()`, already have this functionality and just the two above types were missing.

## Dev notes & details
This minor PR should be completely orthogonal to the recent PRs from @EricaCMitchell. All of these PRs will be needed for the upcoming F12 codes.

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run] `ctest -L quick` passes with no errors

## Status
- [x] Ready for review
- [x] Ready for merge
