### PR TITLE
Print full PSIO error message to cerr as well

### DIFF
--- a/psi4/src/psi4/libpsio/error.cc
+++ b/psi4/src/psi4/libpsio/error.cc
@@ -131,6 +131,7 @@ void psio_error(size_t unit, size_t errval, std::string prev_msg /* = ""*/) {
                         " If you're a developer, get yourself some coffee.\n";
             break;
     }
+    std::cerr << prev_msg << std::endl;
     throw PSIEXCEPTION(prev_msg);
 }
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
For some poorly understood confluence of reasons, for some users error messages can _sometimes_ get completely lost when Psi4 exits with a `PSIEXCEPTION`, especially when a PSIO error happens.
This can be observed in recent bug reports, see:

- https://github.com/psi4/psi4/issues/2970
- https://forum.psicode.org/t/sapt0-calculation-crashes-pointer-error/2839

In both of these cases the users were only seeing the error message that has been written to `cerr`, but not the string that `PSIEXCEPTION` should have printed.

IIRC when I tried to research this quite a while ago, I have found this may be a bug in some versions of libstdc++. This PR adds a simple workaround: the exception message is also printed to `cerr` in `psio_error`.

The only side effect, is that some users, who are currently not affected by the lost message problem, may start getting the same error message twice when a PSIO error happens. Spammy error exits are not great, but PSIO errors are not supposed to happen too often, and when they do loosing the error message is more annoying than having it be duplicated.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] PSIO error messages are now also printed to `cerr`, fixing an issue where (under some circumstances) large parts of the error message would never reach the user, 

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] The same error message that gets passed to `PSIEXCEPTION` is now printed to `cerr` before throwing in `psio_error`

## Checklist
- [x] There is no easy way to add tests for "are error messages getting delivered or not?"
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
