### PR TITLE
Throw PSIEXCEPTION instead of exit(1) in DPD

### DIFF
--- a/psi4/src/psi4/libdpd/block_matrix.cc
+++ b/psi4/src/psi4/libdpd/block_matrix.cc
@@ -50,7 +50,7 @@
 ** zero-priority entries remain), there is still insufficient memory
 ** available to satisfy the request, a nullptr pointer is returned to the
 ** caller, indicating that either an out-of-core algorithm must be
-** used, or the caller must exit().
+** used, or the caller must throw PSIEXCEPTION("").
 **
 ** TDC, 6/24/00
 */
@@ -64,6 +64,7 @@
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/psi4-dec.h"
+#include "psi4/libpsi4util/exception.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -120,7 +121,10 @@ double **DPD::dpd_block_matrix(size_t n, size_t m) {
     if ((A = (double **)malloc(n * sizeof(double *))) == nullptr) {
         outfile->Printf("dpd_block_matrix: trouble allocating memory \n");
         outfile->Printf("n = %zd  m = %zd\n", n, m);
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION(
+            "dpd_block_matrix: trouble allocating memory \n"
+            "n = " + std::to_string(n) + " m = " + std::to_string(n)
+        );
     }
 
     /* Allocate the main block here */

--- a/psi4/src/psi4/libdpd/buf4_mat_irrep_rd.cc
+++ b/psi4/src/psi4/libdpd/buf4_mat_irrep_rd.cc
@@ -34,6 +34,7 @@
 #include <cstdlib>
 #include "psi4/libqt/qt.h"
 #include "dpd.h"
