### PR TITLE
Fix Python3 compatibility in vmd_cube.py

### DIFF
--- a/psi4/share/psi4/scripts/vmd_cube.py
+++ b/psi4/share/psi4/scripts/vmd_cube.py
@@ -328,7 +328,7 @@ def write_and_run_vmd_script(options,cube_files):
 
     # Define a map that contains all the values of the VMD parameters
     replacement_map = {}
-    for k,v in options.iteritems():
+    for k,v in options.items():
         key = "PARAM_" + k.upper()
         replacement_map[key] = v[0]
 


### PR DESCRIPTION
## Description

Running `vmd_cube.py` would produce an error due to the use of deprecated `.iteritems` instead of `.items`

## User API & Changelog headlines
- [x] Fix Python3 compatibility in vmd_cube.py

## Dev notes & details
- Replace `iteritems` with `items`

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
