### PR TITLE
adapt for pydantic v1 and v2

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -100,8 +100,7 @@ jobs:
         pytest-xdist \
         msgpack-python \
         conda-forge::qcelemental \
-        conda-forge::qcengine=0.26.0 \
-        pydantic=1.10.10 \
+        conda-forge::qcengine \
         conda-forge::optking \
         scipy
       source activate p4env

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ message(STATUS "Building using CMake ${CMAKE_VERSION} Generator ${CMAKE_GENERATO
 #    - msgpack-python (runtime only; e.g., `conda install msgpack-python`)
 #    - Eigen (for Libint2; e.g., `conda install eigen`)
 #    - Boost (header-only libs for Libint2; e.g., `conda install boost-cpp`)
-#    - SciPy (runtime only; e.g., `conda install scipy`)
+#    - SciPy (runtime only; avoidable through keyword setting; e.g., `conda install scipy`)
 #    - py-cpuinfo (runtime only; e.g., `conda install py-cpuinfo`)
 #    - psutil (runtime only; e.g., `conda install psutil`)
 

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - libblas=*=*mkl
   - mkl-devel
+  - pydantic=1  # to keep on v1 branch for autodoc-pydantic
     # build
   - cmake
   - doxygen

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -4,8 +4,6 @@ channels:
 dependencies:
   - libblas=*=*mkl
   - mkl-devel
-  - intel-openmp!=2019.5
-  - pydantic<2.0
     # build
   - cmake
   - doxygen
@@ -14,7 +12,7 @@ dependencies:
   - boost-cpp
   - eigen
   - networkx
-  - pybind11
+  - pybind11=2.10.*  # until FixedSize typing percolates upstream
   - python=3.11.*
     # qc
   - gau2grid

--- a/doc/sphinxman/source/build_obtaining.rst
+++ b/doc/sphinxman/source/build_obtaining.rst
@@ -71,7 +71,7 @@ though the below remains valid.
     and optimization for a variety of processor architectures, I'm willing to forgo
     architecture tuning wizardry to avoid compiling it myself.
 
-    * I'm on Linux or Mac or Windows with Ubuntu Bash Shell.
+    * I'm on Linux or Mac (Intel or Silicon chips) or Windows (native or WSL/Ubuntu Bash Shell).
 
       * I'm familiar with conda and want to manage |PSIfour| as an
         ordinary conda package. |w---w| :ref:`Goto Binary-Package
@@ -152,22 +152,22 @@ Conda Binary Package
 
 * **Get Initially**
 
-  The pre-compiled conda packages at https://anaconda.org/psi4/psi4
+  The pre-compiled conda packages at https://anaconda.org/conda-forge/psi4
   can be installed into an existing Anaconda or Miniconda distribution
   according to :ref:`directions <faq:psi4pkg>`. Locally, install into
   a conda environment as below.
 
   .. code-block:: bash
 
-     >>> conda create -n p4env psi4 -c psi4
+     >>> conda create -n p4env psi4 -c conda-forge/label/libint_dev -c conda-forge
      >>> conda activate p4env
 
   .. code-block:: bash
 
-     >>> # nightly build
-     >>> conda create -n p4env psi4 -c psi4/label/dev
-     >>> # Windows
-     >>> conda create -n p4env psi4 -c psi4 -c conda-forge
+     >>> # nightly build (Linux and Windows only)
+     >>> conda create -n p4env psi4/label/dev::psi4 -c conda-forge/label/libint_dev -c conda-forge
+     >>> # release
+     >>> conda create -n p4env                 psi4 -c conda-forge/label/libint_dev -c conda-forge
 
 
 * **Build**
@@ -178,7 +178,7 @@ Conda Binary Package
 
   .. code-block:: bash
 
-     >>> conda update psi4 -c psi4
+     >>> conda update psi4 -c conda-forge
 
 * **Contribute Back**
 

--- a/doc/sphinxman/source/build_planning.rst
+++ b/doc/sphinxman/source/build_planning.rst
@@ -48,6 +48,8 @@ and performance-tuned build path, see :psicode:`installs/latest`
 (select "source"). For pre-built binaries again well-tested,
 performance-tuned, and available for all common operating systems,
 see :psicode:`installs/latest` (select "conda").
+To see working builds for Linux, Mac, and Windows, see :src:
+:source:`[this GHA] <.github/workflows/ecosystem.yml>`
 
 
 .. _`faq:cmakeviasetup`:
@@ -56,7 +58,7 @@ Planning: how to configure Psi4 and invoke CMake
 ------------------------------------------------
 
 |PSIfour| is built through CMake. An abbreviated build guide can be found
-:source:`within the source itself <CMakeLists.txt#L22>` .
+:source:`within the source itself <CMakeLists.txt#L27>` .
 
 CMake does a good job scanning your computer to locate libraries, header
 files, and executables needed for compilation. So it's very possible that
@@ -95,9 +97,12 @@ installing |PSIfour|. More detail is given :ref:`here
 
     >>> cd {top-level-psi4-dir}
     >>> cmake -S. -Bobjdir [your configuration options]
+    # make
     >>> cd objdir
     >>> make -j`getconf _NPROCESSORS_ONLN`
     >>> make install
+    # -or- general
+    >>> cmake --build objdir --target install -j`getconf _NPROCESSORS_ONLN`
 
 
 .. _`faq:builddetailed`:
@@ -155,7 +160,7 @@ How to build, test, and install Psi4, in detail
 .. code-block:: console
 
     >>> cd {objdir}
-    >>> make -j`getconf _NPROCESSORS_ONLN`
+    >>> cmake --build . -j`getconf _NPROCESSORS_ONLN`
 
 **5. Test**
 
@@ -178,7 +183,7 @@ How to build, test, and install Psi4, in detail
 
    ::
 
-   >>> make install
+   >>> cmake --install .
 
 **7. Configure Runtime**
 
@@ -217,15 +222,18 @@ build system will automatically download and build.
 
 * :ref:`gau2grid <cmake:gau2grid>` |w---w| :ref:`[what is gau2grid?] <sec:gau2grid>` :source:`[gau2grid min version] <external/upstream/gau2grid/CMakeLists.txt#L1>`
 
-* :ref:`Libint <cmake:libint>` |w---w| :ref:`[what is Libint?] <sec:libint>` :source:`[Libint min version] <external/upstream/libint/CMakeLists.txt#L1>` (Libint2 as of Nov 2020; added by v1.4)
+* :ref:`Libint <cmake:libint>` |w---w| :ref:`[what is Libint?] <sec:libint>` :source:`[Libint min version] <external/upstream/libint2/CMakeLists.txt#L1>` (Libint2 as of Nov 2020; added by v1.4)
 
   * Eigen https://eigen.tuxfamily.org/index.php?title=Main_Page
+  * Boost https://www.boost.org/ header-only preprocessor library
 
-* :ref:`Libxc <cmake:libxc>` |w---w| :ref:`[what is Libxc?] <sec:libxc>` :source:`[Libxc min version] <external/upstream/libxc/CMakeLists.txt#L1>`
-* pybind11 |w---w| `[what is Pybind11?] <https://pybind11.readthedocs.io/en/stable/>`_ :source:`[Pybind11 min version] <external/upstream/pybind11/CMakeLists.txt#L1>`
-* QCElemental |w---w| `[what is QCElemental?] <https://qcelemental.readthedocs.io/en/latest/>`_
+* :ref:`Libxc <cmake:libxc>` |w---w| :ref:`[what is Libxc?] <sec:libxc>` :source:`[Libxc min version] <external/upstream/libxc/CMakeLists.txt#L4>`
 
-* QCEngine |w---w| `[what is QCEngine?] <https://qcengine.readthedocs.io/en/latest/>`_ (March 2019; added by v1.4)
+* pybind11 |w---w| `[what is Pybind11?] <https://pybind11.readthedocs.io/en/stable/>`_ :source:`[Pybind11 min version] <external/upstream/pybind11/CMakeLists.txt#L2>`
+
+* QCElemental |w---w| `[what is QCElemental?] <https://molssi.github.io/QCElemental/>`_
+
+* QCEngine |w---w| `[what is QCEngine?] <https://molssi.github.io/QCEngine/>`_ (March 2019; added by v1.4)
 
 * optking |w---w| `[what is optking] <https://optking.readthedocs.io/en/latest/>`_ (runtime dependency, required at build-time) 
 
@@ -281,7 +289,7 @@ are available pre-built from conda.
   * Perl (for some auto-documentation scripts) https://www.perl.org/
   * nbsphinx (for converting Jupyter notebooks) http://nbsphinx.readthedocs.io/en/jupyter-theme/
   * sphinx-psi-theme https://github.com/psi4/sphinx-psi-theme
-  * See `["message" lines] :source:`doc/sphinxman/CMakeLists.txt` for advice on obtaining docs dependencies
+  * See :source:`["message" lines] <doc/sphinxman/CMakeLists.txt>` for advice on obtaining docs dependencies or :source:`[conda env spec] <devtools/conda-envs/docs-cf.yaml>`
   * See :source:`.github/workflows/docs.yml` for full docs building procedure to follow
 
 * Ambit |w---w| https://github.com/jturney/ambit

--- a/doc/sphinxman/source/fisapt.rst
+++ b/doc/sphinxman/source/fisapt.rst
@@ -65,30 +65,30 @@ review of the aims of A/F/I-SAPT and the existing state-of-the-art in the field
 in the introduction chapter on partitioned SAPT methods in `Parrish's thesis
 <https://smartech.gatech.edu/handle/1853/53850>`_.
 
-A video tutorial series for the use of the FISAPT module is available `here
-<https://www.youtube.com/playlist?list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
-Specific videos in the series include:
-
-- `F-SAPT#1
-  <https://www.youtube.com/watch?v=J22J0wh4mVo&index=1&list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
-  Describes the use of F-SAPT to analyze the
-  distribution of the intermolecular interaction energy components between the
-  various hydroxyl and phenyl moieties of the phenol dimer.
-- `F-SAPT#2
-  <https://www.youtube.com/watch?v=fqlzXsayec0&index=2&list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
-  Discusses how to plot the order-1 F-SAPT analysis with PyMol and perform a
-  "difference F-SAPT" analysis
-- `I-SAPT#1
-  <https://www.youtube.com/watch?v=fD6mu_tTG_c&index=3&list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
-  Describes the use of I-SAPT to analyze the interaction between the two phenol
-  groups in a 2,4-pentanediol molecule.
-- `I-SAPT#2
-  <https://www.youtube.com/watch?v=hDbonAOD5dY&index=4&list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
-  Discusses how to plot the density fields and ESPs of the various moieties of
-  the I-SAPT embedding scheme with PyMol
-- `F/I-SAPT Options
-  <https://www.youtube.com/watch?v=KFkPKSUZVfI&index=5&list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
-  Details all of the more-advanced options in the F/I-SAPT code (rarely needed).
+.. A video tutorial series for the use of the FISAPT module is available `here
+.. <https://www.youtube.com/playlist?list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
+.. Specific videos in the series include:
+..
+.. - `F-SAPT#1
+..   <https://www.youtube.com/watch?v=J22J0wh4mVo&index=1&list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
+..   Describes the use of F-SAPT to analyze the
+..   distribution of the intermolecular interaction energy components between the
+..   various hydroxyl and phenyl moieties of the phenol dimer.
+.. - `F-SAPT#2
+..   <https://www.youtube.com/watch?v=fqlzXsayec0&index=2&list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
+..   Discusses how to plot the order-1 F-SAPT analysis with PyMol and perform a
+..   "difference F-SAPT" analysis
+.. - `I-SAPT#1
+..   <https://www.youtube.com/watch?v=fD6mu_tTG_c&index=3&list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
+..   Describes the use of I-SAPT to analyze the interaction between the two phenol
+..   groups in a 2,4-pentanediol molecule.
+.. - `I-SAPT#2
+..   <https://www.youtube.com/watch?v=hDbonAOD5dY&index=4&list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
+..   Discusses how to plot the density fields and ESPs of the various moieties of
+..   the I-SAPT embedding scheme with PyMol
+.. - `F/I-SAPT Options
+..   <https://www.youtube.com/watch?v=KFkPKSUZVfI&index=5&list=PLg_zUQpVYlA1Tc1X_HgAbqnFcHNydqN7W>`_.
+..   Details all of the more-advanced options in the F/I-SAPT code (rarely needed).
 
 The scripts discussed below are located in :source:`psi4/share/psi4/fsapt`.
 

--- a/external/upstream/ambit/CMakeLists.txt
+++ b/external/upstream/ambit/CMakeLists.txt
@@ -24,6 +24,8 @@ if(${ENABLE_ambit})
             set(_so_only OFF)
         endif()
 
+        set(_ambit_dir "share/cmake/ambit")
+
         ExternalProject_Add(ambit_external
             DEPENDS lapack_external
                     hdf5_external
@@ -38,7 +40,6 @@ if(${ENABLE_ambit})
                        -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                        -DPYMOD_INSTALL_LIBDIR=${PYMOD_INSTALL_LIBDIR}
                        -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
-                       -DPYMOD_INSTALL_LIBDIR=${PYMOD_INSTALL_LIBDIR}
                        -DSTATIC_ONLY=${_a_only}
                        -DSHARED_ONLY=${_so_only}
                        -DENABLE_OPENMP=${ENABLE_OPENMP}  # relevant
@@ -46,6 +47,7 @@ if(${ENABLE_ambit})
                        #-DEXTRA_Fortran_FLAGS=${CMAKE_EXTRA_Fortran_FLAGS}
                        -DEXTRA_C_FLAGS=${CMAKE_C_FLAGS}
                        -DEXTRA_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                       -Dambit_INSTALL_CMAKEDIR=${_ambit_dir}
                        -DPython_EXECUTABLE=${Python_EXECUTABLE}
                        -DPython_INCLUDE_DIR=${Python_INCLUDE_DIRS}
                        -DPython_LIBRARY=${Python_LIBRARIES}                       
@@ -65,7 +67,7 @@ if(${ENABLE_ambit})
                              -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
                              -DTargetOpenMP_FIND_COMPONENTS:STRING=C;CXX)
 
-        set(ambit_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/ambit CACHE PATH "path to internally built ambitConfig.cmake" FORCE)
+        set(ambit_DIR ${STAGED_INSTALL_PREFIX}/${_ambit_dir} CACHE PATH "path to internally built ambitConfig.cmake" FORCE)
     endif()
 else()
     add_library(ambit_external INTERFACE)  # dummy

--- a/external/upstream/dkh/CMakeLists.txt
+++ b/external/upstream/dkh/CMakeLists.txt
@@ -12,14 +12,18 @@ if(${ENABLE_dkh})
 
         include(ExternalProject)
         message(STATUS "Suitable dkh could not be located, ${Magenta}Building dkh${ColourReset} instead.")
+
+        set(_dkh_dir "share/cmake/dkh")
+
         ExternalProject_Add(dkh_external
             DEPENDS lapack_external
-            URL https://github.com/psi4/dkh/archive/319b320.tar.gz  # v1.2 + cmake
+            URL https://github.com/psi4/dkh/archive/3ba0128.tar.gz  # v1.2 + cmake
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                        -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
+                       -Ddkh_INSTALL_CMAKEDIR=${_dkh_dir}
                        -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
                        -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
@@ -34,7 +38,7 @@ if(${ENABLE_dkh})
             CMAKE_CACHE_ARGS -DCMAKE_Fortran_FLAGS:STRING=${CMAKE_Fortran_FLAGS}
                              -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS})
 
