### PR TITLE
Clean up leftover PRAGMA_WARNING manipulations from deboosting

### DIFF
--- a/psi4/src/psi4/detci/ciwave.cc
+++ b/psi4/src/psi4/detci/ciwave.cc
@@ -44,10 +44,7 @@
 #include "psi4/libpsio/psio.hpp"
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 
 namespace psi {
 namespace detci {

--- a/psi4/src/psi4/detci/ciwave.h
+++ b/psi4/src/psi4/detci/ciwave.h
@@ -30,10 +30,7 @@
 #define CIWAVE_H
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libmints/dimension.h"
 #include "psi4/libmints/wavefunction.h"
 

--- a/psi4/src/psi4/detci/structs.h
+++ b/psi4/src/psi4/detci/structs.h
@@ -44,10 +44,7 @@
 
 #include <string>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libmints/dimension.h"
 #include "psi4/libmints/typedefs.h"
 #include "psi4/libpsi4util/PsiOutStream.h"

--- a/psi4/src/psi4/lib3index/cholesky.cc
+++ b/psi4/src/psi4/lib3index/cholesky.cc
@@ -27,10 +27,7 @@
  */
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libqt/qt.h"
 #include <cmath>
 #include <limits>

--- a/psi4/src/psi4/libdpd/dpd.h
+++ b/psi4/src/psi4/libdpd/dpd.h
@@ -38,10 +38,7 @@
 #include "psi4/psifiles.h"
 #include "psi4/libpsio/config.h"
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include <vector>
 #include "psi4/psi4-dec.h"
 

--- a/psi4/src/psi4/libfunctional/factory.cc
+++ b/psi4/src/psi4/libfunctional/factory.cc
@@ -27,10 +27,7 @@
  */
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "functional.h"
 #include <xc.h>
 #include "psi4/psi4-dec.h"

--- a/psi4/src/psi4/libmints/basisset.h
+++ b/psi4/src/psi4/libmints/basisset.h
@@ -44,10 +44,7 @@
 #include <map>
 #include <type_traits>
 #include <algorithm>
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 
 namespace libint2 {
 struct Shell;

--- a/psi4/src/psi4/libmints/cdsalclist.h
+++ b/psi4/src/psi4/libmints/cdsalclist.h
@@ -32,10 +32,7 @@
 #include <cstdio>
 #include <vector>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libmints/typedefs.h"
 #include "psi4/libpsi4util/exception.h"
 #include "typedefs.h"

--- a/psi4/src/psi4/libmints/coordentry.h
+++ b/psi4/src/psi4/libmints/coordentry.h
@@ -34,10 +34,7 @@
 #include <cmath>
 #include "vector3.h"
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 
 #define CLEANUP_THRESH 1.0E-14
 

--- a/psi4/src/psi4/libmints/gridblock.h
+++ b/psi4/src/psi4/libmints/gridblock.h
@@ -36,10 +36,7 @@
  * Created by Robert Parrish on 04/15/2010
  */
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 
 namespace psi {
 /*! \ingroup LIBMINTS */

--- a/psi4/src/psi4/libmints/integral.h
+++ b/psi4/src/psi4/libmints/integral.h
@@ -30,10 +30,7 @@
 #define _psi_src_lib_libmints_integral_h_
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include <vector>
 
 #include "onebody.h"

--- a/psi4/src/psi4/libmints/integraliter.cc
+++ b/psi4/src/psi4/libmints/integraliter.cc
@@ -34,10 +34,7 @@
 #include "sointegral_onebody.h"
 #include "sointegral_twobody.h"
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include <algorithm>
 
     ;

--- a/psi4/src/psi4/libmints/kinetic.h
+++ b/psi4/src/psi4/libmints/kinetic.h
@@ -30,10 +30,7 @@
 #define _psi_src_lib_libmints_kinetic_h_
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include <vector>
 #include "psi4/libmints/onebody.h"
 

--- a/psi4/src/psi4/libmints/nabla.h
+++ b/psi4/src/psi4/libmints/nabla.h
@@ -30,10 +30,7 @@
 #define _psi_src_lib_libmints_nabla_h_
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libmints/onebody.h"
 
 namespace psi {

--- a/psi4/src/psi4/libmints/petitelist.h
+++ b/psi4/src/psi4/libmints/petitelist.h
@@ -37,10 +37,7 @@
 #include <cstdint>
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 
 namespace psi {
 

--- a/psi4/src/psi4/libmints/pointgrp.h
+++ b/psi4/src/psi4/libmints/pointgrp.h
@@ -90,10 +90,7 @@
 #include <map>
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 
 namespace psi {
 

--- a/psi4/src/psi4/libmints/sointegral.cc
+++ b/psi4/src/psi4/libmints/sointegral.cc
@@ -40,10 +40,7 @@
 #include "psi4/libpsi4util/process.h"
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 
 namespace psi {
 

--- a/psi4/src/psi4/libmints/tracelessquadrupole.h
+++ b/psi4/src/psi4/libmints/tracelessquadrupole.h
@@ -31,10 +31,7 @@
 
 #include <vector>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libmints/onebody.h"
 
 namespace psi {

--- a/psi4/src/psi4/libmints/writer.h
+++ b/psi4/src/psi4/libmints/writer.h
@@ -30,10 +30,7 @@
 #define WRITER_H
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libmints/vector.h"
 #include <string>
 #include "typedefs.h"

--- a/psi4/src/psi4/liboptions/print.cc
+++ b/psi4/src/psi4/liboptions/print.cc
@@ -38,10 +38,7 @@
 #include <algorithm>
 #include <cassert>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libpsi4util/libpsi4util.h"  // Needed for Ref counting, string splitting, and conversions
 #include "psi4/libpsi4util/PsiOutStream.h"

--- a/psi4/src/psi4/libpsi4util/process.h
+++ b/psi4/src/psi4/libpsi4util/process.h
@@ -32,10 +32,7 @@
 #include <string>
 #include <map>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libmints/typedefs.h"

--- a/psi4/src/psi4/libpsio/change_namespace.cc
+++ b/psi4/src/psi4/libpsio/change_namespace.cc
@@ -35,10 +35,7 @@
 #include <cstdlib>
 #include <cstring>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/psi4-dec.h"

--- a/psi4/src/psi4/libpsio/done.cc
+++ b/psi4/src/psi4/libpsio/done.cc
@@ -33,10 +33,7 @@
 
 #include <cstdlib>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 

--- a/psi4/src/psi4/libpsio/filescfg.cc
+++ b/psi4/src/psi4/libpsio/filescfg.cc
@@ -27,10 +27,7 @@
  */
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libpsi4util/libpsi4util.h"

--- a/psi4/src/psi4/libpsio/get_numvols.cc
+++ b/psi4/src/psi4/libpsio/get_numvols.cc
@@ -32,10 +32,7 @@
  */
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include <cstdio>
 #include <cstdlib>
 #include "psi4/libpsio/psio.h"

--- a/psi4/src/psi4/libpsio/init.cc
+++ b/psi4/src/psi4/libpsio/init.cc
@@ -37,10 +37,7 @@
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/psi4-dec.h"
 #include "psi4/psifiles.h"
 

--- a/psi4/src/psi4/libpsio/open_check.cc
+++ b/psi4/src/psi4/libpsio/open_check.cc
@@ -32,10 +32,7 @@
  */
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 

--- a/psi4/src/psi4/libpsio/read.cc
+++ b/psi4/src/psi4/libpsio/read.cc
@@ -34,10 +34,7 @@
 #include <cstdlib>
 #include <cstring>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 

--- a/psi4/src/psi4/libpsio/tocclean.cc
+++ b/psi4/src/psi4/libpsio/tocclean.cc
@@ -34,10 +34,7 @@
 #include <cstring>
 #include <cstdlib>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 namespace psi {

--- a/psi4/src/psi4/libpsio/tocdel.cc
+++ b/psi4/src/psi4/libpsio/tocdel.cc
@@ -35,10 +35,7 @@
 #include <unistd.h>
 #include <cstdlib>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"

--- a/psi4/src/psi4/libpsio/tocprint.cc
+++ b/psi4/src/psi4/libpsio/tocprint.cc
@@ -33,10 +33,7 @@
 
 #include <cstdio>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/psi4-dec.h"

--- a/psi4/src/psi4/libpsio/tocscan.cc
+++ b/psi4/src/psi4/libpsio/tocscan.cc
@@ -33,10 +33,7 @@
 
 #include <cstring>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 

--- a/psi4/src/psi4/libpsio/tocwrite.cc
+++ b/psi4/src/psi4/libpsio/tocwrite.cc
@@ -33,10 +33,7 @@
 
 #include <cstdlib>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 

--- a/psi4/src/psi4/libpsio/write.cc
+++ b/psi4/src/psi4/libpsio/write.cc
@@ -34,10 +34,7 @@
 #include <cstdlib>
 #include <cstring>
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 

--- a/psi4/src/psi4/libpsio/write_entry.cc
+++ b/psi4/src/psi4/libpsio/write_entry.cc
@@ -32,10 +32,7 @@
  */
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 

--- a/psi4/src/psi4/libpsio/zero_disk.cc
+++ b/psi4/src/psi4/libpsio/zero_disk.cc
@@ -32,10 +32,7 @@
  */
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 #include <string.h>

--- a/psi4/src/psi4/psimrcc/blas_diis.cc
+++ b/psi4/src/psi4/psimrcc/blas_diis.cc
@@ -30,10 +30,7 @@
 #include <cmath>
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/psifiles.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libmoinfo/libmoinfo.h"

--- a/psi4/src/psi4/psimrcc/matrix_memory_and_io.cc
+++ b/psi4/src/psi4/psimrcc/matrix_memory_and_io.cc
@@ -39,10 +39,7 @@
 
 #include "psi4/psifiles.h"
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libmoinfo/libmoinfo.h"
 #include "psi4/libpsi4util/libpsi4util.h"

--- a/psi4/src/psi4/psimrcc/mrcc_Heff.cc
+++ b/psi4/src/psi4/psimrcc/mrcc_Heff.cc
@@ -37,10 +37,7 @@
 #include "psi4/libpsi4util/process.h"
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 
 namespace psi {
 namespace psimrcc {

--- a/psi4/src/psi4/psimrcc/mrcc_pert_triples.cc
+++ b/psi4/src/psi4/psimrcc/mrcc_pert_triples.cc
@@ -40,10 +40,7 @@
 #include "psi4/libpsi4util/process.h"
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/psi4-dec.h"
 
 #include "mrcc.h"

--- a/psi4/src/psi4/psimrcc/transform_block.cc
+++ b/psi4/src/psi4/psimrcc/transform_block.cc
@@ -30,10 +30,7 @@
 #include <algorithm>
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsi4util/libpsi4util.h"
 
 #define CCTRANSFORM_USE_BLAS

--- a/psi4/src/psi4/psimrcc/transform_presort.cc
+++ b/psi4/src/psi4/psimrcc/transform_presort.cc
@@ -35,10 +35,7 @@
 #include <cstdlib>
 
 #include "psi4/pragma.h"
-PRAGMA_WARNING_PUSH
-PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS
 #include <memory>
-PRAGMA_WARNING_POP
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libiwl/iwl.h"
 #include "psi4/libmoinfo/libmoinfo.h"


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Around the time when the Boost dependency was being removed, some `PRAGMA_WARNING` manipulations were inserted, presumably to reduce warning noise during builds.
The Boost includes have since been removed and these are no longer necessary. `#include <memory>` thankfully does not require such guarding.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] No user visible changes.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Stop unnecessarily guarding `#include <memory>` with `PRAGMA_WARNING_IGNORE_DEPRECATED_DECLARATIONS` 

## Checklist
- [x] No new features
- [ ] CI tests are passing

## Status
- [x] Ready for review
- [ ] Ready for merge
