### PR TITLE
Fix typo in SplitJK::set_lr_symmetric

### DIFF
--- a/psi4/src/psi4/libfock/SplitJK.h
+++ b/psi4/src/psi4/libfock/SplitJK.h
@@ -108,7 +108,7 @@ class PSI_API SplitJK {
     // => Knobs <= //
 
     void set_early_screening(bool early_screening) { early_screening_ = early_screening; }
-    void set_lr_symmetric(bool lr_symmetric) { lr_symmetric_ = lr_symmetric_; }
+    void set_lr_symmetric(bool lr_symmetric) { lr_symmetric_ = lr_symmetric; }
     /// Bench accessors
     void set_bench(int bench) { bench_ = bench; }
     int get_bench() const { return bench_; }


### PR DESCRIPTION
## Description
Thanks to @JonathonMisiewicz for catching this one!

This PR fixes a typo in `SplitJK::set_lr_symmetric`, wherein the `lr_symmetric_` variable is assigned to itself rather than the intended behavior of being assigned to the function input.

This also opens up the question of why this wasn't caught in testing, which I plan on exploring further and addressing in a second PR. Currently, composite methods where `LinK` is used, throw exceptions for cases where `lr_symmetric_` is set to false; but composite methods using `COSX` does not.

## User API & Changelog headlines
N/A

## Dev notes & details
- [X] `SplitJK::set_lr_symmetric` now behaves as intended.

## Questions
N/A

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [x] Ready for merge
