### PR TITLE
Clean up #includes, macros, unnecessary array init, error exits, and other miscellaneous things in libmoinfo

### DIFF
--- a/psi4/src/psi4/libmoinfo/model_space.cc
+++ b/psi4/src/psi4/libmoinfo/model_space.cc
@@ -31,8 +31,6 @@
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
-#include <cstdio>
-
 namespace psi {
 
 ModelSpace::ModelSpace(MOInfo* moinfo_obj_) : moinfo_obj(moinfo_obj_) {

--- a/psi4/src/psi4/libmoinfo/model_space.cc
+++ b/psi4/src/psi4/libmoinfo/model_space.cc
@@ -27,6 +27,7 @@
  */
 
 #include "model_space.h"
+#include "moinfo.h"
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"

--- a/psi4/src/psi4/libmoinfo/model_space.cc
+++ b/psi4/src/psi4/libmoinfo/model_space.cc
@@ -27,7 +27,6 @@
  */
 
 #include "model_space.h"
-#include "moinfo.h"
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"

--- a/psi4/src/psi4/libmoinfo/model_space.h
+++ b/psi4/src/psi4/libmoinfo/model_space.h
@@ -57,9 +57,6 @@ class ModelSpace {
     std::vector<int> unique_to_all;  // spin-unique  determinants
     MOInfo* moinfo_obj;
 };
-
-extern ModelSpace* model_space;
-
 }  // namespace psi
 
 #endif  // _psi_src_lib_libmoinfo_model_space_h_

--- a/psi4/src/psi4/libmoinfo/model_space.h
+++ b/psi4/src/psi4/libmoinfo/model_space.h
@@ -35,11 +35,9 @@
 */
 
 #include "slater_determinant.h"
+#include "moinfo.h"
 
 namespace psi {
-
-class MOInfo;
-
 class ModelSpace {
    public:
     ModelSpace(MOInfo* moinfo_obj_);

--- a/psi4/src/psi4/libmoinfo/model_space.h
+++ b/psi4/src/psi4/libmoinfo/model_space.h
@@ -35,9 +35,11 @@
 */
 
 #include "slater_determinant.h"
-#include "moinfo.h"
 
 namespace psi {
+
+class MOInfo;
+
 class ModelSpace {
    public:
     ModelSpace(MOInfo* moinfo_obj_);

--- a/psi4/src/psi4/libmoinfo/model_space_build.cc
+++ b/psi4/src/psi4/libmoinfo/model_space_build.cc
@@ -33,7 +33,6 @@
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libpsi4util/libpsi4util.h"
 
-#include <cstdio>
 namespace psi {
 
 void ModelSpace::build() {

--- a/psi4/src/psi4/libmoinfo/model_space_build.cc
+++ b/psi4/src/psi4/libmoinfo/model_space_build.cc
@@ -27,6 +27,7 @@
  */
 
 #include "model_space.h"
+#include "moinfo.h"
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"

--- a/psi4/src/psi4/libmoinfo/model_space_build.cc
+++ b/psi4/src/psi4/libmoinfo/model_space_build.cc
@@ -31,7 +31,7 @@
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
-#include "psi4/psifiles.h"
+#include "psi4/libpsi4util/exception.h"
 
 #include <cstdio>
 namespace psi {

--- a/psi4/src/psi4/libmoinfo/model_space_build.cc
+++ b/psi4/src/psi4/libmoinfo/model_space_build.cc
@@ -31,6 +31,7 @@
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/exception.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include <cstdio>
 namespace psi {

--- a/psi4/src/psi4/libmoinfo/model_space_build.cc
+++ b/psi4/src/psi4/libmoinfo/model_space_build.cc
@@ -27,7 +27,6 @@
  */
 
 #include "model_space.h"
-#include "moinfo.h"
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"

--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -28,7 +28,6 @@
 
 // Standard Libraries
 #include <cmath>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>

--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -141,7 +141,7 @@ void MOInfo::read_info() {
 
     auto ps = options.get_str("PARENT_SYMMETRY");
     if (ps != "") {
-        auto old_pg = std::make_shared<PointGroup> (ps);
+        auto old_pg = std::make_shared<PointGroup>(ps);
         for (int h = 0; h < nirreps; ++h) {
             std::string irr_label_str = old_pg->char_table().gamma(h).symbol_ns();
             trim_spaces(irr_label_str);
@@ -243,7 +243,7 @@ void MOInfo::read_mo_spaces() {
     // Map the symmetry of the input occupations, to account for displacements
     auto ps = options.get_str("PARENT_SYMMETRY");
     if (ps != "") {
-        auto old_pg = std::make_shared<PointGroup> (ps);
+        auto old_pg = std::make_shared<PointGroup>(ps);
         // This is one of a series of displacements;  check the dimension against the parent point group
         int nirreps_ref = old_pg->char_table().nirrep();
         intvec focc_ref;
@@ -272,7 +272,7 @@ void MOInfo::read_mo_spaces() {
         read_mo_space(nirreps_ref, nactv, actv_ref, "ACTIVE");
         read_mo_space(nirreps_ref, nfvir, fvir_ref, "FROZEN_UOCC");
 
-        auto full = std::make_shared<PointGroup> (options.get_str("PARENT_SYMMETRY"));
+        auto full = std::make_shared<PointGroup>(options.get_str("PARENT_SYMMETRY"));
         std::shared_ptr<PointGroup> sub = ref_wfn.molecule()->point_group();
         // Build the correlation table between full, and subgroup
         CorrelationTable corrtab(full, sub);

--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -40,15 +40,11 @@
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsi4util/libpsi4util.h"
-#include "psi4/psi4-dec.h"
 #include "psi4/libmints/corrtab.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/wavefunction.h"
-#include "psi4/libqt/qt.h"
-#include "psi4/psifiles.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
-#include "psi4/libpsi4util/process.h"
 
 #include "moinfo.h"
 

--- a/psi4/src/psi4/libmoinfo/moinfo.h
+++ b/psi4/src/psi4/libmoinfo/moinfo.h
@@ -36,8 +36,6 @@
 
 #include "moinfo_base.h"
 
-#define size_det 2048
-
 namespace psi {
 
 enum ReferenceType { AllRefs, UniqueRefs, ClosedShellRefs, UniqueOpenShellRefs };
@@ -74,7 +72,7 @@ class MOInfo : public MOInfoBase {
         const MOInfo* moinfo;
 
        public:
-        typedef std::bitset<size_det> bitdet;
+        typedef std::bitset<2048> bitdet;
         SlaterDeterminant(const MOInfo*);
         ~SlaterDeterminant();
         void set(int n) { bits.set(n); }

--- a/psi4/src/psi4/libmoinfo/moinfo.h
+++ b/psi4/src/psi4/libmoinfo/moinfo.h
@@ -130,7 +130,6 @@ class MOInfo : public MOInfoBase {
     int get_nocc() const { return (nocc); }
     int get_nvir() const { return (nvir); }
 
-    intvec get_sopi() const { return (sopi); }
     intvec get_mopi() const { return (mopi); }
     intvec get_docc() const { return (docc); }
     intvec get_actv() const { return (actv); }

--- a/psi4/src/psi4/libmoinfo/moinfo.h
+++ b/psi4/src/psi4/libmoinfo/moinfo.h
@@ -37,9 +37,6 @@
 #include "moinfo_base.h"
 
 namespace psi {
-
-enum ReferenceType { AllRefs, UniqueRefs, ClosedShellRefs, UniqueOpenShellRefs };
-
 class MOInfo : public MOInfoBase {
     typedef std::vector<std::string> strvec;
     typedef std::vector<std::pair<int, int> > intpairvec;
@@ -68,6 +65,7 @@ class MOInfo : public MOInfoBase {
       4) Uses
         STL vector
     *********************************************************/
+    enum ReferenceType { AllRefs, UniqueRefs, ClosedShellRefs, UniqueOpenShellRefs };
     class SlaterDeterminant {
         const MOInfo* moinfo;
 

--- a/psi4/src/psi4/libmoinfo/moinfo.h
+++ b/psi4/src/psi4/libmoinfo/moinfo.h
@@ -72,7 +72,7 @@ class MOInfo : public MOInfoBase {
         const MOInfo* moinfo;
 
        public:
-        typedef std::bitset<2048> bitdet;
+        typedef std::bitset<2048> bitdet;  // adjust based on "size det"?
         SlaterDeterminant(const MOInfo*);
         ~SlaterDeterminant();
         void set(int n) { bits.set(n); }

--- a/psi4/src/psi4/libmoinfo/moinfo.h
+++ b/psi4/src/psi4/libmoinfo/moinfo.h
@@ -139,13 +139,9 @@ class MOInfo : public MOInfoBase {
     intvec get_occ() const { return (occ); }
     intvec get_vir() const { return (vir); }
 
-    int get_sopi(int i) const { return (sopi[i]); }
-    int get_mopi(int i) const { return (mopi[i]); }
-    int get_focc(int i) const { return (focc[i]); }
-    int get_docc(int i) const { return (docc[i]); }
-    int get_actv(int i) const { return (actv[i]); }
-    int get_extr(int h) const { return (extr[h]); }
-    int get_fvir(int i) const { return (fvir[i]); }
+    int get_docc(size_t i) const { return (docc[i]); }
+    int get_actv(size_t i) const { return (actv[i]); }
+    int get_extr(size_t h) const { return (extr[h]); }
 
     // Mapping functions
     intvec get_focc_to_mo() const { return (focc_to_mo); }

--- a/psi4/src/psi4/libmoinfo/moinfo.h
+++ b/psi4/src/psi4/libmoinfo/moinfo.h
@@ -37,6 +37,9 @@
 #include "moinfo_base.h"
 
 namespace psi {
+
+enum ReferenceType { AllRefs, UniqueRefs, ClosedShellRefs, UniqueOpenShellRefs };
+
 class MOInfo : public MOInfoBase {
     typedef std::vector<std::string> strvec;
     typedef std::vector<std::pair<int, int> > intpairvec;
@@ -65,7 +68,6 @@ class MOInfo : public MOInfoBase {
       4) Uses
         STL vector
     *********************************************************/
-    enum ReferenceType { AllRefs, UniqueRefs, ClosedShellRefs, UniqueOpenShellRefs };
     class SlaterDeterminant {
         const MOInfo* moinfo;
 

--- a/psi4/src/psi4/libmoinfo/moinfo.h
+++ b/psi4/src/psi4/libmoinfo/moinfo.h
@@ -135,11 +135,9 @@ class MOInfo : public MOInfoBase {
     intvec get_docc() const { return (docc); }
     intvec get_actv() const { return (actv); }
     intvec get_focc() const { return (focc); }
-    intvec get_extr() const { return (extr); }
     intvec get_fvir() const { return (fvir); }
     intvec get_occ() const { return (occ); }
     intvec get_vir() const { return (vir); }
-    intvec get_all() const { return (all); }
 
     int get_sopi(int i) const { return (sopi[i]); }
     int get_mopi(int i) const { return (mopi[i]); }

--- a/psi4/src/psi4/libmoinfo/moinfo.h
+++ b/psi4/src/psi4/libmoinfo/moinfo.h
@@ -200,10 +200,8 @@ class MOInfo : public MOInfoBase {
     double get_sign_internal_excitation(int i, int j);
 
    private:
-    void tuning();
     void read_info();
     void read_mo_spaces();
-    void read_mo_spaces2();
     void compute_mo_mappings();
     void print_info();
     void print_mo();

--- a/psi4/src/psi4/libmoinfo/moinfo_base.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.cc
@@ -62,7 +62,6 @@ void MOInfoBase::startup() {
     wfn_sym = 0;
 
     guess_occupation = true;
-    compute_ioff();
 }
 
 void MOInfoBase::cleanup() {}
@@ -89,12 +88,6 @@ void MOInfoBase::compute_number_of_electrons() {
     if (((nel + 1 - multiplicity) % 2) != 0) throw PSIEXCEPTION("\n\n  MOInfoBase: Wrong multiplicity.\n\n");
     nael = (nel + multiplicity - 1) / 2;
     nbel = nel - nael;
-}
-
-void MOInfoBase::compute_ioff() {
-    ioff.resize(IOFF);
-    ioff[0] = 0;
-    for (size_t i = 1; i < IOFF; i++) ioff[i] = ioff[i - 1] + i;
 }
 
 void MOInfoBase::read_mo_space(int nirreps_ref, int& n, intvec& mo, std::string labels) {

--- a/psi4/src/psi4/libmoinfo/moinfo_base.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.cc
@@ -90,13 +90,13 @@ void MOInfoBase::compute_number_of_electrons() {
     nbel = nel - nael;
 }
 
-void MOInfoBase::read_mo_space(int nirreps_ref, int& n, intvec& mo, std::string labels) {
+void MOInfoBase::read_mo_space(const int nirreps_ref, int& n, intvec& mo, const std::string& labels) {
     bool read = false;
 
-    std::vector<std::string> label_vec = split(labels);
+    const std::vector<std::string> label_vec = split(labels);
     for (size_t k = 0; k < label_vec.size(); ++k) {
         // Does the array exist in the input?
-        std::string& label = label_vec[k];
+        const std::string& label = label_vec[k];
         if (!options[label].has_changed()) continue;  // The user didn't specify this, it's just the default
         int size = options[label].size();
         // Defaults is to set all to zero

--- a/psi4/src/psi4/libmoinfo/moinfo_base.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.cc
@@ -122,7 +122,7 @@ void MOInfoBase::read_mo_space(const int nirreps_ref, int& n, intvec& mo, const 
     }
 }
 
-void MOInfoBase::print_mo_space(int& n, intvec& mo, std::string labels) {
+void MOInfoBase::print_mo_space(int n, const intvec& mo, const std::string& labels) {
     outfile->Printf("\n  %s", labels.c_str());
 
     for (int i = nirreps; i < 8; i++) outfile->Printf("     ");

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -58,7 +58,7 @@ class MOInfoBase {
     intvec get_docc() const { return (docc); }
     intvec get_actv() const { return (actv); }
     bool get_guess_occupation() const { return (guess_occupation); }
-    int get_ndocc() const { return (ndocc); }
+
     int get_nactv() const { return (nactv); }
 
     int get_nael() const { return (nael); }  // # of alpha electrons including frozen

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -68,13 +68,6 @@ class MOInfoBase {
     int get_nbel() const { return (nbel); }  // # of  beta electrons including frozen
 
     double** get_scf_mos() const { return (scf); }
-    double** get_scf_mos(int i) const { return (scf_irrep[i]); }
-    double get_scf_mos(int i, int j) const {
-        if ((i < nmo) && (j < nso))
-            return (scf[i][j]);
-        else
-            return (0.0);
-    }
 
    protected:
     void read_data();

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -73,7 +73,7 @@ class MOInfoBase {
     void read_data();
     void compute_number_of_electrons();
     void correlate(char* ptgrp, int irrep, int& nirreps_old, int& nirreps_new, int*& correlation);
-    void read_mo_space(int nirreps_ref, int& n, intvec& mo, std::string labels);
+    void read_mo_space(const int nirreps_ref, int& n, intvec& mo, const std::string& labels);
     void print_mo_space(int& nmo, intvec& mo, std::string labels);
     intvec convert_int_array_to_vector(int n, const int* array);
 

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -48,7 +48,6 @@ class MOInfoBase {
 
     double get_nuclear_energy() const { return (nuclear_energy); }
 
-    std::vector<std::string> get_irr_labs() const { return (irr_labs); }
     std::string get_irr_labs(int i) const { return (irr_labs[i]); }
 
     int get_nirreps() const { return (nirreps); }

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -71,7 +71,7 @@ class MOInfoBase {
     void compute_number_of_electrons();
     void correlate(char* ptgrp, int irrep, int& nirreps_old, int& nirreps_new, int*& correlation);
     void read_mo_space(const int nirreps_ref, int& n, intvec& mo, const std::string& labels);
-    void print_mo_space(int& nmo, intvec& mo, std::string labels);
+    void print_mo_space(int nmo, const intvec& mo, const std::string& labels);
     intvec convert_int_array_to_vector(int n, const int* array);
 
     void startup();

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -36,6 +36,8 @@
 
 #include <string>
 #include <vector>
+#include "psi4/libmints/wavefunction.h"
+#include "psi4/liboptions/liboptions.h"
 
 namespace psi {
 using intvec = std::vector<int>;

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -34,13 +34,6 @@
     \brief   This class stores all the basic info regarding MOs
 */
 
-#define PSI_nullptr(args) args = nullptr;
-#define PSI_FREE(args) \
-    if (args != nullptr) free(args);
-#define PSI_DELETE(args) \
-    if (args != nullptr) delete args;
-#define PSI_DELETE_ARRAY(args) \
-    if (args != nullptr) delete[] args;
 #define IOFF 5000000
 
 #include <string>

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -36,10 +36,11 @@
 
 #include <string>
 #include <vector>
-#include "psi4/libmints/wavefunction.h"
-#include "psi4/liboptions/liboptions.h"
 
 namespace psi {
+
+class Options;
+class Wavefunction;
 using intvec = std::vector<int>;
 using boolvec = std::vector<bool>;
 

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -44,7 +44,6 @@
 #define IOFF 5000000
 
 #include <string>
-#include "psi4/libpsi4util/libpsi4util.h"
 
 typedef std::vector<int> intvec;
 typedef std::vector<bool> boolvec;

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -39,10 +39,9 @@
 #include <string>
 #include <vector>
 
-typedef std::vector<int> intvec;
-typedef std::vector<bool> boolvec;
-
 namespace psi {
+using intvec = std::vector<int>;
+using boolvec = std::vector<bool>;
 
 class Options;
 class Wavefunction;

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -44,6 +44,7 @@
 #define IOFF 5000000
 
 #include <string>
+#include <vector>
 
 typedef std::vector<int> intvec;
 typedef std::vector<bool> boolvec;

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -34,8 +34,6 @@
     \brief   This class stores all the basic info regarding MOs
 */
 
-#define IOFF 5000000
-
 #include <string>
 #include <vector>
 
@@ -59,7 +57,6 @@ class MOInfoBase {
     int get_nirreps() const { return (nirreps); }
     int get_nso() const { return (nso); }
 
-    const size_t* get_ioff() const { return (ioff.data()); }
     intvec get_sopi() const { return (sopi); }
     intvec get_docc() const { return (docc); }
     intvec get_actv() const { return (actv); }
@@ -89,7 +86,6 @@ class MOInfoBase {
 
     void startup();
     void cleanup();
-    void compute_ioff();
 
     Wavefunction& ref_wfn;
     Options& options;
@@ -107,7 +103,6 @@ class MOInfoBase {
     int nactive_ael;
     int nactive_bel;
 
-    std::vector<size_t> ioff;
     intvec sopi;
     intvec docc;
     intvec actv;

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -48,7 +48,7 @@ class MOInfoBase {
 
     double get_nuclear_energy() const { return (nuclear_energy); }
 
-    std::string get_irr_labs(int i) const { return (irr_labs[i]); }
+    std::string get_irr_lab(int i) const { return (irr_labs[i]); }
 
     int get_nirreps() const { return (nirreps); }
     int get_nso() const { return (nso); }

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -41,9 +41,6 @@ namespace psi {
 using intvec = std::vector<int>;
 using boolvec = std::vector<bool>;
 
-class Options;
-class Wavefunction;
-
 class MOInfoBase {
    public:
     MOInfoBase(Wavefunction& ref_wfn_, Options& options_, bool silent_ = false);

--- a/psi4/src/psi4/libmoinfo/moinfo_model_space.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_model_space.cc
@@ -31,7 +31,6 @@
 #include <cstdlib>
 #include <cstdio>
 
-#include "psi4/psifiles.h"
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libpsi4util/libpsi4util.h"

--- a/psi4/src/psi4/libmoinfo/moinfo_model_space.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_model_space.cc
@@ -29,7 +29,6 @@
 #include <iostream>
 #include <cmath>
 #include <cstdlib>
-#include <cstdio>
 
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/liboptions/liboptions.h"

--- a/psi4/src/psi4/libmoinfo/moinfo_scf.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_scf.cc
@@ -33,11 +33,9 @@
 
 #include "psi4/libmints/corrtab.h"
 #include "psi4/libmints/molecule.h"
-#include "psi4/libciomr/libciomr.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
-#include "psi4/libpsi4util/process.h"
 #include "psi4/libpsi4util/libpsi4util.h"
 
 #include "moinfo_scf.h"

--- a/psi4/src/psi4/libmoinfo/moinfo_scf.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_scf.cc
@@ -37,6 +37,7 @@
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include "moinfo_scf.h"
 

--- a/psi4/src/psi4/libmoinfo/moinfo_scf.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_scf.cc
@@ -91,7 +91,7 @@ void MOInfoSCF::read_mo_spaces() {
     // Map the symmetry of the input occupations, to account for displacements
     auto ps = options.get_str("PARENT_SYMMETRY");
     if (ps != "") {
-        auto old_pg = std::make_shared<PointGroup> (ps);
+        auto old_pg = std::make_shared<PointGroup>(ps);
         // This is one of a series of displacements;  check the dimension against the parent point group
         int nirreps_ref = old_pg->char_table().nirrep();
 
@@ -102,7 +102,7 @@ void MOInfoSCF::read_mo_spaces() {
         read_mo_space(nirreps_ref, nactv, actv_ref, "SOCC");
 
         // Build the correlation table between full, and subgroup
-        auto full = std::make_shared<PointGroup> (options.get_str("PARENT_SYMMETRY"));
+        auto full = std::make_shared<PointGroup>(options.get_str("PARENT_SYMMETRY"));
         std::shared_ptr<PointGroup> sub = ref_wfn.molecule()->point_group();
         CorrelationTable corrtab(full, sub);
 

--- a/psi4/src/psi4/libmoinfo/moinfo_scf.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_scf.cc
@@ -34,6 +34,7 @@
 #include "psi4/libmints/corrtab.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libciomr/libciomr.h"
+#include "psi4/libmints/wavefunction.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"

--- a/psi4/src/psi4/libmoinfo/moinfo_scf.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_scf.h
@@ -36,7 +36,6 @@
 
 #include <string>
 
-#include "psi4/libmints/wavefunction.h"
 #include "moinfo_base.h"
 
 namespace psi {

--- a/psi4/src/psi4/libmoinfo/moinfo_scf.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_scf.h
@@ -34,8 +34,6 @@
     \brief   This class stores all the basic info regarding MOs
 */
 
-#include <string>
-
 #include "moinfo_base.h"
 
 namespace psi {

--- a/psi4/src/psi4/libmoinfo/moinfo_scf.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_scf.h
@@ -50,7 +50,7 @@ class MOInfoSCF : public MOInfoBase {
     void print_mo();
 };
 
-extern MOInfoSCF* moinfo_scf;
+extern MOInfoSCF* moinfo_scf; // Unfortunate, but psi::mcscf assumes that this is declared.
 
 }  // namespace psi
 

--- a/psi4/src/psi4/libmoinfo/moinfo_scf.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_scf.h
@@ -50,7 +50,7 @@ class MOInfoSCF : public MOInfoBase {
     void print_mo();
 };
 
-extern MOInfoSCF* moinfo_scf; // Unfortunate, but psi::mcscf assumes that this is declared.
+extern MOInfoSCF* moinfo_scf;  // Unfortunate, but psi::mcscf assumes that this is declared.
 
 }  // namespace psi
 

--- a/psi4/src/psi4/mcscf/scf.cc
+++ b/psi4/src/psi4/mcscf/scf.cc
@@ -158,7 +158,7 @@ void SCF::startup() {
         outfile->Printf("\n  TWOCON MOs = [");
         for (int I = 0; I < nci; ++I)
             outfile->Printf("%d (%s)%s", tcscf_mos[I] + block_offset[tcscf_sym[I]],
-                            moinfo_scf->get_irr_labs(tcscf_sym[I]).c_str(), I != nci - 1 ? "," : "");
+                            moinfo_scf->get_irr_lab(tcscf_sym[I]).c_str(), I != nci - 1 ? "," : "");
         outfile->Printf("]");
 
         Favg.allocate("Favg", nirreps, sopi, sopi);

--- a/psi4/src/psi4/mcscf/scf_pairs.cc
+++ b/psi4/src/psi4/mcscf/scf_pairs.cc
@@ -92,7 +92,7 @@ void SCF::generate_pairs() {
     }
 
     outfile->Printf("\n\n  Generated %d pairs\n  Distributed as ", npairs);
-    for (int h = 0; h < nirreps; ++h) outfile->Printf("[%d %s]", pairpi[h], moinfo_scf->get_irr_labs(h).c_str());
+    for (int h = 0; h < nirreps; ++h) outfile->Printf("[%d %s]", pairpi[h], moinfo_scf->get_irr_lab(h).c_str());
 }
 
 }  // namespace mcscf

--- a/psi4/src/psi4/mcscf/scf_print_eigenvectors_and_MO.cc
+++ b/psi4/src/psi4/mcscf/scf_print_eigenvectors_and_MO.cc
@@ -52,13 +52,13 @@ void SCF::print_eigenvectors_and_MO() {
 
     for (int h = 0; h < nirreps; ++h)
         for (int i = 0; i < docc[h]; ++i)
-            docc_evals.push_back(std::make_pair(epsilon->get(h, i), moinfo_scf->get_irr_labs(h)));
+            docc_evals.push_back(std::make_pair(epsilon->get(h, i), moinfo_scf->get_irr_lab(h)));
     for (int h = 0; h < nirreps; ++h)
         for (int i = docc[h]; i < docc[h] + actv[h]; ++i)
-            actv_evals.push_back(std::make_pair(epsilon->get(h, i), moinfo_scf->get_irr_labs(h)));
+            actv_evals.push_back(std::make_pair(epsilon->get(h, i), moinfo_scf->get_irr_lab(h)));
     for (int h = 0; h < nirreps; ++h)
         for (int i = docc[h] + actv[h]; i < sopi[h]; ++i)
-            virt_evals.push_back(std::make_pair(epsilon->get(h, i), moinfo_scf->get_irr_labs(h)));
+            virt_evals.push_back(std::make_pair(epsilon->get(h, i), moinfo_scf->get_irr_lab(h)));
 
     sort(docc_evals.begin(), docc_evals.end());
     sort(actv_evals.begin(), actv_evals.end());

--- a/psi4/src/psi4/psimrcc/blas_algorithms.cc
+++ b/psi4/src/psi4/psimrcc/blas_algorithms.cc
@@ -27,6 +27,7 @@
  */
 
 #include "psi4/libmoinfo/libmoinfo.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 #include <cstdio>
 
 #include "blas.h"

--- a/psi4/src/psi4/psimrcc/index.cc
+++ b/psi4/src/psi4/psimrcc/index.cc
@@ -366,7 +366,7 @@ void CCIndex::print() {
     outfile->Printf("\n---------------------------------");
     int index = 0;
     for (int h = 0; h < nirreps; h++) {
-        if (tuplespi[h] > 0) outfile->Printf("\n\t%s", wfn_->moinfo()->get_irr_labs(h).c_str());
+        if (tuplespi[h] > 0) outfile->Printf("\n\t%s", wfn_->moinfo()->get_irr_lab(h).c_str());
         for (size_t tuple = 0; tuple < tuplespi[h]; ++tuple) {
             outfile->Printf("\n\t\t( ");
             for (int k = 0; k < nelements; k++) outfile->Printf("%d ", tuples[index][k]);

--- a/psi4/src/psi4/psimrcc/matrix.cc
+++ b/psi4/src/psi4/psimrcc/matrix.cc
@@ -109,8 +109,8 @@ void CCMatrix::print() {
     outfile->Printf("\n\n\t\t\t\t\t%s Matrix\n", label.c_str());
     for (int i = 0; i < nirreps; i++) {
         if (left->get_pairpi(i) * right->get_pairpi(i)) {
-            outfile->Printf("\nBlock %d (%s,%s)", i, wfn_->moinfo()->get_irr_labs(i).c_str(),
-                            wfn_->moinfo()->get_irr_labs(i).c_str());
+            outfile->Printf("\nBlock %d (%s,%s)", i, wfn_->moinfo()->get_irr_lab(i).c_str(),
+                            wfn_->moinfo()->get_irr_lab(i).c_str());
             print_dpdmatrix(i, "outfile");
         }
     }

--- a/psi4/src/psi4/psimrcc/mrcc_compute.cc
+++ b/psi4/src/psi4/psimrcc/mrcc_compute.cc
@@ -42,6 +42,7 @@
 
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libmoinfo/libmoinfo.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include "blas.h"
 #include "mrcc.h"

--- a/psi4/src/psi4/psimrcc/updater_bw.cc
+++ b/psi4/src/psi4/psimrcc/updater_bw.cc
@@ -29,7 +29,7 @@
 #include "psi4/libmoinfo/libmoinfo.h"
 //#include "mrcc.h"
 //#include "matrix.h"
-//#include "psi4/libpsi4util/libpsi4util.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include "blas.h"
 #include "heff.h"

--- a/psi4/src/psi4/psimrcc/updater_mk.cc
+++ b/psi4/src/psi4/psimrcc/updater_mk.cc
@@ -38,6 +38,7 @@
 
 #include "psi4/libmoinfo/libmoinfo.h"
 #include "psi4/liboptions/liboptions.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include "blas.h"
 #include "heff.h"


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR aims to make a lot of tiny improvements to libmoinfo.
While trying to modernize a bit of libmoinfo code to eliminate some (ab)use of the Dimension functions deprecated by PR #2953 I had to try to get at least some grip on what-does-what, but libmoinfo has accumulated some clutter which made that harder than necessary.
One thing led to another, and now this PR is here to hopefully make it easier for the next person.
Docstring addition and more are the subject of a future PR.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] No user-facing changes

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Removed a some unused macro definitions, inlined the single use of `#define size_det`
- [x] Removed `std::vector<size_t> ioff`, its getter function, and initialization from `MOInfoBase`. It looks like this 5 M element array was getting non-trivially initialized every time an `MOInfoBase` object (or one derived from it) was constructed. RAM usage of these objects should now be 40 MB lower, and their construction should be faster by an unknown amount.
- [x] Removed some class declarations, included the appropriate `.h` instead where required instead of them (Note: some of this was reverted after reviews, see discussion on this PR.)
- [x] Touched-up what-includes-what, along the lines of removing what is not required, but adding what is
- [x] Removed declarations for `tuning()` and `read_mo_spaces2()`, as they are never defined
- [x] Removed some getters from `MOInfo`, either unused or already defined in the base class.
- [x] Removed unused fn `MOInfoBase::get_irr_labs()`
- [x] Renamed `MOInfoBase::get_irr_labs(int i)` to `get_irr_lab`, as it only gets one label. Rename propagated to all of its call sites.
- [x] Removed unused fn `MOInfoBase::get_scf_mos(int i)`
- [x] Moved the `intvec` and `boolvec` typedefs from global namespace, to `namespace psi`. Also modernized them to the `using` syntax.
- [x] Removed an unused `extern ModelSpace* model_space` declaration which was cluttering `namespace psi`
- [x] <strike>Replaced `exit(PSI_RETURN_FAILURE)` and `exit(1)` with `throw PSIEXCEPTION`</strike> Obviated by PR #3118

## Checklist
- [x] No new features
- [x] Tests run by the CI were passing, but now they are failing for unclear reasons

## Status
- [x] Ready for review
- [x] Ready for merge
