### PR TITLE
Cd sherrill patch 3

### DIFF
--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -467,7 +467,7 @@ Bibliography
 
 .. [Schaffer:2013:2570]
    R. Sch\ |a_dots|\ ffer and G. Jansen
-   *Mol. Phys.* **111**, 2570 (2013).
+   *Mol. Phys.* **111**, 2570 (2013), https://doi.org/10.1080/00268976.2013.827253 .
 
 .. [Laqua:2018:204111]
    H. Laqua, J. Kussmann and C. Ochsenfeld

--- a/doc/sphinxman/source/sapt.rst
+++ b/doc/sphinxman/source/sapt.rst
@@ -216,12 +216,12 @@ pair between monomers.
 
 The :math:`S^{2}` approximation is usually pretty good, but may 
 break down for short intermolecular distance, particularly in high-order
-terms. To compensate these deviations, in 2014 Parker et al. [Parker:2014:094106]_ 
+terms. To compensate for these deviations, in 2014 Parker et al. [Parker:2014:094106]_ 
 recommended to scale all :math:`S^{2}` approximated exchange terms by the ratio:
 
 .. math:: p_{EX}(\alpha) = \left( \frac{E_{exch}^{(10)}}{E_{exch}^{(10)}(S^{2})} \right)^{\alpha}
 
-and recommended using the ratio :math:`\alpha = 1`. To obtain SAPT energies with this scaling,
+and recommended using the ratio with exponent :math:`\alpha = 1`. To obtain SAPT energies with this scaling,
 simply set the keyword ``exch_scale_alpha true``. Alternatively, another value for :math:`\alpha`
 can be specified by setting |sapt__exch_scale_alpha| to a value. For example, ::
 
@@ -229,7 +229,7 @@ can be specified by setting |sapt__exch_scale_alpha| to a value. For example, ::
 
 will set :math:`\alpha = 1.0` and scale exchange energies with :math:`p_{EX}(1.0)`.
 
-However, as later pointed out by Schaeffer and Jansen [Schaffer:2013:2570]_
+However, as pointed out by Schaffer and Jansen [Schaffer:2013:2570]_
 in the context of DFT-based SAPT, the ratios :math:`E_{exch}^{(1)}(S^{2})/E_{exch}^{(1)}`,
 :math:`E_{\rm exch-ind}^{(2)}(S^2)/E_{\rm exch-ind}^{(2)}`, and 
 :math:`E_{\rm exch-disp}^{(2)}(S^2)/E_{\rm exch-disp}^{(2)}` are not very similar to

--- a/doc/sphinxman/source/sapt.rst
+++ b/doc/sphinxman/source/sapt.rst
@@ -217,7 +217,7 @@ pair between monomers.
 The :math:`S^{2}` approximation is usually pretty good, but may 
 break down for short intermolecular distance, particularly in high-order
 terms. To compensate these deviations, in 2014 Parker et al. [Parker:2014:094106]_ 
-recommend to scale all :math:`S^{2}` approximated exchange terms by the ratio:
+recommended to scale all :math:`S^{2}` approximated exchange terms by the ratio:
 
 .. math:: p_{EX}(\alpha) = \left( \frac{E_{exch}^{(10)}}{E_{exch}^{(10)}(S^{2})} \right)^{\alpha}
 

--- a/doc/sphinxman/source/sapt.rst
+++ b/doc/sphinxman/source/sapt.rst
@@ -229,7 +229,7 @@ can be specified by setting |sapt__exch_scale_alpha| to a value. For example, ::
 
 will set :math:`\alpha = 1.0` and scale exchange energies with :math:`p_{EX}(1.0)`.
 
-However, as later pointed out by Schaeffer and Jansen [Schaeffer:2013:2570]_
+However, as later pointed out by Schaeffer and Jansen [Schaffer:2013:2570]_
 in the context of DFT-based SAPT, the ratios :math:`E_{exch}^{(1)}(S^{2})/E_{exch}^{(1)}`,
 :math:`E_{\rm exch-ind}^{(2)}(S^2)/E_{\rm exch-ind}^{(2)}`, and 
 :math:`E_{\rm exch-disp}^{(2)}(S^2)/E_{\rm exch-disp}^{(2)}` are not very similar to

--- a/doc/sphinxman/source/sapt.rst
+++ b/doc/sphinxman/source/sapt.rst
@@ -216,12 +216,12 @@ pair between monomers.
 
 The :math:`S^{2}` approximation is usually pretty good, but may 
 break down for short intermolecular distance, particularly in high-order
-terms. To compensate these deviations, Parker et al. [Parker:2014:094106]_ 
+terms. To compensate these deviations, in 2014 Parker et al. [Parker:2014:094106]_ 
 recommend to scale all :math:`S^{2}` approximated exchange terms by the ratio:
 
 .. math:: p_{EX}(\alpha) = \left( \frac{E_{exch}^{(10)}}{E_{exch}^{(10)}(S^{2})} \right)^{\alpha}
 
-where the recommended exponent is :math:`\alpha = 1`. To obtain SAPT energies with this scaling,
+and recommended using the ratio :math:`\alpha = 1`. To obtain SAPT energies with this scaling,
 simply set the keyword ``exch_scale_alpha true``. Alternatively, another value for :math:`\alpha`
 can be specified by setting |sapt__exch_scale_alpha| to a value. For example, ::
 
@@ -229,7 +229,15 @@ can be specified by setting |sapt__exch_scale_alpha| to a value. For example, ::
 
 will set :math:`\alpha = 1.0` and scale exchange energies with :math:`p_{EX}(1.0)`.
 
-Instead of this straightforward scaling, SAPT0 energies benefit from a slightly modified 
+However, as later pointed out by Schaeffer and Jansen [Schaeffer:2013:2570]_
+in the context of DFT-based SAPT, the ratios :math:`E_{exch}^{(1)}(S^{2})/E_{exch}^{(1)}`,
+:math:`E_{\rm exch-ind}^{(2)}(S^2)/E_{\rm exch-ind}^{(2)}`, and 
+:math:`E_{\rm exch-disp}^{(2)}(S^2)/E_{\rm exch-disp}^{(2)}` are not very similar to
+each other.  Hence, in 2016 universal scaling of all :math:`S^{2}` approximated terms
+was turned off by default.
+
+Finally, in 2014 Parker et al. [Parker:2014:094106]_ empirically discovered that 
+SAPT0 energies for van der Waals dimers with close contacts benefit from a slightly modified 
 recipe that involves an empirically adjusted exponent :math:`\alpha = 3.0`. 
 To distinguish it from its unscaled counterpart, this energy is denoted sSAPT0 (see [Parker:2014:094106]_).
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Update the manual to clarify that exchange-scaling of S^2-approximated terms
is no longer done by default, and explain why (cite 2013 Jansen paper)

This is just a quick text edit of the manual, nothing else has changed.

## Status
- [x] Ready for review
- [x] Ready for merge