+#include "psi4/libpsi4util/exception.h"
 
 namespace psi {
 
@@ -106,7 +107,7 @@ int DPD::buf4_mat_irrep_rd(dpdbuf4 *Buf, int irrep) {
         if (f_perm_pq && !b_perm_pq) {
             if (Buf->anti) {
                 printf("\n\tUnpack pq and antisymmetrize?\n");
-                exit(PSI_RETURN_FAILURE);
+                throw PSIEXCEPTION("Unpack pq and antisymmetrize?");
             }
             method = 21;
         } else if (!f_perm_pq && b_perm_pq) {
@@ -116,13 +117,13 @@ int DPD::buf4_mat_irrep_rd(dpdbuf4 *Buf, int irrep) {
                 method = 23;
         } else {
             printf("\n\tInvalid second-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid second-level method!");
         }
     } else if ((b_perm_pq == f_perm_pq) && (b_perm_rs != f_perm_rs) && (b_peq == f_peq)) {
         if (f_perm_rs && !b_perm_rs) {
             if (Buf->anti) {
                 printf("\n\tUnpack rs and antisymmetrize?\n");
-                exit(PSI_RETURN_FAILURE);
+                throw PSIEXCEPTION("Unpack rs and antisymmetrize?");
             }
             method = 31;
         } else if (!f_perm_rs && b_perm_rs) {
@@ -132,20 +133,20 @@ int DPD::buf4_mat_irrep_rd(dpdbuf4 *Buf, int irrep) {
                 method = 33;
         } else {
             printf("\n\tInvalid third-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid third-level method!");
         }
     } else if ((b_perm_pq != f_perm_pq) && (b_perm_rs != f_perm_rs)) {
         if (f_perm_pq && !b_perm_pq) {
             if (f_perm_rs && !b_perm_rs) {
                 if (Buf->anti) {
                     printf("\n\tUnpack pq and rs and antisymmetrize?\n");
-                    exit(PSI_RETURN_FAILURE);
+                    throw PSIEXCEPTION("Unpack pq and rs and antisymmetrize?");
                 } else
                     method = 41;
             } else if (!f_perm_rs && b_perm_rs) {
                 if (Buf->anti) {
                     printf("\n\tUnpack pq and antisymmetrize?\n");
-                    exit(PSI_RETURN_FAILURE);
+                    throw PSIEXCEPTION("Unpack pq and antisymmetrize?");
                 } else
                     method = 42;
             }
@@ -153,7 +154,7 @@ int DPD::buf4_mat_irrep_rd(dpdbuf4 *Buf, int irrep) {
             if (f_perm_rs && !b_perm_rs) {
                 if (Buf->anti) {
                     printf("\n\tUnpack rs and antisymmetrize?\n");
-                    exit(PSI_RETURN_FAILURE);
+                    throw PSIEXCEPTION("Unpack rs and antisymmetrize?");
                 } else
                     method = 43;
             } else if (!f_perm_rs && b_perm_rs) {
@@ -164,11 +165,11 @@ int DPD::buf4_mat_irrep_rd(dpdbuf4 *Buf, int irrep) {
             }
         } else {
             printf("\n\tInvalid fourth-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid fourth-level method!");
         }
     } else {
         printf("\n\tInvalid method in dpd_buf_mat_irrep_rd!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Invalid method in dpd_buf_mat_irrep_rd!");
     }
 
     switch (method) {
@@ -553,12 +554,12 @@ int DPD::buf4_mat_irrep_rd(dpdbuf4 *Buf, int irrep) {
             break;
         case 42: /* Pack pq; unpack rs */
             printf("\n\tHaven't programmed method 42 yet!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Haven't programmed method 42 yet!");
 
             break;
         case 43: /* Unpack pq; pack rs */
             printf("\n\tHaven't programmed method 43 yet!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Haven't programmed method 43 yet!");
 
             break;
         case 44: /* Pack pq; pack rs; antisymmetrize */
@@ -633,7 +634,7 @@ int DPD::buf4_mat_irrep_rd(dpdbuf4 *Buf, int irrep) {
 
                     if (filers < 0) {
                         printf("\n\tNegative colidx in method 44?\n");
-                        exit(PSI_RETURN_FAILURE);
+                        throw PSIEXCEPTION("Negative colidx in method 44?");
                     }
 
                     value = Buf->file.matrix[irrep][filerow][filers];
@@ -653,7 +654,7 @@ int DPD::buf4_mat_irrep_rd(dpdbuf4 *Buf, int irrep) {
             break;
         default: /* Error trapping */
             printf("\n\tInvalid switch case in dpd_buf_mat_irrep_rd!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid switch case in dpd_buf_mat_irrep_rd!");
             break;
     }
 

--- a/psi4/src/psi4/libdpd/buf4_mat_irrep_rd_block.cc
+++ b/psi4/src/psi4/libdpd/buf4_mat_irrep_rd_block.cc
@@ -35,6 +35,7 @@
 #include "psi4/libqt/qt.h"
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -79,7 +80,7 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
         if (f_perm_pq && !b_perm_pq) {
             if (Buf->anti) {
                 outfile->Printf("\n\tUnpack pq and antisymmetrize?\n");
-                exit(PSI_RETURN_FAILURE);
+                throw PSIEXCEPTION("Unpack pq and antisymmetrize?");
             }
             method = 21;
         } else if (!f_perm_pq && b_perm_pq) {
@@ -89,13 +90,13 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
                 method = 23;
         } else {
             outfile->Printf("\n\tInvalid second-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid second-level method!");
         }
     } else if ((b_perm_pq == f_perm_pq) && (b_perm_rs != f_perm_rs) && (b_peq == f_peq)) {
         if (f_perm_rs && !b_perm_rs) {
             if (Buf->anti) {
                 outfile->Printf("\n\tUnpack rs and antisymmetrize?\n");
-                exit(PSI_RETURN_FAILURE);
+                throw PSIEXCEPTION("Unpack rs and antisymmetrize?");
             }
             method = 31;
         } else if (!f_perm_rs && b_perm_rs) {
@@ -105,20 +106,20 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
                 method = 33;
         } else {
             outfile->Printf("\n\tInvalid third-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid third-level method!");
         }
     } else if ((b_perm_pq != f_perm_pq) && (b_perm_rs != f_perm_rs)) {
         if (f_perm_pq && !b_perm_pq) {
             if (f_perm_rs && !b_perm_rs) {
                 if (Buf->anti) {
                     outfile->Printf("\n\tUnpack pq and rs and antisymmetrize?\n");
-                    exit(PSI_RETURN_FAILURE);
+                    throw PSIEXCEPTION("Unpack pq and rs and antisymmetrize?");
                 } else
                     method = 41;
             } else if (!f_perm_rs && b_perm_rs) {
                 if (Buf->anti) {
                     outfile->Printf("\n\tUnpack pq and antisymmetrize?\n");
-                    exit(PSI_RETURN_FAILURE);
+                    throw PSIEXCEPTION("Unpack pq and antisymmetrize?");
                 } else
                     method = 42;
             }
@@ -126,7 +127,7 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
             if (f_perm_rs && !b_perm_rs) {
                 if (Buf->anti) {
                     outfile->Printf("\n\tUnpack rs and antisymmetrize?\n");
-                    exit(PSI_RETURN_FAILURE);
+                    throw PSIEXCEPTION("Unpack rs and antisymmetrize?");
                 } else
                     method = 43;
             } else if (!f_perm_rs && b_perm_rs) {
@@ -137,11 +138,11 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
             }
         } else {
             outfile->Printf("\n\tInvalid fourth-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid fourth-level method!");
         }
     } else {
         outfile->Printf("\n\tInvalid method in dpd_buf_mat_irrep_rd!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Invalid method in dpd_buf_mat_irrep_rd!");
     }
 
     switch (method) {
@@ -439,12 +440,12 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
             break;
         case 42: /* Pack pq; unpack rs */
             outfile->Printf("\n\tHaven't programmed method 42 yet!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Haven't programmed method 42 yet! (Pack pq; unpack rs)");
 
             break;
         case 43: /* Unpack pq; pack rs */
             outfile->Printf("\n\tHaven't programmed method 43 yet!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Haven't programmed method 43 yet! (Unpack pq; pack rs)");
 
             break;
         case 44: /* Pack pq; pack rs; antisymmetrize */
@@ -505,7 +506,7 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
 
                     if (filers < 0) {
                         outfile->Printf("\n\tNegative colidx in method 44?\n");
-                        exit(PSI_RETURN_FAILURE);
+                        throw PSIEXCEPTION("Negative colidx in method 44?");
                     }
 
                     value = Buf->file.matrix[irrep][filerow][filers];
@@ -521,7 +522,7 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
             break;
         default: /* Error trapping */
             outfile->Printf("\n\tInvalid switch case in dpd_buf_mat_irrep_rd!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid switch case in dpd_buf_mat_irrep_rd!");
             break;
     }
 

--- a/psi4/src/psi4/libdpd/buf4_mat_irrep_row_rd.cc
+++ b/psi4/src/psi4/libdpd/buf4_mat_irrep_row_rd.cc
@@ -35,6 +35,7 @@
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -75,7 +76,7 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
         if (f_perm_pq && !b_perm_pq) {
             if (Buf->anti) {
                 outfile->Printf("\n\tUnpack pq and antisymmetrize?\n");
-                exit(PSI_RETURN_FAILURE);
+                throw PSIEXCEPTION("Unpack pq and antisymmetrize?");
             }
             method = 21;
         } else if (!f_perm_pq && b_perm_pq) {
@@ -85,13 +86,13 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
                 method = 23;
         } else {
             outfile->Printf("\n\tInvalid second-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid second-level method!");
         }
     } else if ((b_perm_pq == f_perm_pq) && (b_perm_rs != f_perm_rs) && (b_peq == f_peq)) {
         if (f_perm_rs && !b_perm_rs) {
             if (Buf->anti) {
                 outfile->Printf("\n\tUnpack rs and antisymmetrize?\n");
-                exit(PSI_RETURN_FAILURE);
+                throw PSIEXCEPTION("Unpack rs and antisymmetrize?");
             }
             method = 31;
         } else if (!f_perm_rs && b_perm_rs) {
@@ -101,20 +102,20 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
                 method = 33;
         } else {
             outfile->Printf("\n\tInvalid third-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid third-level method!");
         }
     } else if ((b_perm_pq != f_perm_pq) && (b_perm_rs != f_perm_rs)) {
         if (f_perm_pq && !b_perm_pq) {
             if (f_perm_rs && !b_perm_rs) {
                 if (Buf->anti) {
                     outfile->Printf("\n\tUnpack pq and rs and antisymmetrize?\n");
-                    exit(PSI_RETURN_FAILURE);
+                    throw PSIEXCEPTION("Unpack pq and rs and antisymmetrize?");
                 } else
                     method = 41;
             } else if (!f_perm_rs && b_perm_rs) {
                 if (Buf->anti) {
                     outfile->Printf("\n\tUnpack pq and antisymmetrize?\n");
-                    exit(PSI_RETURN_FAILURE);
+                    throw PSIEXCEPTION("Unpack pq and antisymmetrize?");
                 } else
                     method = 42;
             }
@@ -122,7 +123,7 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
             if (f_perm_rs && !b_perm_rs) {
                 if (Buf->anti) {
                     outfile->Printf("\n\tUnpack rs and antisymmetrize?\n");
-                    exit(PSI_RETURN_FAILURE);
+                    throw PSIEXCEPTION("Unpack rs and antisymmetrize?");
                 } else
                     method = 43;
             } else if (!f_perm_rs && b_perm_rs) {
@@ -133,11 +134,11 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
             }
         } else {
             outfile->Printf("\n\tInvalid fourth-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid fourth-level method!");
         }
     } else {
         outfile->Printf("\n\tInvalid method in dpd_buf_mat_irrep_rd!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Invalid method in dpd_buf_mat_irrep_rd!");
     }
 
     switch (method) {
@@ -405,12 +406,12 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
             break;
         case 42: /* Pack pq; unpack rs */
             outfile->Printf("\n\tHaven't programmed method 42 yet!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Haven't programmed method 42 yet!");
 
             break;
         case 43: /* Unpack pq; pack rs */
             outfile->Printf("\n\tHaven't programmed method 43 yet!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Haven't programmed method 43 yet!");
 
             break;
         case 44: /* Pack pq; pack rs; antisymmetrize */
@@ -466,7 +467,7 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
 
                 if (filers < 0) {
                     outfile->Printf("\n\tNegative colidx in method 44?\n");
-                    exit(PSI_RETURN_FAILURE);
+                    throw PSIEXCEPTION("Negative colidx in method 44?");
                 }
 
                 value = Buf->file.matrix[irrep][filerow][filers];
@@ -481,7 +482,7 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
             break;
         default: /* Error trapping */
             outfile->Printf("\n\tInvalid switch case in dpd_buf_mat_irrep_rd!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid switch case in dpd_buf_mat_irrep_rd!");
             break;
     }
 

--- a/psi4/src/psi4/libdpd/buf4_mat_irrep_row_wrt.cc
+++ b/psi4/src/psi4/libdpd/buf4_mat_irrep_row_wrt.cc
@@ -34,6 +34,7 @@
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -72,7 +73,7 @@ int DPD::buf4_mat_irrep_row_wrt(dpdbuf4 *Buf, int irrep, int pq) {
     if (Buf->anti) {
         outfile->Printf("\n\tCannot write antisymmetrized buffer\n");
         outfile->Printf("\tback to original DPD file!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Cannot write antisymmetrized buffer back to original DPD file!");
     }
 
     if ((b_perm_pq == f_perm_pq) && (b_perm_rs == f_perm_rs) && (b_peq == f_peq) && (b_res == f_res))
@@ -84,7 +85,7 @@ int DPD::buf4_mat_irrep_row_wrt(dpdbuf4 *Buf, int irrep, int pq) {
             method = 23;
         else {
             outfile->Printf("\n\tInvalid second-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid second-level method!");
         }
     } else if ((b_perm_pq == f_perm_pq) && (b_perm_rs != f_perm_rs) && (b_peq == f_peq)) {
         if (f_perm_rs && !b_perm_rs)
@@ -93,7 +94,7 @@ int DPD::buf4_mat_irrep_row_wrt(dpdbuf4 *Buf, int irrep, int pq) {
             method = 33;
         else {
             outfile->Printf("\n\tInvalid third-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid third-level method!");
         }
     } else if ((b_perm_pq != f_perm_pq) && (b_perm_rs != f_perm_rs)) {
         if (f_perm_pq && !b_perm_pq) {
@@ -108,11 +109,11 @@ int DPD::buf4_mat_irrep_row_wrt(dpdbuf4 *Buf, int irrep, int pq) {
                 method = 45;
         } else {
             outfile->Printf("\n\tInvalid fourth-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid fourth-level method!");
         }
     } else {
         outfile->Printf("\n\tInvalid method in dpd_buf_mat_irrep_rd!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Invalid method in dpd_buf_mat_irrep_rd!");
     }
 
     switch (method) {
@@ -157,7 +158,7 @@ int DPD::buf4_mat_irrep_row_wrt(dpdbuf4 *Buf, int irrep, int pq) {
         case 23: /* Unpack pq; no change in rs */
             /* I don't know if I'll ever use this, so I'll avoid it for now */
             outfile->Printf("\n\tShould you be using method %d?\n", method);
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Should you be using method " + std::to_string(method) + "?");
 
             break;
         case 31: /* No change in pq; pack rs */
@@ -188,7 +189,7 @@ int DPD::buf4_mat_irrep_row_wrt(dpdbuf4 *Buf, int irrep, int pq) {
         case 33: /* No change in pq; unpack rs */
             /* I'm not sure if I'll ever need this, so I'm removing it for now */
             outfile->Printf("\n\tShould you be using method %d?\n", method);
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Should you be using method " + std::to_string(method) + "?");
 
             break;
         case 41: /* Pack pq and rs */
@@ -222,23 +223,23 @@ int DPD::buf4_mat_irrep_row_wrt(dpdbuf4 *Buf, int irrep, int pq) {
             break;
         case 42: /* Pack pq; unpack rs */
             outfile->Printf("\n\tHaven't programmed method 42 yet!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Haven't programmed method 42 yet!");
 
             break;
         case 43: /* Unpack pq; pack rs */
             outfile->Printf("\n\tHaven't programmed method 43 yet!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Haven't programmed method 43 yet!");
 
             break;
         case 45: /* Unpack pq and rs */
             /* I'm not sure if I'll ever need this, so I'm removing it for now */
             outfile->Printf("\n\tShould you be using method %d?\n", method);
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Should you be using method " + std::to_string(method) + "?");
 
             break;
         default: /* Error trapping */
             outfile->Printf("\n\tInvalid switch case in dpd_buf_mat_irrep_rd!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid switch case in dpd_buf_mat_irrep_rd!");
             break;
     }
 

--- a/psi4/src/psi4/libdpd/buf4_mat_irrep_shift13.cc
+++ b/psi4/src/psi4/libdpd/buf4_mat_irrep_shift13.cc
@@ -36,6 +36,7 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psi4-dec.h"
+#include "psi4/libpsi4util/exception.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -57,7 +58,7 @@ int DPD::buf4_mat_irrep_shift13(dpdbuf4 *Buf, int buf_block) {
 
     if (Buf->shift.shift_type) {
         outfile->Printf("\n\tShift is already on! %d\n", Buf->shift.shift_type);
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Shift is already on! " + std::to_string(Buf->shift.shift_type));
     } else
         Buf->shift.shift_type = 13;
 

--- a/psi4/src/psi4/libdpd/buf4_mat_irrep_shift31.cc
+++ b/psi4/src/psi4/libdpd/buf4_mat_irrep_shift31.cc
@@ -37,6 +37,7 @@
 #include "psi4/libqt/qt.h"
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -59,7 +60,7 @@ int DPD::buf4_mat_irrep_shift31(dpdbuf4 *Buf, int buf_block) {
 
     if (Buf->shift.shift_type) {
         outfile->Printf("\n\tShift is already on! %d\n", Buf->shift.shift_type);
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Shift is already on! " + std::to_string(Buf->shift.shift_type));
     } else
         Buf->shift.shift_type = 31;
 

--- a/psi4/src/psi4/libdpd/buf4_mat_irrep_wrt.cc
+++ b/psi4/src/psi4/libdpd/buf4_mat_irrep_wrt.cc
@@ -35,6 +35,7 @@
 #include "psi4/libqt/qt.h"
 #include "dpd.h"
 #include "psi4/psi4-dec.h"
+#include "psi4/libpsi4util/exception.h"
 namespace psi {
 
 /* dpd_buf4_mat_irrep_wrt(): Writes an entire irrep from disk into a dpd
@@ -92,7 +93,7 @@ int DPD::buf4_mat_irrep_wrt(dpdbuf4 *Buf, int irrep) {
     if (Buf->anti) {
         printf("\n\tCannot write antisymmetrized buffer\n");
         printf("\tback to original DPD file!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Cannot write antisymmetrized buffer back to original DPD file!");
     }
 
     if ((b_perm_pq == f_perm_pq) && (b_perm_rs == f_perm_rs) && (b_peq == f_peq) && (b_res == f_res))
@@ -104,7 +105,7 @@ int DPD::buf4_mat_irrep_wrt(dpdbuf4 *Buf, int irrep) {
             method = 23;
         else {
             printf("\n\tInvalid second-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid second-level method!");
         }
     } else if ((b_perm_pq == f_perm_pq) && (b_perm_rs != f_perm_rs) && (b_peq == f_peq)) {
         if (f_perm_rs && !b_perm_rs)
@@ -113,7 +114,7 @@ int DPD::buf4_mat_irrep_wrt(dpdbuf4 *Buf, int irrep) {
             method = 33;
         else {
             printf("\n\tInvalid third-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid third-level method!");
         }
     } else if ((b_perm_pq != f_perm_pq) && (b_perm_rs != f_perm_rs)) {
         if (f_perm_pq && !b_perm_pq) {
@@ -128,11 +129,11 @@ int DPD::buf4_mat_irrep_wrt(dpdbuf4 *Buf, int irrep) {
                 method = 45;
         } else {
             printf("\n\tInvalid fourth-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid fourth-level method!");
         }
     } else {
         printf("\n\tInvalid method in dpd_buf_mat_irrep_rd!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Invalid method in dpd_buf_mat_irrep_rd!");
     }
 
     switch (method) {
@@ -192,7 +193,7 @@ int DPD::buf4_mat_irrep_wrt(dpdbuf4 *Buf, int irrep) {
         case 23: /* Unpack pq; no change in rs */
             /* I don't know if I'll ever use this, so I'll avoid it for now */
             printf("\n\tShould you be using method %d?\n", method);
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Should you be using method " + std::to_string(method) + "?");
             /* Prepare the output buffer for the output DPD file */
             file4_mat_irrep_row_init(&(Buf->file), irrep);
 
@@ -258,7 +259,7 @@ int DPD::buf4_mat_irrep_wrt(dpdbuf4 *Buf, int irrep) {
         case 33: /* No change in pq; unpack rs */
             /* I'm not sure if I'll ever need this, so I'm removing it for now */
             printf("\n\tShould you be using method %d?\n", method);
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Should you be using method " + std::to_string(method) + "?");
             /* Prepare the output buffer for the output DPD file */
             file4_mat_irrep_row_init(&(Buf->file), irrep);
 
@@ -322,18 +323,18 @@ int DPD::buf4_mat_irrep_wrt(dpdbuf4 *Buf, int irrep) {
             break;
         case 42: /* Pack pq; unpack rs */
             printf("\n\tHaven't programmed method 42 yet!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Haven't programmed method 42 yet!");
 
             break;
         case 43: /* Unpack pq; pack rs */
             printf("\n\tHaven't programmed method 43 yet!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Haven't programmed method 43 yet!");
 
             break;
         case 45: /* Unpack pq and rs */
             /* I'm not sure if I'll ever need this, so I'm removing it for now */
             printf("\n\tShould you be using method %d?\n", method);
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Should you be using method " + std::to_string(method) + "?");
             /* Prepare the output buffer for the output DPD file */
             file4_mat_irrep_row_init(&(Buf->file), irrep);
 
@@ -367,7 +368,7 @@ int DPD::buf4_mat_irrep_wrt(dpdbuf4 *Buf, int irrep) {
             break;
         default: /* Error trapping */
             printf("\n\tInvalid switch case in dpd_buf_mat_irrep_rd!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid switch case in dpd_buf_mat_irrep_rd!");
             break;
     }
 

--- a/psi4/src/psi4/libdpd/buf4_mat_irrep_wrt_block.cc
+++ b/psi4/src/psi4/libdpd/buf4_mat_irrep_wrt_block.cc
@@ -35,6 +35,7 @@
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -72,7 +73,7 @@ int DPD::buf4_mat_irrep_wrt_block(dpdbuf4 *Buf, int irrep, int start_pq, int num
     if (Buf->anti) {
         outfile->Printf("\n\tCannot write antisymmetrized buffer\n");
         outfile->Printf("\tback to original DPD file!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Cannot write antisymmetrized buffer back to original DPD file!");
     }
 
     if ((b_perm_pq == f_perm_pq) && (b_perm_rs == f_perm_rs) && (b_peq == f_peq) && (b_res == f_res))
@@ -84,7 +85,7 @@ int DPD::buf4_mat_irrep_wrt_block(dpdbuf4 *Buf, int irrep, int start_pq, int num
             method = 23;
         else {
             outfile->Printf("\n\tInvalid second-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid second-level method!");
         }
     } else if ((b_perm_pq == f_perm_pq) && (b_perm_rs != f_perm_rs) && (b_peq == f_peq)) {
         if (f_perm_rs && !b_perm_rs)
@@ -93,7 +94,7 @@ int DPD::buf4_mat_irrep_wrt_block(dpdbuf4 *Buf, int irrep, int start_pq, int num
             method = 33;
         else {
             outfile->Printf("\n\tInvalid third-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid third-level method!");
         }
     } else if ((b_perm_pq != f_perm_pq) && (b_perm_rs != f_perm_rs)) {
         if (f_perm_pq && !b_perm_pq) {
@@ -108,11 +109,11 @@ int DPD::buf4_mat_irrep_wrt_block(dpdbuf4 *Buf, int irrep, int start_pq, int num
                 method = 45;
         } else {
             outfile->Printf("\n\tInvalid fourth-level method!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid fourth-level method!");
         }
     } else {
         outfile->Printf("\n\tInvalid method in dpd_buf_mat_irrep_rd!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Invalid method in dpd_buf_mat_irrep_rd!");
     }
 
     switch (method) {
@@ -162,7 +163,7 @@ int DPD::buf4_mat_irrep_wrt_block(dpdbuf4 *Buf, int irrep, int start_pq, int num
         case 23: /* Unpack pq; no change in rs */
             /* I don't know if I'll ever use this, so I'll avoid it for now */
             outfile->Printf("\n\tShould you be using method %d?\n", method);
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Should you be using method " + std::to_string(method) + "?");
             break;
         case 31: /* No change in pq; pack rs */
             /* Prepare the output buffer for the output DPD file */
@@ -197,31 +198,31 @@ int DPD::buf4_mat_irrep_wrt_block(dpdbuf4 *Buf, int irrep, int start_pq, int num
         case 33: /* No change in pq; unpack rs */
             /* I'm not sure if I'll ever need this, so I'm removing it for now */
             outfile->Printf("\n\tShould you be using method %d?\n", method);
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Should you be using method " + std::to_string(method) + "?");
             break;
         case 41: /* Pack pq and rs */
             /* shouldn't use this for block wrt */
             outfile->Printf("\n\tShould you be using method %d?\n", method);
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Should you be using method " + std::to_string(method) + "?");
             break;
         case 42: /* Pack pq; unpack rs */
             outfile->Printf("\n\tHaven't programmed method 42 yet!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Haven't programmed method 42 yet!");
 
             break;
         case 43: /* Unpack pq; pack rs */
             outfile->Printf("\n\tHaven't programmed method 43 yet!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Haven't programmed method 43 yet!");
 
             break;
         case 45: /* Unpack pq and rs */
             /* I'm not sure if I'll ever need this, so I'm removing it for now */
             outfile->Printf("\n\tShould you be using method %d?\n", method);
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Should you be using method " + std::to_string(method) + "?");
             break;
         default: /* Error trapping */
             outfile->Printf("\n\tInvalid switch case in dpd_buf_mat_irrep_rd!\n");
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Invalid switch case in dpd_buf_mat_irrep_rd!");
             break;
     }
 

--- a/psi4/src/psi4/libdpd/cc3_sigma_RHF.cc
+++ b/psi4/src/psi4/libdpd/cc3_sigma_RHF.cc
@@ -40,6 +40,7 @@
 #include "psi4/psifiles.h"
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
 namespace psi {
 
 /*
@@ -106,7 +107,7 @@ void DPD::cc3_sigma_RHF(dpdbuf4 *CIjAb, dpdbuf4 *WAbEi, dpdbuf4 *WMbIj, int do_s
     GS = SIjAb->file.my_irrep;
     if (GS != (GX3 ^ GW)) {
         outfile->Printf("problem with irreps in cc3_sigma_RHF()\n");
-        exit(1);
+        throw PSIEXCEPTION("problem with irreps in cc3_sigma_RHF()");
     }
     if (do_singles) {
         file2_init(&SIA_inc, PSIF_CC_TMP0, GS, 0, 1, "CC3 SIA"); /* T3->S1 increment */

--- a/psi4/src/psi4/libdpd/cc3_sigma_RHF_ic.cc
+++ b/psi4/src/psi4/libdpd/cc3_sigma_RHF_ic.cc
@@ -44,6 +44,7 @@
 #include "dpd.h"
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
 // MKL Header
 #ifdef USING_LAPACK_MKL
 #include <mkl.h>
@@ -117,7 +118,7 @@ void DPD::cc3_sigma_RHF_ic(dpdbuf4 *CIjAb, dpdbuf4 *WAbEi, dpdbuf4 *WMbIj, int d
     GS = SIjAb->file.my_irrep;
     if (GS != (GX3 ^ GW)) {
         outfile->Printf("problem with irreps in cc3_sigma_RHF()\n");
-        exit(1);
+        throw PSIEXCEPTION("problem with irreps in cc3_sigma_RHF()");
     }
 
     if (do_singles) {

--- a/psi4/src/psi4/libdpd/contract222.cc
+++ b/psi4/src/psi4/libdpd/contract222.cc
@@ -37,6 +37,7 @@
 #include "dpd.h"
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
 namespace psi {
 
 /* dpd_contract222(): Contracts a pair of two-index quantities to
@@ -88,7 +89,7 @@ int DPD::contract222(dpdfile2 *X, dpdfile2 *Y, dpdfile2 *Z, int target_X, int ta
         symlink = 0;
     } else {
         outfile->Printf("Junk X index %d in contract222\n", target_X);
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Junk X index " + std::to_string(target_X) + " in contract222");
     }
     if (target_Y == 0)
         Ytrans = 1;
@@ -96,7 +97,7 @@ int DPD::contract222(dpdfile2 *X, dpdfile2 *Y, dpdfile2 *Z, int target_X, int ta
         Ytrans = 0;
     else {
         outfile->Printf("Junk Y index %d in contract222\n", target_Y);
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Junk Y index " + std::to_string(target_Y) + " in contract222");
     }
 
 #ifdef DPD_DEBUG

--- a/psi4/src/psi4/libdpd/contract244.cc
+++ b/psi4/src/psi4/libdpd/contract244.cc
@@ -36,6 +36,7 @@
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "dpd.h"
+#include "psi4/libpsi4util/exception.h"
 
 namespace psi {
 
@@ -97,7 +98,7 @@ int DPD::contract244(dpdfile2 *X, dpdbuf4 *Y, dpdbuf4 *Z, int sum_X, int sum_Y, 
         symlink = GX;
     } else {
         outfile->Printf("Junk X index %d\n", sum_X);
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Junk X index " + std::to_string(sum_X));
     }
 
     if ((sum_Y == 1) || (sum_Y == 2)) trans4_init(&Yt, Y);

--- a/psi4/src/psi4/libdpd/contract424.cc
+++ b/psi4/src/psi4/libdpd/contract424.cc
@@ -36,6 +36,7 @@
 #include "psi4/libqt/qt.h"
 #include "dpd.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
 
 namespace psi {
 
@@ -95,7 +96,7 @@ int DPD::contract424(dpdbuf4 *X, dpdfile2 *Y, dpdbuf4 *Z, int sum_X, int sum_Y, 
         symlink = GY;
     } else {
         outfile->Printf("Junk Y index %d\n", sum_Y);
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Junk Y index " + std::to_string(sum_Y));
     }
 
     if ((sum_X == 1) || (sum_X == 2)) trans4_init(&Xt, X);

--- a/psi4/src/psi4/libdpd/contract442.cc
+++ b/psi4/src/psi4/libdpd/contract442.cc
@@ -36,6 +36,7 @@
 #include "psi4/libqt/qt.h"
 #include "dpd.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
 
 namespace psi {
 
@@ -145,7 +146,7 @@ int DPD::contract442(dpdbuf4 *X, dpdbuf4 *Y, dpdfile2 *Z, int target_X, int targ
 #endif
         } else {
             outfile->Printf("Junk X index %d in dpd_contract442\n", target_X);
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Junk X index " + std::to_string(target_X) + " in dpd_contract442");
         }
 
         /* read in appropriate block of Y buffer */
@@ -211,7 +212,7 @@ int DPD::contract442(dpdbuf4 *X, dpdbuf4 *Y, dpdfile2 *Z, int target_X, int targ
 #endif
         } else {
             outfile->Printf("Junk Y index %d in contract442\n", target_Y);
-            exit(PSI_RETURN_FAILURE);
+            throw PSIEXCEPTION("Junk Y index " + std::to_string(target_Y) + " in contract442");
         }
 
         if (rking)

--- a/psi4/src/psi4/libdpd/error.cc
+++ b/psi4/src/psi4/libdpd/error.cc
@@ -34,13 +34,15 @@
 #include <cstdlib>
 #include "dpd.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
+
 namespace psi {
 
 void DPD::dpd_error(const char *caller, std::string out) {
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
     printer->Printf("Error in: %s\n", caller);
     dpd_close(dpd_default);
-    exit(PSI_RETURN_FAILURE);
+    throw PSIEXCEPTION("Error in: " + std::string(caller));
 }
 
 }  // namespace psi

--- a/psi4/src/psi4/libdpd/init.cc
+++ b/psi4/src/psi4/libdpd/init.cc
@@ -334,7 +334,7 @@ int DPD::init(int dpd_num_in, int nirreps_in, long int memory_in, int cachetype_
     /* Temporary check until I'm sure I'm doing this right */
     if (num_pairs != cnt) {
         printf("Error in dpd_init()!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Error in dpd_init()!");
     }
 
     /* Build the row/column index lookup arrays */
@@ -550,7 +550,7 @@ int DPD::init(int dpd_num_in, int nirreps_in, long int memory_in, int cachetype_
     /* Temporary check until I'm sure I'm doing this right */
     if (num_pairs != cnt) {
         printf("Error in dpd_init()!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Error in dpd_init()!");
     }
 
     /* Now generate the global list of DPD parameters */

--- a/psi4/src/psi4/libdpd/trans4_mat_irrep_shift13.cc
+++ b/psi4/src/psi4/libdpd/trans4_mat_irrep_shift13.cc
@@ -36,6 +36,7 @@
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "dpd.h"
+#include "psi4/libpsi4util/exception.h"
 
 namespace psi {
 
@@ -56,7 +57,7 @@ int DPD::trans4_mat_irrep_shift13(dpdtrans4 *Trans, int buf_block) {
 
     if (Trans->shift.shift_type) {
         outfile->Printf("\n\tShift is already on! %d\n", Trans->shift.shift_type);
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Shift is already on! " + std::to_string(Trans->shift.shift_type));
     } else
         Trans->shift.shift_type = 13;
 

--- a/psi4/src/psi4/libdpd/trans4_mat_irrep_shift31.cc
+++ b/psi4/src/psi4/libdpd/trans4_mat_irrep_shift31.cc
@@ -36,6 +36,7 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libqt/qt.h"
 #include "dpd.h"
+#include "psi4/libpsi4util/exception.h"
 
 namespace psi {
 
@@ -52,7 +53,7 @@ int DPD::trans4_mat_irrep_shift31(dpdtrans4 *Trans, int buf_block) {
 #endif
     if (Trans->shift.shift_type) {
         outfile->Printf("\n\tShift is already on! %d\n", Trans->shift.shift_type);
-        exit(PSI_RETURN_FAILURE);
+        throw PSIEXCEPTION("Shift is already on! " + std::to_string(Trans->shift.shift_type));
     } else
         Trans->shift.shift_type = 31;
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
A lot of error exits in `libdpd` are implemented with `exit(1)` or equivalent. This makes debugging harder, and results in less informative error messages when a test fails in the CI environment.

This PR modernizes all `exit(1)` error exits in `libdpd` into `throw PSIEXCEPTION`.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Psi4 now prints more detailed error messages if an error happens in its DPD module

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] All `exit(1)` and `exit(PSI_RETURN_FAILURE)` calls in `libdpd` have been replaced with a `throw PSIEXCEPTION`.

## Checklist
- [x] No new features
- [x] CI tests are failing only due to libint being in flux

## Status
- [x] Ready for review
- [x] Ready for merge
