### PR TITLE
Implement fixed reference variant of DirectJK.

### DIFF
--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -741,3 +741,13 @@ Bibliography
    *J. Chem. Phys.* **154**, 064103 (2021).
    https://doi.org/10.1063/5.0040021
 
+.. [Almloef:1982:385]
+   J. Almlöf, K. Faegri Jr, and K. Korsell
+   *J. Comput. Chem.* **3**, 385 (1982).
+   https://doi.org/10.1002/jcc.540030314
+
+.. [Parrish:2016:131101]
+   R. M. Parrish, F. Liu, and T. J. Martínez
+   *J. Chem. Phys.* **144**, 131101 (2016).
+   https://doi.org/10.1063/1.4945277
+

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -837,7 +837,7 @@ of integrals that need to be calculated.
 The typical implementation of incremental Fock matrix formation
 updates the reference at every iteration. This makes the screening
 better and better as the wave function converges, because the density
-changes less and less. But, since small changes can accumulate to a
+changes between SCF iterations go to zero as convergence is approached. But, since small changes can accumulate to a
 non-negligible outcome over many iterations, this procedure is
 susceptible to creeping numerical error. For this reason, a fresh Fock
 matrix needs to be rebuilt every ``N`` iterations

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -862,7 +862,7 @@ It has the following options
 
   |scf__incfock|: Toggles incremental formation of the Fock matrix. Defaults to ``true``.
   |scf__incfock_fixed_reference|: Chooses the algorithm: use a fixed reference Fock matrix instead of updating it every iteration? Defaults to ``false``.
-  |scf__incfock_full_every|: The number of iterations between full rebuilds of the Fock matrix. Defaults to ``5``.
+  |scf__incfock_full_fock_every|: The number of iterations between full rebuilds of the Fock matrix. Defaults to ``5``.
   |scf__incfock_convergence|: The convergence threshold to turn off incremental formation of the Fock matrix. Defaults to ``1e-5``.
 
 .. _`sec:scfddfj`:

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -831,7 +831,7 @@ compute the full matrix at every iteration, only the change from a
 previously computed Fock matrix.  This behavior is toggled by the
 |scf__incfock| keyword. Because the elements in the difference density
 matrix are much smaller than the elements in the density matrix, this
-makes the screening of the integrals much tighter, reducing the number
+makes the screening of the integrals much tighter when density-based screening is used, reducing the number
 of integrals that need to be calculated.
 
 The typical implementation of incremental Fock matrix formation

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -860,10 +860,10 @@ instead of the typical algorithm discussed above, if
 
 It has the following options
 
-  |scf__incfock|: Toggles incremental formation of the Fock matrix. Defaults to ``true``.
-  |scf__incfock_fixed_reference|: Chooses the algorithm: use a fixed reference Fock matrix instead of updating it every iteration? Defaults to ``false``.
-  |scf__incfock_full_fock_every|: The number of iterations between full rebuilds of the Fock matrix. Defaults to ``5``.
-  |scf__incfock_convergence|: The convergence threshold to turn off incremental formation of the Fock matrix. Defaults to ``1e-5``.
+.. include:: autodir_options_c/scf__incfock.rst
+.. include:: autodir_options_c/scf__incfock_fixed_reference.rst
+.. include:: autodir_options_c/scf__incfock_full_fock_every.rst
+.. include:: autodir_options_c/scf__incfock_convergence.rst
 
 .. _`sec:scfddfj`:
 

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -841,7 +841,7 @@ changes between SCF iterations go to zero as convergence is approached. But, sin
 non-negligible outcome over many iterations, this procedure is
 susceptible to creeping numerical error. For this reason, a fresh Fock
 matrix needs to be rebuilt every ``N`` iterations
-(|scf__incfock_full_every|, defaults to 5). In addition, due to the
+(|scf__incfock_full_fock_every|, defaults to 5). In addition, due to the
 danger of the creepup of small errors, the iterative formation is
 turned off when a sufficiently tight convergence
 (|scf__incfock_convergence|, defaults to ``1e-5``) has been reached,

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -161,6 +161,24 @@ void DirectJK::incfock_postiter() {
             if (do_wK_) wK_ao_[jki]->add(wK_reference_[jki]);
         }
 
