### PR TITLE
fix_orientation docstring

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -855,9 +855,9 @@ void export_mints(py::module& m) {
         .def("connectivity", &Molecule::connectivity, "Gets molecule connectivity")
         .def("reinterpret_coordentry", &Molecule::set_reinterpret_coordentry,
              "Do reinterpret coordinate entries during update_geometry().")
-        .def("fix_orientation", &Molecule::set_orientation_fixed, "Fix the orientation at its current frame")
+        .def("fix_orientation", &Molecule::set_orientation_fixed, "Fix the orientation at its current frame. Expert use only; use before molecule finalized by update_geometry.")
         .def("fix_com", &Molecule::set_com_fixed,
-             "Sets whether to fix the Cartesian position, or to translate to the C.O.M.")
+             "Sets whether to fix the Cartesian position, or to translate to the C.O.M. Expert use only; use before molecule finalized by update_geometry.")
         .def("orientation_fixed", &Molecule::orientation_fixed, "Get whether or not orientation is fixed")
         .def("com_fixed", &Molecule::com_fixed, "Gets whether or not center of mass is fixed")
         .def("symmetry_from_input", &Molecule::symmetry_from_input, "Returns the symmetry specified in the input")


### PR DESCRIPTION
## Description
~Nominally a~ clarification of some deceptive commands. ~Really to test whether qcf snowflake testing is as broken as I see on another branch.~

## Dev notes & details
- [x] These commands have tripped up experienced psi4 developers (counting me). They actually can't do anything when used py-side on a built molecule (https://github.com/psi4/psi4/blob/master/psi4/src/psi4/libmints/molecule.cc#L856-L872). They are instead for preparing a molecule before it's finalized by `update_geometry()`. So let's be nice and have a findable warning.

## Status
- [x] Ready for review
- [x] Ready for merge
