### PR TITLE
Drop the default definition of a H2 molecule.

### DIFF
--- a/psi4/driver/inputparser.py
+++ b/psi4/driver/inputparser.py
@@ -746,11 +746,7 @@ def process_input(raw_input: str, print_level: int = 1) -> str:
     else:
         psirc = ''
 
-    blank_mol = 'geometry("""\n'
-    blank_mol += '0 1\nH 0 0 0\nH 0.74 0 0\n'
-    blank_mol += '""","blank_molecule_psi4_yo")\n'
-
-    temp = imports + psirc + blank_mol + temp
+    temp = imports + psirc + temp
 
     # Move up the psi4.core namespace
     for func in dir(core):

--- a/tests/pywrap-db1/input.dat
+++ b/tests/pywrap-db1/input.dat
@@ -27,4 +27,5 @@ compare_values(refS22AmadSAPT0, S22mad, 5, "S22 with S22A subset mean absolute d
 #compare_values(refNBCmadDFMP2, NBCmad, 5, "NBC subset mean absolute deviation")             #TEST
 NBCmad = database('scF','nBc10',cp='on',SYMM='OfF',subset='sMall')  #TEST
 compare_values(refNBCmadSCF, NBCmad, 5, "NBC subset mean absolute deviation")               #TEST
-compare_strings('blank_molecule_psi4_yo', psi4.get_active_molecule().name(), 'user molecule unchanged')  #TEST
+#compare_strings('blank_molecule_psi4_yo', psi4.get_active_molecule().name(), 'user molecule unchanged')  #TEST
+compare(True, psi4.get_active_molecule() is None, 'no user molecule set')  #TEST


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Closes #3115

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] The default definition for a molecule has been removed. Prior to this release, if a `molecule` had not been defined, Psi4 would run on a hydrogen molecule with bond length 0.74 Å. This change only affects Psithon input.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