+        // If we do the typical algorithm, we update the references
+        // here
+        if(not fixed_reference_) {
+          D_reference_.clear();
+          for (auto const& Di : D_ao_) {
+            D_reference_.push_back(Di->clone());
+          }
+
+          J_reference_.clear();
+          K_reference_.clear();
+          wK_reference_.clear();
+          for (size_t jki = 0; jki < njk; jki++) {
+            if (do_J_) J_ao_[jki]->add(J_reference_[jki]);
+            if (do_K_) K_ao_[jki]->add(K_reference_[jki]);
+            if (do_wK_) wK_ao_[jki]->add(wK_reference_[jki]);
+          }
+        }
+
         // If we don't do incremental formation, we can update the reference
     } else {
         // Save a copy of the density for the next iteration

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -250,8 +250,8 @@ class PSI_API JK {
     std::vector<bool> input_symmetry_cast_map_;
     /// Number of ERI shell quartets computed, i.e., not screened out
     size_t num_computed_shells_;
-    /// Tally of ERI shell n-lets (triplets, quartets) computed per SCF iteration 
-    std::unordered_map<std::string, std::vector<size_t> > computed_shells_per_iter_;
+    /// Tally of ERI shell n-lets (triplets, quartets) computed per SCF iteration
+    std::unordered_map<std::string, std::vector<size_t>> computed_shells_per_iter_;
 
     // => Tasks <= //
 
@@ -350,8 +350,8 @@ class PSI_API JK {
     /// Zero out all J, K, and wK matrices
     void zero();
     /**
-    * Return number of ERI shell quartets computed during the JK build process.
-    */
+     * Return number of ERI shell quartets computed during the JK build process.
+     */
     virtual size_t num_computed_shells();
 
    public:
@@ -376,12 +376,12 @@ class PSI_API JK {
     virtual ~JK();
 
     /**
-    * Static instance constructor, used to get prebuilt DiskDFJK/DirectJK objects
-    * using knobs in options.
-    * Nmat and sym are options for GTFock
-    * sym means that all density matrices will be symmetric
-    * @return abstract JK object, tuned in with preset options
-    */
+     * Static instance constructor, used to get prebuilt DiskDFJK/DirectJK objects
+     * using knobs in options.
+     * Nmat and sym are options for GTFock
+     * sym means that all density matrices will be symmetric
+     * @return abstract JK object, tuned in with preset options
+     */
     static std::shared_ptr<JK> build_JK(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary,
                                         Options& options);
     static std::shared_ptr<JK> build_JK(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary,
@@ -437,50 +437,50 @@ class PSI_API JK {
     void set_bench(int bench) { bench_ = bench; }
     int get_bench() const { return bench_; }
     /**
-    * Set to do J tasks
-    * @param do_J do J matrices or not,
-    *        defaults to true
-    */
+     * Set to do J tasks
+     * @param do_J do J matrices or not,
+     *        defaults to true
+     */
     void set_do_J(bool do_J) { do_J_ = do_J; }
     /**
-    * Set to do K tasks
-    * @param do_K do K matrices or not,
-    *        defaults to true
-    */
+     * Set to do K tasks
+     * @param do_K do K matrices or not,
+     *        defaults to true
+     */
     virtual void set_do_K(bool do_K) { do_K_ = do_K; }
     /**
-    * Set to do wK tasks
-    * @param do_wK do wK matrices or not,
-    *        defaults to false
-    */
+     * Set to do wK tasks
+     * @param do_wK do wK matrices or not,
+     *        defaults to false
+     */
     virtual void set_do_wK(bool do_wK) { do_wK_ = do_wK; }
-    bool get_do_wK() {return do_wK_;}
+    bool get_do_wK() { return do_wK_; }
     /**
-    * Set to combine wK integral tensors
-    * @param wcombine do we combine wK matrices?
-    *        defaults to false unless MemDFJK
-    */
+     * Set to combine wK integral tensors
+     * @param wcombine do we combine wK matrices?
+     *        defaults to false unless MemDFJK
+     */
     virtual void set_wcombine(bool wcombine);
     bool get_wcombine() { return wcombine_; }
 
     /**
-    * Set the omega value for wK
-    * @param omega range-separation parameter
-    */
+     * Set the omega value for wK
+     * @param omega range-separation parameter
+     */
     void set_omega(double omega) { omega_ = omega; }
     double get_omega() { return omega_; }
 
     /**
-    * Set the alpha value for w exchange: weight for HF Term                
-    * @param omega_alpha HF-Exchange weight
-    */
+     * Set the alpha value for w exchange: weight for HF Term
+     * @param omega_alpha HF-Exchange weight
+     */
     virtual void set_omega_alpha(double alpha) { omega_alpha_ = alpha; }
-    double get_omega_alpha() {return omega_alpha_; }
+    double get_omega_alpha() { return omega_alpha_; }
 
     /**
-    * Set the beta value for w exchange: weight for dampened Term                
-    * @param omega_beta Dampened Exchange weight
-    */
+     * Set the beta value for w exchange: weight for dampened Term
+     * @param omega_beta Dampened Exchange weight
+     */
     virtual void set_omega_beta(double beta) { omega_beta_ = beta; }
     double get_omega_beta() { return omega_beta_; }
 
@@ -573,15 +573,15 @@ class PSI_API JK {
     const std::vector<SharedMatrix>& D() const { return D_; }
 
     /**
-    * Return number of ERI shell n-lets (triplets, quartets) computed per SCF iteration during the JK build process.
-    */
-    const std::unordered_map<std::string, std::vector<size_t> >& computed_shells_per_iter();
+     * Return number of ERI shell n-lets (triplets, quartets) computed per SCF iteration during the JK build process.
+     */
+    const std::unordered_map<std::string, std::vector<size_t>>& computed_shells_per_iter();
     const std::vector<size_t>& computed_shells_per_iter(const std::string& n_let);
 
     /**
-    * Print header information regarding JK
-    * type on output file
-    */
+     * Print header information regarding JK
+     * type on output file
+     */
     virtual void print_header() const = 0;
 };
 
@@ -634,9 +634,9 @@ class PSI_API DiskJK : public JK {
     // => Accessors <= //
 
     /**
-    * Print header information regarding JK
-    * type on output file
-    */
+     * Print header information regarding JK
+     * type on output file
+     */
     void print_header() const override;
 };
 
@@ -647,7 +647,6 @@ class PSI_API DiskJK : public JK {
  * integral technology
  */
 class PSI_API PKJK : public JK {
-
     std::string name() override { return "PKJK"; }
     size_t memory_estimate() override;
 
@@ -703,9 +702,9 @@ class PSI_API PKJK : public JK {
     // => Accessors <= //
 
     /**
-    * Print header information regarding JK
-    * type on output file
-    */
+     * Print header information regarding JK
+     * type on output file
+     */
     void print_header() const override;
 };
 
@@ -734,21 +733,27 @@ class PSI_API DirectJK : public JK {
     bool density_screening_;
 
     // => Incremental Fock build variables <= //
-    
+
     /// Perform Incremental Fock Build for J and K Matrices? (default false)
     bool incfock_;
+    /// Use fixed reference density and J and K matrices insted of updating them every iteration? (default false)
+    bool fixed_reference_;
     /// The number of times INCFOCK has been performed (includes resets)
     int incfock_count_;
     bool do_incfock_iter_;
+    bool update_reference_;
 
-    /// Previous iteration pseudo-density matrix
-    std::vector<SharedMatrix> D_prev_;
+    /// Reference pseudo-density matrix
+    std::vector<SharedMatrix> D_reference_;
+    /// Reference Coulomb matrix
+    std::vector<SharedMatrix> J_reference_;
+    /// Reference exchange matrix
+    std::vector<SharedMatrix> K_reference_;
+    /// Reference range-separated exchange matrix
+    std::vector<SharedMatrix> wK_reference_;
 
     /// Pseudo-density matrix to be used this iteration
-    std::vector<SharedMatrix> D_ref_;
-
-    // Is the JK currently on the first SCF iteration of this SCF cycle?
-    bool initial_iteration_ = true;
+    std::vector<SharedMatrix> D_current_;
 
     std::string name() override { return "DirectJK"; }
     size_t memory_estimate() override;
@@ -778,15 +783,15 @@ class PSI_API DirectJK : public JK {
      * @param K The list of AO K matrices to build (Same size as D, 0 if no matrices are to be built)
      */
     void build_JK_matrices(std::vector<std::shared_ptr<TwoBodyAOInt>>& ints, const std::vector<SharedMatrix>& D,
-                  std::vector<SharedMatrix>& J, std::vector<SharedMatrix>& K);
+                           std::vector<SharedMatrix>& J, std::vector<SharedMatrix>& K);
 
     /// Common initialization
     void common_init();
 
     /**
-    * Return number of ERI shell quartets computed during the JK build process.
-    */
-    size_t num_computed_shells() override; 
+     * Return number of ERI shell quartets computed during the JK build process.
+     */
+    size_t num_computed_shells() override;
 
    public:
     // => Constructors < = //
@@ -814,9 +819,9 @@ class PSI_API DirectJK : public JK {
     bool do_incfock_iter() { return do_incfock_iter_; }
 
     /**
-    * Print header information regarding JK
-    * type on output file
-    */
+     * Print header information regarding JK
+     * type on output file
+     */
     void print_header() const override;
 };
 
@@ -870,9 +875,9 @@ class GTFockJK : public JK {
      */
     GTFockJK(std::shared_ptr<psi::BasisSet> Primary, size_t NMats, bool AreSymm);
     /** \brief Your interface to GTFock that works well with libfock
-    *   GTFock needs number of densities and symmetric at initialization
-    *   This code calls GTFock once the number of densities was read from jk object
-    */
+     *   GTFock needs number of densities and symmetric at initialization
+     *   This code calls GTFock once the number of densities was read from jk object
+     */
     GTFockJK(std::shared_ptr<psi::BasisSet> Primary);
 };
 
@@ -1038,9 +1043,9 @@ class PSI_API DiskDFJK : public JK {
     // => Accessors <= //
 
     /**
-    * Print header information regarding JK
-    * type on output file
-    */
+     * Print header information regarding JK
+     * type on output file
+     */
     void print_header() const override;
 };
 /**
@@ -1074,9 +1079,9 @@ class PSI_API CDJK : public DiskDFJK {
     // => Accessors <= //
 
     /**
-    * Print header information regarding JK
-    * type on output file
-    */
+     * Print header information regarding JK
+     * type on output file
+     */
     void print_header() const override;
 
    public:
@@ -1170,17 +1175,17 @@ class PSI_API MemDFJK : public JK {
     void set_df_ints_num_threads(int val) { df_ints_num_threads_ = val; }
 
     /**
- * A set_do_wK function that affects the dfhelper object.
- * used to control wK workflow.
- */
+     * A set_do_wK function that affects the dfhelper object.
+     * used to control wK workflow.
+     */
     void set_do_wK(bool do_wK) override;
 
     // => Accessors <= //
 
     /**
-    * Print header information regarding JK
-    * type on output file
-    */
+     * Print header information regarding JK
+     * type on output file
+     */
     void print_header() const override;
 
     void set_omega_alpha(double alpha) override;
@@ -1194,7 +1199,7 @@ class PSI_API MemDFJK : public JK {
 };
 
 /**
- * Class CompositeJK 
+ * Class CompositeJK
  *
  * JK implementation framework enabling arbitrary mixing and matching
  * of separate J and K construction algorithms.
@@ -1205,7 +1210,6 @@ class PSI_API MemDFJK : public JK {
  */
 class PSI_API CompositeJK : public JK {
    protected:
-
     /// The number of threads to be used for integral computation
     int nthreads_;
     /// Options object
@@ -1223,7 +1227,7 @@ class PSI_API CompositeJK : public JK {
     bool density_screening_;
 
     // => Incremental Fock build variables <= //
-    
+
     /// Perform Incremental Fock Build for J and K Matrices? (default false)
     bool incfock_;
     /// The number of times INCFOCK has been performed (includes resets)
@@ -1238,7 +1242,7 @@ class PSI_API CompositeJK : public JK {
 
     // Is the JK currently on the first SCF iteration of this SCF cycle?
     bool initial_iteration_ = true;
-  
+
     size_t memory_estimate() override;
 
     // => Required Algorithm-Specific Methods <= //
@@ -1261,8 +1265,8 @@ class PSI_API CompositeJK : public JK {
     void common_init();
 
     /**
-    * Return number of ERI shell quartets computed during the JK build process.
-    */
+     * Return number of ERI shell quartets computed during the JK build process.
+     */
     size_t num_computed_shells() override;
 
    public:
@@ -1284,33 +1288,32 @@ class PSI_API CompositeJK : public JK {
     /**
      * Clear D_prev_
      */
-    void clear_D_prev() { D_prev_.clear();}
+    void clear_D_prev() { D_prev_.clear(); }
 
     // => Knobs <= //
     std::string name() override { return "CompositeJK"; }
 
     /**
-    * Set to do K tasks
-    * @param do_K do K matrices or not,
-    *        defaults to true
-    */
+     * Set to do K tasks
+     * @param do_K do K matrices or not,
+     *        defaults to true
+     */
     virtual void set_do_K(bool do_K) override;
 
     /**
-    * Knobs for getting and setting current COSX grid for this SCF iteration, if COSX is used
-    * throws by default, if COSX is not used
-    */
+     * Knobs for getting and setting current COSX grid for this SCF iteration, if COSX is used
+     * throws by default, if COSX is not used
+     */
     void set_COSX_grid(std::string current_grid) { return k_algo_->set_COSX_grid(current_grid); }
     std::string get_COSX_grid() { return k_algo_->get_COSX_grid(); }
 
     /**
-    * Print header information regarding JK
-    * type on output file
-    */
+     * Print header information regarding JK
+     * type on output file
+     */
     void print_header() const override;
 };
 
-}
+}  // namespace psi
 
 #endif
-

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -769,6 +769,11 @@ class PSI_API DirectJK : public JK {
     /// Delete integrals, files, etc
     void postiterations() override;
 
+    /// Add the reference contribution to the Fock matrix terms
+    void add_reference_contribution();
+    /// Update the reference terms
+    void update_reference();
+
     /// Set up Incfock variables per iteration
     void incfock_setup();
     /// Post-iteration Incfock processing

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1578,6 +1578,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("SCF_INITIAL_FINISH_DIIS_TRANSITION", 1.0E-4);
         /*- Do perform incremental Fock build? -*/
         options.add_bool("INCFOCK", false);
+        /*- Use a fixed reference in the incremental Fock build? -*/
+        options.add_bool("INCFOCK_FIXED_REFERENCE", false);
         /*- Frequency with which to compute the full Fock matrix if using |scf__incfock| . 
         N means rebuild every N SCF iterations to avoid accumulating error from the incremental procedure. -*/
         options.add_int("INCFOCK_FULL_FOCK_EVERY", 5);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,7 +42,7 @@ foreach(test_name aediis-1
                   cisd-h2o+-2 cisd-h2o-clpse cisd-opt-fd cisd-sp cisd-sp-2
                   ci-property cubeprop cubeprop-frontier decontract dct-grad1 dct-grad2
                   dct-grad3 dct-grad4 dct1 dct2 dct3 dct4 dct5 dct6 dct7 dct8 dct9
-                  dct10 dct11 dct12 ao-dfcasscf-sp density-screen-1 density-screen-2 dfcasscf-sa-sp
+                  dct10 dct11 dct12 ao-dfcasscf-sp density-screen-1 density-screen-2 density-screen-3 dfcasscf-sa-sp
                   dfcasscf-fzc-sp dfcasscf-sp dfccd1 dfccdl1 dfccd-grad1 dfccsd1 dfccsdl1 dfccsd-grad1
                   dfccsd-t-grad1
                   dfccsdt1 dfccsdat1 dfmp2-1 dfmp2-2 dfmp2-3 dfmp2-4 dfmp2-5 dfmp2-fc dfmp2-freq1 dfmp2-freq2

--- a/tests/density-screen-3/CMakeLists.txt
+++ b/tests/density-screen-3/CMakeLists.txt
@@ -1,0 +1,4 @@
+include(TestingMacros)
+
+add_regression_test(density-screen-3 "psi;dft;scf;medlong")
+set_tests_properties(density-screen-3 PROPERTIES COST 500)

--- a/tests/density-screen-3/input.dat
+++ b/tests/density-screen-3/input.dat
@@ -1,0 +1,29 @@
+ref_energy = -155.05718342486921 # TEST (CSAM Screening)
+
+molecule {
+H         -1.94154        0.37711        0.00000
+O         -1.19295       -0.22119        0.00000
+C          0.00000        0.55670        0.00000
+C          1.17015       -0.40258        0.00000
+H          0.03989        1.20005        0.88560
+H          0.03989        1.20005       -0.88560
+H          2.11312        0.14575        0.00000
+H          1.13568       -1.03910       -0.88413
+H          1.13568       -1.03910        0.88413
+}
+
+set basis cc-pVTZ
+set df_scf_guess false
+set scf_type direct
+set incfock false
+noincfock_energy = energy('wb97x')
+psi4.compare_values(ref_energy, noincfock_energy, 9, "wB97X Total Energy, No Incremental Formation")
+
+set incfock true
+set incfock_fixed_reference true
+incfock_fixed_energy = energy('wb97x')
+psi4.compare_values(ref_energy, incfock_fixed_energy, 9, "wB97X Total Energy, Incremental Formation With Fixed Reference Density")
+
+set incfock_fixed_reference false
+incfock_update_energy = energy('wb97x')
+psi4.compare_values(ref_energy, incfock_update_energy, 9, "wB97X Total Energy, Incremental Formation With Updating Reference Density")

--- a/tests/density-screen-3/output.ref
+++ b/tests/density-screen-3/output.ref
@@ -1,0 +1,990 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.10a1.dev2 
+
+                         Git: Rev {directjk_reference} 71abdab dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Saturday, 16 December 2023 07:04PM
+
+    Process ID: 1791953
+    Host:       lenovo
+    PSIDATADIR: /home/work/psi4/install/share/psi4
+    Memory:     500.0 MiB
+    Threads:    6
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+ref_energy = -155.05718342486921 # TEST (CSAM Screening)
+
+molecule {
+H         -1.94154        0.37711        0.00000
+O         -1.19295       -0.22119        0.00000
+C          0.00000        0.55670        0.00000
+C          1.17015       -0.40258        0.00000
+H          0.03989        1.20005        0.88560
+H          0.03989        1.20005       -0.88560
+H          2.11312        0.14575        0.00000
+H          1.13568       -1.03910       -0.88413
+H          1.13568       -1.03910        0.88413
+}
+
+set basis cc-pVTZ
+set df_scf_guess false
+set scf_type direct
+set incfock false
+noincfock_energy = energy('wb97x')
+psi4.compare_values(ref_energy, noincfock_energy, 9, "wB97X Total Energy, No Incremental Formation")
+
+set incfock true
+set incfock_fixed_reference true
+incfock_fixed_energy = energy('wb97x')
+psi4.compare_values(ref_energy, incfock_fixed_energy, 9, "wB97X Total Energy, Incremental Formation With Fixed Reference Density")
+
+set incfock_fixed_reference false
+incfock_update_energy = energy('wb97x')
+psi4.compare_values(ref_energy, incfock_update_energy, 9, "wB97X Total Energy, Incremental Formation With Updating Reference Density")
+--------------------------------------------------------------------------
+
+Scratch directory: /home/work/scratch/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  5, 4, 3
+    Auxiliary basis highest AM E, G, H:  6, 5, 4
+    Onebody   basis highest AM E, G, H:  6, 5, 4
+    Solid Harmonics ordering:            gaussian
+
+*** tstart() called on lenovo
+*** at Sat Dec 16 19:04:47 2023
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 5-9 entry H          line    23 file /home/work/psi4/install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2      entry O          line   262 file /home/work/psi4/install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 3-4    entry C          line   186 file /home/work/psi4/install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        6 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H           -1.887309506942     0.395291385439     0.000000000000     1.007825032230
+         O           -1.138719506942    -0.203008614561     0.000000000000    15.994914619570
+         C            0.054230493058     0.574881385439     0.000000000000    12.000000000000
+         C            1.224380493058    -0.384398614561     0.000000000000    12.000000000000
+         H            0.094120493058     1.218231385439     0.885600000000     1.007825032230
+         H            0.094120493058     1.218231385439    -0.885600000000     1.007825032230
+         H            2.167350493058     0.163931385439     0.000000000000     1.007825032230
+         H            1.189910493058    -1.020918614561    -0.884130000000     1.007825032230
+         H            1.189910493058    -1.020918614561     0.884130000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      1.17239  B =      0.31469  C =      0.27350 [cm^-1]
+  Rotational constants: A =  35147.42429  B =   9434.03450  C =   8199.45385 [MHz]
+  Nuclear repulsion =   81.947474072747198
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 26
+  Nalpha       = 13
+  Nbeta        = 13
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DIRECT.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 66
+    Number of basis functions: 174
+    Number of Cartesian functions: 195
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFT Potential <==
+
+   => LibXC <=
+
+    Version 6.2.2
+    S. Lehtola, C. Steigemann, M. J.T. Oliveira, and M. A.L. Marques.,  SoftwareX 7, 1–5 (2018) (10.1016/j.softx.2017.11.002)
+
+   => Composite Functional: WB97X <= 
+
+    wB97X Hyb-GGA Exchange-Correlation Functional
+
+    J.-D. Chai and M. Head-Gordon.,  J. Chem. Phys. 128, 084106 (2008) (10.1063/1.2834918)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange-Correlation Functionals <=
+
+    1.0000   wB97X range-separated functional
+
+   => Exact (HF) Exchange <=
+
+    0.8423            HF,LR [omega = 0.3000]
+    0.1577               HF 
+
+   => LibXC Density Thresholds  <==
+
+    XC_HYB_GGA_XC_WB97X:  1.00E-14 
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           NONE
+    Nuclear Scheme         =       TREUTLER
+
+    Blocking Scheme        =         OCTREE
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =             75
+    Spherical Points       =            302
+    Total Points           =         194261
+    Total Blocks           =           1485
+    Max Points             =            256
+    Max Functions          =            174
+    Weights Tolerance      =       1.00E-15
+
+  ==> Integral Setup <==
+
+  ==> DirectJK: Integral-Direct J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.000E-01
+    Integrals threads:           6
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
+
+  Cached 33.3% of DFT collocation blocks in 0.275 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 1.0056909791E-03.
+  Reciprocal condition number of the overlap matrix is 1.4774947254E-04.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'       108     108 
+     A"        66      66 
+   -------------------------
+    Total     174     174
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RKS iter SAD:  -154.42754183108582   -1.54428e+02   0.00000e+00 
+   @RKS iter   1:  -154.86391994816049   -4.36378e-01   5.21970e-03 DIIS/ADIIS
+   @RKS iter   2:  -154.92838625400395   -6.44663e-02   4.67734e-03 DIIS/ADIIS
+   @RKS iter   3:  -155.05513386426668   -1.26748e-01   5.52237e-04 DIIS/ADIIS
+   @RKS iter   4:  -155.05687172877546   -1.73786e-03   2.02118e-04 DIIS/ADIIS
+   @RKS iter   5:  -155.05717275619691   -3.01027e-04   3.08268e-05 DIIS
+   @RKS iter   6:  -155.05718291591813   -1.01597e-05   6.67352e-06 DIIS
+   @RKS iter   7:  -155.05718336183216   -4.45914e-07   2.56943e-06 DIIS
+   @RKS iter   8:  -155.05718342486915   -6.30370e-08   5.26261e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   Electrons on quadrature grid:
+      Ntotal   =   25.9999972195 ; deviation = -2.781e-06 
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -19.188977     2Ap   -10.301003     3Ap   -10.242903  
+       4Ap    -1.142989     5Ap    -0.877926     6Ap    -0.731877  
+       7Ap    -0.628543     1App   -0.579023     8Ap    -0.509347  
+       9Ap    -0.486546     2App   -0.470013    10Ap    -0.436388  
+       3App   -0.376738  
+
+    Virtual:                                                              
+
+      11Ap     0.122383    12Ap     0.150947    13Ap     0.183313  
+       4App    0.184355    14Ap     0.203831     5App    0.227472  
+      15Ap     0.264768    16Ap     0.284440    17Ap     0.345031  
+       6App    0.360755    18Ap     0.404871     7App    0.427378  
+      19Ap     0.463500    20Ap     0.478255     8App    0.526319  
+      21Ap     0.547810    22Ap     0.563855    23Ap     0.580467  
+       9App    0.583319    24Ap     0.590026    25Ap     0.653505  
+      10App    0.653942    26Ap     0.669658    27Ap     0.716616  
+      28Ap     0.757216    11App    0.786748    12App    0.842778  
+      29Ap     0.863201    13App    0.901498    30Ap     0.943180  
+      14App    0.998051    31Ap     1.049610    15App    1.069605  
+      32Ap     1.136104    16App    1.156621    33Ap     1.167309  
+      34Ap     1.176224    17App    1.184339    35Ap     1.197480  
+      18App    1.246247    36Ap     1.269160    37Ap     1.285519  
+      38Ap     1.311853    19App    1.337967    20App    1.382462  
+      39Ap     1.408466    40Ap     1.439655    41Ap     1.477022  
+      21App    1.479298    42Ap     1.549402    22App    1.590796  
+      43Ap     1.628382    44Ap     1.665930    45Ap     1.745987  
+      23App    1.945893    46Ap     2.049082    24App    2.090819  
+      47Ap     2.159502    48Ap     2.215422    25App    2.307250  
+      49Ap     2.389951    50Ap     2.413008    26App    2.501577  
+      51Ap     2.503372    52Ap     2.521274    53Ap     2.574120  
+      27App    2.665557    54Ap     2.673235    55Ap     2.764444  
+      56Ap     2.833358    28App    2.876549    29App    2.901764  
+      57Ap     2.949058    30App    2.969976    31App    3.031825  
+      58Ap     3.038647    32App    3.050582    59Ap     3.094782  
+      33App    3.103003    60Ap     3.119821    61Ap     3.154824  
+      34App    3.188132    35App    3.200667    62Ap     3.220698  
+      63Ap     3.233788    36App    3.323789    64Ap     3.328741  
+      37App    3.431681    38App    3.485008    65Ap     3.491567  
+      39App    3.523313    40App    3.546790    66Ap     3.560125  
+      67Ap     3.585104    41App    3.604179    68Ap     3.628438  
+      69Ap     3.671090    42App    3.727526    70Ap     3.801573  
+      43App    3.816771    71Ap     3.874440    72Ap     3.890709  
+      44App    3.924346    73Ap     3.927045    45App    3.953922  
+      74Ap     3.985736    75Ap     4.011417    46App    4.019834  
+      76Ap     4.077582    77Ap     4.129572    78Ap     4.146895  
+      47App    4.167874    48App    4.206356    79Ap     4.214190  
+      80Ap     4.219283    49App    4.228847    81Ap     4.336562  
+      50App    4.366538    51App    4.416473    82Ap     4.441609  
+      83Ap     4.469980    84Ap     4.489012    52App    4.553869  
+      85Ap     4.635034    86Ap     4.791396    87Ap     4.812958  
+      53App    4.829923    88Ap     4.927023    54App    4.941137  
+      89Ap     4.976245    55App    5.003132    90Ap     5.042964  
+      56App    5.082742    91Ap     5.139494    57App    5.301364  
+      92Ap     5.322146    93Ap     5.408634    94Ap     5.427959  
+      58App    5.446827    95Ap     5.470418    96Ap     5.501347  
+      59App    5.550664    97Ap     5.613995    60App    5.665625  
+      98Ap     5.845581    61App    5.993795    99Ap     6.018675  
+      62App    6.020630    63App    6.093281   100Ap     6.254961  
+      64App    6.604003    65App    6.772471   101Ap     6.817990  
+     102Ap     6.834819    66App    6.989693   103Ap     7.104509  
+     104Ap     7.272874   105Ap     7.528651   106Ap    11.864933  
+     107Ap    12.554075   108Ap    13.495544  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [    10,    3 ]
+    NA   [    10,    3 ]
+    NB   [    10,    3 ]
+
+  @RKS Final Energy:  -155.05718342486915
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             81.9474740727471982
+    One-Electron Energy =                -372.1771156878185138
+    Two-Electron Energy =                 150.1394072064400973
+    DFT Exchange-Correlation Energy =     -14.9669490162379191
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                       -155.0571834248691516
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         -2.6479134            2.6645381            0.0166247
+ Dipole Y            :         -0.2745708            0.8932282            0.6186575
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.6188808
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on lenovo at Sat Dec 16 19:05:32 2023
+Module time:
+	user time   =     257.37 seconds =       4.29 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =         45 seconds =       0.75 minutes
+Total time:
+	user time   =     257.37 seconds =       4.29 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =         45 seconds =       0.75 minutes
+    wB97X Total Energy, No Incremental Formation..........................................PASSED
+
+Scratch directory: /home/work/scratch/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  5, 4, 3
+    Auxiliary basis highest AM E, G, H:  6, 5, 4
+    Onebody   basis highest AM E, G, H:  6, 5, 4
+    Solid Harmonics ordering:            gaussian
+
+*** tstart() called on lenovo
+*** at Sat Dec 16 19:05:32 2023
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 5-9 entry H          line    23 file /home/work/psi4/install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2      entry O          line   262 file /home/work/psi4/install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 3-4    entry C          line   186 file /home/work/psi4/install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        6 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H           -1.887309506942     0.395291385439     0.000000000000     1.007825032230
+         O           -1.138719506942    -0.203008614561     0.000000000000    15.994914619570
+         C            0.054230493058     0.574881385439     0.000000000000    12.000000000000
+         C            1.224380493058    -0.384398614561     0.000000000000    12.000000000000
+         H            0.094120493058     1.218231385439     0.885600000000     1.007825032230
+         H            0.094120493058     1.218231385439    -0.885600000000     1.007825032230
+         H            2.167350493058     0.163931385439     0.000000000000     1.007825032230
+         H            1.189910493058    -1.020918614561    -0.884130000000     1.007825032230
+         H            1.189910493058    -1.020918614561     0.884130000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      1.17239  B =      0.31469  C =      0.27350 [cm^-1]
+  Rotational constants: A =  35147.42429  B =   9434.03450  C =   8199.45385 [MHz]
+  Nuclear repulsion =   81.947474072747198
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 26
+  Nalpha       = 13
+  Nbeta        = 13
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DIRECT.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 66
+    Number of basis functions: 174
+    Number of Cartesian functions: 195
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFT Potential <==
+
+   => LibXC <=
+
+    Version 6.2.2
+    S. Lehtola, C. Steigemann, M. J.T. Oliveira, and M. A.L. Marques.,  SoftwareX 7, 1–5 (2018) (10.1016/j.softx.2017.11.002)
+
+   => Composite Functional: WB97X <= 
+
+    wB97X Hyb-GGA Exchange-Correlation Functional
+
+    J.-D. Chai and M. Head-Gordon.,  J. Chem. Phys. 128, 084106 (2008) (10.1063/1.2834918)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange-Correlation Functionals <=
+
+    1.0000   wB97X range-separated functional
+
+   => Exact (HF) Exchange <=
+
+    0.8423            HF,LR [omega = 0.3000]
+    0.1577               HF 
+
+   => LibXC Density Thresholds  <==
+
+    XC_HYB_GGA_XC_WB97X:  1.00E-14 
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           NONE
+    Nuclear Scheme         =       TREUTLER
+
+    Blocking Scheme        =         OCTREE
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =             75
+    Spherical Points       =            302
+    Total Points           =         194261
+    Total Blocks           =           1485
+    Max Points             =            256
+    Max Functions          =            174
+    Weights Tolerance      =       1.00E-15
+
+  ==> Integral Setup <==
+
+  ==> DirectJK: Integral-Direct J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.000E-01
+    Integrals threads:           6
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:          Yes
+    Fixed reference:           Yes
+
+  Cached 33.3% of DFT collocation blocks in 0.275 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 1.0056909791E-03.
+  Reciprocal condition number of the overlap matrix is 1.4774947254E-04.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'       108     108 
+     A"        66      66 
+   -------------------------
+    Total     174     174
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RKS iter SAD:  -154.42754183108582   -1.54428e+02   0.00000e+00 
+   @RKS iter   1:  -154.86391994816097   -4.36378e-01   5.21970e-03 DIIS/ADIIS/INCFOCK
+   @RKS iter   2:  -154.92838625400429   -6.44663e-02   4.67734e-03 DIIS/ADIIS/INCFOCK
+   @RKS iter   3:  -155.05513386426708   -1.26748e-01   5.52237e-04 DIIS/ADIIS/INCFOCK
+   @RKS iter   4:  -155.05687172877572   -1.73786e-03   2.02118e-04 DIIS/ADIIS/INCFOCK
+   @RKS iter   5:  -155.05717275619719   -3.01027e-04   3.08268e-05 DIIS/INCFOCK
+   @RKS iter   6:  -155.05718291591845   -1.01597e-05   6.67352e-06 DIIS/INCFOCK
+   @RKS iter   7:  -155.05718336183261   -4.45914e-07   2.56943e-06 DIIS/INCFOCK
+   @RKS iter   8:  -155.05718342486946   -6.30369e-08   5.26261e-07 DIIS/INCFOCK
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   Electrons on quadrature grid:
+      Ntotal   =   25.9999972195 ; deviation = -2.781e-06 
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -19.188977     2Ap   -10.301003     3Ap   -10.242903  
+       4Ap    -1.142989     5Ap    -0.877926     6Ap    -0.731877  
+       7Ap    -0.628543     1App   -0.579023     8Ap    -0.509347  
+       9Ap    -0.486546     2App   -0.470013    10Ap    -0.436388  
+       3App   -0.376738  
+
+    Virtual:                                                              
+
+      11Ap     0.122383    12Ap     0.150947    13Ap     0.183313  
+       4App    0.184355    14Ap     0.203831     5App    0.227472  
+      15Ap     0.264768    16Ap     0.284440    17Ap     0.345031  
+       6App    0.360755    18Ap     0.404871     7App    0.427378  
+      19Ap     0.463500    20Ap     0.478255     8App    0.526319  
+      21Ap     0.547810    22Ap     0.563855    23Ap     0.580467  
+       9App    0.583319    24Ap     0.590026    25Ap     0.653505  
+      10App    0.653942    26Ap     0.669658    27Ap     0.716616  
+      28Ap     0.757216    11App    0.786748    12App    0.842778  
+      29Ap     0.863201    13App    0.901498    30Ap     0.943180  
+      14App    0.998051    31Ap     1.049610    15App    1.069605  
+      32Ap     1.136104    16App    1.156621    33Ap     1.167309  
+      34Ap     1.176224    17App    1.184339    35Ap     1.197480  
+      18App    1.246247    36Ap     1.269160    37Ap     1.285519  
+      38Ap     1.311853    19App    1.337967    20App    1.382462  
+      39Ap     1.408466    40Ap     1.439655    41Ap     1.477022  
+      21App    1.479298    42Ap     1.549402    22App    1.590796  
+      43Ap     1.628382    44Ap     1.665930    45Ap     1.745987  
+      23App    1.945893    46Ap     2.049082    24App    2.090819  
+      47Ap     2.159502    48Ap     2.215422    25App    2.307250  
+      49Ap     2.389951    50Ap     2.413008    26App    2.501577  
+      51Ap     2.503372    52Ap     2.521274    53Ap     2.574120  
+      27App    2.665557    54Ap     2.673235    55Ap     2.764444  
+      56Ap     2.833358    28App    2.876549    29App    2.901764  
+      57Ap     2.949058    30App    2.969976    31App    3.031825  
+      58Ap     3.038647    32App    3.050582    59Ap     3.094782  
+      33App    3.103003    60Ap     3.119821    61Ap     3.154824  
+      34App    3.188132    35App    3.200667    62Ap     3.220698  
+      63Ap     3.233788    36App    3.323789    64Ap     3.328741  
+      37App    3.431681    38App    3.485008    65Ap     3.491567  
+      39App    3.523313    40App    3.546790    66Ap     3.560125  
+      67Ap     3.585104    41App    3.604179    68Ap     3.628438  
+      69Ap     3.671090    42App    3.727526    70Ap     3.801573  
+      43App    3.816771    71Ap     3.874440    72Ap     3.890709  
+      44App    3.924346    73Ap     3.927045    45App    3.953922  
+      74Ap     3.985736    75Ap     4.011417    46App    4.019834  
+      76Ap     4.077582    77Ap     4.129572    78Ap     4.146895  
+      47App    4.167874    48App    4.206356    79Ap     4.214190  
+      80Ap     4.219283    49App    4.228847    81Ap     4.336562  
+      50App    4.366538    51App    4.416473    82Ap     4.441609  
+      83Ap     4.469980    84Ap     4.489012    52App    4.553869  
+      85Ap     4.635034    86Ap     4.791396    87Ap     4.812958  
+      53App    4.829923    88Ap     4.927023    54App    4.941137  
+      89Ap     4.976245    55App    5.003132    90Ap     5.042964  
+      56App    5.082742    91Ap     5.139494    57App    5.301364  
+      92Ap     5.322146    93Ap     5.408634    94Ap     5.427959  
+      58App    5.446827    95Ap     5.470418    96Ap     5.501347  
+      59App    5.550664    97Ap     5.613995    60App    5.665625  
+      98Ap     5.845581    61App    5.993795    99Ap     6.018675  
+      62App    6.020630    63App    6.093281   100Ap     6.254961  
+      64App    6.604003    65App    6.772471   101Ap     6.817990  
+     102Ap     6.834819    66App    6.989693   103Ap     7.104509  
+     104Ap     7.272874   105Ap     7.528651   106Ap    11.864933  
+     107Ap    12.554075   108Ap    13.495544  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [    10,    3 ]
+    NA   [    10,    3 ]
+    NB   [    10,    3 ]
+
+  @RKS Final Energy:  -155.05718342486946
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             81.9474740727471982
+    One-Electron Energy =                -372.1771156878186844
+    Two-Electron Energy =                 150.1394072064400120
+    DFT Exchange-Correlation Energy =     -14.9669490162379848
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                       -155.0571834248694643
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         -2.6479134            2.6645381            0.0166247
+ Dipole Y            :         -0.2745708            0.8932282            0.6186575
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.6188808
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on lenovo at Sat Dec 16 19:06:22 2023
+Module time:
+	user time   =     288.59 seconds =       4.81 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =         50 seconds =       0.83 minutes
+Total time:
+	user time   =     546.01 seconds =       9.10 minutes
+	system time =       0.57 seconds =       0.01 minutes
+	total time  =         95 seconds =       1.58 minutes
+    wB97X Total Energy, Incremental Formation With Fixed Reference Density................PASSED
+
+Scratch directory: /home/work/scratch/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  5, 4, 3
+    Auxiliary basis highest AM E, G, H:  6, 5, 4
+    Onebody   basis highest AM E, G, H:  6, 5, 4
+    Solid Harmonics ordering:            gaussian
+
+*** tstart() called on lenovo
+*** at Sat Dec 16 19:06:22 2023
+
+   => Loading Basis Set <=
+
+    Name: CC-PVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1, 5-9 entry H          line    23 file /home/work/psi4/install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 2      entry O          line   262 file /home/work/psi4/install/share/psi4/basis/cc-pvtz.gbs 
+    atoms 3-4    entry C          line   186 file /home/work/psi4/install/share/psi4/basis/cc-pvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RKS Reference
+                        6 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H           -1.887309506942     0.395291385439     0.000000000000     1.007825032230
+         O           -1.138719506942    -0.203008614561     0.000000000000    15.994914619570
+         C            0.054230493058     0.574881385439     0.000000000000    12.000000000000
+         C            1.224380493058    -0.384398614561     0.000000000000    12.000000000000
+         H            0.094120493058     1.218231385439     0.885600000000     1.007825032230
+         H            0.094120493058     1.218231385439    -0.885600000000     1.007825032230
+         H            2.167350493058     0.163931385439     0.000000000000     1.007825032230
+         H            1.189910493058    -1.020918614561    -0.884130000000     1.007825032230
+         H            1.189910493058    -1.020918614561     0.884130000000     1.007825032230
+
+  Running in cs symmetry.
+
+  Rotational constants: A =      1.17239  B =      0.31469  C =      0.27350 [cm^-1]
+  Rotational constants: A =  35147.42429  B =   9434.03450  C =   8199.45385 [MHz]
+  Nuclear repulsion =   81.947474072747198
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 26
+  Nalpha       = 13
+  Nbeta        = 13
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DIRECT.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVTZ
+    Blend: CC-PVTZ
+    Number of shells: 66
+    Number of basis functions: 174
+    Number of Cartesian functions: 195
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> DFT Potential <==
+
+   => LibXC <=
+
+    Version 6.2.2
+    S. Lehtola, C. Steigemann, M. J.T. Oliveira, and M. A.L. Marques.,  SoftwareX 7, 1–5 (2018) (10.1016/j.softx.2017.11.002)
+
+   => Composite Functional: WB97X <= 
+
+    wB97X Hyb-GGA Exchange-Correlation Functional
+
+    J.-D. Chai and M. Head-Gordon.,  J. Chem. Phys. 128, 084106 (2008) (10.1063/1.2834918)
+
+    Deriv               =              1
+    GGA                 =           TRUE
+    Meta                =          FALSE
+
+    Exchange Hybrid     =           TRUE
+    MP2 Hybrid          =          FALSE
+
+   => Exchange-Correlation Functionals <=
+
+    1.0000   wB97X range-separated functional
+
+   => Exact (HF) Exchange <=
+
+    0.8423            HF,LR [omega = 0.3000]
+    0.1577               HF 
+
+   => LibXC Density Thresholds  <==
+
+    XC_HYB_GGA_XC_WB97X:  1.00E-14 
+
+   => Molecular Quadrature <=
+
+    Radial Scheme          =       TREUTLER
+    Pruning Scheme         =           NONE
+    Nuclear Scheme         =       TREUTLER
+
+    Blocking Scheme        =         OCTREE
+    BS radius alpha        =              1
+    Pruning alpha          =              1
+    Radial Points          =             75
+    Spherical Points       =            302
+    Total Points           =         194261
+    Total Blocks           =           1485
+    Max Points             =            256
+    Max Functions          =            174
+    Weights Tolerance      =       1.00E-15
+
+  ==> Integral Setup <==
+
+  ==> DirectJK: Integral-Direct J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                 Yes
+    Omega:               3.000E-01
+    Integrals threads:           6
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:          Yes
+    Fixed reference:            No
+
+  Cached 33.3% of DFT collocation blocks in 0.275 [GiB].
+
+  Minimum eigenvalue in the overlap matrix is 1.0056909791E-03.
+  Reciprocal condition number of the overlap matrix is 1.4774947254E-04.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'       108     108 
+     A"        66      66 
+   -------------------------
+    Total     174     174
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RKS iter SAD:  -154.42754183108582   -1.54428e+02   0.00000e+00 
+   @RKS iter   1:  -154.86391994816088   -4.36378e-01   5.21970e-03 DIIS/ADIIS
+   @RKS iter   2:  -154.92838625400429   -6.44663e-02   4.67734e-03 DIIS/ADIIS/INCFOCK
+   @RKS iter   3:  -155.05513386426728   -1.26748e-01   5.52237e-04 DIIS/ADIIS/INCFOCK
+   @RKS iter   4:  -155.05687172877575   -1.73786e-03   2.02118e-04 DIIS/ADIIS/INCFOCK
+   @RKS iter   5:  -155.05717275619719   -3.01027e-04   3.08268e-05 DIIS/INCFOCK
+   @RKS iter   6:  -155.05718291591825   -1.01597e-05   6.67352e-06 DIIS
+   @RKS iter   7:  -155.05718336183241   -4.45914e-07   2.56943e-06 DIIS
+   @RKS iter   8:  -155.05718342486941   -6.30370e-08   5.26261e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   Electrons on quadrature grid:
+      Ntotal   =   25.9999972195 ; deviation = -2.781e-06 
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -19.188977     2Ap   -10.301003     3Ap   -10.242903  
+       4Ap    -1.142989     5Ap    -0.877926     6Ap    -0.731877  
+       7Ap    -0.628543     1App   -0.579023     8Ap    -0.509347  
+       9Ap    -0.486546     2App   -0.470013    10Ap    -0.436388  
+       3App   -0.376738  
+
+    Virtual:                                                              
+
+      11Ap     0.122383    12Ap     0.150947    13Ap     0.183313  
+       4App    0.184355    14Ap     0.203831     5App    0.227472  
+      15Ap     0.264768    16Ap     0.284440    17Ap     0.345031  
+       6App    0.360755    18Ap     0.404871     7App    0.427378  
+      19Ap     0.463500    20Ap     0.478255     8App    0.526319  
+      21Ap     0.547810    22Ap     0.563855    23Ap     0.580467  
+       9App    0.583319    24Ap     0.590026    25Ap     0.653505  
+      10App    0.653942    26Ap     0.669658    27Ap     0.716616  
+      28Ap     0.757216    11App    0.786748    12App    0.842778  
+      29Ap     0.863201    13App    0.901498    30Ap     0.943180  
+      14App    0.998051    31Ap     1.049610    15App    1.069605  
+      32Ap     1.136104    16App    1.156621    33Ap     1.167309  
+      34Ap     1.176224    17App    1.184339    35Ap     1.197480  
+      18App    1.246247    36Ap     1.269160    37Ap     1.285519  
+      38Ap     1.311853    19App    1.337967    20App    1.382462  
+      39Ap     1.408466    40Ap     1.439655    41Ap     1.477022  
+      21App    1.479298    42Ap     1.549402    22App    1.590796  
+      43Ap     1.628382    44Ap     1.665930    45Ap     1.745987  
+      23App    1.945893    46Ap     2.049082    24App    2.090819  
+      47Ap     2.159502    48Ap     2.215422    25App    2.307250  
+      49Ap     2.389951    50Ap     2.413008    26App    2.501577  
+      51Ap     2.503372    52Ap     2.521274    53Ap     2.574120  
+      27App    2.665557    54Ap     2.673235    55Ap     2.764444  
+      56Ap     2.833358    28App    2.876549    29App    2.901764  
+      57Ap     2.949058    30App    2.969976    31App    3.031825  
+      58Ap     3.038647    32App    3.050582    59Ap     3.094782  
+      33App    3.103003    60Ap     3.119821    61Ap     3.154824  
+      34App    3.188132    35App    3.200667    62Ap     3.220698  
+      63Ap     3.233788    36App    3.323789    64Ap     3.328741  
+      37App    3.431681    38App    3.485008    65Ap     3.491567  
+      39App    3.523313    40App    3.546790    66Ap     3.560125  
+      67Ap     3.585104    41App    3.604179    68Ap     3.628438  
+      69Ap     3.671090    42App    3.727526    70Ap     3.801573  
+      43App    3.816771    71Ap     3.874440    72Ap     3.890709  
+      44App    3.924346    73Ap     3.927045    45App    3.953922  
+      74Ap     3.985736    75Ap     4.011417    46App    4.019834  
+      76Ap     4.077582    77Ap     4.129572    78Ap     4.146895  
+      47App    4.167874    48App    4.206356    79Ap     4.214190  
+      80Ap     4.219283    49App    4.228847    81Ap     4.336562  
+      50App    4.366538    51App    4.416473    82Ap     4.441609  
+      83Ap     4.469980    84Ap     4.489012    52App    4.553869  
+      85Ap     4.635034    86Ap     4.791396    87Ap     4.812958  
+      53App    4.829923    88Ap     4.927023    54App    4.941137  
+      89Ap     4.976245    55App    5.003132    90Ap     5.042964  
+      56App    5.082742    91Ap     5.139494    57App    5.301364  
+      92Ap     5.322146    93Ap     5.408634    94Ap     5.427959  
+      58App    5.446827    95Ap     5.470418    96Ap     5.501347  
+      59App    5.550664    97Ap     5.613995    60App    5.665625  
+      98Ap     5.845581    61App    5.993795    99Ap     6.018675  
+      62App    6.020630    63App    6.093281   100Ap     6.254961  
+      64App    6.604003    65App    6.772471   101Ap     6.817990  
+     102Ap     6.834819    66App    6.989693   103Ap     7.104509  
+     104Ap     7.272874   105Ap     7.528651   106Ap    11.864933  
+     107Ap    12.554075   108Ap    13.495544  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [    10,    3 ]
+    NA   [    10,    3 ]
+    NB   [    10,    3 ]
+
+  @RKS Final Energy:  -155.05718342486941
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             81.9474740727471982
+    One-Electron Energy =                -372.1771156878187412
+    Two-Electron Energy =                 150.1394072064400689
+    DFT Exchange-Correlation Energy =     -14.9669490162379173
+    Empirical Dispersion Energy =           0.0000000000000000
+    VV10 Nonlocal Energy =                  0.0000000000000000
+    Total Energy =                       -155.0571834248694074
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         -2.6479134            2.6645381            0.0166247
+ Dipole Y            :         -0.2745708            0.8932282            0.6186575
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.6188808
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on lenovo at Sat Dec 16 19:07:14 2023
+Module time:
+	user time   =     294.22 seconds =       4.90 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =         52 seconds =       0.87 minutes
+Total time:
+	user time   =     840.29 seconds =      14.00 minutes
+	system time =       0.74 seconds =       0.01 minutes
+	total time  =        147 seconds =       2.45 minutes
+    wB97X Total Energy, Incremental Formation With Updating Reference Density.............PASSED
+
+    Psi4 stopped on: Saturday, 16 December 2023 07:07PM
+    Psi4 wall time for execution: 0:02:27.47
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/density-screen-3/test_input.py
+++ b/tests/density-screen-3/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("dft;scf;medlong")
+def test_density_screen_3():
+    ctest_runner(__file__)
+


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This is the variant of DirectJK I mentioned at the end of @davpoolechem's talk at PsiCon last Saturday. The idea is simple: instead of updating the reference every iteration, which is subject to creeping numerical noise, use a fixed reference density and JK matrix for all iterations.

I also simplified some of the DirectJK code, and added missing documentation.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Should full formation still happen every N iterations? I don't know if this truly is less susceptible to numerical noise accumulation...

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
