### PR TITLE
make `psi4 --version` faster

### DIFF
--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -33,6 +33,7 @@ import atexit
 import datetime
 import json
 import os
+import re
 import sys
 import warnings
 from pathlib import Path
@@ -200,6 +201,13 @@ if args["psidatadir"] is not None:
     data_dir = os.path.abspath(os.path.expanduser(args["psidatadir"]))
     os.environ["PSIDATADIR"] = data_dir
 
+if args["version"]:
+    with (psi4_module_loc / "metadata.py").open() as fp:
+        verline = fp.readline()
+    __version__ = re.match(r"__version__ = ['\"](?P<ver>.*)['\"]", verline).group("ver")
+    print(__version__)
+    sys.exit()
+
 ### Actually import psi4 and apply setup ###
 
 # Arrange for warnings to ignore everything except the message
@@ -211,10 +219,6 @@ warnings.formatwarning = custom_formatwarning
 # Import installed psi4
 sys.path.insert(1, lib_dir)
 import psi4  # isort:skip
-
-if args["version"]:
-    print(psi4.__version__)
-    sys.exit()
 
 # Prevents a poor option combination
 if args['plugin_template'] and (not args['plugin_name']):

--- a/psi4/run_psi4.py
+++ b/psi4/run_psi4.py
@@ -202,8 +202,7 @@ if args["psidatadir"] is not None:
     os.environ["PSIDATADIR"] = data_dir
 
 if args["version"]:
-    with (psi4_module_loc / "metadata.py").open() as fp:
-        verline = fp.readline()
+    with (psi4_module_loc / "metadata.py").open() as fp: verline = fp.readline()
     __version__ = re.match(r"__version__ = ['\"](?P<ver>.*)['\"]", verline).group("ver")
     print(__version__)
     sys.exit()


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] When running `psi4 --version`, short circuit the `import psi4` command that can be slow on networked drives. Instead, just read the string out of the file.

## Status
- [x] Ready for review
- [x] Ready for merge
