### PR TITLE
restrain pydantic to v1

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -101,6 +101,7 @@ jobs:
         msgpack-python \
         conda-forge::qcelemental \
         conda-forge::qcengine=0.26.0 \
+        pydantic<2.0 \
         conda-forge::optking \
         scipy
       source activate p4env

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -101,7 +101,7 @@ jobs:
         msgpack-python \
         conda-forge::qcelemental \
         conda-forge::qcengine=0.26.0 \
-        pydantic<2.0 \
+        pydantic=1.10.10 \
         conda-forge::optking \
         scipy
       source activate p4env

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -142,7 +142,7 @@ jobs:
                         conda-forge/label/libint_dev::libint=2.7.3dev1 ^
                         qcelemental ^
                         qcengine ^
-                        pydantic<2.0 ^
+                        pydantic=1.10.10 ^
                         optking ^
                         scipy
           conda install --only-deps anaconda-client

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -142,6 +142,7 @@ jobs:
                         conda-forge/label/libint_dev::libint=2.7.3dev1 ^
                         qcelemental ^
                         qcengine ^
+                        pydantic<2.0 ^
                         optking ^
                         scipy
           conda install --only-deps anaconda-client

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -124,6 +124,7 @@ jobs:
           - ninja
           - numpy
           - pybind11
+          - pydantic<2.0
             # qc req'd
           - gau2grid
           - conda-forge/label/libint_dev::libint=2.7.3dev1
@@ -171,7 +172,7 @@ jobs:
           - python=${{ matrix.cfg.python-version }}
           - scipy
           - toml
-          - typing-extensions=4.5.0
+          - pydantic<2.0
             # non-qc opt'l
           - memory_profiler
             # qc req'd

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -5,6 +5,7 @@ dependencies:
   - libblas=*=*mkl
   - mkl-devel
   - intel-openmp!=2019.5
+  - pydantic<2.0
     # build
   - cmake
   - doxygen


### PR DESCRIPTION
## Description
Current qcel not compatible with the new pydantic v2. I minted a new qcel build with the constraint, but the solver sometimes optimizes for pydantic anyways. So let's try explicit constraint.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
