### PR TITLE
Touch up block_matrix in libciomr

### DIFF
--- a/psi4/src/psi4/libciomr/block_matrix.cc
+++ b/psi4/src/psi4/libciomr/block_matrix.cc
@@ -84,14 +84,16 @@ PSI_API [[nodiscard]] double **block_matrix(size_t n, size_t m, bool memlock) {
     if (A == nullptr) {
         outfile->Printf("block_matrix: trouble allocating memory \n");
         outfile->Printf("n = %ld\n", n);
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Could not allocate memory in block_matrix! Tried to allocate " +
+                           std::to_string(n * sizeof(double *)) + " bytes.");
     }
 
     B = new double[n * m];
     if (B == nullptr) {
         outfile->Printf("block_matrix: trouble allocating memory \n");
         outfile->Printf("m = %ld\n", m);
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Could not allocate memory in block_matrix! Tried to allocate " +
+                           std::to_string(n * m * sizeof(double)) + " bytes.");
     }
     memset(static_cast<void *>(B), 0, m * n * sizeof(double));
 

--- a/psi4/src/psi4/libciomr/block_matrix.cc
+++ b/psi4/src/psi4/libciomr/block_matrix.cc
@@ -75,7 +75,6 @@ namespace psi {
 PSI_API [[nodiscard]] double **block_matrix(size_t n, size_t m, bool memlock) {
     double **A = nullptr;
     double *B = nullptr;
-    size_t i;
 
     if (!m || !n) return (static_cast<double **>(nullptr));
 
@@ -96,7 +95,7 @@ PSI_API [[nodiscard]] double **block_matrix(size_t n, size_t m, bool memlock) {
     }
     memset(static_cast<void *>(B), 0, m * n * sizeof(double));
 
-    for (i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++) {
         A[i] = &(B[i * m]);
     }
 

--- a/psi4/src/psi4/libciomr/block_matrix.cc
+++ b/psi4/src/psi4/libciomr/block_matrix.cc
@@ -73,7 +73,7 @@ namespace psi {
 ** \ingroup CIOMR
 */
 
-PSI_API double **block_matrix(size_t n, size_t m, bool memlock) {
+PSI_API [[nodiscard]] double **block_matrix(size_t n, size_t m, bool memlock) {
     double **A = nullptr;
     double *B = nullptr;
     size_t i;

--- a/psi4/src/psi4/libciomr/block_matrix.cc
+++ b/psi4/src/psi4/libciomr/block_matrix.cc
@@ -72,7 +72,7 @@ namespace psi {
 ** \remark Based on init_matrix() from libciomr
 ** \ingroup CIOMR
 */
-PSI_API [[nodiscard]] double **block_matrix(size_t n, size_t m, bool memlock) {
+[[nodiscard]] PSI_API double **block_matrix(size_t n, size_t m, bool memlock) {
     double **A = nullptr;
     double *B = nullptr;
 

--- a/psi4/src/psi4/libciomr/block_matrix.cc
+++ b/psi4/src/psi4/libciomr/block_matrix.cc
@@ -47,9 +47,9 @@
 namespace psi {
 
 /*!
-** block_matrix(): Allocate a 2D array of doubles using contiguous memory
+** \brief block_matrix() allocates a 2D array of doubles using contiguous memory.
 **
-** Allocates a contiguous block of memory for an array of
+** \details Allocates a contiguous block of memory for an array of
 ** doubles, allocates an array of pointers to the beginning of each row and
 ** returns the pointer to the first row pointer.  This allows transparent
 ** 2d-array style access, but keeps memory together such that the matrix
@@ -64,15 +64,14 @@ namespace psi {
 **   into physical RAM or not, and available only where _POSIX_MEMLOCK
 **   is defined. Defaults to false if not specified.
 **
-** Returns: double star pointer to newly allocated matrix
+** \return double star pointer to newly allocated matrix
 **
-** T. Daniel Crawford
-** Sometime in 1994
+** \author T. Daniel Crawford
+** \date Sometime in 1994
 **
-** Based on init_matrix() from libciomr
+** \remark Based on init_matrix() from libciomr
 ** \ingroup CIOMR
 */
-
 PSI_API [[nodiscard]] double **block_matrix(size_t n, size_t m, bool memlock) {
     double **A = nullptr;
     double *B = nullptr;
@@ -152,4 +151,4 @@ void PSI_API free_block(double **array) {
     delete[] array[0];
     delete[] array;
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libciomr/libciomr.h
+++ b/psi4/src/psi4/libciomr/libciomr.h
@@ -44,7 +44,8 @@
 
 namespace psi {
 
-PSI_API int psi_start(FILE **infile, FILE **outfile, char **psi_file_prefix, int argc, char *argv[], int overwrite_output);
+PSI_API int psi_start(FILE **infile, FILE **outfile, char **psi_file_prefix, int argc, char *argv[],
+                      int overwrite_output);
 PSI_API int psi_stop(FILE *infile, FILE *outfile, char *psi_file_prefix);
 PSI_API char *psi_ifname();
 PSI_API char *psi_ofname();

--- a/psi4/src/psi4/libciomr/libciomr.h
+++ b/psi4/src/psi4/libciomr/libciomr.h
@@ -111,7 +111,7 @@ PSI_API void print_long_int_mat(long int **a, int m, int n, std::string out);
 PSI_API size_t *init_size_t_array(int size);
 
 /* Functions in block_matrix.c */
-PSI_API double **block_matrix(size_t n, size_t m, bool mlock = false);
+PSI_API [[nodiscard]] double **block_matrix(size_t n, size_t m, bool mlock = false);
 PSI_API void free_block(double **array);
 
 /* Functions in fndcor */

--- a/psi4/src/psi4/libciomr/libciomr.h
+++ b/psi4/src/psi4/libciomr/libciomr.h
@@ -111,7 +111,7 @@ PSI_API void print_long_int_mat(long int **a, int m, int n, std::string out);
 PSI_API size_t *init_size_t_array(int size);
 
 /* Functions in block_matrix.c */
-PSI_API [[nodiscard]] double **block_matrix(size_t n, size_t m, bool mlock = false);
+[[nodiscard]] PSI_API double **block_matrix(size_t n, size_t m, bool mlock = false);
 PSI_API void free_block(double **array);
 
 /* Functions in fndcor */


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
`block_matrix` should not let its callers discard the arrays it allocates. This PR adds the `[[nodiscard]]` attribute.
Also, if an allocation fails, `block_matrix` now throws instead of calling `exit(1)` and tells the user how many bytes it has tried and failed to allocate.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] PSI_API function `double **block_matrix(size_t n, size_t m, bool mlock = false)` now has the `[[nodiscard]]` attribute, as discarding its return value is a guaranteed memory leak (unless n or m is zero, in which case no allocation happens).

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `[[nodiscard]]` attribute added to declaration and definition
- [x] `exit(PSI_RETURN_FAILURE)` replaced with `throw PSIEXCEPTION`
- [x] VScode can now parse the docstring of the function

## Checklist
- [x] No new features
- [x] All tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
