### PR TITLE
reroute docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -125,10 +125,10 @@ jobs:
 
     - name: Compare Docs (generated vs psi4/psi4docs)
       if: ${{ github.repository == 'psi4/psi4' }}
-      working-directory: ./docs
+      working-directory: ./docs/sphinxman/master
       id: compare-psi4docs
       run: |
-        cp -pR ../code/objdir/doc/sphinxman/html .
+        cp -pR ../../../code/objdir/doc/sphinxman/html/ .
         echo "::group::Selective Git Diff"
         git diff --color-words -I"Last updated on" -I"psi4/tree"
         echo "::endgroup::"


### PR DESCRIPTION
## Description
I've changed the structure of psi4/psi4docs so that it can store snapshots as well as master. See table https://github.com/psi4/psi4docs#readme . This is a great boon to the psicode.org website processing b/c hugo doesn't like the tens of thousands of static files we have of docs snapshots. Hopefully these lines send the build docs to the new location in the psi4docs repo.

## Status
- [x] Ready for review
- [x] Ready for merge
