### PR TITLE
Refactor `JK_deriv2`

### DIFF
--- a/psi4/src/psi4/scfgrad/scf_grad.h
+++ b/psi4/src/psi4/scfgrad/scf_grad.h
@@ -97,18 +97,22 @@ protected:
                    int nso, int nocc, int nvir, bool alpha);
 #endif
 
+    // Compute the JK contribution to the the Fock derivative onthe
+    //   right-side of the CP-SCF equations.
     void JK_deriv1(std::shared_ptr<Matrix> D1,
                    std::shared_ptr<Matrix> C1, 
                    std::shared_ptr<Matrix> C1occ,
                    std::shared_ptr<Matrix> D2, 
                    int nso, int nocc, int nvir, bool alpha);
 
+    // Compute the JK contribution to the the overlap derivative *
+    //   TEI term  on the right-side of the CP-SCF equations.
     void JK_deriv2(std::shared_ptr<JK> jk, int mem, 
-                   std::shared_ptr<Matrix> C1, 
-                   std::shared_ptr<Matrix> C1occ,
-                   std::shared_ptr<Matrix> C2, 
-                   std::shared_ptr<Matrix> C2occ,
-                   int nso, int n1occ, int n2occ, int nvir, bool alpha);
+                   std::shared_ptr<Matrix> Ca,
+                   std::shared_ptr<Matrix> Caocc,
+                   std::shared_ptr<Matrix> Cb,
+                   std::shared_ptr<Matrix> Cbocc,
+                   int nso, int naocc, int nbocc, int navir);
 
     void VXC_deriv(std::shared_ptr<Matrix> C, 
                    std::shared_ptr<Matrix> Cocc,


### PR DESCRIPTION
## Description
The `JK_deriv2` function exists to compute the overlap-derivative-times-TEI part of the right side of the CPHF equation. It's a J-term and a K-like term. with overlap derivative integrals instead of a density.[1] The previous algorithm to do this first computed the alpha spin part in one function call, and then the beta spin part in another function call. This approach was redundant. The first function call had all the intermediates _necessary_ to compute the beta part, but didn't use them. As a result, the function re-computed JK.

This PR refactors `JK_deriv2` so it computes both spin cases in a single function call.

[1] = There's also a Vx term, but its implementation was both unused and buggy. Now it's just unused. Trying to use it in the _old_ way would be even more redundant.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] The UHF hessian algorithm has been slightly adjusted, which should lead to slightly faster computations. Please report any errors.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Refactored `JK_deriv2` to compute both spin cases in a single function call.
- [x] Makes UKS LDA hessians much less ugly.
- [x] Makes `JK_deriv2` comply with `compute_Vx`'s expected function signature  

## Checklist
- [x] `ctest -R scf-hess` passes

## Status
- [x] Ready for review
- [x] Ready for merge
