### PR TITLE
fix docs build after QCArchive documentation shuffle

### DIFF
--- a/doc/sphinxman/source/conf.py.in
+++ b/doc/sphinxman/source/conf.py.in
@@ -421,10 +421,9 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3.10', None),
                        "numpy": ("https://numpy.org/doc/stable/", None),
                        'scipy': ('https://docs.scipy.org/doc/scipy/', None),
                        'matplotlib': ('https://matplotlib.org/stable/', None),
-                       "qcelemental": ("http://docs.qcarchive.molssi.org/projects/QCElemental/en/latest/", None),
-                       "qcengine": ("http://docs.qcarchive.molssi.org/projects/QCEngine/en/latest/", None),
-                       "qcfractal": ("http://docs.qcarchive.molssi.org/projects/QCFractal/en/latest/", None),
-                       "qcportal": ("http://docs.qcarchive.molssi.org/projects/QCPortal/en/latest/", None),
+                       "qcelemental": ("https://molssi.github.io/QCElemental/", None),
+                       "qcengine": ("https://molssi.github.io/QCEngine/", None),
+                       "qcfractal": ("https://molssi.github.io/QCFractal/", None),
                       }
 
 


### PR DESCRIPTION
## Description

## Dev notes & details
- [x] when we link of functions/classes outside psi4, it looks for the intersphinx object inventory to link to their docstring. this updates the location from the old RTD pages to the new GHpages docs for QCArchive. not a surprise that it broke since the QCFractal release is triggering site shuffling of all the supporting material.


## Checklist
- [x] docs build works locally

## Status
- [x] Ready for review
- [x] Ready for merge