-        set(dkh_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/dkh CACHE PATH "path to internally built dkhConfig.cmake" FORCE)
+        set(dkh_DIR ${STAGED_INSTALL_PREFIX}/${_dkh_dir} CACHE PATH "path to internally built dkhConfig.cmake" FORCE)
     endif()
 else()
     add_library(dkh_external INTERFACE)  # dummy

--- a/external/upstream/pcmsolver/CMakeLists.txt
+++ b/external/upstream/pcmsolver/CMakeLists.txt
@@ -38,7 +38,7 @@
                        -DPYMOD_INSTALL_LIBDIR=${PYMOD_INSTALL_LIBDIR}
                        -DCMAKE_INSTALL_DATADIR=${CMAKE_INSTALL_DATADIR}
                        -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
-                       -DCMAKECONFIG_INSTALL_DIR=${_pcmsolver_dir}
+                       -DPCMSolver_INSTALL_CMAKEDIR=${_pcmsolver_dir}
                        -DPython_EXECUTABLE=${Python_EXECUTABLE}
                        -DSTATIC_LIBRARY_ONLY=${_a_only}
                        -DSHARED_LIBRARY_ONLY=${_so_only}

--- a/external/upstream/qcelemental/CMakeLists.txt
+++ b/external/upstream/qcelemental/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_qcelemental}))
     include(FindPythonModule)
-    find_python_module(qcelemental ATLEAST 0.24.0 QUIET)
+    find_python_module(qcelemental ATLEAST 0.26.0 QUIET)
 endif()
 
 if(${qcelemental_FOUND})
@@ -19,13 +19,15 @@ else()
 
     ExternalProject_Add(qcelemental_external
         BUILD_ALWAYS 1
-        URL https://github.com/MolSSI/QCElemental/archive/v0.25.1.tar.gz
+        URL https://github.com/MolSSI/QCElemental/archive/v0.26.0.tar.gz
+        DOWNLOAD_NO_EXTRACT 1
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
-        BUILD_COMMAND ${Python_EXECUTABLE} setup.py build
+        BUILD_COMMAND ""
         BUILD_IN_SOURCE 1
-        INSTALL_COMMAND ${Python_EXECUTABLE} setup.py install
-                                                      --record=record.txt
-                                                      --single-version-externally-managed
-                                                      --install-lib=${_install_lib})
+        INSTALL_COMMAND ${Python_EXECUTABLE} -m pip install <DOWNLOADED_FILE>
+                                                      --target=${_install_lib}
+                                                      --no-deps
+                                                      #-v
+        )
 endif()

--- a/external/upstream/qcengine/CMakeLists.txt
+++ b/external/upstream/qcengine/CMakeLists.txt
@@ -25,8 +25,7 @@ else()
     ExternalProject_Add(qcengine_external
         DEPENDS qcelemental_external
         BUILD_ALWAYS 1
-        URL https://github.com/loriab/QCEngine/archive/v0.26.0.dev1.tar.gz
-        #URL https://github.com/MolSSI/QCEngine/archive/v0.27.0.tar.gz
+        URL https://github.com/MolSSI/QCEngine/archive/v0.27.0.tar.gz
         DOWNLOAD_NO_EXTRACT 1
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""

--- a/external/upstream/qcengine/CMakeLists.txt
+++ b/external/upstream/qcengine/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_qcengine}))
     include(FindPythonModule)
-    find_python_module(qcengine ATLEAST 0.26.0 QUIET)
+    find_python_module(qcengine ATLEAST 0.27.0 QUIET)
 endif()
 
 if(${qcengine_FOUND})
@@ -18,17 +18,23 @@ else()
     file(TO_NATIVE_PATH "${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}${PYMOD_INSTALL_LIBDIR}" _install_lib)
     file(TO_NATIVE_PATH "${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}" _install_bin)
 
+    # Note: Without downgrading setuptools or `sed`ing "git_refnames" (_version.py for versioneer-generated),
+    #   pip will strenuously resist ("Invalid version: <branch or commit>") arbitrary branch or commit refs from GH.
+    #   Make a proper PEP440 tag (e.g., `git tag -a v0.26.0.dev1 -m "v0.26.0.dev1"`), push it, and use in URL below.
+
     ExternalProject_Add(qcengine_external
         DEPENDS qcelemental_external
         BUILD_ALWAYS 1
-        URL https://github.com/MolSSI/QCEngine/archive/v0.26.0.tar.gz
+        URL https://github.com/loriab/QCEngine/archive/v0.26.0.dev1.tar.gz
+        #URL https://github.com/MolSSI/QCEngine/archive/v0.27.0.tar.gz
+        DOWNLOAD_NO_EXTRACT 1
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
-        BUILD_COMMAND ${Python_EXECUTABLE} setup.py build
+        BUILD_COMMAND ""
         BUILD_IN_SOURCE 1
-        INSTALL_COMMAND ${Python_EXECUTABLE} setup.py install
-                                                      --record=record.txt
-                                                      --single-version-externally-managed
-                                                      --install-scripts=${_install_bin}
-                                                      --install-lib=${_install_lib})
+        INSTALL_COMMAND ${Python_EXECUTABLE} -m pip install <DOWNLOADED_FILE>
+                                                      --target=${_install_lib}
+                                                      --no-deps
+                                                      #-v
+        )
 endif()

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -152,7 +152,10 @@ pp = pprint.PrettyPrinter(width=120, compact=True, indent=1)
 import logging
 
 import numpy as np
