### PR TITLE
Disable cmake policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 cmake_policy(SET CMP0094 NEW)
 cmake_policy(SET CMP0075 NEW)
-cmake_policy(SET CMP0144 NEW)
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
     # Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
     cmake_policy(SET CMP0135 NEW)


### PR DESCRIPTION
## Description
Disable cmake policy CMP0144 due to limited cmake support.

## User API & Changelog headlines
- [x] Remove cmake policy CMP0144 from the main CMakeLists.txt file

## Questions
- [x] Is this policy critical? It appears not.

## Checklist
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge