### PR TITLE
Throw exceptions for broken JK+SCREENING combos

### DIFF
--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -88,8 +88,15 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
         can_do_density_screen.cend(),
         [&](std::string jk_algo) { return jk_type == jk_algo; }
     ); 
- 
-    bool do_df_scf_guess = options.get_bool("DF_SCF_GUESS");
+
+    std::array<std::string, 3> can_be_in_df_scf_guess = { "DIRECT", "MEM_DF", "DISK_DF" };
+    bool is_in_df_scf_guess = std::any_of(
+        can_be_in_df_scf_guess.cbegin(),
+        can_be_in_df_scf_guess.cend(),
+        [&](std::string jk_algo) { return jk_type == jk_algo; }
+    ); 
+    bool do_df_scf_guess = options.get_bool("DF_SCF_GUESS") && is_in_df_scf_guess;
+
     bool is_incompatible_density_screen = !(is_compatible_density_screen || do_df_scf_guess);
     
     if (do_density_screen && is_incompatible_density_screen) {

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -79,15 +79,58 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
       [&](std::string composite_algo) { return jk_type.find(composite_algo) != std::string::npos; }
     );
 
+    // exit calculation if density screening is selected for incompatible JK algo
     bool do_density_screen = options.get_str("SCREENING") == "DENSITY";
-    bool do_df_scf_guess = options.get_bool("DF_SCF_GUESS");
-    
-    bool can_do_density_screen = (jk_type == "DIRECT" || jk_type == "DFDIRJ+LINK" || jk_type == "DFDIRJ");
 