-from pydantic import Field, validator
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
 from qcelemental.models import AtomicResult, DriverEnum
 
 from psi4 import core

--- a/psi4/driver/driver_findif.py
+++ b/psi4/driver/driver_findif.py
@@ -143,7 +143,10 @@ from functools import partial
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
-from pydantic import Field, validator
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
 from qcelemental.models import DriverEnum, AtomicResult
 from qcelemental import constants
 

--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -149,8 +149,10 @@ import math
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, TYPE_CHECKING
 from ast import literal_eval
 from enum import Enum
-
-from pydantic import Field, validator
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
 
 import pprint
 pp = pprint.PrettyPrinter(width=120, compact=True, indent=1)

--- a/psi4/driver/task_base.py
+++ b/psi4/driver/task_base.py
@@ -38,7 +38,10 @@ import logging
 import pprint
 from typing import Any, Dict, Optional, Tuple, Union, TYPE_CHECKING
 
-from pydantic import Field, validator
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
 import qcelemental as qcel
 from qcelemental.models import DriverEnum, AtomicInput, AtomicResult
 qcel.models.molecule.GEOMETRY_NOISE = 13  # need more precision in geometries for high-res findif


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->


## User API & Changelog headlines
- [x] Allow psi4 to be used with pydantic v1 or v2.

## Dev notes & details
- [x] still using pydantic v1 API but now tolerant of a v1 or v2 pydantic environment. qcel v0.26 and qcng v0.27 have recieved the same treatment. This is that part that's worthy of backport. It's already available on the c-f 1.8.1 build number `_2` conda packages, having been applied by patch.
- [x] bump qcel and qcng versions. for local build cases, switch from `python setup.py` to `pip install` from src. the latter is preferred as setup.py gets phased out, and, in any case, was necessary for qcel, which has transitioned from a setuptools to poetry build backend. this only handles the module, so if a module comes with an executable (e.g., `bin/qcengine` from qcng, that doesn't end up in the right place. 
- [x] fix docs GHA by constraining pb11 to 2.10 for the docs build spec. https://github.com/pybind/pybind11/pull/4679 seems to be the culprit. It's a good and standards-conforming change, but other tooling and/or typing stores on the internet to which sphinx refers all need time to adapt.
- [x] generalize a few cmake config dir locations for addons.
- [x] remove youtube links to F/I SAPT tutorials that have been taken private.
- [x] some build docs I had lying around.

## Status
- [x] Ready for review
- [x] Ready for merge
