### PR TITLE
reroute docs build again

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -125,11 +125,12 @@ jobs:
         tar -zcf doxyman.tar.gz html/
 
     - name: Compare Docs (generated vs psi4/psi4docs)
-      if: github.event_name == 'push' && github.repository == 'psi4/psi4' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )
-      working-directory: ./docs/sphinxman/master
+      if: github.event_name == 'push' && github.repository == 'psi4/psi4'
+      working-directory: ./docs/sphinxman
       id: compare-psi4docs
       run: |
-        cp -pR ../../../code/objdir/doc/sphinxman/html/* .
+        cp -pR ../../../code/objdir/doc/sphinxman/html/ .
+        mv html ${{ github.ref_name }}
         echo "::group::Selective Git Diff"
         git diff --color-words -I"Last updated on" -I"psi4/tree"
         echo "::endgroup::"
@@ -137,17 +138,6 @@ jobs:
         git config --local user.name "GitHub Action"
         git add -A
         git commit -m "auto-generated from Psi4 master"
-
-    - name: Shift Docs (maintenance)
-      if: github.event_name == 'push' && github.repository == 'psi4/psi4' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref != 'refs/heads/master' )
-      working-directory: ./docs/sphinxman/maintenance
-      id: compare-psi4docs-m
-      run: |
-        cp -pR ../../../code/objdir/doc/sphinxman/html/* .
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add -A
-        git commit -m "auto-generated from Psi4 maintenance"
 
     - name: Push Changes to psi4/psi4docs
       if: github.repository == 'psi4/psi4'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -137,7 +137,7 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add -A
-        git commit -m "auto-generated from Psi4 master"
+        git commit -m "auto-generated from Psi4 ${{ github.ref_name }}"
 
     - name: Push Changes to psi4/psi4docs
       if: github.repository == 'psi4/psi4'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - gha-docs
+      - '1.*.x'
 
 concurrency:
   group: latest-docs-group
@@ -124,11 +125,11 @@ jobs:
         tar -zcf doxyman.tar.gz html/
 
     - name: Compare Docs (generated vs psi4/psi4docs)
-      if: ${{ github.repository == 'psi4/psi4' }}
+      if: github.event_name == 'push' && github.repository == 'psi4/psi4' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )
       working-directory: ./docs/sphinxman/master
       id: compare-psi4docs
       run: |
-        cp -pR ../../../code/objdir/doc/sphinxman/html/ .
+        cp -pR ../../../code/objdir/doc/sphinxman/html/* .
         echo "::group::Selective Git Diff"
         git diff --color-words -I"Last updated on" -I"psi4/tree"
         echo "::endgroup::"
@@ -137,8 +138,19 @@ jobs:
         git add -A
         git commit -m "auto-generated from Psi4 master"
 
+    - name: Shift Docs (maintenance)
+      if: github.event_name == 'push' && github.repository == 'psi4/psi4' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref != 'refs/heads/master' )
+      working-directory: ./docs/sphinxman/maintenance
+      id: compare-psi4docs-m
+      run: |
+        cp -pR ../../../code/objdir/doc/sphinxman/html/* .
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add -A
+        git commit -m "auto-generated from Psi4 maintenance"
+
     - name: Push Changes to psi4/psi4docs
-      if: ${{ github.repository == 'psi4/psi4' }}
+      if: github.repository == 'psi4/psi4'
       uses: ad-m/github-push-action@master
       with:
         directory: ./docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -129,7 +129,7 @@ jobs:
       working-directory: ./docs/sphinxman
       id: compare-psi4docs
       run: |
-        cp -pR ../../../code/objdir/doc/sphinxman/html/ .
+        cp -pR ../../code/objdir/doc/sphinxman/html .
         mv html ${{ github.ref_name }}
         echo "::group::Selective Git Diff"
         git diff --color-words -I"Last updated on" -I"psi4/tree"


### PR DESCRIPTION
## Description
This continues #3056, which was off by a directory level. This time I remembered the backup trigger branch, so it's tested.

## User API & Changelog headlines

## Dev notes & details
- [x] Now build docs for `1.{Y}.x` branches, too, as well as `master`. Save them to a dir at psi4/psi4docs according to branch name, so easy to reposition. 

## Status
- [x] Ready for review
- [x] Ready for merge
