### PR TITLE
Fix `oeprop` argument case behavior

### DIFF
--- a/psi4/driver/p4util/util.py
+++ b/psi4/driver/p4util/util.py
@@ -74,7 +74,7 @@ def oeprop(wfn: core.Wavefunction, *args: List[str], **kwargs):
     if 'title' in kwargs:
         oe.set_title(kwargs['title'])
     for prop in args:
-        oe.add(prop)
+        oe.add(prop.upper())
 
         # If we're doing MBIS, we want the free-atom volumes
         # in order to compute volume ratios,


### PR DESCRIPTION
## Description
Fixes issue #3085 

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] `oeprop()` args are no longer case-sensitive (py-side)

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
