### PR TITLE
Import slayer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ debug_latest
 TEST
 */test.py
 */test.dat
+install*
 
 # Other random files people have added.
 svn_source

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,5 +6,5 @@ use_parentheses=True
 multi_line_output=3
 profile=black
 skip_gitignore=True
-skip_glob=psi4/driver/qcdb/*, psi4/driver/procrouting/*, samples/*, tests/*
+skip_glob=psi4/driver/qcdb/*, samples/*, tests/*
 

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+line_length=120
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+multi_line_output=3
+profile=black
+

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,6 @@ force_grid_wrap=0
 use_parentheses=True
 multi_line_output=3
 profile=black
+skip_gitignore=True
+skip_glob=psi4/driver/qcdb/*, psi4/driver/procrouting/*, samples/*, tests/*
 

--- a/conda/_conda_vers.py
+++ b/conda/_conda_vers.py
@@ -33,6 +33,7 @@ computed version number into the conda recipe.
 import sys
 from distutils.core import setup
 
+
 def version_func():
     import subprocess
 

--- a/devtools/scripts/ci_print_failing.py
+++ b/devtools/scripts/ci_print_failing.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-import re
-import sys
 import json
 import os
+import re
+import sys
 
 badtests = []
 testfail = re.compile(r'^\s*(?P<num>\d+) - (?P<name>\w+(?:-\w+)*) \(Failed\)\s*$')

--- a/devtools/scripts/ci_run_test.py
+++ b/devtools/scripts/ci_run_test.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
+import subprocess
 import sys
 import time
-import subprocess
-
 
 # <<<  run ctest  >>>
 retcode = subprocess.Popen(['ctest', '-j2', '-L', 'smoke'], bufsize=0,

--- a/doc/sphinxman/document_capabilities.py
+++ b/doc/sphinxman/document_capabilities.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import ast
 import argparse
+import ast
 import unicodedata
 from pathlib import Path
 
-from psi4.driver.procrouting.proc_data import method_governing_type_keywords
 from psi4.driver.p4util.exceptions import sanitize_method
+from psi4.driver.procrouting.proc_data import method_governing_type_keywords
 
 # stdsuite DFT methods set explicitly to "scf_type" since the DFTs aren't individually entered in proc_data.py
 method_governing_type_keywords["svwn"] = "scf_type"

--- a/doc/sphinxman/document_cfour.py
+++ b/doc/sphinxman/document_cfour.py
@@ -28,11 +28,10 @@
 # @END LICENSE
 #
 
-import sys
-import os
 import glob
+import os
 import re
-
+import sys
 
 DriverPath = ''
 InsertPath = '/../../../'

--- a/doc/sphinxman/document_databases.py
+++ b/doc/sphinxman/document_databases.py
@@ -28,11 +28,10 @@
 # @END LICENSE
 #
 
-import sys
-import os
 import glob
+import os
 import re
-
+import sys
 
 DriverPath = ''
 if (len(sys.argv) == 2):

--- a/doc/sphinxman/document_driver.py
+++ b/doc/sphinxman/document_driver.py
@@ -28,11 +28,10 @@
 # @END LICENSE
 #
 
-import sys
-import os
 import glob
+import os
 import re
-
+import sys
 
 DriverPath = ''
 InsertPath = '/../../../'

--- a/doc/sphinxman/document_efpfrag.py
+++ b/doc/sphinxman/document_efpfrag.py
@@ -28,11 +28,10 @@
 # @END LICENSE
 #
 
-import sys
-import os
 import glob
+import os
 import re
-
+import sys
 
 DriverPath = ''
 InsertPath = '/../../../'

--- a/doc/sphinxman/document_plugins.py
+++ b/doc/sphinxman/document_plugins.py
@@ -28,11 +28,10 @@
 # @END LICENSE
 #
 
-import sys
-import os
 import glob
+import os
 import re
-
+import sys
 
 DriverPath = ''
 InsertPath = '/../../../'

--- a/doc/sphinxman/document_psifiles.py
+++ b/doc/sphinxman/document_psifiles.py
@@ -28,11 +28,10 @@
 # @END LICENSE
 #
 
-import sys
-import os
 import glob
+import os
 import re
-
+import sys
 
 DriverPath = ''
 InsertPath = '/../../../'

--- a/doc/sphinxman/document_stubs.py
+++ b/doc/sphinxman/document_stubs.py
@@ -28,12 +28,11 @@
 # @END LICENSE
 #
 
-import sys
-import os
 import glob
+import os
 import re
+import sys
 from pathlib import Path
-
 
 DriverPath = ''
 if (len(sys.argv) == 2):

--- a/doc/sphinxman/extract_changeset.py
+++ b/doc/sphinxman/extract_changeset.py
@@ -30,6 +30,7 @@
 
 import os
 import sys
+
 # Extracts last git changelog item into html for psicode
 
 gitlast = 'feed/latest_trac_changeset.txt'  # path to output file with latest changeset

--- a/psi4/__init__.py
+++ b/psi4/__init__.py
@@ -26,6 +26,9 @@
 # @END LICENSE
 #
 
+"""
+isort:skip_file
+"""
 
 # Figure out paths
 # * in figuring out psidatadir: envvar trumps staged/installed

--- a/psi4/driver/__init__.py
+++ b/psi4/driver/__init__.py
@@ -29,7 +29,6 @@
 isort:skip_file
 """
 
-import pickle
 
 from .constants import *
 from . import psifiles as psif

--- a/psi4/driver/__init__.py
+++ b/psi4/driver/__init__.py
@@ -31,8 +31,10 @@ from .constants import *
 
 # isort: split
 
-from . import schema_wrapper  # Deprecate in 1.4
-from . import aliases, diatomic, frac, gaussian_n, wrapper_autofrag, wrapper_database
+from . import aliases, diatomic, frac, gaussian_n
+from . import schema_wrapper as json_wrapper  # Deprecate in 1.4
+from . import schema_wrapper as schema_wrapper
+from . import wrapper_autofrag, wrapper_database
 from .driver import *
 from .driver_cbs import cbs  # remove in v1.8 when UpgradeHelper expires
 from .inputparser import process_input

--- a/psi4/driver/__init__.py
+++ b/psi4/driver/__init__.py
@@ -25,6 +25,9 @@
 #
 # @END LICENSE
 #
+"""
+isort:skip_file
+"""
 
 import pickle
 

--- a/psi4/driver/__init__.py
+++ b/psi4/driver/__init__.py
@@ -28,31 +28,33 @@
 
 import pickle
 
+from . import dependency_check
+
 from .constants import *
-from psi4.driver import psifiles as psif
+from . import psifiles as psif
 
-from psi4.driver.ipi_broker import ipi_broker
-from psi4.driver.molutil import *
-from psi4.driver.inputparser import process_input
-from psi4.driver.p4util.util import *
-from psi4.driver.p4util.testing import *
-from psi4.driver.p4util.fcidump import *
-from psi4.driver.p4util.fchk import *
-from psi4.driver.p4util.text import *
-from psi4.driver.qmmm import QMMM, QMMMbohr
-from psi4.driver.pluginutil import *
+from .ipi_broker import ipi_broker
+from .molutil import *
+from .inputparser import process_input
+from .p4util.util import *
+from .p4util.testing import *
+from .p4util.fcidump import *
+from .p4util.fchk import *
+from .p4util.text import *
+from .qmmm import QMMM, QMMMbohr
+from .pluginutil import *
 
-from psi4.driver import gaussian_n
-from psi4.driver import aliases
-from psi4.driver import diatomic
-from psi4.driver import wrapper_database
-from psi4.driver import wrapper_autofrag
-from psi4.driver import schema_wrapper
-from psi4.driver import schema_wrapper as json_wrapper # Deprecate in 1.4
-from psi4.driver import frac
+from . import gaussian_n
+from . import aliases
+from . import diatomic
+from . import wrapper_database
+from . import wrapper_autofrag
+from . import schema_wrapper
+from . import schema_wrapper as json_wrapper  # Deprecate in 1.4
+from . import frac
 
-from psi4.driver.driver import *
+from .driver import *
 
 # Single functions
-from psi4.driver.driver_cbs import cbs  # remove in v1.8 when UpgradeHelper expires
-from psi4.driver.p4util.python_helpers import set_options, set_module_options, pcm_helper, basis_helper
+from .driver_cbs import cbs  # remove in v1.8 when UpgradeHelper expires
+from .p4util.python_helpers import set_options, set_module_options, pcm_helper, basis_helper

--- a/psi4/driver/__init__.py
+++ b/psi4/driver/__init__.py
@@ -25,36 +25,24 @@
 #
 # @END LICENSE
 #
-"""
-isort:skip_file
-"""
 
-
-from .constants import *
 from . import psifiles as psif
+from .constants import *
 
+# isort: split
+
+from . import schema_wrapper  # Deprecate in 1.4
+from . import aliases, diatomic, frac, gaussian_n, wrapper_autofrag, wrapper_database
+from .driver import *
+from .driver_cbs import cbs  # remove in v1.8 when UpgradeHelper expires
+from .inputparser import process_input
 from .ipi_broker import ipi_broker
 from .molutil import *
-from .inputparser import process_input
-from .p4util.util import *
-from .p4util.testing import *
-from .p4util.fcidump import *
 from .p4util.fchk import *
+from .p4util.fcidump import *
+from .p4util.python_helpers import basis_helper, pcm_helper, set_module_options, set_options
+from .p4util.testing import *
 from .p4util.text import *
-from .qmmm import QMMM, QMMMbohr
+from .p4util.util import *
 from .pluginutil import *
-
-from . import gaussian_n
-from . import aliases
-from . import diatomic
-from . import wrapper_database
-from . import wrapper_autofrag
-from . import schema_wrapper
-from . import schema_wrapper as json_wrapper  # Deprecate in 1.4
-from . import frac
-
-from .driver import *
-
-# Single functions
-from .driver_cbs import cbs  # remove in v1.8 when UpgradeHelper expires
-from .p4util.python_helpers import set_options, set_module_options, pcm_helper, basis_helper
+from .qmmm import QMMM, QMMMbohr

--- a/psi4/driver/__init__.py
+++ b/psi4/driver/__init__.py
@@ -28,8 +28,6 @@
 
 import pickle
 
-from . import dependency_check
-
 from .constants import *
 from . import psifiles as psif
 

--- a/psi4/driver/aliases.py
+++ b/psi4/driver/aliases.py
@@ -40,9 +40,6 @@ __all__ = [
     "sherrill_gold_standard",
 ]
 
-import os
-import re
-import warnings
 from typing import Any, Dict, List
 
 CBSMetadata = List[Dict[str, Any]]

--- a/psi4/driver/constants.py
+++ b/psi4/driver/constants.py
@@ -56,7 +56,9 @@ except ImportError:
 # printing and logging formatting niceties
 import pprint
 from functools import partial
+
 import numpy as np
+
 pp = pprint.PrettyPrinter(width=120, compact=True, indent=1)
 nppp = partial(np.array_str, max_line_width=120, precision=8, suppress_small=True)
 nppp10 = partial(np.array_str, max_line_width=120, precision=10, suppress_small=True)
@@ -64,5 +66,6 @@ del np, partial, pprint
 
 # ensure Psi4 py-side constants are fixed at CODATA 2014, regardless of qcel default
 import qcelemental as qcel
+
 constants = qcel.PhysicalConstantsContext("CODATA2014")
 del qcel

--- a/psi4/driver/diatomic.py
+++ b/psi4/driver/diatomic.py
@@ -36,6 +36,7 @@ from typing import Any, Dict, List
 import numpy as np
 
 from psi4 import core
+
 from . import constants
 from .p4util.exceptions import *
 

--- a/psi4/driver/diatomic.py
+++ b/psi4/driver/diatomic.py
@@ -36,8 +36,8 @@ from typing import Any, Dict, List
 import numpy as np
 
 from psi4 import core
-from psi4.driver import constants
-from psi4.driver.p4util.exceptions import *
+from . import constants
+from .p4util.exceptions import *
 
 
 def least_squares_fit_polynomial(

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -44,19 +44,18 @@ import logging
 import numpy as np
 
 from psi4 import core  # for typing
-from .constants import constants
-from psi4.driver import driver_util
-from psi4.driver import driver_cbs
-from psi4.driver import driver_nbody
-from psi4.driver import driver_findif
-from psi4.driver import task_planner
-from psi4.driver import p4util
-from psi4.driver import qcdb
-from psi4.driver import pp, nppp, nppp10
-from psi4.driver.p4util.exceptions import *
-from psi4.driver.procrouting import *
-from psi4.driver.mdi_engine import mdi_run
-from psi4.driver.task_base import AtomicComputer
+from . import driver_util
+from . import driver_cbs
+from . import driver_nbody
+from . import driver_findif
+from . import task_planner
+from . import p4util
+from . import qcdb
+from .constants import constants pp, nppp, nppp10
+from .p4util.exceptions import *
+from .procrouting import *
+from .mdi_engine import mdi_run
+from .task_base import AtomicComputer
 
 # never import wrappers or aliases into this file
 

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -37,7 +37,6 @@ import logging
 import os
 import re
 import shutil
-import sys
 from typing import Dict, Optional, Union
 
 import numpy as np

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -51,7 +51,7 @@ from . import driver_findif
 from . import task_planner
 from . import p4util
 from . import qcdb
-from .constants import constants pp, nppp, nppp10
+from .constants import constants, pp, nppp, nppp10
 from .p4util.exceptions import *
 from .procrouting import *
 from .mdi_engine import mdi_run

--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -31,30 +31,24 @@ single-point energies, geometry optimizations, properties, and vibrational
 frequency calculations.
 
 """
+import copy
 import json
+import logging
 import os
 import re
-import copy
 import shutil
 import sys
-import logging
 from typing import Dict, Optional, Union
-import logging
 
 import numpy as np
 
 from psi4 import core  # for typing
-from . import driver_util
-from . import driver_cbs
-from . import driver_nbody
-from . import driver_findif
-from . import task_planner
-from . import p4util
-from . import qcdb
-from .constants import constants, pp, nppp, nppp10
+
+from . import driver_cbs, driver_findif, driver_nbody, driver_util, p4util, qcdb, task_planner
+from .constants import constants, nppp, nppp10, pp
+from .mdi_engine import mdi_run
 from .p4util.exceptions import *
 from .procrouting import *
-from .mdi_engine import mdi_run
 from .task_base import AtomicComputer
 
 # never import wrappers or aliases into this file

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -144,7 +144,6 @@ CompositeComputer.get_psi_results()
 
 import copy
 import logging
-import math
 import re
 import sys
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
@@ -1031,7 +1030,6 @@ def cbs(func, label, **kwargs):
     >>> TODO optimize('mp2', corl_basis='cc-pV[DT]Z', corl_scheme='corl_xtpl_helgaker_2', func=cbs)
 
     """
-    pass
 
 
 ##  Aliases  ##

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -146,9 +146,7 @@ import math
 import re
 import sys
 import copy
-import pprint
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
-pp = pprint.PrettyPrinter(width=120, compact=True, indent=1)
 import logging
 
 import numpy as np
@@ -159,13 +157,14 @@ except ImportError:
 from qcelemental.models import AtomicResult, DriverEnum
 
 from psi4 import core
-from psi4.driver import driver_util, p4util, pp
-from psi4.driver import qcdb
-from psi4.driver.driver_cbs_helper import composite_procedures, register_composite_function, register_xtpl_function, xtpl_procedures  # lgtm[py/unused-import]
-from psi4.driver.driver_util import UpgradeHelper
-from psi4.driver.p4util.exceptions import ValidationError
-from psi4.driver.procrouting.interface_cfour import cfour_psivar_list
-from psi4.driver.task_base import AtomicComputer, BaseComputer, EnergyGradientHessianWfnReturn
+from . import driver_util, p4util
+from . import qcdb
+from .constants import pp
+from .driver_cbs_helper import composite_procedures, register_composite_function, register_xtpl_function, xtpl_procedures  # lgtm[py/unused-import]
+from .driver_util import UpgradeHelper
+from .p4util.exceptions import ValidationError
+from .procrouting.interface_cfour import cfour_psivar_list
+from .task_base import AtomicComputer, BaseComputer, EnergyGradientHessianWfnReturn
 
 if TYPE_CHECKING:
     import qcportal

--- a/psi4/driver/driver_cbs.py
+++ b/psi4/driver/driver_cbs.py
@@ -142,25 +142,32 @@ CompositeComputer.get_psi_results()
 
 """
 
+import copy
+import logging
 import math
 import re
 import sys
-import copy
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
-import logging
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
+
 try:
     from pydantic.v1 import Field, validator
 except ImportError:
     from pydantic import Field, validator
+
 from qcelemental.models import AtomicResult, DriverEnum
 
 from psi4 import core
-from . import driver_util, p4util
-from . import qcdb
+
+from . import driver_util, p4util, qcdb
 from .constants import pp
-from .driver_cbs_helper import composite_procedures, register_composite_function, register_xtpl_function, xtpl_procedures  # lgtm[py/unused-import]
+from .driver_cbs_helper import (  # lgtm[py/unused-import]
+    composite_procedures,
+    register_composite_function,
+    register_xtpl_function,
+    xtpl_procedures,
+)
 from .driver_util import UpgradeHelper
 from .p4util.exceptions import ValidationError
 from .procrouting.interface_cfour import cfour_psivar_list

--- a/psi4/driver/driver_cbs_helper.py
+++ b/psi4/driver/driver_cbs_helper.py
@@ -34,9 +34,9 @@ import logging
 import numpy as np
 
 from psi4 import core
-from psi4.driver.p4util.exceptions import ValidationError
-nppp = partial(np.array_str, max_line_width=120, precision=8, suppress_small=True)  # when safe, "from psi4.driver import nppp"
-from psi4.driver.aliases import sherrill_gold_standard, allen_focal_point
+from .p4util.exceptions import ValidationError
+from .constants import nppp
+from .aliases import sherrill_gold_standard, allen_focal_point
 
 logger = logging.getLogger(__name__)
 

--- a/psi4/driver/driver_cbs_helper.py
+++ b/psi4/driver/driver_cbs_helper.py
@@ -28,7 +28,6 @@
 
 import logging
 import math
-from functools import partial
 from typing import Callable, Optional, Union
 
 import numpy as np

--- a/psi4/driver/driver_cbs_helper.py
+++ b/psi4/driver/driver_cbs_helper.py
@@ -26,17 +26,18 @@
 # @END LICENSE
 #
 
+import logging
 import math
 from functools import partial
 from typing import Callable, Optional, Union
-import logging
 
 import numpy as np
 
 from psi4 import core
-from .p4util.exceptions import ValidationError
+
+from .aliases import allen_focal_point, sherrill_gold_standard
 from .constants import nppp
-from .aliases import sherrill_gold_standard, allen_focal_point
+from .p4util.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
 

--- a/psi4/driver/driver_findif.py
+++ b/psi4/driver/driver_findif.py
@@ -151,9 +151,11 @@ from qcelemental.models import DriverEnum, AtomicResult
 from .constants import constants
 
 from psi4 import core
-from psi4.driver import p4util, pp, qcdb, nppp10
-from psi4.driver.p4util.exceptions import ValidationError
-from psi4.driver.task_base import AtomicComputer, BaseComputer, EnergyGradientHessianWfnReturn
+from . import p4util
+from . import qcdb
+from .constants import pp, nppp10
+from .p4util.exceptions import ValidationError
+from .task_base import AtomicComputer, BaseComputer, EnergyGradientHessianWfnReturn
 
 if TYPE_CHECKING:
     import qcportal

--- a/psi4/driver/driver_findif.py
+++ b/psi4/driver/driver_findif.py
@@ -140,20 +140,21 @@ FiniteDifferenceComputer.get_psi_results()
 import copy
 import logging
 from functools import partial
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
+
 try:
     from pydantic.v1 import Field, validator
 except ImportError:
     from pydantic import Field, validator
-from qcelemental.models import DriverEnum, AtomicResult
-from .constants import constants
+
+from qcelemental.models import AtomicResult, DriverEnum
 
 from psi4 import core
-from . import p4util
-from . import qcdb
-from .constants import pp, nppp10
+
+from . import p4util, qcdb
+from .constants import constants, nppp10, pp
 from .p4util.exceptions import ValidationError
 from .task_base import AtomicComputer, BaseComputer, EnergyGradientHessianWfnReturn
 

--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -148,7 +148,7 @@ import itertools
 import math
 from ast import literal_eval
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union
 
 try:
     from pydantic.v1 import Field, validator
@@ -237,7 +237,6 @@ def nbody():
         Add atom-centered point charges for fragments whose basis sets are not included in the computation.
 
     """
-    pass
 
 
 class BsseEnum(str, Enum):

--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -154,19 +154,18 @@ try:
 except ImportError:
     from pydantic import Field, validator
 
-import pprint
-pp = pprint.PrettyPrinter(width=120, compact=True, indent=1)
 import logging
 
 import numpy as np
 from qcelemental.models import DriverEnum, AtomicResult
 
 from psi4 import core
-from psi4.driver import constants, driver_nbody_multilevel, p4util
-from psi4.driver.p4util.exceptions import *
-from psi4.driver.task_base import BaseComputer, AtomicComputer, EnergyGradientHessianWfnReturn
-from psi4.driver.driver_cbs import CompositeComputer
-from psi4.driver.driver_findif import FiniteDifferenceComputer
+from .constants import constants, pp
+from . import driver_nbody_multilevel, p4util
+from .p4util.exceptions import *
+from .task_base import BaseComputer, AtomicComputer, EnergyGradientHessianWfnReturn
+from .driver_cbs import CompositeComputer
+from .driver_findif import FiniteDifferenceComputer
 
 if TYPE_CHECKING:
     import qcportal

--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -146,9 +146,10 @@ __all__ = [
 import copy
 import itertools
 import math
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, TYPE_CHECKING
 from ast import literal_eval
 from enum import Enum
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union
+
 try:
     from pydantic.v1 import Field, validator
 except ImportError:
@@ -157,15 +158,16 @@ except ImportError:
 import logging
 
 import numpy as np
-from qcelemental.models import DriverEnum, AtomicResult
+from qcelemental.models import AtomicResult, DriverEnum
 
 from psi4 import core
-from .constants import constants, pp
+
 from . import driver_nbody_multilevel, p4util
-from .p4util.exceptions import *
-from .task_base import BaseComputer, AtomicComputer, EnergyGradientHessianWfnReturn
+from .constants import constants, pp
 from .driver_cbs import CompositeComputer
 from .driver_findif import FiniteDifferenceComputer
+from .p4util.exceptions import *
+from .task_base import AtomicComputer, BaseComputer, EnergyGradientHessianWfnReturn
 
 if TYPE_CHECKING:
     import qcportal

--- a/psi4/driver/driver_nbody_multilevel.py
+++ b/psi4/driver/driver_nbody_multilevel.py
@@ -26,7 +26,7 @@
 # @END LICENSE
 #
 
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import numpy as np
 

--- a/psi4/driver/driver_util.py
+++ b/psi4/driver/driver_util.py
@@ -26,13 +26,14 @@
 # @END LICENSE
 #
 
-import re
 import math
+import re
 from typing import Any, Dict, Optional, Tuple, Union
 
 from psi4 import core
+
 from . import p4util
-from .p4util.exceptions import docs_table_link, ManagedMethodError, MissingMethodError, UpgradeHelper, ValidationError
+from .p4util.exceptions import ManagedMethodError, MissingMethodError, UpgradeHelper, ValidationError, docs_table_link
 from .procrouting import proc
 from .procrouting.proc_table import procedures
 

--- a/psi4/driver/driver_util.py
+++ b/psi4/driver/driver_util.py
@@ -27,7 +27,6 @@
 #
 
 import math
-import re
 from typing import Any, Dict, Optional, Tuple, Union
 
 from psi4 import core

--- a/psi4/driver/driver_util.py
+++ b/psi4/driver/driver_util.py
@@ -31,9 +31,10 @@ import math
 from typing import Any, Dict, Optional, Tuple, Union
 
 from psi4 import core
-from psi4.driver import p4util
-from psi4.driver.p4util.exceptions import docs_table_link, ManagedMethodError, MissingMethodError, UpgradeHelper, ValidationError
-from psi4.driver.procrouting import *
+from . import p4util
+from .p4util.exceptions import docs_table_link, ManagedMethodError, MissingMethodError, UpgradeHelper, ValidationError
+from .procrouting import proc
+from .procrouting.proc_table import procedures
 
 
 def negotiate_convergence_criterion(dermode: Union[Tuple[str, str], Tuple[int, int]], method: str, return_optstash: bool = False):

--- a/psi4/driver/endorsed_plugins.py
+++ b/psi4/driver/endorsed_plugins.py
@@ -30,7 +30,6 @@
 
 __all__ = []
 
-import sys
 
 try:
     import v2rdm_casscf

--- a/psi4/driver/frac.py
+++ b/psi4/driver/frac.py
@@ -35,8 +35,8 @@ __all__ = [
 from typing import Callable, Dict, Union
 
 from psi4 import core
-from . import p4util
-from . import driver
+
+from . import driver, p4util
 from .p4util.exceptions import *
 
 

--- a/psi4/driver/frac.py
+++ b/psi4/driver/frac.py
@@ -35,9 +35,9 @@ __all__ = [
 from typing import Callable, Dict, Union
 
 from psi4 import core
-from psi4.driver import p4util
-from psi4.driver import driver
-from psi4.driver.p4util.exceptions import *
+from . import p4util
+from . import driver
+from .p4util.exceptions import *
 
 
 def frac_traverse(name: Union[str, Callable], **kwargs) -> Dict[float, float]:

--- a/psi4/driver/gaussian_n.py
+++ b/psi4/driver/gaussian_n.py
@@ -28,10 +28,10 @@
 
 __all__ = []
 
-from psi4.driver import driver
-from psi4.driver import p4util
-from psi4.driver import constants
-from psi4.driver.p4util.exceptions import ValidationError
+from . import driver
+from . import p4util
+from .constants import constants
+from .p4util.exceptions import ValidationError
 
 from psi4 import core
 

--- a/psi4/driver/gaussian_n.py
+++ b/psi4/driver/gaussian_n.py
@@ -28,12 +28,11 @@
 
 __all__ = []
 
-from . import driver
-from . import p4util
+from psi4 import core
+
+from . import driver, p4util
 from .constants import constants
 from .p4util.exceptions import ValidationError
-
-from psi4 import core
 
 # never import aliases into this file
 

--- a/psi4/driver/inputparser.py
+++ b/psi4/driver/inputparser.py
@@ -39,9 +39,8 @@ import sys
 import uuid
 
 from psi4 import core
-from psi4.driver.p4util.util import set_memory
 from psi4.driver.p4util.exceptions import *
-
+from psi4.driver.p4util.util import set_memory
 
 # inputfile contents to be preserved from the processor
 literals = {}

--- a/psi4/driver/inputparser.py
+++ b/psi4/driver/inputparser.py
@@ -35,7 +35,6 @@ __all__ = ["process_input"]
 
 import os
 import re
-import sys
 import uuid
 
 from psi4 import core

--- a/psi4/driver/ipi_broker.py
+++ b/psi4/driver/ipi_broker.py
@@ -38,6 +38,7 @@ from typing import Dict, Optional, Union
 import numpy as np
 
 import psi4
+
 try:
     from ipi.interfaces.clients import Client
     ipi_available = True

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -43,9 +43,18 @@ import psi4
 
 _have_mdi = False
 try:
-    from mdi import MDI_Init, MDI_MPI_get_world_comm, MDI_Accept_Communicator, \
-        MDI_Send, MDI_Recv, MDI_Recv_Command, MDI_INT, MDI_DOUBLE, \
-        MDI_Register_Node, MDI_Register_Command
+    from mdi import (
+        MDI_DOUBLE,
+        MDI_INT,
+        MDI_Accept_Communicator,
+        MDI_Init,
+        MDI_MPI_get_world_comm,
+        MDI_Recv,
+        MDI_Recv_Command,
+        MDI_Register_Command,
+        MDI_Register_Node,
+        MDI_Send,
+    )
     _have_mdi = True
 except ImportError:
     pass

--- a/psi4/driver/molutil.py
+++ b/psi4/driver/molutil.py
@@ -34,9 +34,8 @@ import qcelemental as qcel
 
 from .constants import constants
 from psi4 import core
-from psi4.driver.p4util import temp_circular_import_blocker
-from psi4.driver import qcdb
-from psi4.driver.p4util.exceptions import *
+from . import qcdb
+from .p4util.exceptions import *
 
 
 def molecule_set_attr(self, name, value):

--- a/psi4/driver/molutil.py
+++ b/psi4/driver/molutil.py
@@ -32,9 +32,10 @@ from typing import Dict, Tuple, Union
 import numpy as np
 import qcelemental as qcel
 
-from .constants import constants
 from psi4 import core
+
 from . import qcdb
+from .constants import constants
 from .p4util.exceptions import *
 
 

--- a/psi4/driver/p4util/exceptions.py
+++ b/psi4/driver/p4util/exceptions.py
@@ -52,7 +52,6 @@ from psi4 import core, extras
 class PsiException(Exception):
     """Error class for |PSIfour|. Flags success as False (triggering coffee)."""
     extras._success_flag_ = False
-    pass
 
 
 class ValidationError(PsiException):

--- a/psi4/driver/p4util/exceptions.py
+++ b/psi4/driver/p4util/exceptions.py
@@ -45,6 +45,7 @@ __all__ = [
 ]
 
 from typing import Any, Dict, List, Optional
+
 from psi4 import core, extras
 
 

--- a/psi4/driver/p4util/fchk.py
+++ b/psi4/driver/p4util/fchk.py
@@ -31,8 +31,10 @@ import re
 from typing import Union
 
 import numpy as np
-from ..p4util.testing import compare_strings, compare_arrays, compare_values, compare_integers
+
 from psi4 import core
+
+from ..p4util.testing import compare_arrays, compare_integers, compare_strings, compare_values
 from .exceptions import ValidationError
 
 __all__ = [

--- a/psi4/driver/p4util/fchk.py
+++ b/psi4/driver/p4util/fchk.py
@@ -31,7 +31,7 @@ import re
 from typing import Union
 
 import numpy as np
-from psi4.driver.p4util.testing import compare_strings, compare_arrays, compare_values, compare_integers
+from ..p4util.testing import compare_strings, compare_arrays, compare_values, compare_integers
 from psi4 import core
 from .exceptions import ValidationError
 

--- a/psi4/driver/p4util/fcidump.py
+++ b/psi4/driver/p4util/fcidump.py
@@ -38,9 +38,9 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
-from psi4.driver import psifiles as psif
-from psi4.driver.p4util.testing import compare_integers, compare_values, compare_recursive
-from psi4.driver.procrouting.proc_util import check_iwl_file_from_scf_type
+from .. import psifiles as psif
+from .testing import compare_integers, compare_values, compare_recursive
+from ..procrouting.proc_util import check_iwl_file_from_scf_type
 
 from psi4 import core
 from .exceptions import ValidationError, TestComparisonError

--- a/psi4/driver/p4util/fcidump.py
+++ b/psi4/driver/p4util/fcidump.py
@@ -38,12 +38,12 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
-from .. import psifiles as psif
-from .testing import compare_integers, compare_values, compare_recursive
-from ..procrouting.proc_util import check_iwl_file_from_scf_type
-
 from psi4 import core
-from .exceptions import ValidationError, TestComparisonError
+
+from .. import psifiles as psif
+from ..procrouting.proc_util import check_iwl_file_from_scf_type
+from .exceptions import TestComparisonError, ValidationError
+from .testing import compare_integers, compare_recursive, compare_values
 
 
 def fcidump(wfn: core.Wavefunction, fname: str = 'INTDUMP', oe_ints: Optional[List] = None):

--- a/psi4/driver/p4util/numpy_helper.py
+++ b/psi4/driver/p4util/numpy_helper.py
@@ -41,7 +41,6 @@ __all__ = [
 ]
 
 
-import sys
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np

--- a/psi4/driver/p4util/optproc.py
+++ b/psi4/driver/p4util/optproc.py
@@ -35,7 +35,6 @@ __all__ = [
     "OptionsState",
 ]
 
-import sys
 from contextlib import contextmanager
 from typing import Iterator, List, Optional
 

--- a/psi4/driver/p4util/optproc.py
+++ b/psi4/driver/p4util/optproc.py
@@ -37,7 +37,7 @@ __all__ = [
 
 import sys
 from contextlib import contextmanager
-from typing import Optional, Iterator, List
+from typing import Iterator, List, Optional
 
 from psi4 import core
 

--- a/psi4/driver/p4util/procutil.py
+++ b/psi4/driver/p4util/procutil.py
@@ -45,13 +45,8 @@ __all__ = [
     "state_to_atomicinput",
 ]
 
-import ast
 import collections
-import inspect
-import math
 import os
-import pickle
-import sys
 import warnings
 from contextlib import contextmanager
 from types import ModuleType

--- a/psi4/driver/p4util/procutil.py
+++ b/psi4/driver/p4util/procutil.py
@@ -45,25 +45,26 @@ __all__ = [
     "state_to_atomicinput",
 ]
 
-import os
 import ast
-import sys
-import math
-import pickle
+import collections
 import inspect
+import math
+import os
+import pickle
+import sys
 import warnings
 from contextlib import contextmanager
-import collections
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Union
 from types import ModuleType
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Union
 
 import numpy as np
 from qcelemental.models import AtomicInput
 
 from psi4 import core
 from psi4.metadata import __version__
-from .exceptions import ValidationError
+
 from . import p4regex
+from .exceptions import ValidationError
 
 
 def kwargs_lower(kwargs: Dict[str, Any]) -> Dict[str, Any]:
@@ -538,7 +539,7 @@ def prepare_options_for_set_options() -> Dict[str, Any]:
     # we need the following dirty hack.
 
     try:
-        import forte # Needed for Forte options to run.
+        import forte  # Needed for Forte options to run.
     except ImportError:
         pass
     else:

--- a/psi4/driver/p4util/prop_util.py
+++ b/psi4/driver/p4util/prop_util.py
@@ -28,6 +28,7 @@
 """Module with property-related helper functions."""
 
 import psi4
+
 from . import optproc
 
 __all__ = ['free_atom_volumes']

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -66,7 +66,7 @@ import numpy as np
 import qcelemental as qcel
 from psi4 import core
 from psi4 import extras
-from psi4.driver import qcdb
+from .. import qcdb
 
 from . import optproc
 from .exceptions import TestComparisonError, ValidationError, UpgradeHelper

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -52,7 +52,6 @@ __all__ = [
 import math
 import os
 import re
-import sys
 import uuid
 import warnings
 from collections import Counter

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -49,10 +49,10 @@ __all__ = [
 ]
 
 
+import math
 import os
 import re
 import sys
-import math
 import uuid
 import warnings
 from collections import Counter
@@ -62,14 +62,13 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-
 import qcelemental as qcel
-from psi4 import core
-from psi4 import extras
-from .. import qcdb
 
+from psi4 import core, extras
+
+from .. import qcdb
 from . import optproc
-from .exceptions import TestComparisonError, ValidationError, UpgradeHelper
+from .exceptions import TestComparisonError, UpgradeHelper, ValidationError
 
 ## Python basis helps
 

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -46,7 +46,6 @@ __all__ = [
     "plump_qcvar",
     "set_options",
     "set_module_options",
-    "temp_circular_import_blocker",  # retire ASAP
 ]
 
 
@@ -653,10 +652,6 @@ def pcm_helper(block: str):
 def _basname(name: str) -> str:
     """Imitates :py:meth:`core.BasisSet.make_filename` without the gbs extension."""
     return name.lower().replace('+', 'p').replace('*', 's').replace('(', '_').replace(')', '_').replace(',', '_')
-
-
-def temp_circular_import_blocker():
-    pass
 
 
 def basis_helper(block: str, name: str = '', key: str = 'BASIS', set_option: bool = True):

--- a/psi4/driver/p4util/solvers.py
+++ b/psi4/driver/p4util/solvers.py
@@ -525,7 +525,6 @@ class SolverEngine(ABC):
            order. Where H2 is described in :func:`hamiltonian_solver`.
            ``len(H2X) == len(X)``
         """
-        pass
 
     @abstractmethod
     def precondition(self, R_k, w_k):
@@ -548,7 +547,6 @@ class SolverEngine(ABC):
            The preconditioned residual vector, a correction vector that will be
            used to augment the guess space
         """
-        pass
 
     @abstractmethod
     def new_vector(self):
@@ -567,7 +565,6 @@ class SolverEngine(ABC):
            This should be a new vector object with the correct dimensions,
            assumed to be zeroed out
         """
-        pass
 
     def vector_dot(X, Y) -> float:
         """Compute a dot product between two `vectors`
@@ -582,7 +579,6 @@ class SolverEngine(ABC):
         a : float
            The dot product  (X x Y)
         """
-        pass
 
     # cython doesn't like static+ decorators https://github.com/cython/cython/issues/1434#issuecomment-608975116
     vector_dot = staticmethod(abstractmethod(vector_dot))
@@ -606,7 +602,6 @@ class SolverEngine(ABC):
           The solver assumes that Y is updated, and returned. So it is safe to
           avoid a copy of Y if possible
         """
-        pass
 
     @abstractmethod
     def vector_scale(a: float, X):
@@ -625,7 +620,6 @@ class SolverEngine(ABC):
           The solver assumes that the passed vector is modifed. So it is save
           to avoid a copy of X if possible.
         """
-        pass
 
     @abstractmethod
     def vector_copy(X):
@@ -642,7 +636,6 @@ class SolverEngine(ABC):
            A copy of `X` should be distinct object that can be modified
            independently of the passed object, Has the same data when returned.
         """
-        pass
 
     @abstractmethod
     def residue(self, X, so_prop_ints):
@@ -662,7 +655,6 @@ class SolverEngine(ABC):
         residue : Any
           The transition property.
         """
-        pass
 
 
 def davidson_solver(

--- a/psi4/driver/p4util/spectrum.py
+++ b/psi4/driver/p4util/spectrum.py
@@ -40,7 +40,7 @@ from dataclasses import dataclass
 from typing import Callable, Dict, List, Union
 
 import numpy as np
-from psi4.driver import constants
+from ..constants import constants
 
 
 @dataclass

--- a/psi4/driver/p4util/spectrum.py
+++ b/psi4/driver/p4util/spectrum.py
@@ -40,6 +40,7 @@ from dataclasses import dataclass
 from typing import Callable, Dict, List, Union
 
 import numpy as np
+
 from ..constants import constants
 
 

--- a/psi4/driver/p4util/testing.py
+++ b/psi4/driver/p4util/testing.py
@@ -48,6 +48,7 @@ import numpy as np
 import qcelemental as qcel
 
 from psi4 import core
+
 from .. import qcdb
 from .exceptions import TestComparisonError
 

--- a/psi4/driver/p4util/testing.py
+++ b/psi4/driver/p4util/testing.py
@@ -48,7 +48,7 @@ import numpy as np
 import qcelemental as qcel
 
 from psi4 import core
-from psi4.driver import qcdb
+from .. import qcdb
 from .exceptions import TestComparisonError
 
 # TODO in multistage compare_* fns, we're potentially stopping the fn prematurely and not in the manner of the handling fn.

--- a/psi4/driver/p4util/text.py
+++ b/psi4/driver/p4util/text.py
@@ -37,14 +37,13 @@ __all__ = [
     "message_box",
 ]
 
-from typing import List, Optional
-
 import sys
 import warnings
-
-from .. import constants
+from typing import List, Optional
 
 from psi4 import core
+
+from .. import constants
 
 
 def banner(text: str, type: int = 1, width: int = 35, strNotOutfile: bool = False) -> Optional[str]:

--- a/psi4/driver/p4util/text.py
+++ b/psi4/driver/p4util/text.py
@@ -42,7 +42,7 @@ from typing import List, Optional
 import sys
 import warnings
 
-from psi4.driver import constants
+from .. import constants
 
 from psi4 import core
 

--- a/psi4/driver/p4util/text.py
+++ b/psi4/driver/p4util/text.py
@@ -37,8 +37,6 @@ __all__ = [
     "message_box",
 ]
 
-import sys
-import warnings
 from typing import List, Optional
 
 from psi4 import core

--- a/psi4/driver/p4util/util.py
+++ b/psi4/driver/p4util/util.py
@@ -45,6 +45,7 @@ import warnings
 from typing import Dict, List, Union
 
 from psi4 import core
+
 from .exceptions import ValidationError
 from .prop_util import *
 

--- a/psi4/driver/p4util/util.py
+++ b/psi4/driver/p4util/util.py
@@ -45,7 +45,6 @@ import warnings
 from typing import Dict, List, Union
 
 from psi4 import core
-from psi4.driver.procrouting import *
 from .exceptions import ValidationError
 from .prop_util import *
 

--- a/psi4/driver/p4util/util.py
+++ b/psi4/driver/p4util/util.py
@@ -40,8 +40,6 @@ __all__ = [
 
 import os
 import re
-import sys
-import warnings
 from typing import Dict, List, Union
 
 from psi4 import core

--- a/psi4/driver/p4util/writer.py
+++ b/psi4/driver/p4util/writer.py
@@ -34,7 +34,7 @@ __all__ = []
 
 from typing import Optional
 
-from psi4.driver import constants
+from ..constants import constants
 
 from psi4 import core
 

--- a/psi4/driver/p4util/writer.py
+++ b/psi4/driver/p4util/writer.py
@@ -34,9 +34,10 @@ __all__ = []
 
 from typing import Optional
 
+from psi4 import core
+
 from ..constants import constants
 
-from psi4 import core
 
 def _write_nbo(self, name: str):
     """Write wavefunction information in *wfn* to *name* in NBO format.

--- a/psi4/driver/pluginutil.py
+++ b/psi4/driver/pluginutil.py
@@ -36,7 +36,7 @@ import sys
 from pathlib import Path
 
 from psi4 import core
-from psi4.driver.util import tty
+from .util import tty
 
 
 def sanitize_name(name: str) -> str:

--- a/psi4/driver/pluginutil.py
+++ b/psi4/driver/pluginutil.py
@@ -36,6 +36,7 @@ import sys
 from pathlib import Path
 
 from psi4 import core
+
 from .util import tty
 
 

--- a/psi4/driver/procrouting/__init__.py
+++ b/psi4/driver/procrouting/__init__.py
@@ -26,11 +26,7 @@
 # @END LICENSE
 #
 
-from .proc_table import procedures, hooks, energy_only_methods, integrated_basis_methods
-from .proc import scf_helper, scf_wavefunction_factory
+from . import dft, diis, libcubeprop, response, scf_proc
 from .empirical_dispersion import EmpiricalDispersion
-from . import dft
-from . import diis
-from . import libcubeprop
-from . import response
-from . import scf_proc
+from .proc import scf_helper, scf_wavefunction_factory
+from .proc_table import energy_only_methods, hooks, integrated_basis_methods, procedures

--- a/psi4/driver/procrouting/dft/__init__.py
+++ b/psi4/driver/procrouting/dft/__init__.py
@@ -26,5 +26,5 @@
 # @END LICENSE
 #
 
-from .superfunctionals import build_superfunctional
 from .dft_builder import build_superfunctional_from_dictionary, dashcoeff_supplement, functionals
+from .superfunctionals import build_superfunctional

--- a/psi4/driver/procrouting/dft/dft_builder.py
+++ b/psi4/driver/procrouting/dft/dft_builder.py
@@ -79,20 +79,15 @@ dict = {
     },
 }
 """
-from ...p4util.exceptions import ValidationError
-import copy
 import collections
+import copy
 
 from qcengine.programs.empirical_dispersion_resources import dashcoeff, get_dispersion_aliases
 
 from psi4 import core
 
-from . import libxc_functionals
-from . import lda_functionals
-from . import gga_functionals
-from . import mgga_functionals
-from . import hyb_functionals
-from . import dh_functionals
+from ...p4util.exceptions import ValidationError
+from . import dh_functionals, gga_functionals, hyb_functionals, lda_functionals, libxc_functionals, mgga_functionals
 
 dict_functionals = {}
 dict_functionals.update(libxc_functionals.functional_list)

--- a/psi4/driver/procrouting/dft/dft_builder.py
+++ b/psi4/driver/procrouting/dft/dft_builder.py
@@ -79,7 +79,7 @@ dict = {
     },
 }
 """
-from psi4.driver.p4util.exceptions import ValidationError
+from ...p4util.exceptions import ValidationError
 import copy
 import collections
 

--- a/psi4/driver/procrouting/dft/superfunctionals.py
+++ b/psi4/driver/procrouting/dft/superfunctionals.py
@@ -33,7 +33,7 @@ import re
 import os
 
 from psi4 import core
-from psi4.driver.p4util.exceptions import ValidationError
+from ...p4util.exceptions import ValidationError
 from . import dft_builder
 
 

--- a/psi4/driver/procrouting/dft/superfunctionals.py
+++ b/psi4/driver/procrouting/dft/superfunctionals.py
@@ -29,10 +29,11 @@
 Module to provide lightweight definitions of functionals and
 SuperFunctionals
 """
-import re
 import os
+import re
 
 from psi4 import core
+
 from ...p4util.exceptions import ValidationError
 from . import dft_builder
 

--- a/psi4/driver/procrouting/diis.py
+++ b/psi4/driver/procrouting/diis.py
@@ -3,7 +3,7 @@ from itertools import product
 import os
 
 from psi4 import core
-from psi4.driver import psifiles as psif
+from .. import psifiles as psif
 
 import numpy as np
 from qcelemental.util import which_import

--- a/psi4/driver/procrouting/diis.py
+++ b/psi4/driver/procrouting/diis.py
@@ -1,12 +1,14 @@
+import os
 from enum import Enum
 from itertools import product
-import os
-
-from psi4 import core
-from .. import psifiles as psif
 
 import numpy as np
 from qcelemental.util import which_import
+
+from psi4 import core
+
+from .. import psifiles as psif
+
 
 class RemovalPolicy(Enum):
     LargestError = 1

--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -30,10 +30,11 @@ import collections
 from typing import Dict, List, Tuple, Union
 
 import numpy as np
-from qcelemental.models import AtomicInput
 import qcengine as qcng
+from qcelemental.models import AtomicInput
 
 from psi4 import core
+
 from .. import p4util
 from ..p4util.exceptions import ValidationError
 
@@ -375,7 +376,7 @@ class EmpiricalDispersion():
             (3*nat, 3*nat) dispersion Hessian [Eh/a0/a0].
 
         """
-        from psi4.driver.driver_findif import hessian_from_gradients_geometries, assemble_hessian_from_gradients
+        from psi4.driver.driver_findif import assemble_hessian_from_gradients, hessian_from_gradients_geometries
 
         optstash = p4util.OptionsState(['PRINT'], ['PARENT_SYMMETRY'])
         core.set_global_option('PRINT', 0)

--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -34,9 +34,8 @@ from qcelemental.models import AtomicInput
 import qcengine as qcng
 
 from psi4 import core
-from psi4.driver import p4util
-from psi4.driver import driver_findif
-from psi4.driver.p4util.exceptions import ValidationError
+from .. import p4util
+from ..p4util.exceptions import ValidationError
 
 _engine_can_do = collections.OrderedDict([
     # engine order establishes default for each disp
@@ -376,6 +375,8 @@ class EmpiricalDispersion():
             (3*nat, 3*nat) dispersion Hessian [Eh/a0/a0].
 
         """
+        from psi4.driver.driver_findif import hessian_from_gradients_geometries, assemble_hessian_from_gradients
+
         optstash = p4util.OptionsState(['PRINT'], ['PARENT_SYMMETRY'])
         core.set_global_option('PRINT', 0)
 
@@ -391,14 +392,14 @@ class EmpiricalDispersion():
         # Record undisplaced symmetry for projection of diplaced point groups
         core.set_global_option("PARENT_SYMMETRY", molecule.schoenflies_symbol())
 
-        findif_meta_dict = driver_findif.hessian_from_gradients_geometries(molclone, -1)
+        findif_meta_dict = hessian_from_gradients_geometries(molclone, -1)
         for displacement in findif_meta_dict["displacements"].values():
             geom_array = np.reshape(displacement["geometry"], (-1, 3))
             molclone.set_geometry(core.Matrix.from_array(geom_array))
             molclone.update_geometry()
             displacement["gradient"] = self.compute_gradient(molclone).np.ravel().tolist()
 
-        H = driver_findif.assemble_hessian_from_gradients(findif_meta_dict, -1)
+        H = assemble_hessian_from_gradients(findif_meta_dict, -1)
         if wfn is not None:
             wfn.set_variable('DISPERSION CORRECTION HESSIAN', H)
         optstash.restore()

--- a/psi4/driver/procrouting/empirical_dispersion.py
+++ b/psi4/driver/procrouting/empirical_dispersion.py
@@ -27,7 +27,7 @@
 #
 
 import collections
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Union
 
 import numpy as np
 import qcengine as qcng

--- a/psi4/driver/procrouting/findif_response_utils/__init__.py
+++ b/psi4/driver/procrouting/findif_response_utils/__init__.py
@@ -35,5 +35,5 @@ approach.
 New drivers should be added to the registered_props dict in
 db_helper.py
 """
-from .db_helper import *
 from .data_collection_helper import *
+from .db_helper import *

--- a/psi4/driver/procrouting/findif_response_utils/data_collection_helper.py
+++ b/psi4/driver/procrouting/findif_response_utils/data_collection_helper.py
@@ -31,7 +31,7 @@ Module of helper functions for distributed ccresponse computations.
 
 Defines functions for retrieving data computed at displaced geometries.
 """
-from psi4.driver import p4util
+from ... import p4util
 
 
 def collect_displaced_matrix_data(db, signature, row_dim):

--- a/psi4/driver/procrouting/findif_response_utils/db_helper.py
+++ b/psi4/driver/procrouting/findif_response_utils/db_helper.py
@@ -35,10 +35,11 @@ Properties that are able to use this module should be added to
 the registered_props dictionary.
 
 """
-import os
 import collections
+import os
 
 from psi4 import core
+
 from ... import p4util
 
 

--- a/psi4/driver/procrouting/findif_response_utils/db_helper.py
+++ b/psi4/driver/procrouting/findif_response_utils/db_helper.py
@@ -39,7 +39,7 @@ import os
 import collections
 
 from psi4 import core
-from psi4.driver import p4util
+from ... import p4util
 
 
 def generate_inputs(db,name):

--- a/psi4/driver/procrouting/interface_cfour.py
+++ b/psi4/driver/procrouting/interface_cfour.py
@@ -32,20 +32,21 @@ Also calls to qcdb module are here and not elsewhere in driver.
 Organizationally, this module isolates qcdb code from psi4 code.
 
 """
+import inspect
 import os
 import re
+import shutil
+import subprocess
 import sys
 import uuid
-import shutil
-import inspect
-import subprocess
 
 import qcelemental as qcel
 
-from .. import qcdb
-from .. import p4util
-from ..p4util.exceptions import *
 from psi4 import core
+
+from .. import p4util, qcdb
+from ..p4util.exceptions import *
+
 # never import driver, wrappers, or aliases into this file
 
 P4C4_INFO = {}

--- a/psi4/driver/procrouting/interface_cfour.py
+++ b/psi4/driver/procrouting/interface_cfour.py
@@ -42,9 +42,9 @@ import subprocess
 
 import qcelemental as qcel
 
-from psi4.driver import qcdb
-from psi4.driver import p4util
-from psi4.driver.p4util.exceptions import *
+from .. import qcdb
+from .. import p4util
+from ..p4util.exceptions import *
 from psi4 import core
 # never import driver, wrappers, or aliases into this file
 

--- a/psi4/driver/procrouting/libcubeprop/cubeprop.py
+++ b/psi4/driver/procrouting/libcubeprop/cubeprop.py
@@ -30,7 +30,7 @@ import os
 
 from psi4 import core
 
-from psi4.driver.p4util.exceptions import ValidationError
+from ...p4util.exceptions import ValidationError
 
 
 def cubeprop_compute_properties(self):

--- a/psi4/driver/procrouting/mcscf/augmented_hessian.py
+++ b/psi4/driver/procrouting/mcscf/augmented_hessian.py
@@ -31,6 +31,7 @@ import os
 import numpy as np
 
 from psi4 import core
+
 from ... import p4util
 from ...p4util.exceptions import *
 

--- a/psi4/driver/procrouting/mcscf/augmented_hessian.py
+++ b/psi4/driver/procrouting/mcscf/augmented_hessian.py
@@ -26,7 +26,6 @@
 # @END LICENSE
 #
 
-import os
 
 import numpy as np
 

--- a/psi4/driver/procrouting/mcscf/augmented_hessian.py
+++ b/psi4/driver/procrouting/mcscf/augmented_hessian.py
@@ -31,8 +31,8 @@ import os
 import numpy as np
 
 from psi4 import core
-from psi4.driver import p4util
-from psi4.driver.p4util.exceptions import *
+from ... import p4util
+from ...p4util.exceptions import *
 
 
 def ah_iteration(mcscf_obj, tol=1e-3, max_iter=15, lindep=1e-14, print_micro=True):

--- a/psi4/driver/procrouting/mcscf/mcscf_solver.py
+++ b/psi4/driver/procrouting/mcscf/mcscf_solver.py
@@ -31,9 +31,9 @@ import os
 import numpy as np
 
 from psi4 import core
-from psi4.driver import p4util
-from psi4.driver import qcdb
-from psi4.driver.p4util import solvers
+from ... import p4util
+from ... import qcdb
+from ...p4util import solvers
 from .augmented_hessian import ah_iteration
 from .. import proc_util
 

--- a/psi4/driver/procrouting/mcscf/mcscf_solver.py
+++ b/psi4/driver/procrouting/mcscf/mcscf_solver.py
@@ -31,11 +31,11 @@ import os
 import numpy as np
 
 from psi4 import core
-from ... import p4util
-from ... import qcdb
+
+from ... import p4util, qcdb
 from ...p4util import solvers
-from .augmented_hessian import ah_iteration
 from .. import proc_util
+from .augmented_hessian import ah_iteration
 
 
 def print_iteration(mtype, niter, energy, de, orb_rms, ci_rms, nci, norb, stype):

--- a/psi4/driver/procrouting/mcscf/mcscf_solver.py
+++ b/psi4/driver/procrouting/mcscf/mcscf_solver.py
@@ -26,7 +26,6 @@
 # @END LICENSE
 #
 
-import os
 
 import numpy as np
 

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -31,36 +31,39 @@ calls for each of the *name* values of the energy(), optimize(),
 response(), and frequency() function. *name* can be assumed lowercase by here.
 
 """
-import re
 import os
-import sys
+import re
 import shutil
 import subprocess
+import sys
 import warnings
 from typing import Dict, List, Union
 
 import numpy as np
-from ..constants import constants
 from qcelemental.util import parse_version, which
 
-from psi4 import extras
-from psi4 import core
+from psi4 import core, extras
+
 from .. import p4util
-from .. import qcdb
 from .. import psifiles as psif
-from ..p4util.exceptions import ManagedMethodError, PastureRequiredError, UpgradeHelper, ValidationError, docs_table_link
+from .. import qcdb
+from ..constants import constants
+from ..p4util.exceptions import (
+    ManagedMethodError,
+    PastureRequiredError,
+    UpgradeHelper,
+    ValidationError,
+    docs_table_link,
+)
+
 #from psi4.driver.molutil import *
 from ..qcdb.basislist import corresponding_basis
-# never import driver, wrappers, or aliases into this file
-
+from . import dft, empirical_dispersion, mcscf, proc_util, response, solvent
 from .proc_data import method_algorithm_type
 from .roa import run_roa
-from . import proc_util
-from . import empirical_dispersion
-from . import dft
-from . import mcscf
-from . import response
-from . import solvent
+
+# never import driver, wrappers, or aliases into this file
+
 
 
 # ADVICE on new additions:

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -45,12 +45,12 @@ from qcelemental.util import parse_version, which
 
 from psi4 import extras
 from psi4 import core
-from psi4.driver import p4util
-from psi4.driver import qcdb
-from psi4.driver import psifiles as psif
-from psi4.driver.p4util.exceptions import ManagedMethodError, PastureRequiredError, UpgradeHelper, ValidationError, docs_table_link
+from .. import p4util
+from .. import qcdb
+from .. import psifiles as psif
+from ..p4util.exceptions import ManagedMethodError, PastureRequiredError, UpgradeHelper, ValidationError, docs_table_link
 #from psi4.driver.molutil import *
-from psi4.driver.qcdb.basislist import corresponding_basis
+from ..qcdb.basislist import corresponding_basis
 # never import driver, wrappers, or aliases into this file
 
 from .proc_data import method_algorithm_type

--- a/psi4/driver/procrouting/proc_data.py
+++ b/psi4/driver/procrouting/proc_data.py
@@ -32,7 +32,6 @@ Avoid importing from psi4 into here.
 from collections import namedtuple
 from typing import Tuple
 
-
 # A negative order indicates perturbative method
 mrcc_methods = {
             'ccsd'          : { 'method': 1, 'order':  2, 'fullname': 'CCSD'         },

--- a/psi4/driver/procrouting/proc_table.py
+++ b/psi4/driver/procrouting/proc_table.py
@@ -36,7 +36,7 @@ from . import proc
 from . import interface_cfour
 from . import proc_data
 
-from psi4.driver.procrouting.dft import functionals, build_superfunctional_from_dictionary
+from .dft import functionals, build_superfunctional_from_dictionary
 
 # never import wrappers or aliases into this file
 

--- a/psi4/driver/procrouting/proc_table.py
+++ b/psi4/driver/procrouting/proc_table.py
@@ -31,12 +31,8 @@ chemical methods.
 
 from qcelemental.util import which
 
-from . import sapt
-from . import proc
-from . import interface_cfour
-from . import proc_data
-
-from .dft import functionals, build_superfunctional_from_dictionary
+from . import interface_cfour, proc, proc_data, sapt
+from .dft import build_superfunctional_from_dictionary, functionals
 
 # never import wrappers or aliases into this file
 

--- a/psi4/driver/procrouting/proc_util.py
+++ b/psi4/driver/procrouting/proc_util.py
@@ -32,10 +32,10 @@ import numpy as np
 from ..constants import constants
 
 from psi4 import core
-from psi4.driver import p4util
-from psi4.driver.p4util.exceptions import *
-from psi4.driver.procrouting.dft import functionals, build_superfunctional_from_dictionary
-from psi4.driver.procrouting.sapt import fisapt_proc
+from .. import p4util
+from ..p4util.exceptions import *
+from .dft import functionals, build_superfunctional_from_dictionary
+from .sapt import fisapt_proc
 
 
 def scf_set_reference_local(name, is_dft=False):

--- a/psi4/driver/procrouting/proc_util.py
+++ b/psi4/driver/procrouting/proc_util.py
@@ -29,12 +29,12 @@ from typing import Tuple
 
 import numpy as np
 
-from ..constants import constants
-
 from psi4 import core
+
 from .. import p4util
+from ..constants import constants
 from ..p4util.exceptions import *
-from .dft import functionals, build_superfunctional_from_dictionary
+from .dft import build_superfunctional_from_dictionary, functionals
 from .sapt import fisapt_proc
 
 

--- a/psi4/driver/procrouting/proc_util.py
+++ b/psi4/driver/procrouting/proc_util.py
@@ -35,7 +35,6 @@ from .. import p4util
 from ..constants import constants
 from ..p4util.exceptions import *
 from .dft import build_superfunctional_from_dictionary, functionals
-from .sapt import fisapt_proc
 
 
 def scf_set_reference_local(name, is_dft=False):
@@ -266,6 +265,8 @@ def prepare_sapt_molecule(sapt_dimer: core.Molecule, sapt_basis: str) -> Tuple[c
 
 
 def sapt_empirical_dispersion(name, dimer_wfn, **kwargs):
+    from .sapt import fisapt_proc
+
     sapt_dimer = dimer_wfn.molecule()
     sapt_dimer, monomerA, monomerB = prepare_sapt_molecule(sapt_dimer, "dimer")
     disp_name = name.split("-")[1]

--- a/psi4/driver/procrouting/response/__init__.py
+++ b/psi4/driver/procrouting/response/__init__.py
@@ -26,5 +26,4 @@
 # @END LICENSE
 #
 
-from . import scf_response
-from . import scf_products
+from . import scf_products, scf_response

--- a/psi4/driver/procrouting/response/scf_products.py
+++ b/psi4/driver/procrouting/response/scf_products.py
@@ -29,7 +29,7 @@
 import numpy as np
 
 from psi4 import core
-from psi4.driver.p4util.exceptions import *
+from ...p4util.exceptions import *
 """
 This module provides ``engine`` objects that can be used by the :func:`~psi4.driver.p4util.solvers.davidson_solver` and
 :func:`~psi4.driver.p4util.solvers.hamiltonian_solver`

--- a/psi4/driver/procrouting/response/scf_products.py
+++ b/psi4/driver/procrouting/response/scf_products.py
@@ -29,7 +29,9 @@
 import numpy as np
 
 from psi4 import core
+
 from ...p4util.exceptions import *
+
 """
 This module provides ``engine`` objects that can be used by the :func:`~psi4.driver.p4util.solvers.davidson_solver` and
 :func:`~psi4.driver.p4util.solvers.hamiltonian_solver`

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -36,10 +36,10 @@ except ImportError:
 import numpy as np
 
 from psi4 import core
-from psi4.driver import constants
-from psi4.driver.p4util import solvers
-from psi4.driver.p4util.exceptions import *
-from psi4.driver.procrouting.response.scf_products import (TDRSCFEngine, TDUSCFEngine)
+from ...constants import constants
+from ...p4util import solvers
+from ...p4util.exceptions import *
+from .scf_products import (TDRSCFEngine, TDUSCFEngine)
 
 # TODO: Split this file into a CPSCF file (frequency-independent case) and TD-SCF file (frequency-dependent case).
 # Neither "half" of the file uses any function from the other "half". The danger is what could happen to import paths...

--- a/psi4/driver/procrouting/response/scf_response.py
+++ b/psi4/driver/procrouting/response/scf_response.py
@@ -27,7 +27,8 @@
 #
 
 from collections import Counter
-from typing import Union, List
+from typing import List, Union
+
 try:
     from dataclasses import dataclass
 except ImportError:
@@ -36,10 +37,11 @@ except ImportError:
 import numpy as np
 
 from psi4 import core
+
 from ...constants import constants
 from ...p4util import solvers
 from ...p4util.exceptions import *
-from .scf_products import (TDRSCFEngine, TDUSCFEngine)
+from .scf_products import TDRSCFEngine, TDUSCFEngine
 
 # TODO: Split this file into a CPSCF file (frequency-independent case) and TD-SCF file (frequency-dependent case).
 # Neither "half" of the file uses any function from the other "half". The danger is what could happen to import paths...

--- a/psi4/driver/procrouting/roa.py
+++ b/psi4/driver/procrouting/roa.py
@@ -28,7 +28,7 @@
 import shelve
 
 from psi4 import core
-from psi4.driver.p4util import *
+from ..p4util import *
 from . import findif_response_utils
 
 

--- a/psi4/driver/procrouting/roa.py
+++ b/psi4/driver/procrouting/roa.py
@@ -28,6 +28,7 @@
 import shelve
 
 from psi4 import core
+
 from ..p4util import *
 from . import findif_response_utils
 

--- a/psi4/driver/procrouting/sapt/__init__.py
+++ b/psi4/driver/procrouting/sapt/__init__.py
@@ -26,4 +26,4 @@
 # @END LICENSE
 #
 
-from .sapt_proc import run_sapt_dft, sapt_dft, run_sf_sapt
+from .sapt_proc import run_sapt_dft, run_sf_sapt, sapt_dft

--- a/psi4/driver/procrouting/sapt/fisapt_proc.py
+++ b/psi4/driver/procrouting/sapt/fisapt_proc.py
@@ -31,6 +31,7 @@ import os
 import numpy as np
 
 from psi4 import core
+
 from .. import empirical_dispersion
 
 

--- a/psi4/driver/procrouting/sapt/sapt_jk_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_jk_terms.py
@@ -31,8 +31,8 @@ import time
 import numpy as np
 
 from psi4 import core
-from psi4.driver.p4util.exceptions import *
-from psi4.driver.p4util import solvers
+from ...p4util.exceptions import *
+from ...p4util import solvers
 from .sapt_util import print_sapt_var
 
 

--- a/psi4/driver/procrouting/sapt/sapt_jk_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_jk_terms.py
@@ -31,8 +31,9 @@ import time
 import numpy as np
 
 from psi4 import core
-from ...p4util.exceptions import *
+
 from ...p4util import solvers
+from ...p4util.exceptions import *
 from .sapt_util import print_sapt_var
 
 

--- a/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
@@ -31,9 +31,9 @@ import time
 import numpy as np
 
 from psi4 import core
-from psi4.driver.p4util.exceptions import *
-from psi4.driver import p4util
-from psi4.driver import psifiles as psif
+from ...p4util.exceptions import *
+from ... import p4util
+from ... import psifiles as psif
 
 from .sapt_util import print_sapt_var
 

--- a/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
@@ -31,10 +31,10 @@ import time
 import numpy as np
 
 from psi4 import core
-from ...p4util.exceptions import *
+
 from ... import p4util
 from ... import psifiles as psif
-
+from ...p4util.exceptions import *
 from .sapt_util import print_sapt_var
 
 

--- a/psi4/driver/procrouting/sapt/sapt_proc.py
+++ b/psi4/driver/procrouting/sapt/sapt_proc.py
@@ -29,16 +29,14 @@
 import numpy as np
 
 from psi4 import core
-from ...constants import constants
-from ... import p4util
-from ...p4util.exceptions import *
-from ..proc import scf_helper
-from .. import proc_util
 
-from . import sapt_jk_terms
-from .sapt_util import print_sapt_var, print_sapt_hf_summary, print_sapt_dft_summary
-from . import sapt_mp2_terms
-from . import sapt_sf_terms
+from ... import p4util
+from ...constants import constants
+from ...p4util.exceptions import *
+from .. import proc_util
+from ..proc import scf_helper
+from . import sapt_jk_terms, sapt_mp2_terms, sapt_sf_terms
+from .sapt_util import print_sapt_dft_summary, print_sapt_hf_summary, print_sapt_var
 
 # Only export the run_ scripts
 __all__ = ['run_sapt_dft', 'sapt_dft', 'run_sf_sapt']

--- a/psi4/driver/procrouting/sapt/sapt_proc.py
+++ b/psi4/driver/procrouting/sapt/sapt_proc.py
@@ -29,12 +29,11 @@
 import numpy as np
 
 from psi4 import core
-from psi4.driver import constants
-from psi4.driver import p4util
-from psi4.driver.p4util.exceptions import *
-from psi4.driver.molutil import *
-from psi4.driver.procrouting.proc import scf_helper
-from psi4.driver.procrouting import proc_util
+from ...constants import constants
+from ... import p4util
+from ...p4util.exceptions import *
+from ..proc import scf_helper
+from .. import proc_util
 
 from . import sapt_jk_terms
 from .sapt_util import print_sapt_var, print_sapt_hf_summary, print_sapt_dft_summary

--- a/psi4/driver/procrouting/sapt/sapt_sf_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_sf_terms.py
@@ -26,13 +26,14 @@
 # @END LICENSE
 #
 
-import numpy as np
 from collections import OrderedDict
 
-from psi4 import core
-from ...p4util.exceptions import *
-from ...p4util import solvers
+import numpy as np
 
+from psi4 import core
+
+from ...p4util import solvers
+from ...p4util.exceptions import *
 from .sapt_util import print_sapt_var
 
 __all__ = ["compute_sapt_sf"]

--- a/psi4/driver/procrouting/sapt/sapt_sf_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_sf_terms.py
@@ -30,8 +30,8 @@ import numpy as np
 from collections import OrderedDict
 
 from psi4 import core
-from psi4.driver.p4util.exceptions import *
-from psi4.driver.p4util import solvers
+from ...p4util.exceptions import *
+from ...p4util import solvers
 
 from .sapt_util import print_sapt_var
 

--- a/psi4/driver/procrouting/sapt/sapt_util.py
+++ b/psi4/driver/procrouting/sapt/sapt_util.py
@@ -27,7 +27,7 @@
 #
 
 from psi4 import core
-from psi4.driver import constants
+from ...constants import constants
 
 
 def print_sapt_var(name, value, short=False, start_spacer="    "):

--- a/psi4/driver/procrouting/sapt/sapt_util.py
+++ b/psi4/driver/procrouting/sapt/sapt_util.py
@@ -27,6 +27,7 @@
 #
 
 from psi4 import core
+
 from ...constants import constants
 
 

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -34,8 +34,9 @@ from ..solvent.efp import (get_qm_atoms_opts, modify_Fock_induced,
                            modify_Fock_permanent)
 
 from psi4 import core
-from psi4.driver import constants, p4util
-from psi4.driver.p4util.exceptions import SCFConvergenceError, ValidationError
+from ...constants import constants
+from ... import p4util
+from ...p4util.exceptions import SCFConvergenceError, ValidationError
 
 #import logging
 #logger = logging.getLogger("scf.scf_iterator")

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -30,13 +30,12 @@ The SCF iteration functions
 """
 import numpy as np
 
-from ..solvent.efp import (get_qm_atoms_opts, modify_Fock_induced,
-                           modify_Fock_permanent)
-
 from psi4 import core
-from ...constants import constants
+
 from ... import p4util
+from ...constants import constants
 from ...p4util.exceptions import SCFConvergenceError, ValidationError
+from ..solvent.efp import get_qm_atoms_opts, modify_Fock_induced, modify_Fock_permanent
 
 #import logging
 #logger = logging.getLogger("scf.scf_iterator")

--- a/psi4/driver/procrouting/scf_proc/subclass_methods.py
+++ b/psi4/driver/procrouting/scf_proc/subclass_methods.py
@@ -1,10 +1,13 @@
 import math
+
 import numpy as np
 
 from psi4 import core
-from ..diis import DIIS, StoragePolicy, RemovalPolicy
-from ..response.scf_products import TDUSCFEngine
+
 from ...p4util import solvers
+from ..diis import DIIS, RemovalPolicy, StoragePolicy
+from ..response.scf_products import TDUSCFEngine
+
 
 def diis_engine_helper(self):
     engines = set()

--- a/psi4/driver/procrouting/solvent/ddx.py
+++ b/psi4/driver/procrouting/solvent/ddx.py
@@ -31,7 +31,7 @@ from qcelemental.util import parse_version
 
 from ...constants import constants
 from psi4 import core
-from psi4.driver.p4util.exceptions import ValidationError
+from ...p4util.exceptions import ValidationError
 
 import pyddx
 import pyddx.data

--- a/psi4/driver/procrouting/solvent/ddx.py
+++ b/psi4/driver/procrouting/solvent/ddx.py
@@ -26,15 +26,14 @@
 # @END LICENSE
 #
 import numpy as np
-
-from qcelemental.util import parse_version
-
-from ...constants import constants
-from psi4 import core
-from ...p4util.exceptions import ValidationError
-
 import pyddx
 import pyddx.data
+from qcelemental.util import parse_version
+
+from psi4 import core
+
+from ...constants import constants
+from ...p4util.exceptions import ValidationError
 
 
 def get_ddx_options(molecule):

--- a/psi4/driver/procrouting/solvent/pol_embed.py
+++ b/psi4/driver/procrouting/solvent/pol_embed.py
@@ -28,14 +28,15 @@
 
 from tempfile import NamedTemporaryFile
 
-import numpy as np
 import cppe
+import numpy as np
 from qcelemental.util import parse_version
 
-from ...constants import constants
 from psi4 import core
-from ...qcdb import libmintsbasisset
+
+from ...constants import constants
 from ...p4util.exceptions import ValidationError
+from ...qcdb import libmintsbasisset
 
 
 def get_pe_options():

--- a/psi4/driver/procrouting/solvent/pol_embed.py
+++ b/psi4/driver/procrouting/solvent/pol_embed.py
@@ -34,8 +34,8 @@ from qcelemental.util import parse_version
 
 from ...constants import constants
 from psi4 import core
-from psi4.driver.qcdb import libmintsbasisset
-from psi4.driver.p4util.exceptions import ValidationError
+from ...qcdb import libmintsbasisset
+from ...p4util.exceptions import ValidationError
 
 
 def get_pe_options():

--- a/psi4/driver/procrouting/wrappers_cfour.py
+++ b/psi4/driver/procrouting/wrappers_cfour.py
@@ -41,7 +41,7 @@ import difflib
 import datetime
 import subprocess
 
-from psi4.driver.p4util.exceptions import *
+from ..p4util.exceptions import *
 
 # Not maintained: see https://github.com/psi4/psi4/issues/2478
 

--- a/psi4/driver/procrouting/wrappers_cfour.py
+++ b/psi4/driver/procrouting/wrappers_cfour.py
@@ -32,13 +32,13 @@ Also calls to qcdb module are here and not elsewhere in driver.
 Organizationally, this module isolates qcdb code from psi4 code.
 
 """
+import datetime
+import difflib
+import glob
 import os
 import re
-import glob
 import shelve
 import shutil
-import difflib
-import datetime
 import subprocess
 
 from ..p4util.exceptions import *

--- a/psi4/driver/qmmm.py
+++ b/psi4/driver/qmmm.py
@@ -32,6 +32,8 @@ a QM calculation.
 """
 
 from psi4.driver import *
+from psi4 import core
+from .p4util.exceptions import UpgradeHelper
 
 
 class Diffuse():

--- a/psi4/driver/qmmm.py
+++ b/psi4/driver/qmmm.py
@@ -32,6 +32,7 @@ a QM calculation.
 """
 
 from psi4 import core
+
 from .driver import *
 from .p4util.exceptions import UpgradeHelper
 

--- a/psi4/driver/qmmm.py
+++ b/psi4/driver/qmmm.py
@@ -31,8 +31,8 @@ a QM calculation.
 
 """
 
-from psi4.driver import *
 from psi4 import core
+from .driver import *
 from .p4util.exceptions import UpgradeHelper
 
 

--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -54,7 +54,8 @@ import qcengine as qcng
 from psi4.extras import exit_printing
 from psi4.header import print_header
 from psi4.metadata import __version__
-from psi4.driver import driver, p4util
+from . import driver
+from . import p4util
 
 from psi4 import core
 

--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -51,13 +51,13 @@ from typing import Any, Dict, Union
 import numpy as np
 import qcelemental as qcel
 import qcengine as qcng
+
+from psi4 import core
 from psi4.extras import exit_printing
 from psi4.header import print_header
 from psi4.metadata import __version__
-from . import driver
-from . import p4util
 
-from psi4 import core
+from . import driver, p4util
 
 pp = pprint.PrettyPrinter(width=120, compact=True, indent=1)
 
@@ -587,7 +587,7 @@ def run_json_qcschema(json_data, clean, json_serialization, keep_wfn=False):
     # Set options
     ## The Forte plugin needs special treatment.
     try:
-        import forte # Needed for Forte options to run.
+        import forte  # Needed for Forte options to run.
     except ImportError:
         pass
     else:

--- a/psi4/driver/task_base.py
+++ b/psi4/driver/task_base.py
@@ -48,7 +48,7 @@ qcel.models.molecule.GEOMETRY_NOISE = 13  # need more precision in geometries fo
 import qcengine as qcng
 
 from psi4 import core
-from psi4.driver import p4util
+from . import p4util
 
 if TYPE_CHECKING:
     import qcportal

--- a/psi4/driver/task_base.py
+++ b/psi4/driver/task_base.py
@@ -36,18 +36,21 @@ import abc
 import copy
 import logging
 import pprint
-from typing import Any, Dict, Optional, Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 try:
     from pydantic.v1 import Field, validator
 except ImportError:
     from pydantic import Field, validator
+
 import qcelemental as qcel
-from qcelemental.models import DriverEnum, AtomicInput, AtomicResult
+from qcelemental.models import AtomicInput, AtomicResult, DriverEnum
+
 qcel.models.molecule.GEOMETRY_NOISE = 13  # need more precision in geometries for high-res findif
 import qcengine as qcng
 
 from psi4 import core
+
 from . import p4util
 
 if TYPE_CHECKING:

--- a/psi4/driver/task_base.py
+++ b/psi4/driver/task_base.py
@@ -35,7 +35,6 @@ __all__ = [
 import abc
 import copy
 import logging
-import pprint
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 try:

--- a/psi4/driver/task_planner.py
+++ b/psi4/driver/task_planner.py
@@ -32,20 +32,22 @@ __all__ = [
     "TaskComputers",
 ]
 
-import os
 import copy
 import logging
+import os
 from typing import Dict, Tuple, Union
 
 from qcelemental.models import DriverEnum
+
+from psi4 import core
+
 from . import p4util
 from .constants import pp
-from .task_base import AtomicComputer
+from .driver_cbs import CompositeComputer, cbs_text_parser, composite_procedures
 from .driver_findif import FiniteDifferenceComputer
 from .driver_nbody import ManyBodyComputer
-from .driver_cbs import CompositeComputer, composite_procedures, cbs_text_parser
-from .driver_util import negotiate_derivative_type, negotiate_convergence_criterion
-from psi4 import core
+from .driver_util import negotiate_convergence_criterion, negotiate_derivative_type
+from .task_base import AtomicComputer
 
 logger = logging.getLogger(__name__)
 

--- a/psi4/driver/task_planner.py
+++ b/psi4/driver/task_planner.py
@@ -38,7 +38,8 @@ import logging
 from typing import Dict, Tuple, Union
 
 from qcelemental.models import DriverEnum
-from psi4.driver import p4util, pp
+from . import p4util
+from .constants import pp
 from .task_base import AtomicComputer
 from .driver_findif import FiniteDifferenceComputer, FDComputerEnum
 from .driver_nbody import ManyBodyComputer

--- a/psi4/driver/task_planner.py
+++ b/psi4/driver/task_planner.py
@@ -39,11 +39,11 @@ from typing import Dict, Tuple, Union
 
 from qcelemental.models import DriverEnum
 from psi4.driver import p4util, pp
-from psi4.driver.task_base import AtomicComputer
-from psi4.driver.driver_findif import FiniteDifferenceComputer
-from psi4.driver.driver_nbody import ManyBodyComputer
-from psi4.driver.driver_cbs import CompositeComputer, composite_procedures, cbs_text_parser
-from psi4.driver.driver_util import negotiate_derivative_type, negotiate_convergence_criterion
+from .task_base import AtomicComputer
+from .driver_findif import FiniteDifferenceComputer, FDComputerEnum
+from .driver_nbody import ManyBodyComputer
+from .driver_cbs import CompositeComputer, composite_procedures, cbs_text_parser
+from .driver_util import negotiate_derivative_type, negotiate_convergence_criterion
 from psi4 import core
 
 logger = logging.getLogger(__name__)

--- a/psi4/driver/task_planner.py
+++ b/psi4/driver/task_planner.py
@@ -41,7 +41,7 @@ from qcelemental.models import DriverEnum
 from . import p4util
 from .constants import pp
 from .task_base import AtomicComputer
-from .driver_findif import FiniteDifferenceComputer, FDComputerEnum
+from .driver_findif import FiniteDifferenceComputer
 from .driver_nbody import ManyBodyComputer
 from .driver_cbs import CompositeComputer, composite_procedures, cbs_text_parser
 from .driver_util import negotiate_derivative_type, negotiate_convergence_criterion

--- a/psi4/driver/wrapper_database.py
+++ b/psi4/driver/wrapper_database.py
@@ -45,9 +45,11 @@ import re
 import sys
 
 from psi4 import core
-from .constants import constants
+
 from . import p4util
+from .constants import constants
 from .driver import *
+
 # never import aliases into this file
 
 

--- a/psi4/driver/wrapper_database.py
+++ b/psi4/driver/wrapper_database.py
@@ -45,9 +45,9 @@ import re
 import sys
 
 from psi4 import core
-from psi4.driver import constants
-from psi4.driver import p4util
-from psi4.driver.driver import *
+from .constants import constants
+from . import p4util
+from .driver import *
 # never import aliases into this file
 
 

--- a/psi4/extras.py
+++ b/psi4/extras.py
@@ -30,8 +30,8 @@ import atexit
 import datetime
 import itertools
 import os
-from typing import List, Optional, Union
 from pathlib import Path
+from typing import List, Optional, Union
 
 from qcelemental.util import which, which_import
 
@@ -284,6 +284,7 @@ def set_output_file(
 
     # Get the custom logger
     import logging
+
     from psi4 import logger
     if not inherit_loglevel:
         logger.setLevel(loglevel)

--- a/psi4/share/psi4/basis/primitives/diff_gbs.py
+++ b/psi4/share/psi4/basis/primitives/diff_gbs.py
@@ -31,15 +31,16 @@
 """Run on a single gbs file to get a periodic table printout or on two to compare gbs contents."""
 
 from __future__ import print_function
+
 import os
-import sys
 import subprocess
+import sys
 
 qcdb_module = os.path.normpath(os.path.dirname(os.path.abspath(__file__)) + '../../../../../driver')
 sys.path.append(qcdb_module)
 import qcdb
-from qcdb.libmintsbasissetparser import Gaussian94BasisSetParser
 import qcelemental as qcel
+from qcdb.libmintsbasissetparser import Gaussian94BasisSetParser
 
 
 class bcolors:

--- a/psi4/share/psi4/basis/primitives/dunning_prepend_and_checknew.py
+++ b/psi4/share/psi4/basis/primitives/dunning_prepend_and_checknew.py
@@ -29,9 +29,10 @@
 #
 
 from __future__ import print_function
+
 import os
-import sys
 import subprocess
+import sys
 
 qcdb_module = os.path.normpath(os.path.dirname(os.path.abspath(__file__)) + '../../../../../driver')
 sys.path.append(qcdb_module)

--- a/psi4/share/psi4/scripts/merge_stdsuite.py
+++ b/psi4/share/psi4/scripts/merge_stdsuite.py
@@ -1,9 +1,8 @@
 import ast
-import shutil
 import getpass
-import pathlib
 import operator
-
+import pathlib
+import shutil
 
 # How do pytest tests in `test_standard_suite.py` communicate with docs?
 # * after calling psi4 for each test, `standard_suite_runner.py` appends a one-line dict describing the result to local file "stdsuite_psi4.txt".

--- a/psi4/share/psi4/scripts/test_threading.py
+++ b/psi4/share/psi4/scripts/test_threading.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python
 
-import os
-import sys
-import math
-import time
-import importlib
-import sysconfig
-import subprocess
+"""
+isort:skip_file
+"""
 import collections
+import importlib
+import math
+import os
+import subprocess
+import sys
+import sysconfig
+import time
 
 if sys.version_info <= (3, 0):
     print('Much of this script needs py3')

--- a/tests/cookbook/rohf-orb-rot/input.dat
+++ b/tests/cookbook/rohf-orb-rot/input.dat
@@ -70,6 +70,7 @@ compare_values(-150.347533153677489, ccsd_e, 6, 'X CCSD energy') #TEST
 
 # Rotate HOMO and SOMO by 90 degrees to obtain guess for A state of HO2 in C1.
 # N.B. the orbitals are numbered using zero based indexing.
+import math
 ccsd_wfn.Ca().rotate_columns(0, 7, 8, math.pi / 2.0)
 
 # Serialize the wavefunction so that the SCF code can read it as a guess.

--- a/tests/freq-masses/input.dat
+++ b/tests/freq-masses/input.dat
@@ -38,6 +38,7 @@ ene, wwfn = frequencies('hf/cc-pvdz', molecule=weird, return_wfn=True, dertype=2
 masses = [weird.mass(iat) for iat in range(weird.natom())]
 w_freq = wwfn.frequencies().np[0]  # 984.044
 compare_values(1000., masses[1], "weird H mass", atol=1.e-6)
+import math
 compare_values(math.sqrt(mu_weird / mu_plain), p_freq / w_freq, "HbyH sqrt(mu):freq ratio", atol=1.e-6)
 
 clean()

--- a/tests/scf4/input.dat
+++ b/tests/scf4/input.dat
@@ -48,6 +48,7 @@ count = 0
 
 print(" Testing polar coordinates") #TEST
 
+import math
 for R in Rvals:
     for A in Avals:
         molecule h2o {


### PR DESCRIPTION
## Description
So in the course of working on DDD/pydantic, a fix I needed triggered the dreaded "circular import" error, which anyone who's tried to alter the driver's fragile import structure has probably seen, too. Being sick of this, I located https://medium.com/brexeng/avoiding-circular-imports-in-python-7c35ec8145ed with advice to do `from .driver import energy`, not `from psi4.driver.driver import energy`. So that's the first pass on the driver imports. This fixes my circular import problem and makes it easier to find others.

Since all the imports are churned anyways, I set up `isort` (that is, you can run isort on the repo, not that it's enforced on the repo). This is a utility (https://pycqa.github.io/isort/index.html) that sorts all the imports at the top of the file into stdlib, third_party, and first_party blocks and then alphabetizes the imports within. It also effectively tests the fragility of the import structure by jumbling them all into alphabetical order. Attempts in past years to run isort led to circular imports and a retreat. This time I was able to fix the single one that came about.

Third pass is that I ran `autoflake` on the driver to remove unused stdlib imports. It also removed some `pass` on empty fns that weren't needed because the docstring suffices for the syntax.

## User notes
- [x] the import structure has changed. you might need to add standard library imports to your input files if you use them (e.g., `import math` before `math.pi`) that previously were preloaded by psi4.

## Dev notes & details
- [x] switched import style to relative imports, ran isort, ran autoflake
- [x] actual material changes:
  * stop importing `molutil` into `sapt_proc`. this is the main one that allows killing off the embarrassing `temp_circular_import_blocker` fn. https://github.com/psi4/psi4/compare/master...loriab:psi4:import_slayer?expand=1#diff-f3e93ffa6125dd1f79abad7630bbf259bb1daeee89e983d2889b68af6038875aL35
  * delay loading fisapt_proc until runtime in sapt_util. this releases the main circular import in procrouting. https://github.com/psi4/psi4/compare/master...loriab:psi4:import_slayer?expand=1#diff-b3bc4df41c2c04c815d7a8a9b374c88759487db4a68e9dc962785dae8cb4b73cR268
  * delay loading driver_findif in empirical_dispersion. https://github.com/psi4/psi4/compare/master...loriab:psi4:import_slayer?expand=1#diff-6c949ad06bfcc0f8d646a54c79a427c47e008cbdae82ca148b0f0af1e1319a63R379
  * kill off circular_import blocker from python_helpers and molutil https://github.com/psi4/psi4/compare/master...loriab:psi4:import_slayer?expand=1#diff-f1bd68ebb5a84a2a1bfea1cce073adda3b39a3146012026cb7841280ef8ca25dL658

## Checklist
- ~tests added for any new features~
- [x] full tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
