### PR TITLE
Libint2 Generator

### DIFF
--- a/external/upstream/libint2/CMakeLists.txt
+++ b/external/upstream/libint2/CMakeLists.txt
@@ -61,6 +61,12 @@ else()
         message(FATAL_ERROR "Suitable Libint2 could not be externally located as user insists")
     endif()
 
+    # stopgap to avert a report that static lib not working on Linux
+    set(_build_shared_libs "ON")
+
+    # reportedly Debug takes forever to build on Mac
+    set(_cmake_build_type "Release")
+
     include(ExternalProject)
 
     if(NOT ${BUILD_Libint2_GENERATOR})
@@ -77,13 +83,7 @@ else()
         if (MSVC)
             # Windows shared (dll) can't work
             set(_build_shared_libs "OFF")
-        else()
-            # stopgap to avert a report that static lib not working on Linux
-            set(_build_shared_libs "ON")
         endif()
-
-        # reportedly Debug takes forever to build on Mac
-        set(_cmake_build_type "Release")
 
         ExternalProject_Add(libint2_external
             URL ${_url_l2_tarball}


### PR DESCRIPTION
## Description
Small fix to Libint build generator

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [X] Moves `_build_shared_libs`  and `_cmake_build_type` outside of if-else statement so they are defined for both cases for `BUILD_Libint2_GENERATOR`

## Checklist
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge
