### PR TITLE
Implement fitted SAP guess

### DIFF
--- a/psi4/src/psi4/libmints/basisset.cc
+++ b/psi4/src/psi4/libmints/basisset.cc
@@ -1256,3 +1256,9 @@ void BasisSet::compute_phi(double* phi_ao, double x, double y, double z) {
         ao += INT_NFUNC(puream_, am);
     }  // nshell
 }
+
+void BasisSet::convert_sap_contraction() {
+  for (auto shell: shells_) {
+    shell.convert_sap_contraction();
+  }
+}

--- a/psi4/src/psi4/libmints/basisset.h
+++ b/psi4/src/psi4/libmints/basisset.h
@@ -400,6 +400,9 @@ class PSI_API BasisSet {
     void move_atom(int atom, const Vector3 &trans);
     // Returns the values of the basis functions at a point
     void compute_phi(double *phi_ao, double x, double y, double z);
+
+    // Converts the contraction to match the SAP approach
+    void convert_sap_contraction();
     
    private: 
     /// Helper functions for frozen core to reduce LOC

--- a/psi4/src/psi4/libmints/gshell.cc
+++ b/psi4/src/psi4/libmints/gshell.cc
@@ -143,6 +143,13 @@ int ShellInfo::nfunction() const { return INT_NFUNC(puream_, l_); }
 
 int ShellInfo::nprimitive() const { return exp_.size(); }
 
+void ShellInfo::convert_sap_contraction() {
+  // Converts overlap normalized coefficients to Coulomb normalized coefficients
+  for (auto i = 0; i < nprimitive(); ++i) {
+    coef_[i] *= std::sqrt(exp_[i]);
+  }
+}
+
 void ShellInfo::print(std::string out) const {
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
 

--- a/psi4/src/psi4/libmints/gshell.h
+++ b/psi4/src/psi4/libmints/gshell.h
@@ -295,6 +295,9 @@ class PSI_API GaussianShell {
     int function_index() const { return start_; }
     void set_function_index(int i) { start_ = i; }
     double evaluate(double r, int l) const;
+
+    /// Convert error function contractions to Gaussians for SAP
+    void convert_sap_contraction();
 };
 
 }  // namespace psi

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -214,6 +214,8 @@ class HF : public Wavefunction {
     virtual void compute_SAD_guess(bool natorb);
     /// Huckel guess
     virtual void compute_huckel_guess(bool updated_rule);
+    /// Forms the SAPGAU guess
+    virtual void compute_sapgau_guess();
 
     /** Transformation, diagonalization, and backtransform of Fock matrix */
     virtual void diagonalize_F(const SharedMatrix& F, SharedMatrix& C, std::shared_ptr<Vector>& eps);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1446,7 +1446,9 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("INTS_TOLERANCE", 1E-12);
         /*- The type of guess orbitals. See :ref:`sec:scfguess` for what the options mean and
          what the defaults are. -*/
-        options.add_str("GUESS", "AUTO", "AUTO CORE GWH SAD SADNO SAP HUCKEL MODHUCKEL READ");
+        options.add_str("GUESS", "AUTO", "AUTO CORE GWH SAD SADNO SAP SAPGAU HUCKEL MODHUCKEL READ");
+        /*- The potential basis set used for the SAPGAU guess -*/
+        options.add_str("SAPGAU_BASIS", "helfem_large");
         /*- Mix the HOMO/LUMO in UHF or UKS to break alpha/beta spatial symmetry.
         Useful to produce broken-symmetry unrestricted solutions.
         Notice that this procedure is defined only for calculations in C1 symmetry. -*/


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This is an implementation of the fitted version of the SAP guess, described in [J. Chem. Phys. 152, 144105 (2020)](https://doi.org/10.1063/5.0004046).

The repulsive potential on every atom is fit in terms of error function potentials, which means that the guess can be evaluated with few two-electron integrals; namely

$$ {\bf F}^\text{SAP}  = {\bf H} + {\bf V}^\text{SAP} $$

$$ V_{\mu \nu}^\text{SAP} =  \sum_{A} (A|\mu \nu) $$

I have no idea how the integrals work in Psi4. I followed [a Psi4Numpy example](https://github.com/psi4/psi4numpy/blob/master/Moller-Plesset/DF-MP2_NAF.py) @loriab hinted me at.

The appears to compile; the only problem being the final assembly, i.e. the sum over the 3-center integrals. If anyone can tell me what I should be doing, help would be appreciated...

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Implement scheme and get something that matches ERKALE
- [ ] Use optimal storage

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
