### PR TITLE
Fix compilation error for C++20

### DIFF
--- a/psi4/src/psi4/libpsi4util/exception.h
+++ b/psi4/src/psi4/libpsi4util/exception.h
@@ -206,7 +206,7 @@ class LimitExceeded : public PsiException {
 
     T actual_value() const noexcept { return errorval_; }
 
-    ~LimitExceeded<T>() noexcept override {};
+    ~LimitExceeded() noexcept override {};
 };
 
 /**


### PR DESCRIPTION
## Description
In C++, the destructor for a templated class should not include the template parameter in the destructor's name. This is not a problem for C++17 and earlier standards, but with C++20 compilers it raises an error. This PR fixes one instance of this problem in psi4.

## User API & Changelog headlines
- [x] API should now be compatible with both C++17 and C++20

## Dev notes & details
- [x] Change one line

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