-    if (do_density_screen && !(can_do_density_screen || do_df_scf_guess)) {
-        throw PSIEXCEPTION("Density screening has not been implemented for non-Direct SCF algorithms.");
+    std::array<std::string, 3> can_do_density_screen = { "DIRECT", "DFDIRJ+LINK", "DFDIRJ" };
+    bool is_compatible_density_screen = std::any_of(
+        can_do_density_screen.cbegin(),
+        can_do_density_screen.cend(),
+        [&](std::string jk_algo) { return jk_type == jk_algo; }
+    ); 
+ 
+    bool do_df_scf_guess = options.get_bool("DF_SCF_GUESS");
+    bool is_incompatible_density_screen = !(is_compatible_density_screen || do_df_scf_guess);
+    
+    if (do_density_screen && is_incompatible_density_screen) {
+        std::string error_message = "SCREENING=DENSITY has not been implemented for ";
+        error_message += (do_df_scf_guess) ? "DF_SCF_GUESS" : jk_type;
+        error_message += ".";
+   
+        throw PSIEXCEPTION(error_message);
+    }
+    
+    // exit calculation if no screening is selected for incompatible JK algo
+    bool do_no_screen = options.get_str("SCREENING") == "NONE";
+    
+    std::array<std::string, 3> cant_do_no_screen = { "PK", "DISK_DF", "DIRECT" };
+    bool is_incompatible_no_screen = std::any_of(
+        cant_do_no_screen.cbegin(),
+        cant_do_no_screen.cend(),
+        [&](std::string jk_algo) { return jk_type == jk_algo; }
+    ); 
+    is_incompatible_no_screen |= is_composite; 
+    
+    if (do_no_screen && is_incompatible_no_screen) {
+        std::string error_message = "SCREENING=NONE has not been implemented for ";
+        error_message += jk_type;
+        error_message += ".";
+ 
+        throw PSIEXCEPTION(error_message);
     }
 
+    // exit calculation for other incompatible JK + SCREENING combos 
+    std::string screening_type = options.get_str("SCREENING");
+    if (jk_type == "DFDIRJ+LINK" && ((screening_type == "SCHWARZ") || screening_type == "CSAM" )) {
+        std::string error_message = "SCREENING=";
+        error_message += screening_type;
+        error_message += " has not been implemented for ";
+        error_message += jk_type;
+        error_message += ".";
+ 
+        throw PSIEXCEPTION(error_message);
+    }
+   
     // Throw small DF warning
     if (jk_type == "DF") {
         outfile->Printf("\n  Warning: JK type 'DF' found in simple constructor, defaulting to DiskDFJK.\n");

--- a/tests/pytests/test_comprehensive_jk_screening.py
+++ b/tests/pytests/test_comprehensive_jk_screening.py
@@ -56,31 +56,20 @@ def test_comprehensive_jk_screening(scf_type, scf_subtype, screening):
 
     #== certain combinations of SCF_TYPE and SCREENING should throw an exception by design ==#
     should_throw = False
-    #== specifically, non-integral-direct methods and DFDirJ+COSX with SCREENING = DENSITY ==# 
+    #== specifically, non-integral-direct methods and DFDirJ+COSX with SCREENING = DENSITY... ==# 
     should_throw = should_throw or (scf_type not in [ "DIRECT", "DFDIRJ+LINK" ] and screening == "DENSITY")
-
-    #== other combinations error out badly and need to be fixed; skip them here ==#
-    should_error_out = False
-    #== this includes Composite methods with SCREENING=NONE... ==#
-    should_error_out = should_error_out or (scf_type in Eref["Singlet"]["Composite"].keys() and screening == "NONE")
-    #== .. DFDIRJ+LINK with SCREENING=SCHWARZ or CSAM... ==#
-    should_error_out = should_error_out or (scf_type == "DFDIRJ+LINK" and screening in [ "SCHWARZ", "CSAM" ])
-    #== .. and DISK_DF, DIRECT, or PK with SCREENING=NONE ==#
-    should_error_out = should_error_out or (scf_type == "PK" and screening == "NONE")
-    should_error_out = should_error_out or (scf_type == "DISK_DF" and screening == "NONE")
-    should_error_out = should_error_out or (scf_type == "DIRECT" and screening == "NONE")
-  
+    #== ... Composite methods with SCREENING=NONE... ==#
+    should_throw = should_throw or (scf_type in Eref["Singlet"]["Composite"].keys() and screening == "NONE")
+    #== .. DISK_DF, DIRECT, or PK with SCREENING=NONE ==#
+    should_throw = should_throw or (scf_type == "PK" and screening == "NONE")
+    should_throw = should_throw or (scf_type == "DISK_DF" and screening == "NONE")
+    should_throw = should_throw or (scf_type == "DIRECT" and screening == "NONE")
+    #== .. and DFDIRJ+LINK with SCREENING=SCHWARZ or CSAM... ==#
+    should_throw = should_throw or (scf_type == "DFDIRJ+LINK" and screening in [ "SCHWARZ", "CSAM" ])
+ 
     E = 0.0 
     
-    #== check that should_error_out and should_throw are not simultaneously true, for better testing ==# 
-    if should_error_out and should_throw:
-        raise Exception(f'Duplicate checks on {scf_type}({scf_subtype})+{screening}!')
-    #== xfail if current option combo is expected to break ==#
-    elif should_error_out and not should_throw:
-        pytest.xfail(f'Singlet {scf_type}({scf_subtype})+{screening}  xfailed: will error out')
-
-    #== if expected, test if current option combo throws exception ==# 
-    elif not should_error_out and should_throw:
+    if should_throw:
         with pytest.raises(Exception) as e_info:
             E = psi4.energy('scf')
 


### PR DESCRIPTION
## Description
This is an intermediary PR to https://github.com/psi4/psi4/pull/3060. Reviews on that PR have made me reconsider some design decisions as implemented in that PR. At the same time, I want to ensure that no end user runs into any hard failures due to broken `SCF_TYPE` + `SCF_SUBTYPE` + `SCREENING` combinations in v1.9. So this PR goes and simply throws exceptions for every hard failure case as logged in `test_comprehensive_jk_screening.py`. Tests are updated to match, and there's some small refactoring of how JK type + screening exceptions are handled in `jk.cc.` 

## User API & Changelog headlines
- [X] N/A

## Dev notes & details
- [x] Broken combinations of `SCF_TYPE` + `SCF_SUBTYPE` + `SCREENING` now throw an exception, instead of running to failure.

## Questions
- [X] N/A

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
