### PR TITLE
Refactor assemble_Q

### DIFF
--- a/psi4/src/psi4/scfgrad/scf_grad.h
+++ b/psi4/src/psi4/scfgrad/scf_grad.h
@@ -127,7 +127,7 @@ protected:
                     std::shared_ptr<Matrix> C1occ,
                     std::shared_ptr<Matrix> C2, 
                     std::shared_ptr<Matrix> C2occ, 
-                    int nso, int n1occ, int n2occ, int nvir,bool alpha);
+                    int nso, int n1occ, int n2occ, int nvir);
 
     void dipole_derivatives(std::shared_ptr<Matrix> C1, 
                             std::shared_ptr<Matrix> C1occ,


### PR DESCRIPTION
## Description
Refactor `assemble_Q` [like `JK_deriv2`](https://github.com/psi4/psi4/pull/2994). The code had the same problem, so I use the same solution.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Refactored `assemble_Q` to compute both spin cases in a single function call.
- [x] Makes UKS LDA hessians much less ugly.
- [x] Makes `assemble_Q` comply with `compute_Vx`'s expected function signature  

## Checklist
- [x] `ctest -R scf_hess` passes

## Status
- [x] Ready for review
- [x] Ready for merge
