### PR TITLE
Created variable and method for storing and retrieving the gradients …

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1640,6 +1640,7 @@ void export_mints(py::module& m) {
              "Append a vector of charge tuples to a current ExternalPotential")
         .def("addBasis", &ExternalPotential::addBasis, "Add a basis of S auxiliary functions iwth Df coefficients",
              "basis"_a, "coefs"_a)
+        .def("gradient", &ExternalPotential::gradient, "Get the gradient on the embedded charges")
         .def("clear", &ExternalPotential::clear, "Reset the field to zero (eliminates all entries)")
         .def("computePotentialMatrix", &ExternalPotential::computePotentialMatrix,
              "Compute the external potential matrix in the given basis set", "basis"_a)

--- a/psi4/src/psi4/libmints/extern.h
+++ b/psi4/src/psi4/libmints/extern.h
@@ -61,6 +61,8 @@ class PSI_API ExternalPotential {
     std::vector<std::tuple<double, double, double, double> > charges_;
     /// Auxiliary basis sets (with accompanying molecules and coefs) of diffuse charges
     std::vector<std::pair<std::shared_ptr<BasisSet>, SharedVector> > bases_;
+    /// Gradient, if available, as number of charges x 3 SharedMatrix
+    SharedMatrix gradient_;
 
    public:
     /// Constructur, does nothing
@@ -100,6 +102,9 @@ class PSI_API ExternalPotential {
 
     // Compute the interaction of this potential with an external potential
     double computeExternExternInteraction(std::shared_ptr<ExternalPotential> other_extern);
+
+    /// Returns the gradient on the external potential point charges from the wfn-extern interaction
+    SharedMatrix gradient();
 
     /// Print a trace of the external potential
     void print(const std::string& out_fname = "outfile") const;


### PR DESCRIPTION
…on the external point charges of the ExternalPotential.

## Description
Provides a way to get the gradient of the potential between a Wavefunction object and an ExternalPotential object on the external point charges. These gradients are collected and stored in a protected SharedMatrix object of the ExternalPotnetial during the ExternalPotential.computePotentialGradients() routine, and they are accessible through a ExternalPotential.gradient() method which is bound to a corresponding method in the Python API.

## User API & Changelog headlines
- [ ] Given a Wavefunction object with an ExternalPotential for which a gradient call has been made, the corresponding gradient on the embedded point charges represented by the ExternalPotential can be retrieved by calling gradient() on the ExternalField

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
