### PR TITLE
Turning off FDDS disp when SAPT_DFT_FUNCTIONAL = HF

### DIFF
--- a/psi4/driver/procrouting/sapt/sapt_util.py
+++ b/psi4/driver/procrouting/sapt/sapt_util.py
@@ -104,7 +104,7 @@ def print_sapt_hf_summary(data, name, short=False, delta_hf=False):
 
     else:
         # Dispersion
-        disp = data["Disp20,u"] + data["Exch-Disp20,u"]
+        disp = data["Disp20"] + data["Exch-Disp20,u"]
         ret += print_sapt_var("Dispersion", disp) + "\n"
         ret += print_sapt_var("  Disp20", data["Disp20,u"]) + "\n"
         ret += print_sapt_var("  Exch-Disp20", data["Exch-Disp20,u"]) + "\n"

--- a/psi4/driver/procrouting/sapt/sapt_util.py
+++ b/psi4/driver/procrouting/sapt/sapt_util.py
@@ -104,7 +104,7 @@ def print_sapt_hf_summary(data, name, short=False, delta_hf=False):
 
     else:
         # Dispersion
-        disp = data["Disp20"] + data["Exch-Disp20,u"]
+        disp = data["Disp20,u"] + data["Exch-Disp20,u"]
         ret += print_sapt_var("Dispersion", disp) + "\n"
         ret += print_sapt_var("  Disp20", data["Disp20,u"]) + "\n"
         ret += print_sapt_var("  Exch-Disp20", data["Exch-Disp20,u"]) + "\n"
@@ -122,8 +122,7 @@ def print_sapt_hf_summary(data, name, short=False, delta_hf=False):
         return ret
 
 
-def print_sapt_dft_summary(data, name, short=False):
-
+def print_sapt_dft_summary(data, name, do_dft=True, short=False):
     ret = "   %s Results\n" % name
     ret += "  " + "-" * 105 + "\n"
 
@@ -162,16 +161,24 @@ def print_sapt_dft_summary(data, name, short=False):
     core.set_variable("SAPT IND ENERGY", ind)
 
     # Dispersion
-    disp = data["Disp20"] + data["Exch-Disp20,r"]
-    ret += print_sapt_var("Dispersion", disp) + "\n"
-    ret += print_sapt_var("  Disp2,r", data["Disp20"]) + "\n"
-    ret += print_sapt_var("  Disp2,u", data["Disp20,u"]) + "\n"
-    if core.get_option("SAPT", "SAPT_DFT_EXCH_DISP_SCALE_SCHEME") != "NONE":
-        ret += print_sapt_var("  Est. Exch-Disp2,r", data["Exch-Disp20,r"]) + "\n"
-    ret += print_sapt_var("  Exch-Disp2,u", data["Exch-Disp20,u"]) + "\n"
-    ret += "\n"
-    core.set_variable("SAPT DISP ENERGY", disp)
-
+    if do_dft:
+        disp = data["Disp20"] + data["Exch-Disp20,r"]
+        ret += print_sapt_var("Dispersion", disp) + "\n"
+        ret += print_sapt_var("  Disp2,r", data["Disp20"]) + "\n"
+        ret += print_sapt_var("  Disp2,u", data["Disp20,u"]) + "\n"
+        if core.get_option("SAPT", "SAPT_DFT_EXCH_DISP_SCALE_SCHEME") != "NONE":
+            ret += print_sapt_var("  Est. Exch-Disp2,r", data["Exch-Disp20,r"]) + "\n"
+        ret += print_sapt_var("  Exch-Disp2,u", data["Exch-Disp20,u"]) + "\n"
+        ret += "\n"
+        core.set_variable("SAPT DISP ENERGY", disp)
+    else:
+        disp = data["Disp20,u"] + data["Exch-Disp20,u"]
+        ret += print_sapt_var("Dispersion", disp) + "\n"
+        ret += print_sapt_var("  Disp20", data["Disp20,u"]) + "\n"
+        ret += print_sapt_var("  Exch-Disp20", data["Exch-Disp20,u"]) + "\n"
+        ret += "\n"
+        core.set_variable("SAPT DISP ENERGY", disp)
+    
     # Total energy
     total = data["Elst10,r"] + data["Exch10"] + ind + disp
     ret += print_sapt_var("Total %-17s" % name, total, start_spacer="    ") + "\n"


### PR DESCRIPTION
## Description
The purpose of this PR is to turn off FDDS dispersion when SAPT_DFT_FUNCTIONAL = HF in SAPT(DFT). 

SAPT0 uses a HF description of monomers, whereas SAPT(DFT) replaces this description with KS-DFT.  When SAPT(DFT)’s functional is set to HF, the results should be equivalent to those of SAPT0. Currently, SAPT(DFT) / SAPT_DFT_FUNCTIONAL HF computes coupled dispersion with FDDS. This step is costly and unnecessary. 


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] The dispersion energy for SAPT(DFT) with HF will now match SAPT0 and no longer calculate or print Disp2,r or Est. Exch-Disp2,r
- [x] No change necessary in input files

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Places SAPT(DFT)'s FDDS dispersion into an if statement so that FDDS disp is only computed when the functional is not HF
- [x] Carries information regarding the functional into the printing code so that the correct dispersion terms are printed out

## Questions
- [ ] Question1

## Checklist
- [x] sapt-dft1, sapt-dft2, and sapt-compare all pass; no need for the creation of additional tests


## Status
- [x] Ready for review
- [ ] Ready for merge

