### PR TITLE
Implement another variant of the Hückel guess.

### DIFF
--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -477,6 +477,10 @@ Bibliography
    S. Lehtola
    *J. Chem. Theory Comput.* **15**, 1593 (2019), https://doi.org/10.1021/acs.jctc.8b01089.
 
+.. [Ammeter:1978:3686]
+   J. H. Ammeter, H.-B. B\ |u_dots|\ rgi, J. C. Thibeault, and R. Hoffmann
+   *J. Am. Chem. Soc.* **100**, 3686 (1978), https://doi.org/10.1021/ja00480a005
+
 .. [Lehtola:2019:241102]
    S. Lehtola
    *J. Chem. Phys.* **151**, 241102 (2019), https://doi.org/10.1063/1.5139948.

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -497,6 +497,11 @@ GWH
 HUCKEL
     An extended H\ |u_dots|\ ckel guess based on on-the-fly atomic UHF
     calculations alike SAD, see [Lehtola:2019:1593]_.
+MODHUCKEL
+    Like HUCKEL, an extended H\ |u_dots|\ ckel guess based on
+    on-the-fly atomic UHF calculations alike SAD, see
+    [Lehtola:2019:1593]_. This variant employs an updated rule for the
+    generalized Wolfsberg-Helmholz formula from [Ammeter:1978:3686]_.
 READ
     Read the previous orbitals from a ``wfn`` file, casting from
     one basis to another if needed. Useful for starting anion

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1467,7 +1467,7 @@ def scf_wavefunction_factory(name, ref_wfn, reference, **kwargs):
         wfn.set_basisset("BASIS_RELATIVISTIC", decon_basis)
 
     # Set the multitude of SAD basis sets
-    if (core.get_option("SCF", "GUESS") in ["SAD", "SADNO", "HUCKEL"]):
+    if (core.get_option("SCF", "GUESS") in ["SAD", "SADNO", "HUCKEL", "MODHUCKEL"]):
         sad_basis_list = core.BasisSet.build(wfn.molecule(), "ORBITAL",
                                              core.get_global_option("BASIS"),
                                              puream=wfn.basisset().has_puream(),

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -1078,7 +1078,28 @@ void HF::guess() {
         if (!options_.get_bool("SAD_FRAC_OCC")) {
             throw PSIEXCEPTION("  Huckel guess requires SAD_FRAC_OCC = True!");
         }
-        compute_huckel_guess();
+        compute_huckel_guess(false);
+
+        form_initial_C();
+        form_D();
+        guess_E = compute_initial_E();
+
+    } else if (guess_type == "MODHUCKEL") {
+      if (print_)
+            outfile->Printf("  SCF Guess: Huckel guess via on-the-fly atomic UHF (doi:10.1021/acs.jctc.8b01089) with the updated GWH rule from doi:10.1021/ja00480a005.\n\n");
+
+        // Huckel guess, written by Susi Lehtola 2019-01-27.  See "An
+        // assessment of initial guesses for self-consistent field
+        // calculations. Superposition of Atomic Potentials: simple
+        // yet efficient", JCTC 2019, doi: 10.1021/acs.jctc.8b01089.
+
+        if (!options_.get_bool("SAD_SPIN_AVERAGE")) {
+            throw PSIEXCEPTION("  Huckel guess requires SAD_SPIN_AVERAGE = True!");
+        }
+        if (!options_.get_bool("SAD_FRAC_OCC")) {
+            throw PSIEXCEPTION("  Huckel guess requires SAD_FRAC_OCC = True!");
+        }
+        compute_huckel_guess(true);
 
         form_initial_C();
         form_D();

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -213,7 +213,7 @@ class HF : public Wavefunction {
     /// SAD Guess and propagation
     virtual void compute_SAD_guess(bool natorb);
     /// Huckel guess
-    virtual void compute_huckel_guess();
+    virtual void compute_huckel_guess(bool updated_rule);
 
     /** Transformation, diagonalization, and backtransform of Fock matrix */
     virtual void diagonalize_F(const SharedMatrix& F, SharedMatrix& C, std::shared_ptr<Vector>& eps);

--- a/psi4/src/psi4/libscf_solver/sad.h
+++ b/psi4/src/psi4/libscf_solver/sad.h
@@ -78,7 +78,7 @@ class SADGuess {
     SharedMatrix Ca() const { return Ca_; }
     SharedMatrix Cb() const { return Cb_; }
 
-    SharedMatrix huckel_guess();
+    SharedMatrix huckel_guess(bool updated_rule);
 
     void set_atomic_fit_bases(std::vector<std::shared_ptr<BasisSet>> fit_bases) { atomic_fit_bases_ = fit_bases; }
     void set_print(int print) { print_ = print; }

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1446,7 +1446,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("INTS_TOLERANCE", 1E-12);
         /*- The type of guess orbitals. See :ref:`sec:scfguess` for what the options mean and
          what the defaults are. -*/
-        options.add_str("GUESS", "AUTO", "AUTO CORE GWH SAD SADNO SAP HUCKEL READ");
+        options.add_str("GUESS", "AUTO", "AUTO CORE GWH SAD SADNO SAP HUCKEL MODHUCKEL READ");
         /*- Mix the HOMO/LUMO in UHF or UKS to break alpha/beta spatial symmetry.
         Useful to produce broken-symmetry unrestricted solutions.
         Notice that this procedure is defined only for calculations in C1 symmetry. -*/

--- a/tests/pytests/test_scf_options.py
+++ b/tests/pytests/test_scf_options.py
@@ -10,6 +10,7 @@ pytestmark = [pytest.mark.psi, pytest.mark.api]
     pytest.param({'options': {"guess": "core"}}, id="core"),
     pytest.param({'options': {"guess": "gwh"}}, id="gwh"),
     pytest.param({'options': {"guess": "huckel"}}, id="huckel"),
+    pytest.param({'options': {"guess": "modhuckel"}}, id="modhuckel"),
     pytest.param({'late_options': {"guess": "read"}}, id="read"),
     pytest.param({'options': {"guess": "sad"}}, id="sad"),
     pytest.param({'options': {"guess": "sadno"}}, id="sadno"),

--- a/tests/scf-guess/input.dat
+++ b/tests/scf-guess/input.dat
@@ -41,6 +41,10 @@ set guess huckel
 energy('scf')
 compare_values(refneut_rhf, variable("SCF TOTAL ENERGY"), 6, "RHF  energy, HUCKEL guess (a.u.)");             #TEST
 
+set guess modhuckel
+energy('scf')
+compare_values(refneut_rhf, variable("SCF TOTAL ENERGY"), 6, "RHF  energy, MODHUCKEL guess (a.u.)");             #TEST
+
 set guess sap
 energy('scf')
 compare_values(refneut_rhf, variable("SCF TOTAL ENERGY"), 6, "RHF  energy, SAP    guess (a.u.)");             #TEST
@@ -76,6 +80,10 @@ set guess huckel
 energy('scf')
 compare_values(refcat_uhf, variable("SCF TOTAL ENERGY"), 6, "UHF  energy, HUCKEL guess (a.u.)");             #TEST
 
+set guess modhuckel
+energy('scf')
+compare_values(refcat_uhf, variable("SCF TOTAL ENERGY"), 6, "UHF  energy, MODHUCKEL guess (a.u.)");             #TEST
+
 set guess sap
 energy('scf')
 compare_values(refcat_uhf, variable("SCF TOTAL ENERGY"), 6, "UHF  energy, SAP    guess (a.u.)");             #TEST
@@ -104,6 +112,10 @@ set guess huckel
 energy('scf')
 compare_values(refcat_rohf, variable("SCF TOTAL ENERGY"), 6, "ROHF energy, HUCKEL guess (a.u.)");             #TEST
 
+set guess modhuckel
+energy('scf')
+compare_values(refcat_rohf, variable("SCF TOTAL ENERGY"), 6, "ROHF energy, MODHUCKEL guess (a.u.)");             #TEST
+
 set guess sap
 energy('scf')
 compare_values(refcat_rohf, variable("SCF TOTAL ENERGY"), 6, "ROHF energy, SAP    guess (a.u.)");             #TEST
@@ -131,6 +143,10 @@ compare_values(refcat_cuhf, variable("SCF TOTAL ENERGY"), 6, "CUHF energy, SADNO
 set guess huckel
 energy('scf')
 compare_values(refcat_cuhf, variable("SCF TOTAL ENERGY"), 6, "CUHF energy, HUCKEL guess (a.u.)");             #TEST
+
+set guess modhuckel
+energy('scf')
+compare_values(refcat_cuhf, variable("SCF TOTAL ENERGY"), 6, "CUHF energy, MODHUCKEL guess (a.u.)");             #TEST
 
 set guess sap
 energy('scf')


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR implements another variant of the Hückel guess.
The only modification is that the `k` parameter in the GWH rule is replaced by the updated rule from [doi:10.1021/ja00480a005](https://doi.org/10.1021/ja00480a005)

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
