### PR TITLE
docs and win build

### DIFF
--- a/conda/win/meta.yaml
+++ b/conda/win/meta.yaml
@@ -14,8 +14,8 @@ requirements:
     - networkx
     - numpy
     - python={{ PY_VER }}
-    - qcelemental=0.25.1
-    - qcengine=0.26.0
+    - qcelemental=0.26.0
+    - qcengine=0.27.0
     - msgpack-python
     - optking
     - gau2grid

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -28,7 +28,7 @@ dependencies:
   - jupyter_client
   - nbsphinx
   - python-graphviz
-  - sphinx
+  - sphinx=6
   - sphinx-autodoc-typehints
   - sphinx-automodapi
   - psi4/label/dev::sphinx-psi-theme


### PR DESCRIPTION
## Description
For now, a shot in the dark to fix the psicode docs and the nightly windows package. As far as I can tell, there's nothing wrong with the master docs build --  https://psi4manual.netlify.app/ has all its links working just fine. But there's something a little different about how the internal links are expressed, and that makes the redirects misfire when accessed from psicode.org https://github.com/psi4/psicode-hugo-website/blob/master/netlify.toml#L12 .

## Status
- [x] Ready for review
- [x] Ready for merge
