### PR TITLE
Do not call exit

### DIFF
--- a/psi4/src/create_new_plugin.cc
+++ b/psi4/src/create_new_plugin.cc
@@ -99,11 +99,7 @@ class PluginFileManager {
         std::string psiDataDirWithPlugin = (filesystem::path(psiDataDirName) / filesystem::path("plugin")).str();
 
         if (!filesystem::path(psiDataDirWithPlugin).is_directory()) {
-            printf(
-                "Unable to read the Psi4 plugin folder - check the PSIDATADIR environmental variable\n"
-                "      Current value of PSIDATADIR is %s\n",
-                psiDataDirName.c_str());
-            exit(1);
+            throw std::runtime_error("Unable to read the Psi4 plugin folder - check the PSIDATADIR environmental variable!\nCurrent value of PSIDATADIR is " + psiDataDirName + "\n");
         }
 
         // Make a faux camel-case of the name
@@ -129,8 +125,7 @@ class PluginFileManager {
             // Load in Makefile.template
             FILE *fp = fopen(source_name.c_str(), "r");
             if (fp == nullptr) {
-                printf("create_new_plugin: Unable to open %s template.\n", source_name.c_str());
-                exit(1);
+                throw std::runtime_error("create_new_plugin: Unable to open " + source_name + " template.\n");
             }
             // Stupid way to read in entire file.
             char line[256];
@@ -148,8 +143,7 @@ class PluginFileManager {
             fp = fopen(target_name.c_str(), "w");
             if (fp == 0) {
                 // boost::filesystem::remove_all(plugin_name_);
-                printf("Unable to create %s\n", target_name.c_str());
-                exit(1);
+                throw std::runtime_error("Unable to create " + target_name + "\n");
             }
             fputs(filestring.c_str(), fp);
             fclose(fp);
@@ -168,8 +162,7 @@ void create_new_plugin(std::string name, const std::string &template_name) {
     // Start == check to make sure the plugin name is valid
     std::string plugin_name = make_filename(name);
     if (!std::isalpha(plugin_name[0])) {
-        printf("Plugin name must begin with a letter.\n");
-        exit(1);
+        throw std::logic_error("Plugin name must begin with a letter.\n");
     }
     // End == check to make sure the plugin name is valid
 
@@ -177,8 +170,7 @@ void create_new_plugin(std::string name, const std::string &template_name) {
 
     // Make a directory with the name plugin_name
     if (!filesystem::create_directory(plugin_name)) {
-        printf("Plugin directory %s already exists.\n", plugin_name.c_str());
-        exit(1);
+        throw std::runtime_error("Plugin directory " + plugin_name + " already exists.\n");
     }
     printf("Created new plugin directory, %s, using '%s' template.\n", plugin_name.c_str(),
            template_name_lower.c_str());

--- a/psi4/src/psi4/cc/cceom/cache.cc
+++ b/psi4/src/psi4/cc/cceom/cache.cc
@@ -32,6 +32,7 @@
 */
 #include <cstdio>
 #include <cstdlib>
+#include <stdexcept>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/psifiles.h"
 
@@ -105,8 +106,7 @@ int **cacheprep_uhf(int level, int *cachefiles) {
 
         return cachelist;
     } else {
-        printf("Error: invalid cache level!\n");
-        exit(1);
+        throw std::logic_error("Error: invalid cache level!\n");
     }
 }
 
@@ -166,8 +166,7 @@ int **cacheprep_rhf(int level, int *cachefiles) {
 
         return cachelist;
     } else {
-        printf("Error: invalid cache level!\n");
-        exit(1);
+        throw std::logic_error("Error: invalid cache level!\n");
     }
 }
 

--- a/psi4/src/psi4/cc/cceom/cc2_sigma.cc
+++ b/psi4/src/psi4/cc/cceom/cc2_sigma.cc
@@ -265,11 +265,9 @@ void cc2_sigma(int i, int C_irr) {
         global_dpd_->buf4_close(&Z);
         global_dpd_->buf4_close(&SIjAb);
     } else if (params.eom_ref == 1) { /* ROHF */
-        printf("ROHF EOM_CC2 is not currently implemented\n");
-        exit(PSI_RETURN_FAILURE);
+        throw std::logic_error("ROHF EOM_CC2 is not currently implemented\n");
     } else { /* UHF */
-        printf("UHF EOM_CC2 is not currently implemented\n");
-        exit(PSI_RETURN_FAILURE);
+        throw std::logic_error("UHF EOM_CC2 is not currently implemented\n");
     }
 }
 
@@ -318,11 +316,9 @@ void cc2_sigmaSS(int i, int C_irr) {
         global_dpd_->file2_close(&CME);
         global_dpd_->file2_close(&SIA);
     } else if (params.eom_ref == 1) { /* ROHF */
-        printf("ROHF CC2-LR is not currently implemented\n");
-        exit(PSI_RETURN_FAILURE);
+        throw std::logic_error("ROHF CC2-LR is not currently implemented\n");
     } else { /* UHF */
-        printf("UHF CC2-LR is not currently implemented\n");
-        exit(PSI_RETURN_FAILURE);
+        throw std::logic_error("UHF CC2-LR is not currently implemented\n");
     }
 }
 

--- a/psi4/src/psi4/cc/cceom/diag.cc
+++ b/psi4/src/psi4/cc/cceom/diag.cc
@@ -61,15 +61,15 @@ namespace cceom {
 #include "psi4/psifiles.h"
 
 extern void test_dpd();
-extern void rzero(int C_irr, const std::vector<bool>& converged);
-extern void rzero_rhf(int C_irr, const std::vector<bool>& converged);
+extern void rzero(int C_irr, const std::vector<bool> &converged);
+extern void rzero_rhf(int C_irr, const std::vector<bool> &converged);
 void init_S1(int index, int irrep);
 void init_S2(int index, int irrep);
 void init_C1(int i, int C_irr);
 void init_C0(int i);
 void init_S0(int i);
 void init_C2(int index, int irrep);
-extern void write_Rs(int C_irr, const std::vector<double>& energies, const std::vector<bool>& converged);
+extern void write_Rs(int C_irr, const std::vector<double> &energies, const std::vector<bool> &converged);
 extern double norm_C(dpdfile2 *CME, dpdfile2 *Cme, dpdbuf4 *CMNEF, dpdbuf4 *Cmnef, dpdbuf4 *CMnEf);
 extern double norm_C_full(double C0, dpdfile2 *CME, dpdfile2 *Cme, dpdbuf4 *CMNEF, dpdbuf4 *Cmnef, dpdbuf4 *CMnEf);
 extern double norm_C_rhf(dpdfile2 *CME, dpdbuf4 *CMnEf, dpdbuf4 *CMnfE);
@@ -132,7 +132,7 @@ void amp_write_ROHF(dpdfile2 *, dpdfile2 *, dpdbuf4 *, dpdbuf4 *, dpdbuf4 *, int
 void overlap(int C_irr, int current);
 void overlap_stash(int C_irr);
 
-void diag(ccenergy::CCEnergyWavefunction& wfn) {
+void diag(ccenergy::CCEnergyWavefunction &wfn) {
     dpdfile2 CME, CME2, Cme, SIA, Sia, RIA, Ria, DIA, Dia, tIA, tia, LIA, Lia;
     dpdbuf4 CMNEF, Cmnef, CMnEf, SIJAB, Sijab, SIjAb, RIJAB, Rijab, RIjAb, RIjbA;
     dpdbuf4 CMnEf1, CMnfE1, CMnfE, CMneF, C2;
@@ -260,8 +260,7 @@ void diag(ccenergy::CCEnergyWavefunction& wfn) {
                     }
 #endif
                 } else {
-                    outfile->Printf("Invalid initial guess method.\n");
-                    exit(PSI_RETURN_FAILURE);
+                    throw std::logic_error("Invalid initial guess method.\n");
                 }
             }
         }
@@ -418,7 +417,7 @@ void diag(ccenergy::CCEnergyWavefunction& wfn) {
             if (ignore_G_old) {
                 already_sigma = 0;
             }
-            auto temp_slice = Slice(Dimension(std::vector<int> {0}), Dimension(std::vector<int> {already_sigma}));
+            auto temp_slice = Slice(Dimension(std::vector<int>{0}), Dimension(std::vector<int>{already_sigma}));
             G->set_block(temp_slice, *G_old->get_block(temp_slice));
 
             for (int i = 0; i < L; ++i) {
@@ -1043,7 +1042,6 @@ void diag(ccenergy::CCEnergyWavefunction& wfn) {
 
                     // ===> Write wfn overlap, if requested <===
                     if (params.overlap) overlap(C_irr, i);
-
                 }
             }
         }
@@ -1052,7 +1050,7 @@ void diag(ccenergy::CCEnergyWavefunction& wfn) {
         if (params.overlap) overlap_stash(C_irr);
 
         free_block(alpha_old);
-    } // End Master Loop
+    }  // End Master Loop
 
     // => Save Psivars <=
     // Edify the auto-docs.
@@ -1078,16 +1076,16 @@ void diag(ccenergy::CCEnergyWavefunction& wfn) {
     std::sort(state_data.begin(), state_data.end());
     std::map<std::tuple<int, int>, int> state_idx_to_identifiers;
     for (int i = 0; i < state_data.size(); ++i) {
-        const auto& tuple = state_data[i];
+        const auto &tuple = state_data[i];
         auto total_energy = std::get<0>(tuple);
         auto trans_irrep_lbl = moinfo.irr_labs[std::get<1>(tuple)];
         auto target_irrep = moinfo.sym ^ std::get<1>(tuple);
         auto target_irrep_lbl = moinfo.irr_labs[moinfo.sym ^ std::get<1>(tuple)];
         auto corr_energy = std::get<2>(tuple);
         auto irrep_idx = irrep_counts[target_irrep_lbl];
-        const std::vector<std::string> names {"CC", short_name};
+        const std::vector<std::string> names{"CC", short_name};
         state_idx_to_identifiers[{irrep_idx, target_irrep}] = i;
-        for (const auto& name : names) {
+        for (const auto &name : names) {
             auto varname = name + " ROOT " + std::to_string(i) + " TOTAL ENERGY";
             Process::environment.globals[varname] = total_energy;
             varname = name + " ROOT " + std::to_string(i) + " CORRELATION ENERGY";
@@ -1251,5 +1249,5 @@ void init_S2(int i, int C_irr) {
     }
 }
 
-}
+}  // namespace cceom
 }  // namespace psi

--- a/psi4/src/psi4/cc/cceom/diagSS.cc
+++ b/psi4/src/psi4/cc/cceom/diagSS.cc
@@ -34,6 +34,7 @@
 #include <cstdio>
 #include <string>
 #include <cmath>
+#include <sstream>
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
@@ -243,8 +244,8 @@ void diagSS(int C_irr) {
 
         if (pf) outfile->Printf("%d initial single excitation guesses\n", C_index);
         if (C_index == 0) {
-            outfile->Printf("No initial guesses obtained for %s state \n", moinfo.irr_labs[moinfo.sym ^ C_irr].c_str());
-            exit(1);
+            throw std::runtime_error("No initial guesses obtained for " + moinfo.irr_labs[moinfo.sym ^ C_irr] +
+                                     " state.\n");
         }
     } else {
         C_index = eom_params.cs_per_irrep[0];
@@ -596,8 +597,9 @@ void precondition_SS_RHF(dpdfile2 *RIA, double eval) {
             ii = i * nocc + i;
 
             if (!local.pairdom_len[ii]) {
-                outfile->Printf("\n\tlocal_filter_T1: Pair ii = [%d] is zero-length, which makes no sense.\n", ii);
-                exit(2);
+                std::ostringstream oss;
+                oss << "local_filter_T1: Pair ii = " << ii << "  is zero-length, which makes no sense.\n";
+                throw std::logic_error(oss.str());
             }
 
             T1tilde = init_array(local.pairdom_len[ii]);
@@ -801,5 +803,5 @@ void restart_SS(double **alpha, int L, int num, int C_irr) {
     }
     return;
 }
-}
+}  // namespace cceom
 }  // namespace psi

--- a/psi4/src/psi4/cc/cceom/local.cc
+++ b/psi4/src/psi4/cc/cceom/local.cc
@@ -36,6 +36,7 @@
 #include <string>
 #include <cstring>
 #include <cmath>
+#include <sstream>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libiwl/iwl.h"
@@ -220,8 +221,9 @@ void local_filter_T1(dpdfile2 *T1) {
         ii = i * nocc + i; /* diagonal element of pair matrices */
 
         if (!local.pairdom_len[ii]) {
-            outfile->Printf("\n\tlocal_filter_T1: Pair ii = [%d] is zero-length, which makes no sense.\n", ii);
-            exit(PSI_RETURN_FAILURE);
+            std::ostringstream oss;
+            oss << "local_filter_T1: Pair ii = " << ii << "  is zero-length, which makes no sense.\n";
+            throw std::logic_error(oss.str());
         }
 
         T1tilde = init_array(local.pairdom_len[ii]);

--- a/psi4/src/psi4/cc/cceom/precondition.cc
+++ b/psi4/src/psi4/cc/cceom/precondition.cc
@@ -34,6 +34,7 @@
 #include <cstdio>
 #include <cmath>
 #include <cstring>
+#include <sstream>
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libciomr/libciomr.h"
@@ -210,8 +211,9 @@ void precondition_RHF(dpdfile2 *RIA, dpdbuf4 *RIjAb, double eval) {
                 ii = i * nocc + i;
 
                 if (!local.pairdom_len[ii]) {
-                    outfile->Printf("\n\tlocal_filter_T1: Pair ii = [%d] is zero-length, which makes no sense.\n", ii);
-                    exit(2);
+                    std::ostringstream oss;
+                    oss << "local_filter_T1: Pair ii = " << ii << "  is zero-length, which makes no sense.\n";
+                    throw std::logic_error(oss.str());
                 }
 
                 T1tilde = init_array(local.pairdom_len[ii]);

--- a/psi4/src/psi4/cc/cceom/read_guess.cc
+++ b/psi4/src/psi4/cc/cceom/read_guess.cc
@@ -62,8 +62,7 @@ void read_guess_init() {
     /* Read number of guess = number of final states to solve for */
     errcod = ip_count("EOM_GUESS_VECTORS", &num_vectors, 0);
     if (errcod != IPE_OK) {
-        outfile->Printf("\nread_guess(): Unable to read number of guesses from input.\n");
-        exit(2);
+        throw std::runtime_error("\nread_guess(): Unable to read number of guesses from input.\n");
     }
 
     for (k = 0; k < num_vectors; k++) {
@@ -76,8 +75,7 @@ void read_guess_init() {
             errcod = ip_data("EOM_GUESS_VECTORS", "%d", &spin, 4, k, l, 3);
 
             if ((spin != 0) && (params.eom_ref == 0)) {
-                outfile->Printf("only alpha guesses allowed for EOM_REF = RHF\n");
-                exit(1);
+                throw std::logic_error("only alpha guesses allowed for EOM_REF = RHF\n");
             }
 
             if (params.eom_ref == 0) {
@@ -87,8 +85,9 @@ void read_guess_init() {
                     eom_params.states_per_irrep[this_irrep ^ moinfo.sym] += 1;
                 } else { /* check consistency of other excitations */
                     if (moinfo.occ_sym[i] ^ moinfo.vir_sym[a] != this_irrep) {
-                        outfile->Printf("\nInconsistent symmetries in components of guess %d.\n", k);
-                        exit(2);
+                        std::ostringstream oss;
+                        oss << "Inconsistent symmetries in components of guess " << k << ".\n";
+                        throw std::logic_error(oss.str());
                     }
                 }
             } else {
@@ -103,13 +102,15 @@ void read_guess_init() {
                 } else { /* check consistency of other excitations */
                     if (spin == 0) {
                         if (moinfo.aocc_sym[i] ^ moinfo.avir_sym[a] != this_irrep) {
-                            outfile->Printf("\nInconsistent symmetries in components of guess %d.\n", k);
-                            exit(2);
+                            std::ostringstream oss;
+                            oss << "Inconsistent symmetries in components of guess " << k << ".\n";
+                            throw std::logic_error(oss.str());
                         }
                     } else {
                         if (moinfo.bocc_sym[i] ^ moinfo.bvir_sym[a] != this_irrep) {
-                            outfile->Printf("\nInconsistent symmetries in components of guess %d.\n", k);
-                            exit(2);
+                            std::ostringstream oss;
+                            oss << "Inconsistent symmetries in components of guess " << k << ".\n";
+                            throw std::logic_error(oss.str());
                         }
                     }
                 }
@@ -173,8 +174,9 @@ void read_guess(int C_irr) {
                     this_irrep = moinfo.occ_sym[i] ^ moinfo.vir_sym[a];
                 } else { /* check other excitations for consistency */
                     if (moinfo.occ_sym[i] ^ moinfo.vir_sym[a] != this_irrep) {
-                        outfile->Printf("\nInconsistent symmetries in components of guess %d.\n", k);
-                        exit(2);
+                        std::ostringstream oss;
+                        oss << "Inconsistent symmetries in components of guess " << k << ".\n";
+                        throw std::logic_error(oss.str());
                     }
                 }
             } else {
@@ -186,13 +188,15 @@ void read_guess(int C_irr) {
                 } else { /* check other excitations for consistency */
                     if (spin == 0) {
                         if (moinfo.aocc_sym[i] ^ moinfo.avir_sym[a] != this_irrep) {
-                            outfile->Printf("\nInconsistent symmetries in components of guess %d.\n", k);
-                            exit(2);
+                            std::ostringstream oss;
+                            oss << "Inconsistent symmetries in components of guess " << k << ".\n";
+                            throw std::logic_error(oss.str());
                         }
                     } else {
                         if (moinfo.bocc_sym[i] ^ moinfo.bvir_sym[a] != this_irrep) {
-                            outfile->Printf("\nInconsistent symmetries in components of guess %d.\n", k);
-                            exit(2);
+                            std::ostringstream oss;
+                            oss << "Inconsistent symmetries in components of guess " << k << ".\n";
+                            throw std::logic_error(oss.str());
                         }
                     }
                 }

--- a/psi4/src/psi4/cc/cchbar/Wabei_RHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_RHF.cc
@@ -275,8 +275,7 @@ void Wabei_RHF() {
             coltot = F.params->coltot[h];
             if (coltot) maxrows = DPD_BIGNUM / coltot;
             if (maxrows < 1) {
-                outfile->Printf("\nWabei_RHF Error: A single row of ovvv > 2 GW.\n");
-                exit(PSI_RETURN_FAILURE);
+                throw std::runtime_error("\nWabei_RHF Error: A single row of ovvv > 2 GW.\n");
             } else
                 maxrows = DPD_BIGNUM;
             rowtot = F.params->rowtot[h];

--- a/psi4/src/psi4/cctransort/cache.cc
+++ b/psi4/src/psi4/cctransort/cache.cc
@@ -28,6 +28,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <stdexcept>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/psifiles.h"
 
@@ -101,8 +102,7 @@ int **cacheprep_uhf(int level, int *cachefiles) {
 
         return cachelist;
     } else {
-        printf("Error: invalid cache level!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw std::logic_error("Error: invalid cache level!\n");
     }
 }
 
@@ -159,8 +159,7 @@ int **cacheprep_rhf(int level, int *cachefiles) {
 
         return cachelist;
     } else {
-        printf("Error: invalid cache level!\n");
-        exit(PSI_RETURN_FAILURE);
+        throw std::logic_error("Error: invalid cache level!\n");
     }
 }
 

--- a/psi4/src/psi4/cctransort/cctransort.cc
+++ b/psi4/src/psi4/cctransort/cctransort.cc
@@ -473,10 +473,7 @@ PsiReturnType cctransort(SharedWavefunction ref, Options &options) {
     outfile->Printf("\tFrozen core energy     =  %20.14f\n", efzc);
 
     if (nfzc && (std::fabs(efzc) < 1e-7)) {
-        outfile->Printf("\tCCSORT Error: Orbitals are frozen in input,\n");
-        outfile->Printf("\tbut frozen core energy is small!\n");
-        outfile->Printf("\tCalculation will be aborted...\n");
-        exit(PSI_RETURN_FAILURE);
+        throw std::runtime_error("CCSORT Error: Orbitals are frozen in input, but frozen core energy is small!\n");
     } else if (!nfzc && std::fabs(efzc)) {
         outfile->Printf("\tCCSORT Warning: No orbitals are frozen,\n");
         outfile->Printf("\tbut the frozen-core energy in wfn is non-zero.\n");

--- a/psi4/src/psi4/dfocc/ccd_tpdm.cc
+++ b/psi4/src/psi4/dfocc/ccd_tpdm.cc
@@ -39,143 +39,530 @@ namespace dfoccwave {
 void DFOCC::ccd_tpdm() {
     timer_on("tpdm");
 
- // RHF
- if (reference_ == "RESTRICTED") {
-    SharedTensor2d T, U, Tau, G, G2, V, X, Y, Z;
-    SharedTensor2d Ts, Ta, Vs, Va, S, A;
+    // RHF
+    if (reference_ == "RESTRICTED") {
+        SharedTensor2d T, U, Tau, G, G2, V, X, Y, Z;
+        SharedTensor2d Ts, Ta, Vs, Va, S, A;
 
-    //============================
-    // OO-Block Correlation TPDM
-    //============================
+        //============================
+        // OO-Block Correlation TPDM
+        //============================
 
-    // G_ij^Q += P+(ij) V_ij^Q
-    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IJ)", nQ, naoccA, naoccA);
-    V = std::make_shared<Tensor2d>("V (Q|IJ)", nQ, naoccA, naoccA);
-    V->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(V, 1.0);
-    V.reset();
-    // G_ij^Q -= P+(ij) 2*V'_ij^Q
-    V = std::make_shared<Tensor2d>("Vp (Q|IJ)", nQ, naoccA, naoccA);
-    V->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(V, -2.0);
-    V.reset();
+        // G_ij^Q += P+(ij) V_ij^Q
+        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IJ)", nQ, naoccA, naoccA);
+        V = std::make_shared<Tensor2d>("V (Q|IJ)", nQ, naoccA, naoccA);
+        V->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(V, 1.0);
+        V.reset();
+        // G_ij^Q -= P+(ij) 2*V'_ij^Q
+        V = std::make_shared<Tensor2d>("Vp (Q|IJ)", nQ, naoccA, naoccA);
+        V->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(V, -2.0);
+        V.reset();
 
-    // symmetrize
-    G->symmetrize3(G);
-    G->scale(2.0);
-    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OO)", nQ, noccA, noccA);
-    G2->set3_act_oo(nfrzc, G);
-    G.reset();
-    G2->write(psio_, PSIF_DFOCC_DENS);
-    if (print_ > 3) G2->print();
-    G2.reset();
+        // symmetrize
+        G->symmetrize3(G);
+        G->scale(2.0);
+        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OO)", nQ, noccA, noccA);
+        G2->set3_act_oo(nfrzc, G);
+        G.reset();
+        G2->write(psio_, PSIF_DFOCC_DENS);
+        if (print_ > 3) G2->print();
+        G2.reset();
 
-    //============================
-    // OV-Block Correlation TPDM
-    //============================
+        //============================
+        // OV-Block Correlation TPDM
+        //============================
 
-    // G_ia^Q = T_ia^Q
-    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IA)", nQ, naoccA, navirA);
-    T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
-    T->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(T, 1.0);
-    T.reset();
-    // G_ia^Q += L_ia^Q
-    T = std::make_shared<Tensor2d>("L2 (Q|IA)", nQ, naoccA, navirA);
-    T->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(T, 1.0);
-    T.reset();
-    // G_ia^Q += 2*y_ia^Q
-    T = std::make_shared<Tensor2d>("Y (Q|IA)", nQ, naoccA, navirA);
-    T->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(T, 2.0);
-    T.reset();
+        // G_ia^Q = T_ia^Q
+        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IA)", nQ, naoccA, navirA);
+        T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
+        T->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(T, 1.0);
+        T.reset();
+        // G_ia^Q += L_ia^Q
+        T = std::make_shared<Tensor2d>("L2 (Q|IA)", nQ, naoccA, navirA);
+        T->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(T, 1.0);
+        T.reset();
+        // G_ia^Q += 2*y_ia^Q
+        T = std::make_shared<Tensor2d>("Y (Q|IA)", nQ, naoccA, navirA);
+        T->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(T, 2.0);
+        T.reset();
 
-    // G_ia^Q -= \sum(m) T_ma^Q G_im
-    T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
-    T->read(psio_, PSIF_DFOCC_AMPS);
-    G->contract233(false, false, naoccA, navirA, GijA, T, -1.0, 1.0);
+        // G_ia^Q -= \sum(m) T_ma^Q G_im
+        T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
+        T->read(psio_, PSIF_DFOCC_AMPS);
+        G->contract233(false, false, naoccA, navirA, GijA, T, -1.0, 1.0);
 
-    // G_ia^Q += \sum(e) T_ie^Q G_ea
-    G->contract(false, false, nQ * naoccA, navirA, navirA, T, GabA, 1.0, 1.0);
-    // G->cont323("IA", "IE", "EA", false, T, GabA, 1.0, 1.0); // it works
-    T.reset();
+        // G_ia^Q += \sum(e) T_ie^Q G_ea
+        G->contract(false, false, nQ * naoccA, navirA, navirA, T, GabA, 1.0, 1.0);
+        // G->cont323("IA", "IE", "EA", false, T, GabA, 1.0, 1.0); // it works
+        T.reset();
 
-    // G_ia^Q += \sum(me) U(ia,me) (G_em^Q - G_me^Q)
-    U = std::make_shared<Tensor2d>("G (Q|AI)", nQ, navirA, naoccA);
-    U->read(psio_, PSIF_DFOCC_AMPS);
-    T = std::make_shared<Tensor2d>("Temp (Q|IA)", nQ, naoccA, navirA);
-    T->swap_3index_col(U);
-    U.reset();
-    U = std::make_shared<Tensor2d>("G (Q|IA)", nQ, naoccA, navirA);
-    U->read(psio_, PSIF_DFOCC_AMPS);
-    T->axpy(U, -1.0);
-    U.reset();
-    U = std::make_shared<Tensor2d>("U2 (IA|JB)", naoccA, navirA, naoccA, navirA);
-    U->read_symm(psio_, PSIF_DFOCC_AMPS);
-    G->gemm(false, true, T, U, 1.0, 1.0);
-    U.reset();
-    T.reset();
+        // G_ia^Q += \sum(me) U(ia,me) (G_em^Q - G_me^Q)
+        U = std::make_shared<Tensor2d>("G (Q|AI)", nQ, navirA, naoccA);
+        U->read(psio_, PSIF_DFOCC_AMPS);
+        T = std::make_shared<Tensor2d>("Temp (Q|IA)", nQ, naoccA, navirA);
+        T->swap_3index_col(U);
+        U.reset();
+        U = std::make_shared<Tensor2d>("G (Q|IA)", nQ, naoccA, navirA);
+        U->read(psio_, PSIF_DFOCC_AMPS);
+        T->axpy(U, -1.0);
+        U.reset();
+        U = std::make_shared<Tensor2d>("U2 (IA|JB)", naoccA, navirA, naoccA, navirA);
+        U->read_symm(psio_, PSIF_DFOCC_AMPS);
+        G->gemm(false, true, T, U, 1.0, 1.0);
+        U.reset();
+        T.reset();
 
-    // Form overall OV Block
-    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OV)", nQ, noccA, nvirA);
-    G2->set3_act_ov(nfrzc, naoccA, navirA, nvirA, G);
-    G.reset();
-    G2->write(psio_, PSIF_DFOCC_DENS);
-    if (print_ > 3) G2->print();
+        // Form overall OV Block
+        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OV)", nQ, noccA, nvirA);
+        G2->set3_act_ov(nfrzc, naoccA, navirA, nvirA, G);
+        G.reset();
+        G2->write(psio_, PSIF_DFOCC_DENS);
+        if (print_ > 3) G2->print();
 
-    // Form G_vo^Q
-    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VO)", nQ, nvirA, noccA);
-    G->swap_3index_col(G2);
-    G2.reset();
-    G->write(psio_, PSIF_DFOCC_DENS);
-    if (print_ > 3) G->print();
-    G.reset();
+        // Form G_vo^Q
+        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VO)", nQ, nvirA, noccA);
+        G->swap_3index_col(G2);
+        G2.reset();
+        G->write(psio_, PSIF_DFOCC_DENS);
+        if (print_ > 3) G->print();
+        G.reset();
 
-    //============================
-    // VV-Block Correlation TPDM
-    //============================
+        //============================
+        // VV-Block Correlation TPDM
+        //============================
 
-    // G_ab^Q -= P+(ab) 2*V_ab^Q
-    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|AB)", nQ, navirA, navirA);
-    V = std::make_shared<Tensor2d>("V (Q|AB)", nQ, navirA, navirA);
-    V->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(V, -2.0);
-    V.reset();
+        // G_ab^Q -= P+(ab) 2*V_ab^Q
+        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|AB)", nQ, navirA, navirA);
+        V = std::make_shared<Tensor2d>("V (Q|AB)", nQ, navirA, navirA);
+        V->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(V, -2.0);
+        V.reset();
 
-    // G_ab^Q += P+(ab) \sum(ef) Vt_aebf b_ef^Q
-    // Read b_ef^Q
+        // G_ab^Q += P+(ab) \sum(ef) Vt_aebf b_ef^Q
+        // Read b_ef^Q
+        bQabA = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|AB)", nQ, navirA, navirA);
+        bQabA->read(psio_, PSIF_DFOCC_INTS, true, true);
+
+        // (+)Ut(mn, ae) = 1/2 (Ut_mn^ae + Ut_nm^ae) * (2 - \delta_{mn})
+        // (-)Ut(mn, ae) = 1/2 (Ut_mn^ae - Ut_nm^ae) * (2 - \delta_{mn})
+        T = std::make_shared<Tensor2d>("Ut2 (IA|JB)", naoccA, navirA, naoccA, navirA);
+        T->read_symm(psio_, PSIF_DFOCC_AMPS);
+        U = std::make_shared<Tensor2d>("Ut2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
+        U->sort(1324, T, 1.0, 0.0);
+        T.reset();
+        Ts = std::make_shared<Tensor2d>("(+)Ut [I>=J|A>=B]", ntri_ijAA, ntri_abAA);
+        Ta = std::make_shared<Tensor2d>("(-)Ut [I>=J|A>=B]", ntri_ijAA, ntri_abAA);
+        Ts->symm_row_packed4(U);
+        Ta->antisymm_row_packed4(U);
+        U.reset();
+
+        // Symmetric & Anti-symmetric contributions
+        U = std::make_shared<Tensor2d>("T2 (IA|JB)", naoccA, navirA, naoccA, navirA);
+        U->read_symm(psio_, PSIF_DFOCC_AMPS);
+        Tau = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
+        Tau->sort(1324, U, 1.0, 0.0);
+        U.reset();
+        Vs = std::make_shared<Tensor2d>("(+)T[B] (F,M>=N)", navirA, ntri_ijAA);
+        Va = std::make_shared<Tensor2d>("(-)T[B] (F,M>=N)", navirA, ntri_ijAA);
+        S = std::make_shared<Tensor2d>("S[B] (F,A>=E)", navirA, ntri_abAA);
+        A = std::make_shared<Tensor2d>("A[B] (F,A>=E)", navirA, ntri_abAA);
+        V = std::make_shared<Tensor2d>("V[B] (A,EF)", navirA, navirA, navirA);
+        X = std::make_shared<Tensor2d>("TPDM[B] (Q|A)", nQ, navirA);
+        // Main loop
+        for (int b = 0; b < navirA; ++b) {
+// Form (+)Tau[b](f, m>=n)
+#pragma omp parallel for
+            for (int m = 0; m < naoccA; ++m) {
+                for (int n = 0; n <= m; ++n) {
+                    int mn2 = index2(m, n);
+                    int mn = n + (m * naoccA);
+                    int nm = m + (n * naoccA);
+                    for (int f = 0; f < navirA; ++f) {
+                        int bf = f + (b * navirA);
+                        double value1 = 0.5 * (Tau->get(mn, bf) + Tau->get(nm, bf));
+                        double value2 = 0.5 * (Tau->get(mn, bf) - Tau->get(nm, bf));
+                        Vs->set(f, mn2, value1);
+                        Va->set(f, mn2, value2);
+                    }
+                }
+            }
+
+            // Form S[b](f,a>=e) = \sum(m>=n) (+)Ut(m>=n,a>=e) * Tau[b](f,m>=n)
+            S->contract(false, false, navirA, ntri_abAA, ntri_ijAA, Vs, Ts, 1.0, 0.0);
+            A->contract(false, false, navirA, ntri_abAA, ntri_ijAA, Va, Ta, 1.0, 0.0);
+
+// Form V[b](a,ef)
+#pragma omp parallel for
+            for (int a = 0; a < navirA; ++a) {
+                for (int e = 0; e < navirA; ++e) {
+                    int ae = index2(a, e);
+                    for (int f = 0; f < navirA; ++f) {
+                        int ef = ab_idxAA->get(e, f);
+                        int perm1 = (a > e) ? 1 : -1;
+                        double value = S->get(f, ae) + (perm1 * A->get(f, ae));
+                        V->set(a, ef, value);
+                    }
+                }
+            }
+
+            // G2[b](Q,a) = \sum(ef) b(Q,ef) * V[b](a,ef)
+            X->gemm(false, true, bQabA, V, 1.0, 0.0);
+
+// Form G2
+#pragma omp parallel for
+            for (int Q = 0; Q < nQ; ++Q) {
+                for (int a = 0; a < navirA; ++a) {
+                    int ab = ab_idxAA->get(a, b);
+                    G->add(Q, ab, X->get(Q, a));
+                }
+            }
+        }
+        Tau.reset();
+        Ts.reset();
+        Ta.reset();
+        Vs.reset();
+        Va.reset();
+        S.reset();
+        A.reset();
+        X.reset();
+        V.reset();
+        bQabA.reset();
+
+        // symmetrize
+        G->symmetrize3(G);
+        G->scale(2.0);
+        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VV)", nQ, nvirA, nvirA);
+        G2->set3_act_vv(G);
+        G.reset();
+        G2->write(psio_, PSIF_DFOCC_DENS, true, true);
+        if (print_ > 3) G2->print();
+        G2.reset();
+
+    }  // end if (reference_ == "RESTRICTED")
+
+    // UHF
+    else if (reference_ == "UNRESTRICTED") {
+        SharedTensor2d T, T2, L2, Tau, X, Y, Z, V, U, L, G, G2;
+        SharedTensor2d T1, Ts, Ta, Vs, Va, S, A;
+        // std::cout << "TPDM is starting \n";
+
+        /////////////////////////////////
+        //// OO-Block ///////////////////
+        /////////////////////////////////
+
+        //// Alpha BLock ////////////////
+
+        // G_IJ^Q += 0.5 * P+(IJ) V_IJ^Q
+        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IJ)", nQ, naoccA, naoccA);
+        V = std::make_shared<Tensor2d>("V (Q|IJ)", nQ, naoccA, naoccA);
+        V->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(V, 0.5);
+        V.reset();
+
+        // G_IJ^Q -= 0.5 * P+(IJ) 2*V'_IJ^Q
+        V = std::make_shared<Tensor2d>("Vp (Q|IJ)", nQ, naoccA, naoccA);
+        V->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(V, -1.0);
+        V.reset();
+
+        // SYMMETRIZE
+        G->symmetrize3(G);
+        G->scale(2.0);
+        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OO)", nQ, noccA, noccA);
+        G2->set3_act_oo(nfrzc, G);
+        G.reset();
+        G2->write(psio_, PSIF_DFOCC_DENS);
+        if (print_ > 3) G2->print();
+        G2.reset();
+
+        //// Beta BLock  ////////////////
+
+        // G_ij^Q += 0.5 * P+(ij) V_ij^Q
+        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ij)", nQ, naoccB, naoccB);
+        V = std::make_shared<Tensor2d>("V (Q|ij)", nQ, naoccB, naoccB);
+        V->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(V, 0.5);
+        V.reset();
+
+        // G_ij^Q -= 0.5 * P+(ij) 2*V'_ij^Q
+        V = std::make_shared<Tensor2d>("Vp (Q|ij)", nQ, naoccB, naoccB);
+        V->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(V, -1.0);
+        V.reset();
+
+        // symmetrize
+        G->symmetrize3(G);
+        G->scale(2.0);
+        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|oo)", nQ, noccB, noccB);
+        G2->set3_act_oo(nfrzc, G);
+        G.reset();
+        G2->write(psio_, PSIF_DFOCC_DENS);
+        if (print_ > 3) G2->print();
+        G2.reset();
+
+        /////////////////////////////////
+        //// OV-Block ///////////////////
+        /////////////////////////////////
+
+        //// Alpha BLock ////////////////
+
+        // G_IA^Q = 0.5 * T_IA^Q
+        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IA)", nQ, naoccA, navirA);
+        T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
+        T->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(T, 0.5);
+        T.reset();
+
+        // G_IA^Q += 0.5 * L_IA^Q
+        T = std::make_shared<Tensor2d>("L2 (Q|IA)", nQ, naoccA, navirA);
+        T->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(T, 0.5);
+        T.reset();
+
+        // G_IA^Q += 0.5 * 2*y_IA^Q
+        T = std::make_shared<Tensor2d>("Y (Q|IA)", nQ, naoccA, navirA);
+        T->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(T, 1.0);
+        T.reset();
+
+        // G_IA^Q -= 0.5 * \sum(M) T_MA^Q G_IM
+        T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
+        T->read(psio_, PSIF_DFOCC_AMPS);
+        G->contract233(false, false, naoccA, navirA, GijA, T, -0.5, 1.0);
+
+        // G_IA^Q += 0.5 * \sum(E) T_IE^Q G_EA
+        G->contract(false, false, nQ * naoccA, navirA, navirA, T, GabA, 0.5, 1.0);
+        T.reset();
+
+        // G_IA^Q += 0.5 * \sum(ME) T(IM,AE) (G_EM^Q - G_ME^Q)
+        U = std::make_shared<Tensor2d>("G (Q|AI)", nQ, navirA, naoccA);
+        U->read(psio_, PSIF_DFOCC_AMPS);
+        T = std::make_shared<Tensor2d>("Temp (Q|IA)", nQ, naoccA, navirA);
+        T->swap_3index_col(U);
+        U.reset();
+        U = std::make_shared<Tensor2d>("G (Q|IA)", nQ, naoccA, navirA);
+        U->read(psio_, PSIF_DFOCC_AMPS);
+        T->axpy(U, -1.0);
+        U.reset();
+        Tau = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
+        Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+        U = std::make_shared<Tensor2d>("T2 (ME|IA)", naoccA, navirA, naoccA, navirA);
+        U->sort(2413, Tau, 1.0, 0.0);
+        Tau.reset();
+        G->gemm(false, false, T, U, 0.5, 1.0);
+        U.reset();
+        T.reset();
+
+        // G_IA^Q += 0.5 * \sum(me) T(Im,Ae) (Gt_em^Q - Gt_me^Q)
+        U = std::make_shared<Tensor2d>("G (Q|ai)", nQ, navirB, naoccB);
+        U->read(psio_, PSIF_DFOCC_AMPS);
+        T = std::make_shared<Tensor2d>("Temp (Q|ia)", nQ, naoccB, navirB);
+        T->swap_3index_col(U);
+        U.reset();
+        U = std::make_shared<Tensor2d>("G (Q|ia)", nQ, naoccB, navirB);
+        U->read(psio_, PSIF_DFOCC_AMPS);
+        T->axpy(U, -1.0);
+        U.reset();
+        Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+        Tau->read(psio_, PSIF_DFOCC_AMPS);
+        U = std::make_shared<Tensor2d>("T2 (me|IA)", naoccB, navirB, naoccA, navirA);
+        U->sort(2413, Tau, 1.0, 0.0);
+        Tau.reset();
+        G->gemm(false, false, T, U, 0.5, 1.0);
+        U.reset();
+        T.reset();
+
+        // Form overall OV Block
+        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OV)", nQ, noccA, nvirA);
+        G2->set3_act_ov(nfrzc, naoccA, navirA, nvirA, G);
+        G.reset();
+        G2->write(psio_, PSIF_DFOCC_DENS);
+        if (print_ > 3) G2->print();
+
+        // Form G_vo^Q
+        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VO)", nQ, nvirA, noccA);
+        G->swap_3index_col(G2);
+        G2.reset();
+        G->write(psio_, PSIF_DFOCC_DENS);
+        if (print_ > 3) G->print();
+        G.reset();
+
+        //// Beta BLock  ////////////////
+
+        // G_ia^Q = 0.5 * T_ia^Q
+        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ia)", nQ, naoccB, navirB);
+        T = std::make_shared<Tensor2d>("T2 (Q|ia)", nQ, naoccB, navirB);
+        T->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(T, 0.5);
+        T.reset();
+        // G_ia^Q += 0.5 * L_ia^Q
+        T = std::make_shared<Tensor2d>("L2 (Q|ia)", nQ, naoccB, navirB);
+        T->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(T, 0.5);
+        T.reset();
+        // G_ia^Q += 0.5 * 2*y_ia^Q
+        T = std::make_shared<Tensor2d>("Y (Q|ia)", nQ, naoccB, navirB);
+        T->read(psio_, PSIF_DFOCC_AMPS);
+        G->axpy(T, 1.0);
+        T.reset();
+
+        // G_ia^Q -= 0.5 * \sum(m) T_ma^Q G_im
+        T = std::make_shared<Tensor2d>("T2 (Q|ia)", nQ, naoccB, navirB);
+        T->read(psio_, PSIF_DFOCC_AMPS);
+        G->contract233(false, false, naoccB, navirB, GijB, T, -0.5, 1.0);
+
+        // G_ia^Q += 0.5 * \sum(e) T_ie^Q G_ea
+        G->contract(false, false, nQ * naoccB, navirB, navirB, T, GabB, 0.5, 1.0);
+        T.reset();
+
+        // G_ia^Q += 0.5 * \sum(me) T(im,ae) (G_em^Q - G_me^Q)
+        U = std::make_shared<Tensor2d>("G (Q|ai)", nQ, navirB, naoccB);
+        U->read(psio_, PSIF_DFOCC_AMPS);
+        T = std::make_shared<Tensor2d>("Temp (Q|ia)", nQ, naoccB, navirB);
+        T->swap_3index_col(U);
+        U.reset();
+        U = std::make_shared<Tensor2d>("G (Q|ia)", nQ, naoccB, navirB);
+        U->read(psio_, PSIF_DFOCC_AMPS);
+        T->axpy(U, -1.0);
+        U.reset();
+        Tau = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
+        Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+        U = std::make_shared<Tensor2d>("T2 (me|ia)", naoccB, navirB, naoccB, navirB);
+        U->sort(2413, Tau, 1.0, 0.0);
+        Tau.reset();
+        G->gemm(false, false, T, U, 0.5, 1.0);
+        U.reset();
+        T.reset();
+
+        // G_ia^Q += 0.5 * \sum(ME) T(Mi,Ea) (G_EM^Q - G_ME^Q)
+        U = std::make_shared<Tensor2d>("G (Q|AI)", nQ, navirA, naoccA);
+        U->read(psio_, PSIF_DFOCC_AMPS);
+        T = std::make_shared<Tensor2d>("Temp (Q|IA)", nQ, naoccA, navirA);
+        T->swap_3index_col(U);
+        U.reset();
+        U = std::make_shared<Tensor2d>("G (Q|IA)", nQ, naoccA, navirA);
+        U->read(psio_, PSIF_DFOCC_AMPS);
+        T->axpy(U, -1.0);
+        U.reset();
+        Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+        Tau->read(psio_, PSIF_DFOCC_AMPS);
+        U = std::make_shared<Tensor2d>("T2 (ME|ia)", naoccA, navirA, naoccB, navirB);
+        U->sort(1324, Tau, 1.0, 0.0);
+        Tau.reset();
+        G->gemm(false, false, T, U, 0.5, 1.0);
+        U.reset();
+        T.reset();
+
+        // Form overall OV Block
+        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ov)", nQ, noccB, nvirB);
+        G2->set3_act_ov(nfrzc, naoccB, navirB, nvirB, G);
+        G.reset();
+        G2->write(psio_, PSIF_DFOCC_DENS);
+        if (print_ > 3) G2->print();
+
+        // Form G_vo^Q
+        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|vo)", nQ, nvirB, noccB);
+        G->swap_3index_col(G2);
+        G2.reset();
+        G->write(psio_, PSIF_DFOCC_DENS);
+        if (print_ > 3) G->print();
+        G.reset();
+
+        /////////////////////////////////
+        //// VV-Block ///////////////////
+        /////////////////////////////////
+
+        //// Alpha BLock ////////////////
+
+        // G_AB^Q = P+(AB) V_AB^Q
+        V = std::make_shared<Tensor2d>("V (Q|AB)", nQ, navirA, navirA);
+        V->read(psio_, PSIF_DFOCC_AMPS);
+        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|AB)", nQ, navirA, navirA);
+        G->axpy(V, -1.0);
+        V.reset();
+
+        // PPL
+        ccd_tpdm_pplA(G, "T2");
+
+        // SYMMETRIZE
+        G->symmetrize3(G);
+        G->scale(2.0);
+        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VV)", nQ, nvirA, nvirA);
+        G2->set3_act_vv(G);
+        G.reset();
+        G2->write(psio_, PSIF_DFOCC_DENS, true, true);
+        if (print_ > 3) G2->print();
+        G2.reset();
+
+        //// Beta BLock ////////////////
+
+        // G_ab^Q -= P+(ab) V_ab^Q
+        V = std::make_shared<Tensor2d>("V (Q|ab)", nQ, navirB, navirB);
+        V->read(psio_, PSIF_DFOCC_AMPS);
+        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ab)", nQ, navirB, navirB);
+        G->axpy(V, -1.0);
+        V.reset();
+
+        // PPL
+        ccd_tpdm_pplB(G, "T2");
+
+        // symmetrize
+        G->symmetrize3(G);
+        G->scale(2.0);
+        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|vv)", nQ, nvirB, nvirB);
+        G2->set3_act_vv(G);
+        G.reset();
+        G2->write(psio_, PSIF_DFOCC_DENS, true, true);
+        if (print_ > 3) G2->print();
+
+    }  // else if (reference_ == "UNRESTRICTED")
+    timer_off("tpdm");
+}  // end ccd_tpdm
+
+//======================================================================
+//    PPL Alpha
+//======================================================================
+void DFOCC::ccd_tpdm_pplA(SharedTensor2d& G, std::string amps) {
+    SharedTensor2d T, T2, L2, Tau, X, Y, Z, V, U, L, G2;
+    SharedTensor2d T1, Ts, Ta, Vs, Va, S, A;
+
+    // G_AB^Q += P+(ab) 1/2\sum(EF) V_AEBF b_EF^Q
+    // V_AEBF = 1/2 \sum(MN) L_MN^AE T_MN^BF
+    // Read b_EF^Q
     bQabA = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|AB)", nQ, navirA, navirA);
     bQabA->read(psio_, PSIF_DFOCC_INTS, true, true);
 
-    // (+)Ut(mn, ae) = 1/2 (Ut_mn^ae + Ut_nm^ae) * (2 - \delta_{mn})
-    // (-)Ut(mn, ae) = 1/2 (Ut_mn^ae - Ut_nm^ae) * (2 - \delta_{mn})
-    T = std::make_shared<Tensor2d>("Ut2 (IA|JB)", naoccA, navirA, naoccA, navirA);
-    T->read_symm(psio_, PSIF_DFOCC_AMPS);
-    U = std::make_shared<Tensor2d>("Ut2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-    U->sort(1324, T, 1.0, 0.0);
-    T.reset();
-    Ts = std::make_shared<Tensor2d>("(+)Ut [I>=J|A>=B]", ntri_ijAA, ntri_abAA);
+    // (-)Tt(mn, ae) = 1/2 (L_mn^ae - L_nm^ae) * (2 - \delta_{mn})
+    T1 = std::make_shared<Tensor2d>("L2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
+    T1->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
     Ta = std::make_shared<Tensor2d>("(-)Ut [I>=J|A>=B]", ntri_ijAA, ntri_abAA);
-    Ts->symm_row_packed4(U);
-    Ta->antisymm_row_packed4(U);
-    U.reset();
+    Ta->antisymm_row_packed4(T1);
 
-    // Symmetric & Anti-symmetric contributions
-    U = std::make_shared<Tensor2d>("T2 (IA|JB)", naoccA, navirA, naoccA, navirA);
-    U->read_symm(psio_, PSIF_DFOCC_AMPS);
-    Tau = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-    Tau->sort(1324, U, 1.0, 0.0);
-    U.reset();
-    Vs = std::make_shared<Tensor2d>("(+)T[B] (F,M>=N)", navirA, ntri_ijAA);
+    // Anti-symmetric contributions
+    if (amps == "T2") {
+        T2 = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
+        T2->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+    } else if (amps == "Tau") {
+        Tau = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
+        Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+        T2 = std::make_shared<Tensor2d>("Tau <IJ|AB>", naoccA, naoccA, navirA, navirA);
+        uccsd_tau_amps(naoccA, naoccA, navirA, navirA, T2, Tau, t1A, t1A);
+        Tau.reset();
+    } else {
+        throw std::logic_error("ccd_tpdm_pplA ---> Unrecognized amps, it should be T2 or Tau ! \n");
+    }
     Va = std::make_shared<Tensor2d>("(-)T[B] (F,M>=N)", navirA, ntri_ijAA);
-    S = std::make_shared<Tensor2d>("S[B] (F,A>=E)", navirA, ntri_abAA);
     A = std::make_shared<Tensor2d>("A[B] (F,A>=E)", navirA, ntri_abAA);
     V = std::make_shared<Tensor2d>("V[B] (A,EF)", navirA, navirA, navirA);
     X = std::make_shared<Tensor2d>("TPDM[B] (Q|A)", nQ, navirA);
     // Main loop
     for (int b = 0; b < navirA; ++b) {
-// Form (+)Tau[b](f, m>=n)
+// Form (+)T[b](f, m>=n)
 #pragma omp parallel for
         for (int m = 0; m < naoccA; ++m) {
             for (int n = 0; n <= m; ++n) {
@@ -184,17 +571,14 @@ void DFOCC::ccd_tpdm() {
                 int nm = m + (n * naoccA);
                 for (int f = 0; f < navirA; ++f) {
                     int bf = f + (b * navirA);
-                    double value1 = 0.5 * (Tau->get(mn, bf) + Tau->get(nm, bf));
-                    double value2 = 0.5 * (Tau->get(mn, bf) - Tau->get(nm, bf));
-                    Vs->set(f, mn2, value1);
+                    double value2 = 0.5 * (T2->get(mn, bf) - T2->get(nm, bf));
                     Va->set(f, mn2, value2);
                 }
             }
         }
 
-        // Form S[b](f,a>=e) = \sum(m>=n) (+)Ut(m>=n,a>=e) * Tau[b](f,m>=n)
-        S->contract(false, false, navirA, ntri_abAA, ntri_ijAA, Vs, Ts, 1.0, 0.0);
-        A->contract(false, false, navirA, ntri_abAA, ntri_ijAA, Va, Ta, 1.0, 0.0);
+        // Form A[b](f,a>=e) = 1/2 \sum(m>=n) (+)Tt(m>=n,a>=e) * T[b](f,m>=n)
+        A->contract(false, false, navirA, ntri_abAA, ntri_ijAA, Va, Ta, 0.5, 0.0);
 
 // Form V[b](a,ef)
 #pragma omp parallel for
@@ -204,14 +588,14 @@ void DFOCC::ccd_tpdm() {
                 for (int f = 0; f < navirA; ++f) {
                     int ef = ab_idxAA->get(e, f);
                     int perm1 = (a > e) ? 1 : -1;
-                    double value = S->get(f, ae) + (perm1 * A->get(f, ae));
+                    double value = perm1 * A->get(f, ae);
                     V->set(a, ef, value);
                 }
             }
         }
 
-        // G2[b](Q,a) = \sum(ef) b(Q,ef) * V[b](a,ef)
-        X->gemm(false, true, bQabA, V, 1.0, 0.0);
+        // G2[b](Q,a) = 1/2\sum(ef) b(Q,ef) * V[b](a,ef)
+        X->gemm(false, true, bQabA, V, 0.5, 0.0);
 
 // Form G2
 #pragma omp parallel for
@@ -222,464 +606,73 @@ void DFOCC::ccd_tpdm() {
             }
         }
     }
-    Tau.reset();
-    Ts.reset();
+    T1.reset();
+    T2.reset();
     Ta.reset();
-    Vs.reset();
     Va.reset();
-    S.reset();
     A.reset();
     X.reset();
     V.reset();
     bQabA.reset();
 
-    // symmetrize
-    G->symmetrize3(G);
-    G->scale(2.0);
-    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VV)", nQ, nvirA, nvirA);
-    G2->set3_act_vv(G);
-    G.reset();
-    G2->write(psio_, PSIF_DFOCC_DENS, true, true);
-    if (print_ > 3) G2->print();
-    G2.reset();
+    // G_AB^Q += P+(AB) 1/2 \sum(ef) V_AeBf b_ef^Q
+    // V_AeBf = \sum(Mn) L_Mn^Ae T_Mn^Bf
+    // Read b_ef^Q
+    bQabB = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|ab)", nQ, navirB, navirB);
+    bQabB->read(psio_, PSIF_DFOCC_INTS, true, true);
 
- }// end if (reference_ == "RESTRICTED")
-
- // UHF
- else if (reference_ == "UNRESTRICTED") {
-    SharedTensor2d T, T2, L2, Tau, X, Y, Z, V, U, L, G, G2;
-    SharedTensor2d T1, Ts, Ta, Vs, Va, S, A;
-    //std::cout << "TPDM is starting \n";
-
-    /////////////////////////////////
-    //// OO-Block ///////////////////
-    /////////////////////////////////
-
-    //// Alpha BLock ////////////////
-
-    // G_IJ^Q += 0.5 * P+(IJ) V_IJ^Q
-    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IJ)", nQ, naoccA, naoccA);
-    V = std::make_shared<Tensor2d>("V (Q|IJ)", nQ, naoccA, naoccA);
-    V->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(V, 0.5);
-    V.reset();
-
-    // G_IJ^Q -= 0.5 * P+(IJ) 2*V'_IJ^Q
-    V = std::make_shared<Tensor2d>("Vp (Q|IJ)", nQ, naoccA, naoccA);
-    V->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(V, -1.0);
-    V.reset();
-
-    // SYMMETRIZE
-    G->symmetrize3(G);
-    G->scale(2.0);
-    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OO)", nQ, noccA, noccA);
-    G2->set3_act_oo(nfrzc, G);
-    G.reset();
-    G2->write(psio_, PSIF_DFOCC_DENS);
-    if (print_ > 3) G2->print();
-    G2.reset();
-
-    //// Beta BLock  ////////////////
-
-    // G_ij^Q += 0.5 * P+(ij) V_ij^Q
-    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ij)", nQ, naoccB, naoccB);
-    V = std::make_shared<Tensor2d>("V (Q|ij)", nQ, naoccB, naoccB);
-    V->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(V, 0.5);
-    V.reset();
-
-    // G_ij^Q -= 0.5 * P+(ij) 2*V'_ij^Q
-    V = std::make_shared<Tensor2d>("Vp (Q|ij)", nQ, naoccB, naoccB);
-    V->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(V, -1.0);
-    V.reset();
-
-    // symmetrize
-    G->symmetrize3(G);
-    G->scale(2.0);
-    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|oo)", nQ, noccB, noccB);
-    G2->set3_act_oo(nfrzc, G);
-    G.reset();
-    G2->write(psio_, PSIF_DFOCC_DENS);
-    if (print_ > 3) G2->print();
-    G2.reset();
-
-    /////////////////////////////////
-    //// OV-Block ///////////////////
-    /////////////////////////////////
-
-    //// Alpha BLock ////////////////
-
-    // G_IA^Q = 0.5 * T_IA^Q
-    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IA)", nQ, naoccA, navirA);
-    T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
-    T->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(T, 0.5);
-    T.reset();
-
-    // G_IA^Q += 0.5 * L_IA^Q
-    T = std::make_shared<Tensor2d>("L2 (Q|IA)", nQ, naoccA, navirA);
-    T->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(T, 0.5);
-    T.reset();
-
-    // G_IA^Q += 0.5 * 2*y_IA^Q
-    T = std::make_shared<Tensor2d>("Y (Q|IA)", nQ, naoccA, navirA);
-    T->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(T, 1.0);
-    T.reset();
-
-    // G_IA^Q -= 0.5 * \sum(M) T_MA^Q G_IM
-    T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
-    T->read(psio_, PSIF_DFOCC_AMPS);
-    G->contract233(false, false, naoccA, navirA, GijA, T, -0.5, 1.0);
-
-    // G_IA^Q += 0.5 * \sum(E) T_IE^Q G_EA
-    G->contract(false, false, nQ * naoccA, navirA, navirA, T, GabA, 0.5, 1.0);
-    T.reset();
-
-    // G_IA^Q += 0.5 * \sum(ME) T(IM,AE) (G_EM^Q - G_ME^Q)
-    U = std::make_shared<Tensor2d>("G (Q|AI)", nQ, navirA, naoccA);
-    U->read(psio_, PSIF_DFOCC_AMPS);
-    T = std::make_shared<Tensor2d>("Temp (Q|IA)", nQ, naoccA, navirA);
-    T->swap_3index_col(U);
-    U.reset();
-    U = std::make_shared<Tensor2d>("G (Q|IA)", nQ, naoccA, navirA);
-    U->read(psio_, PSIF_DFOCC_AMPS);
-    T->axpy(U, -1.0);
-    U.reset();
-    Tau = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-    Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-    U = std::make_shared<Tensor2d>("T2 (ME|IA)", naoccA, navirA, naoccA, navirA);
-    U->sort(2413, Tau, 1.0, 0.0);
-    Tau.reset();
-    G->gemm(false, false, T, U, 0.5, 1.0);
-    U.reset();
-    T.reset();
-
-    // G_IA^Q += 0.5 * \sum(me) T(Im,Ae) (Gt_em^Q - Gt_me^Q)
-    U = std::make_shared<Tensor2d>("G (Q|ai)", nQ, navirB, naoccB);
-    U->read(psio_, PSIF_DFOCC_AMPS);
-    T = std::make_shared<Tensor2d>("Temp (Q|ia)", nQ, naoccB, navirB);
-    T->swap_3index_col(U);
-    U.reset();
-    U = std::make_shared<Tensor2d>("G (Q|ia)", nQ, naoccB, navirB);
-    U->read(psio_, PSIF_DFOCC_AMPS);
-    T->axpy(U, -1.0);
-    U.reset();
-    Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-    Tau->read(psio_, PSIF_DFOCC_AMPS);
-    U = std::make_shared<Tensor2d>("T2 (me|IA)", naoccB, navirB, naoccA, navirA);
-    U->sort(2413, Tau, 1.0, 0.0);
-    Tau.reset();
-    G->gemm(false, false, T, U, 0.5, 1.0);
-    U.reset();
-    T.reset();
-
-    // Form overall OV Block
-    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OV)", nQ, noccA, nvirA);
-    G2->set3_act_ov(nfrzc, naoccA, navirA, nvirA, G);
-    G.reset();
-    G2->write(psio_, PSIF_DFOCC_DENS);
-    if (print_ > 3) G2->print();
-
-    // Form G_vo^Q
-    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VO)", nQ, nvirA, noccA);
-    G->swap_3index_col(G2);
-    G2.reset();
-    G->write(psio_, PSIF_DFOCC_DENS);
-    if (print_ > 3) G->print();
-    G.reset();
-
-    //// Beta BLock  ////////////////
-
-    // G_ia^Q = 0.5 * T_ia^Q
-    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ia)", nQ, naoccB, navirB);
-    T = std::make_shared<Tensor2d>("T2 (Q|ia)", nQ, naoccB, navirB);
-    T->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(T, 0.5);
-    T.reset();
-    // G_ia^Q += 0.5 * L_ia^Q
-    T = std::make_shared<Tensor2d>("L2 (Q|ia)", nQ, naoccB, navirB);
-    T->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(T, 0.5);
-    T.reset();
-    // G_ia^Q += 0.5 * 2*y_ia^Q
-    T = std::make_shared<Tensor2d>("Y (Q|ia)", nQ, naoccB, navirB);
-    T->read(psio_, PSIF_DFOCC_AMPS);
-    G->axpy(T, 1.0);
-    T.reset();
-
-    // G_ia^Q -= 0.5 * \sum(m) T_ma^Q G_im
-    T = std::make_shared<Tensor2d>("T2 (Q|ia)", nQ, naoccB, navirB);
-    T->read(psio_, PSIF_DFOCC_AMPS);
-    G->contract233(false, false, naoccB, navirB, GijB, T, -0.5, 1.0);
-
-    // G_ia^Q += 0.5 * \sum(e) T_ie^Q G_ea
-    G->contract(false, false, nQ * naoccB, navirB, navirB, T, GabB, 0.5, 1.0);
-    T.reset();
-
-    // G_ia^Q += 0.5 * \sum(me) T(im,ae) (G_em^Q - G_me^Q)
-    U = std::make_shared<Tensor2d>("G (Q|ai)", nQ, navirB, naoccB);
-    U->read(psio_, PSIF_DFOCC_AMPS);
-    T = std::make_shared<Tensor2d>("Temp (Q|ia)", nQ, naoccB, navirB);
-    T->swap_3index_col(U);
-    U.reset();
-    U = std::make_shared<Tensor2d>("G (Q|ia)", nQ, naoccB, navirB);
-    U->read(psio_, PSIF_DFOCC_AMPS);
-    T->axpy(U, -1.0);
-    U.reset();
-    Tau = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
-    Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-    U = std::make_shared<Tensor2d>("T2 (me|ia)", naoccB, navirB, naoccB, navirB);
-    U->sort(2413, Tau, 1.0, 0.0);
-    Tau.reset();
-    G->gemm(false, false, T, U, 0.5, 1.0);
-    U.reset();
-    T.reset();
-
-    // G_ia^Q += 0.5 * \sum(ME) T(Mi,Ea) (G_EM^Q - G_ME^Q)
-    U = std::make_shared<Tensor2d>("G (Q|AI)", nQ, navirA, naoccA);
-    U->read(psio_, PSIF_DFOCC_AMPS);
-    T = std::make_shared<Tensor2d>("Temp (Q|IA)", nQ, naoccA, navirA);
-    T->swap_3index_col(U);
-    U.reset();
-    U = std::make_shared<Tensor2d>("G (Q|IA)", nQ, naoccA, navirA);
-    U->read(psio_, PSIF_DFOCC_AMPS);
-    T->axpy(U, -1.0);
-    U.reset();
-    Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-    Tau->read(psio_, PSIF_DFOCC_AMPS);
-    U = std::make_shared<Tensor2d>("T2 (ME|ia)", naoccA, navirA, naoccB, navirB);
-    U->sort(1324, Tau, 1.0, 0.0);
-    Tau.reset();
-    G->gemm(false, false, T, U, 0.5, 1.0);
-    U.reset();
-    T.reset();
-
-    // Form overall OV Block
-    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ov)", nQ, noccB, nvirB);
-    G2->set3_act_ov(nfrzc, naoccB, navirB, nvirB, G);
-    G.reset();
-    G2->write(psio_, PSIF_DFOCC_DENS);
-    if (print_ > 3) G2->print();
-
-    // Form G_vo^Q
-    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|vo)", nQ, nvirB, noccB);
-    G->swap_3index_col(G2);
-    G2.reset();
-    G->write(psio_, PSIF_DFOCC_DENS);
-    if (print_ > 3) G->print();
-    G.reset();
-
-    /////////////////////////////////
-    //// VV-Block ///////////////////
-    /////////////////////////////////
-
-    //// Alpha BLock ////////////////
-
-    // G_AB^Q = P+(AB) V_AB^Q
-    V = std::make_shared<Tensor2d>("V (Q|AB)", nQ, navirA, navirA);
-    V->read(psio_, PSIF_DFOCC_AMPS);
-    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|AB)", nQ, navirA, navirA);
-    G->axpy(V, -1.0);
-    V.reset();
-
-    // PPL
-    ccd_tpdm_pplA(G, "T2");
-
-    // SYMMETRIZE
-    G->symmetrize3(G);
-    G->scale(2.0);
-    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VV)", nQ, nvirA, nvirA);
-    G2->set3_act_vv(G);
-    G.reset();
-    G2->write(psio_, PSIF_DFOCC_DENS, true, true);
-    if (print_ > 3) G2->print();
-    G2.reset();
-
-    //// Beta BLock ////////////////
-
-    // G_ab^Q -= P+(ab) V_ab^Q
-    V = std::make_shared<Tensor2d>("V (Q|ab)", nQ, navirB, navirB);
-    V->read(psio_, PSIF_DFOCC_AMPS);
-    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ab)", nQ, navirB, navirB);
-    G->axpy(V, -1.0);
-    V.reset();
-
-    // PPL
-    ccd_tpdm_pplB(G, "T2");
-
-    // symmetrize
-    G->symmetrize3(G);
-    G->scale(2.0);
-    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|vv)", nQ, nvirB, nvirB);
-    G2->set3_act_vv(G);
-    G.reset();
-    G2->write(psio_, PSIF_DFOCC_DENS, true, true);
-    if (print_ > 3) G2->print();
-
- }// else if (reference_ == "UNRESTRICTED")
-    timer_off("tpdm");
-}  // end ccd_tpdm
-
-//======================================================================
-//    PPL Alpha
-//======================================================================
-void DFOCC::ccd_tpdm_pplA(SharedTensor2d& G, std::string amps) {
-
-    SharedTensor2d T, T2, L2, Tau, X, Y, Z, V, U, L, G2;
-    SharedTensor2d T1, Ts, Ta, Vs, Va, S, A;
-
-        // G_AB^Q += P+(ab) 1/2\sum(EF) V_AEBF b_EF^Q
-        // V_AEBF = 1/2 \sum(MN) L_MN^AE T_MN^BF
-        // Read b_EF^Q
-        bQabA = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|AB)", nQ, navirA, navirA);
-        bQabA->read(psio_, PSIF_DFOCC_INTS, true, true);
-
-        // (-)Tt(mn, ae) = 1/2 (L_mn^ae - L_nm^ae) * (2 - \delta_{mn})
-        T1 = std::make_shared<Tensor2d>("L2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-        T1->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-        Ta = std::make_shared<Tensor2d>("(-)Ut [I>=J|A>=B]", ntri_ijAA, ntri_abAA);
-        Ta->antisymm_row_packed4(T1);
-
-        // Anti-symmetric contributions
-        if (amps == "T2") {
-            T2 = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-            T2->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-        }
-        else if (amps == "Tau") {
-            Tau = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-            Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-            T2 = std::make_shared<Tensor2d>("Tau <IJ|AB>", naoccA, naoccA, navirA, navirA);
-            uccsd_tau_amps(naoccA, naoccA, navirA, navirA, T2, Tau, t1A, t1A);
-            Tau.reset();
-        }
-        else {
-             std::cout << "ccd_tpdm_pplA ---> Unrecognized amps, it should be T2 or Tau ! \n";
-             exit(1);
-        }
-        Va = std::make_shared<Tensor2d>("(-)T[B] (F,M>=N)", navirA, ntri_ijAA);
-        A = std::make_shared<Tensor2d>("A[B] (F,A>=E)", navirA, ntri_abAA);
-        V = std::make_shared<Tensor2d>("V[B] (A,EF)", navirA, navirA, navirA);
-        X = std::make_shared<Tensor2d>("TPDM[B] (Q|A)", nQ, navirA);
-        // Main loop
-        for (int b = 0; b < navirA; ++b) {
-// Form (+)T[b](f, m>=n)
-#pragma omp parallel for
-            for (int m = 0; m < naoccA; ++m) {
-                for (int n = 0; n <= m; ++n) {
-                    int mn2 = index2(m, n);
-                    int mn = n + (m * naoccA);
-                    int nm = m + (n * naoccA);
-                    for (int f = 0; f < navirA; ++f) {
-                        int bf = f + (b * navirA);
-                        double value2 = 0.5 * (T2->get(mn, bf) - T2->get(nm, bf));
-                        Va->set(f, mn2, value2);
-                    }
-                }
-            }
-
-            // Form A[b](f,a>=e) = 1/2 \sum(m>=n) (+)Tt(m>=n,a>=e) * T[b](f,m>=n)
-            A->contract(false, false, navirA, ntri_abAA, ntri_ijAA, Va, Ta, 0.5, 0.0);
-
-// Form V[b](a,ef)
-#pragma omp parallel for
-            for (int a = 0; a < navirA; ++a) {
-                for (int e = 0; e < navirA; ++e) {
-                    int ae = index2(a, e);
-                    for (int f = 0; f < navirA; ++f) {
-                        int ef = ab_idxAA->get(e, f);
-                        int perm1 = (a > e) ? 1 : -1;
-                        double value = perm1 * A->get(f, ae);
-                        V->set(a, ef, value);
-                    }
-                }
-            }
-
-            // G2[b](Q,a) = 1/2\sum(ef) b(Q,ef) * V[b](a,ef)
-            X->gemm(false, true, bQabA, V, 0.5, 0.0);
-
-// Form G2
-#pragma omp parallel for
-            for (int Q = 0; Q < nQ; ++Q) {
-                for (int a = 0; a < navirA; ++a) {
-                    int ab = ab_idxAA->get(a, b);
-                    G->add(Q, ab, X->get(Q, a));
-                }
-            }
-        }
-        T1.reset();
-        T2.reset();
-        Ta.reset();
-        Va.reset();
-        A.reset();
-        X.reset();
-        V.reset();
-        bQabA.reset();
-
-        // G_AB^Q += P+(AB) 1/2 \sum(ef) V_AeBf b_ef^Q
-        // V_AeBf = \sum(Mn) L_Mn^Ae T_Mn^Bf
-        // Read b_ef^Q
-        bQabB = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|ab)", nQ, navirB, navirB);
-        bQabB->read(psio_, PSIF_DFOCC_INTS, true, true);
-
-        T1 = std::make_shared<Tensor2d>("L2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-        T1->read(psio_, PSIF_DFOCC_AMPS);
-        if (amps == "T2") {
-            T2 = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-            T2->read(psio_, PSIF_DFOCC_AMPS);
-        }
-        else if (amps == "Tau") {
-            Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-            Tau->read(psio_, PSIF_DFOCC_AMPS);
-            T2 = std::make_shared<Tensor2d>("Tau <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-            uccsd_tau_amps_OS(naoccA, naoccB, navirA, navirB, T2, Tau, t1A, t1B);
-            Tau.reset();
-        }
-        else {
-             std::cout << "ccd_tpdm_pplA ---> Unrecognized amps, it should be T2 or Tau ! \n";
-             exit(1);
-        }
-        Ts = std::make_shared<Tensor2d>("T[B] (Mn,f)", naoccA * naoccB, navirB);
-        V = std::make_shared<Tensor2d>("V[B] (A,ef)", navirA, navirB * navirB);
-        X = std::make_shared<Tensor2d>("TPDM[B] (Q|A)", nQ, navirA);
-        // Main loop
-        for (int b = 0; b < navirA; ++b) {
+    T1 = std::make_shared<Tensor2d>("L2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+    T1->read(psio_, PSIF_DFOCC_AMPS);
+    if (amps == "T2") {
+        T2 = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+        T2->read(psio_, PSIF_DFOCC_AMPS);
+    } else if (amps == "Tau") {
+        Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+        Tau->read(psio_, PSIF_DFOCC_AMPS);
+        T2 = std::make_shared<Tensor2d>("Tau <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+        uccsd_tau_amps_OS(naoccA, naoccB, navirA, navirB, T2, Tau, t1A, t1B);
+        Tau.reset();
+    } else {
+        throw std::logic_error("ccd_tpdm_pplA ---> Unrecognized amps, it should be T2 or Tau ! \n");
+    }
+    Ts = std::make_shared<Tensor2d>("T[B] (Mn,f)", naoccA * naoccB, navirB);
+    V = std::make_shared<Tensor2d>("V[B] (A,ef)", navirA, navirB * navirB);
+    X = std::make_shared<Tensor2d>("TPDM[B] (Q|A)", nQ, navirA);
+    // Main loop
+    for (int b = 0; b < navirA; ++b) {
 // Form (+)T[B](Mn,f)
 #pragma omp parallel for
-            for (int m = 0; m < naoccA; ++m) {
-                for (int n = 0; n < naoccB; ++n) {
-                    int mn = n + (m * naoccB);
-                    for (int f = 0; f < navirB; ++f) {
-                        int bf = f + (b * navirB);
-                        Ts->set(mn, f, T2->get(mn, bf));
-                    }
+        for (int m = 0; m < naoccA; ++m) {
+            for (int n = 0; n < naoccB; ++n) {
+                int mn = n + (m * naoccB);
+                for (int f = 0; f < navirB; ++f) {
+                    int bf = f + (b * navirB);
+                    Ts->set(mn, f, T2->get(mn, bf));
                 }
             }
+        }
 
-            // Form V[B](A,ef) = \sum(Mn) L(Mn,Ae) T[B](Mn,f)
-            V->contract(true, false, navirA * navirB, navirB, naoccA * naoccB, T1, Ts, 1.0, 0.0);
+        // Form V[B](A,ef) = \sum(Mn) L(Mn,Ae) T[B](Mn,f)
+        V->contract(true, false, navirA * navirB, navirB, naoccA * naoccB, T1, Ts, 1.0, 0.0);
 
-            // G2[B](Q,A) = 1/2\sum(ef) b(Q,ef) * V[B](A,ef)
-            X->gemm(false, true, bQabB, V, 0.5, 0.0);
+        // G2[B](Q,A) = 1/2\sum(ef) b(Q,ef) * V[B](A,ef)
+        X->gemm(false, true, bQabB, V, 0.5, 0.0);
 
 // Form G2
 #pragma omp parallel for
-            for (int Q = 0; Q < nQ; ++Q) {
-                for (int a = 0; a < navirA; ++a) {
-                    int ab = ab_idxAA->get(a, b);
-                    G->add(Q, ab, X->get(Q, a));
-                }
+        for (int Q = 0; Q < nQ; ++Q) {
+            for (int a = 0; a < navirA; ++a) {
+                int ab = ab_idxAA->get(a, b);
+                G->add(Q, ab, X->get(Q, a));
             }
-        }// main b-loop
-        T1.reset();
-        T2.reset();
-        Ts.reset();
-        X.reset();
-        V.reset();
-        bQabB.reset();
+        }
+    }  // main b-loop
+    T1.reset();
+    T2.reset();
+    Ts.reset();
+    X.reset();
+    V.reset();
+    bQabB.reset();
 
 }  // end ccd_tpdm_pplA
 
@@ -687,175 +680,167 @@ void DFOCC::ccd_tpdm_pplA(SharedTensor2d& G, std::string amps) {
 //    PPL Beta
 //======================================================================
 void DFOCC::ccd_tpdm_pplB(SharedTensor2d& G, std::string amps) {
-
     SharedTensor2d T, T2, L2, Tau, X, Y, Z, V, U, L, G2;
     SharedTensor2d T1, Ts, Ta, Vs, Va, S, A;
 
-        // G_ab^Q += P+(ab) 1/2 \sum(ef) V_aebf b_ef^Q
-        // V_aebf = 1/2 \sum(MN) L_mn^ae T_mn^bf
-        // Read b_ef^Q
-        bQabB = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|ab)", nQ, navirB, navirB);
-        bQabB->read(psio_, PSIF_DFOCC_INTS, true, true);
+    // G_ab^Q += P+(ab) 1/2 \sum(ef) V_aebf b_ef^Q
+    // V_aebf = 1/2 \sum(MN) L_mn^ae T_mn^bf
+    // Read b_ef^Q
+    bQabB = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|ab)", nQ, navirB, navirB);
+    bQabB->read(psio_, PSIF_DFOCC_INTS, true, true);
 
-        // (-)Tt(mn, ae) = 1/2 (T_mn^ae - T_nm^ae) * (2 - \delta_{mn})
-        T1 = std::make_shared<Tensor2d>("L2 <ij|ab>", naoccB, naoccB, navirB, navirB);
-        T1->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-        Ta = std::make_shared<Tensor2d>("(-)Ut [i>=j|a>=b]", ntri_ijBB, ntri_abBB);
-        Ta->antisymm_row_packed4(T1);
+    // (-)Tt(mn, ae) = 1/2 (T_mn^ae - T_nm^ae) * (2 - \delta_{mn})
+    T1 = std::make_shared<Tensor2d>("L2 <ij|ab>", naoccB, naoccB, navirB, navirB);
+    T1->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+    Ta = std::make_shared<Tensor2d>("(-)Ut [i>=j|a>=b]", ntri_ijBB, ntri_abBB);
+    Ta->antisymm_row_packed4(T1);
 
-        // Anti-symmetric contributions
-        if (amps == "T2") {
-            T2 = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
-            T2->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-        }
-        else if (amps == "Tau") {
-            Tau = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
-            Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-            T2 = std::make_shared<Tensor2d>("Tau <ij|ab>", naoccB, naoccB, navirB, navirB);
-            uccsd_tau_amps(naoccB, naoccB, navirB, navirB, T2, Tau, t1B, t1B);
-            Tau.reset();
-        }
-        else {
-             std::cout << "ccd_tpdm_pplB --> Unrecognized amps, it should be T2 or Tau ! \n";
-             exit(1);
-        }
-        Va = std::make_shared<Tensor2d>("(-)T[b] (f,m>=n)", navirB, ntri_ijBB);
-        A = std::make_shared<Tensor2d>("A[b] (f,a>=e)", navirB, ntri_abBB);
-        V = std::make_shared<Tensor2d>("V[b] (a,ef)", navirB, navirB, navirB);
-        X = std::make_shared<Tensor2d>("TPDM[b] (Q|a)", nQ, navirB);
-        // Main loop
-        for (int b = 0; b < navirB; ++b) {
+    // Anti-symmetric contributions
+    if (amps == "T2") {
+        T2 = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
+        T2->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+    } else if (amps == "Tau") {
+        Tau = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
+        Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+        T2 = std::make_shared<Tensor2d>("Tau <ij|ab>", naoccB, naoccB, navirB, navirB);
+        uccsd_tau_amps(naoccB, naoccB, navirB, navirB, T2, Tau, t1B, t1B);
+        Tau.reset();
+    } else {
+        throw std::logic_error("ccd_tpdm_pplB --> Unrecognized amps, it should be T2 or Tau ! \n");
+    }
+    Va = std::make_shared<Tensor2d>("(-)T[b] (f,m>=n)", navirB, ntri_ijBB);
+    A = std::make_shared<Tensor2d>("A[b] (f,a>=e)", navirB, ntri_abBB);
+    V = std::make_shared<Tensor2d>("V[b] (a,ef)", navirB, navirB, navirB);
+    X = std::make_shared<Tensor2d>("TPDM[b] (Q|a)", nQ, navirB);
+    // Main loop
+    for (int b = 0; b < navirB; ++b) {
 // Form (+)T[b](f, m>=n)
 #pragma omp parallel for
-            for (int m = 0; m < naoccB; ++m) {
-                for (int n = 0; n <= m; ++n) {
-                    int mn2 = index2(m, n);
-                    int mn = n + (m * naoccB);
-                    int nm = m + (n * naoccB);
-                    for (int f = 0; f < navirB; ++f) {
-                        int bf = f + (b * navirB);
-                        double value2 = 0.5 * (T2->get(mn, bf) - T2->get(nm, bf));
-                        Va->set(f, mn2, value2);
-                    }
+        for (int m = 0; m < naoccB; ++m) {
+            for (int n = 0; n <= m; ++n) {
+                int mn2 = index2(m, n);
+                int mn = n + (m * naoccB);
+                int nm = m + (n * naoccB);
+                for (int f = 0; f < navirB; ++f) {
+                    int bf = f + (b * navirB);
+                    double value2 = 0.5 * (T2->get(mn, bf) - T2->get(nm, bf));
+                    Va->set(f, mn2, value2);
                 }
             }
+        }
 
-            // Form A[b](f,a>=e) = 1/2 \sum(m>=n) (+)Tt(m>=n,a>=e) * T[b](f,m>=n)
-            A->contract(false, false, navirB, ntri_abBB, ntri_ijBB, Va, Ta, 0.5, 0.0);
+        // Form A[b](f,a>=e) = 1/2 \sum(m>=n) (+)Tt(m>=n,a>=e) * T[b](f,m>=n)
+        A->contract(false, false, navirB, ntri_abBB, ntri_ijBB, Va, Ta, 0.5, 0.0);
 
 // Form V[b](a,ef)
 #pragma omp parallel for
-            for (int a = 0; a < navirB; ++a) {
-                for (int e = 0; e < navirB; ++e) {
-                    int ae = index2(a, e);
-                    for (int f = 0; f < navirB; ++f) {
-                        int ef = ab_idxBB->get(e, f);
-                        int perm1 = (a > e) ? 1 : -1;
-                        double value = perm1 * A->get(f, ae);
-                        V->set(a, ef, value);
-                    }
+        for (int a = 0; a < navirB; ++a) {
+            for (int e = 0; e < navirB; ++e) {
+                int ae = index2(a, e);
+                for (int f = 0; f < navirB; ++f) {
+                    int ef = ab_idxBB->get(e, f);
+                    int perm1 = (a > e) ? 1 : -1;
+                    double value = perm1 * A->get(f, ae);
+                    V->set(a, ef, value);
                 }
             }
+        }
 
-            // G2[b](Q,a) = 1/2\sum(ef) b(Q,ef) * V[b](a,ef)
-            X->gemm(false, true, bQabB, V, 0.5, 0.0);
+        // G2[b](Q,a) = 1/2\sum(ef) b(Q,ef) * V[b](a,ef)
+        X->gemm(false, true, bQabB, V, 0.5, 0.0);
 
 // Form G2
 #pragma omp parallel for
-            for (int Q = 0; Q < nQ; ++Q) {
-                for (int a = 0; a < navirB; ++a) {
-                    int ab = ab_idxBB->get(a, b);
-                    G->add(Q, ab, X->get(Q, a));
-                }
+        for (int Q = 0; Q < nQ; ++Q) {
+            for (int a = 0; a < navirB; ++a) {
+                int ab = ab_idxBB->get(a, b);
+                G->add(Q, ab, X->get(Q, a));
             }
         }
-        T1.reset();
-        T2.reset();
-        Ta.reset();
-        Va.reset();
-        A.reset();
-        X.reset();
-        V.reset();
-        bQabB.reset();
+    }
+    T1.reset();
+    T2.reset();
+    Ta.reset();
+    Va.reset();
+    A.reset();
+    X.reset();
+    V.reset();
+    bQabB.reset();
 
-        // G_ab^Q += P+(ab) 1/2 \sum(ef) V_EaFb b_EF^Q
-        // V_EaFb = \sum(Mn) L_Mn^Ea T_Mn^Fb
-        // Read b_EF^Q
-        bQabA = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|AB)", nQ, navirA, navirA);
-        bQabA->read(psio_, PSIF_DFOCC_INTS, true, true);
+    // G_ab^Q += P+(ab) 1/2 \sum(ef) V_EaFb b_EF^Q
+    // V_EaFb = \sum(Mn) L_Mn^Ea T_Mn^Fb
+    // Read b_EF^Q
+    bQabA = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|AB)", nQ, navirA, navirA);
+    bQabA->read(psio_, PSIF_DFOCC_INTS, true, true);
 
-        T1 = std::make_shared<Tensor2d>("L2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-        T1->read(psio_, PSIF_DFOCC_AMPS);
-        if (amps == "T2") {
-            T2 = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-            T2->read(psio_, PSIF_DFOCC_AMPS);
-        }
-        else if (amps == "Tau") {
-            Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-            Tau->read(psio_, PSIF_DFOCC_AMPS);
-            T2 = std::make_shared<Tensor2d>("Tau <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-            uccsd_tau_amps_OS(naoccA, naoccB, navirA, navirB, T2, Tau, t1A, t1B);
-            Tau.reset();
-        }
-        else {
-             std::cout << "ccd_tpdm_pplB ---> Unrecognized amps, it should be T2 or Tau ! \n";
-             exit(1);
-        }
-        Ts = std::make_shared<Tensor2d>("T[b] (Mn,F)", naoccA * naoccB, navirA);
-        V = std::make_shared<Tensor2d>("V[b] (Ea,F)", navirA * navirB, navirA);
-        Vs = std::make_shared<Tensor2d>("V[b] (EF,a)", navirA * navirA, navirB);
-        X = std::make_shared<Tensor2d>("TPDM[b] (Q|a)", nQ, navirB);
-        // Main loop
-        for (int b = 0; b < navirB; ++b) {
+    T1 = std::make_shared<Tensor2d>("L2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+    T1->read(psio_, PSIF_DFOCC_AMPS);
+    if (amps == "T2") {
+        T2 = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+        T2->read(psio_, PSIF_DFOCC_AMPS);
+    } else if (amps == "Tau") {
+        Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+        Tau->read(psio_, PSIF_DFOCC_AMPS);
+        T2 = std::make_shared<Tensor2d>("Tau <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+        uccsd_tau_amps_OS(naoccA, naoccB, navirA, navirB, T2, Tau, t1A, t1B);
+        Tau.reset();
+    } else {
+        throw std::logic_error("ccd_tpdm_pplB ---> Unrecognized amps, it should be T2 or Tau ! \n");
+    }
+    Ts = std::make_shared<Tensor2d>("T[b] (Mn,F)", naoccA * naoccB, navirA);
+    V = std::make_shared<Tensor2d>("V[b] (Ea,F)", navirA * navirB, navirA);
+    Vs = std::make_shared<Tensor2d>("V[b] (EF,a)", navirA * navirA, navirB);
+    X = std::make_shared<Tensor2d>("TPDM[b] (Q|a)", nQ, navirB);
+    // Main loop
+    for (int b = 0; b < navirB; ++b) {
 // Form (+)T[b](Mn,F)
 #pragma omp parallel for
-            for (int m = 0; m < naoccA; ++m) {
-                for (int n = 0; n < naoccB; ++n) {
-                    int mn = n + (m * naoccB);
-                    for (int f = 0; f < navirA; ++f) {
-                        int fb = (f * navirB) + b;
-                        Ts->set(mn, f, T2->get(mn, fb));
-                    }
+        for (int m = 0; m < naoccA; ++m) {
+            for (int n = 0; n < naoccB; ++n) {
+                int mn = n + (m * naoccB);
+                for (int f = 0; f < navirA; ++f) {
+                    int fb = (f * navirB) + b;
+                    Ts->set(mn, f, T2->get(mn, fb));
                 }
             }
+        }
 
-            // Form V[b](Ea,F) = \sum(Mn) L(Mn,Ea) T[b](Mn,F)
-            V->gemm(true, false, T1, Ts, 1.0, 0.0);
+        // Form V[b](Ea,F) = \sum(Mn) L(Mn,Ea) T[b](Mn,F)
+        V->gemm(true, false, T1, Ts, 1.0, 0.0);
 
 // Form Vs[b](EF,a)
 #pragma omp parallel for
-            for (int e = 0; e < navirA; ++e) {
-                for (int f = 0; f < navirA; ++f) {
-                    int ef = ab_idxAA->get(e, f);
-                    for (int a = 0; a < navirB; ++a) {
-                        int ea = (e * navirB) + a;
-                        Vs->set(ef, a, V->get(ea, f));
-                    }
-                }
-            }
-
-            // G2[b](Q,a) = 1/2 \sum(EF) b(Q,EF) * Vs[b](EF,a)
-            X->gemm(false, false, bQabA, Vs, 0.5, 0.0);
-
-// Form G2
-#pragma omp parallel for
-            for (int Q = 0; Q < nQ; ++Q) {
+        for (int e = 0; e < navirA; ++e) {
+            for (int f = 0; f < navirA; ++f) {
+                int ef = ab_idxAA->get(e, f);
                 for (int a = 0; a < navirB; ++a) {
-                    int ab = ab_idxBB->get(a, b);
-                    G->add(Q, ab, X->get(Q, a));
+                    int ea = (e * navirB) + a;
+                    Vs->set(ef, a, V->get(ea, f));
                 }
             }
         }
-        T1.reset();
-        T2.reset();
-        Ts.reset();
-        X.reset();
-        V.reset();
-        Vs.reset();
-        bQabA.reset();
+
+        // G2[b](Q,a) = 1/2 \sum(EF) b(Q,EF) * Vs[b](EF,a)
+        X->gemm(false, false, bQabA, Vs, 0.5, 0.0);
+
+// Form G2
+#pragma omp parallel for
+        for (int Q = 0; Q < nQ; ++Q) {
+            for (int a = 0; a < navirB; ++a) {
+                int ab = ab_idxBB->get(a, b);
+                G->add(Q, ab, X->get(Q, a));
+            }
+        }
+    }
+    T1.reset();
+    T2.reset();
+    Ts.reset();
+    X.reset();
+    V.reset();
+    Vs.reset();
+    bQabA.reset();
 
 }  // end ccd_tpdm_pplB
-
 
 }  // namespace dfoccwave
 }  // namespace psi

--- a/psi4/src/psi4/dfocc/ccd_tpdm.cc
+++ b/psi4/src/psi4/dfocc/ccd_tpdm.cc
@@ -39,143 +39,533 @@ namespace dfoccwave {
 void DFOCC::ccd_tpdm() {
     timer_on("tpdm");
 
-    // RHF
-    if (reference_ == "RESTRICTED") {
-        SharedTensor2d T, U, Tau, G, G2, V, X, Y, Z;
-        SharedTensor2d Ts, Ta, Vs, Va, S, A;
+ // RHF
+ if (reference_ == "RESTRICTED") {
+    SharedTensor2d T, U, Tau, G, G2, V, X, Y, Z;
+    SharedTensor2d Ts, Ta, Vs, Va, S, A;
 
-        //============================
-        // OO-Block Correlation TPDM
-        //============================
+    //============================
+    // OO-Block Correlation TPDM
+    //============================
 
-        // G_ij^Q += P+(ij) V_ij^Q
-        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IJ)", nQ, naoccA, naoccA);
-        V = std::make_shared<Tensor2d>("V (Q|IJ)", nQ, naoccA, naoccA);
-        V->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(V, 1.0);
-        V.reset();
-        // G_ij^Q -= P+(ij) 2*V'_ij^Q
-        V = std::make_shared<Tensor2d>("Vp (Q|IJ)", nQ, naoccA, naoccA);
-        V->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(V, -2.0);
-        V.reset();
+    // G_ij^Q += P+(ij) V_ij^Q
+    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IJ)", nQ, naoccA, naoccA);
+    V = std::make_shared<Tensor2d>("V (Q|IJ)", nQ, naoccA, naoccA);
+    V->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(V, 1.0);
+    V.reset();
+    // G_ij^Q -= P+(ij) 2*V'_ij^Q
+    V = std::make_shared<Tensor2d>("Vp (Q|IJ)", nQ, naoccA, naoccA);
+    V->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(V, -2.0);
+    V.reset();
 
-        // symmetrize
-        G->symmetrize3(G);
-        G->scale(2.0);
-        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OO)", nQ, noccA, noccA);
-        G2->set3_act_oo(nfrzc, G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS);
-        if (print_ > 3) G2->print();
-        G2.reset();
+    // symmetrize
+    G->symmetrize3(G);
+    G->scale(2.0);
+    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OO)", nQ, noccA, noccA);
+    G2->set3_act_oo(nfrzc, G);
+    G.reset();
+    G2->write(psio_, PSIF_DFOCC_DENS);
+    if (print_ > 3) G2->print();
+    G2.reset();
 
-        //============================
-        // OV-Block Correlation TPDM
-        //============================
+    //============================
+    // OV-Block Correlation TPDM
+    //============================
 
-        // G_ia^Q = T_ia^Q
-        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IA)", nQ, naoccA, navirA);
-        T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
-        T->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(T, 1.0);
-        T.reset();
-        // G_ia^Q += L_ia^Q
-        T = std::make_shared<Tensor2d>("L2 (Q|IA)", nQ, naoccA, navirA);
-        T->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(T, 1.0);
-        T.reset();
-        // G_ia^Q += 2*y_ia^Q
-        T = std::make_shared<Tensor2d>("Y (Q|IA)", nQ, naoccA, navirA);
-        T->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(T, 2.0);
-        T.reset();
+    // G_ia^Q = T_ia^Q
+    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IA)", nQ, naoccA, navirA);
+    T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
+    T->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(T, 1.0);
+    T.reset();
+    // G_ia^Q += L_ia^Q
+    T = std::make_shared<Tensor2d>("L2 (Q|IA)", nQ, naoccA, navirA);
+    T->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(T, 1.0);
+    T.reset();
+    // G_ia^Q += 2*y_ia^Q
+    T = std::make_shared<Tensor2d>("Y (Q|IA)", nQ, naoccA, navirA);
+    T->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(T, 2.0);
+    T.reset();
 
-        // G_ia^Q -= \sum(m) T_ma^Q G_im
-        T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
-        T->read(psio_, PSIF_DFOCC_AMPS);
-        G->contract233(false, false, naoccA, navirA, GijA, T, -1.0, 1.0);
+    // G_ia^Q -= \sum(m) T_ma^Q G_im
+    T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
+    T->read(psio_, PSIF_DFOCC_AMPS);
+    G->contract233(false, false, naoccA, navirA, GijA, T, -1.0, 1.0);
 
-        // G_ia^Q += \sum(e) T_ie^Q G_ea
-        G->contract(false, false, nQ * naoccA, navirA, navirA, T, GabA, 1.0, 1.0);
-        // G->cont323("IA", "IE", "EA", false, T, GabA, 1.0, 1.0); // it works
-        T.reset();
+    // G_ia^Q += \sum(e) T_ie^Q G_ea
+    G->contract(false, false, nQ * naoccA, navirA, navirA, T, GabA, 1.0, 1.0);
+    // G->cont323("IA", "IE", "EA", false, T, GabA, 1.0, 1.0); // it works
+    T.reset();
 
-        // G_ia^Q += \sum(me) U(ia,me) (G_em^Q - G_me^Q)
-        U = std::make_shared<Tensor2d>("G (Q|AI)", nQ, navirA, naoccA);
-        U->read(psio_, PSIF_DFOCC_AMPS);
-        T = std::make_shared<Tensor2d>("Temp (Q|IA)", nQ, naoccA, navirA);
-        T->swap_3index_col(U);
-        U.reset();
-        U = std::make_shared<Tensor2d>("G (Q|IA)", nQ, naoccA, navirA);
-        U->read(psio_, PSIF_DFOCC_AMPS);
-        T->axpy(U, -1.0);
-        U.reset();
-        U = std::make_shared<Tensor2d>("U2 (IA|JB)", naoccA, navirA, naoccA, navirA);
-        U->read_symm(psio_, PSIF_DFOCC_AMPS);
-        G->gemm(false, true, T, U, 1.0, 1.0);
-        U.reset();
-        T.reset();
+    // G_ia^Q += \sum(me) U(ia,me) (G_em^Q - G_me^Q)
+    U = std::make_shared<Tensor2d>("G (Q|AI)", nQ, navirA, naoccA);
+    U->read(psio_, PSIF_DFOCC_AMPS);
+    T = std::make_shared<Tensor2d>("Temp (Q|IA)", nQ, naoccA, navirA);
+    T->swap_3index_col(U);
+    U.reset();
+    U = std::make_shared<Tensor2d>("G (Q|IA)", nQ, naoccA, navirA);
+    U->read(psio_, PSIF_DFOCC_AMPS);
+    T->axpy(U, -1.0);
+    U.reset();
+    U = std::make_shared<Tensor2d>("U2 (IA|JB)", naoccA, navirA, naoccA, navirA);
+    U->read_symm(psio_, PSIF_DFOCC_AMPS);
+    G->gemm(false, true, T, U, 1.0, 1.0);
+    U.reset();
+    T.reset();
 
-        // Form overall OV Block
-        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OV)", nQ, noccA, nvirA);
-        G2->set3_act_ov(nfrzc, naoccA, navirA, nvirA, G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS);
-        if (print_ > 3) G2->print();
+    // Form overall OV Block
+    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OV)", nQ, noccA, nvirA);
+    G2->set3_act_ov(nfrzc, naoccA, navirA, nvirA, G);
+    G.reset();
+    G2->write(psio_, PSIF_DFOCC_DENS);
+    if (print_ > 3) G2->print();
 
-        // Form G_vo^Q
-        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VO)", nQ, nvirA, noccA);
-        G->swap_3index_col(G2);
-        G2.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-        if (print_ > 3) G->print();
-        G.reset();
+    // Form G_vo^Q
+    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VO)", nQ, nvirA, noccA);
+    G->swap_3index_col(G2);
+    G2.reset();
+    G->write(psio_, PSIF_DFOCC_DENS);
+    if (print_ > 3) G->print();
+    G.reset();
 
-        //============================
-        // VV-Block Correlation TPDM
-        //============================
+    //============================
+    // VV-Block Correlation TPDM
+    //============================
 
-        // G_ab^Q -= P+(ab) 2*V_ab^Q
-        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|AB)", nQ, navirA, navirA);
-        V = std::make_shared<Tensor2d>("V (Q|AB)", nQ, navirA, navirA);
-        V->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(V, -2.0);
-        V.reset();
+    // G_ab^Q -= P+(ab) 2*V_ab^Q
+    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|AB)", nQ, navirA, navirA);
+    V = std::make_shared<Tensor2d>("V (Q|AB)", nQ, navirA, navirA);
+    V->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(V, -2.0);
+    V.reset();
 
-        // G_ab^Q += P+(ab) \sum(ef) Vt_aebf b_ef^Q
-        // Read b_ef^Q
+    // G_ab^Q += P+(ab) \sum(ef) Vt_aebf b_ef^Q
+    // Read b_ef^Q
+    bQabA = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|AB)", nQ, navirA, navirA);
+    bQabA->read(psio_, PSIF_DFOCC_INTS, true, true);
+
+    // (+)Ut(mn, ae) = 1/2 (Ut_mn^ae + Ut_nm^ae) * (2 - \delta_{mn})
+    // (-)Ut(mn, ae) = 1/2 (Ut_mn^ae - Ut_nm^ae) * (2 - \delta_{mn})
+    T = std::make_shared<Tensor2d>("Ut2 (IA|JB)", naoccA, navirA, naoccA, navirA);
+    T->read_symm(psio_, PSIF_DFOCC_AMPS);
+    U = std::make_shared<Tensor2d>("Ut2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
+    U->sort(1324, T, 1.0, 0.0);
+    T.reset();
+    Ts = std::make_shared<Tensor2d>("(+)Ut [I>=J|A>=B]", ntri_ijAA, ntri_abAA);
+    Ta = std::make_shared<Tensor2d>("(-)Ut [I>=J|A>=B]", ntri_ijAA, ntri_abAA);
+    Ts->symm_row_packed4(U);
+    Ta->antisymm_row_packed4(U);
+    U.reset();
+
+    // Symmetric & Anti-symmetric contributions
+    U = std::make_shared<Tensor2d>("T2 (IA|JB)", naoccA, navirA, naoccA, navirA);
+    U->read_symm(psio_, PSIF_DFOCC_AMPS);
+    Tau = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
+    Tau->sort(1324, U, 1.0, 0.0);
+    U.reset();
+    Vs = std::make_shared<Tensor2d>("(+)T[B] (F,M>=N)", navirA, ntri_ijAA);
+    Va = std::make_shared<Tensor2d>("(-)T[B] (F,M>=N)", navirA, ntri_ijAA);
+    S = std::make_shared<Tensor2d>("S[B] (F,A>=E)", navirA, ntri_abAA);
+    A = std::make_shared<Tensor2d>("A[B] (F,A>=E)", navirA, ntri_abAA);
+    V = std::make_shared<Tensor2d>("V[B] (A,EF)", navirA, navirA, navirA);
+    X = std::make_shared<Tensor2d>("TPDM[B] (Q|A)", nQ, navirA);
+    // Main loop
+    for (int b = 0; b < navirA; ++b) {
+// Form (+)Tau[b](f, m>=n)
+#pragma omp parallel for
+        for (int m = 0; m < naoccA; ++m) {
+            for (int n = 0; n <= m; ++n) {
+                int mn2 = index2(m, n);
+                int mn = n + (m * naoccA);
+                int nm = m + (n * naoccA);
+                for (int f = 0; f < navirA; ++f) {
+                    int bf = f + (b * navirA);
+                    double value1 = 0.5 * (Tau->get(mn, bf) + Tau->get(nm, bf));
+                    double value2 = 0.5 * (Tau->get(mn, bf) - Tau->get(nm, bf));
+                    Vs->set(f, mn2, value1);
+                    Va->set(f, mn2, value2);
+                }
+            }
+        }
+
+        // Form S[b](f,a>=e) = \sum(m>=n) (+)Ut(m>=n,a>=e) * Tau[b](f,m>=n)
+        S->contract(false, false, navirA, ntri_abAA, ntri_ijAA, Vs, Ts, 1.0, 0.0);
+        A->contract(false, false, navirA, ntri_abAA, ntri_ijAA, Va, Ta, 1.0, 0.0);
+
+// Form V[b](a,ef)
+#pragma omp parallel for
+        for (int a = 0; a < navirA; ++a) {
+            for (int e = 0; e < navirA; ++e) {
+                int ae = index2(a, e);
+                for (int f = 0; f < navirA; ++f) {
+                    int ef = ab_idxAA->get(e, f);
+                    int perm1 = (a > e) ? 1 : -1;
+                    double value = S->get(f, ae) + (perm1 * A->get(f, ae));
+                    V->set(a, ef, value);
+                }
+            }
+        }
+
+        // G2[b](Q,a) = \sum(ef) b(Q,ef) * V[b](a,ef)
+        X->gemm(false, true, bQabA, V, 1.0, 0.0);
+
+// Form G2
+#pragma omp parallel for
+        for (int Q = 0; Q < nQ; ++Q) {
+            for (int a = 0; a < navirA; ++a) {
+                int ab = ab_idxAA->get(a, b);
+                G->add(Q, ab, X->get(Q, a));
+            }
+        }
+    }
+    Tau.reset();
+    Ts.reset();
+    Ta.reset();
+    Vs.reset();
+    Va.reset();
+    S.reset();
+    A.reset();
+    X.reset();
+    V.reset();
+    bQabA.reset();
+
+    // symmetrize
+    G->symmetrize3(G);
+    G->scale(2.0);
+    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VV)", nQ, nvirA, nvirA);
+    G2->set3_act_vv(G);
+    G.reset();
+    G2->write(psio_, PSIF_DFOCC_DENS, true, true);
+    if (print_ > 3) G2->print();
+    G2.reset();
+
+ }// end if (reference_ == "RESTRICTED")
+
+ // UHF
+ else if (reference_ == "UNRESTRICTED") {
+    SharedTensor2d T, T2, L2, Tau, X, Y, Z, V, U, L, G, G2;
+    SharedTensor2d T1, Ts, Ta, Vs, Va, S, A;
+    //std::cout << "TPDM is starting \n";
+
+    /////////////////////////////////
+    //// OO-Block ///////////////////
+    /////////////////////////////////
+
+    //// Alpha BLock ////////////////
+
+    // G_IJ^Q += 0.5 * P+(IJ) V_IJ^Q
+    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IJ)", nQ, naoccA, naoccA);
+    V = std::make_shared<Tensor2d>("V (Q|IJ)", nQ, naoccA, naoccA);
+    V->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(V, 0.5);
+    V.reset();
+
+    // G_IJ^Q -= 0.5 * P+(IJ) 2*V'_IJ^Q
+    V = std::make_shared<Tensor2d>("Vp (Q|IJ)", nQ, naoccA, naoccA);
+    V->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(V, -1.0);
+    V.reset();
+
+    // SYMMETRIZE
+    G->symmetrize3(G);
+    G->scale(2.0);
+    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OO)", nQ, noccA, noccA);
+    G2->set3_act_oo(nfrzc, G);
+    G.reset();
+    G2->write(psio_, PSIF_DFOCC_DENS);
+    if (print_ > 3) G2->print();
+    G2.reset();
+
+    //// Beta BLock  ////////////////
+
+    // G_ij^Q += 0.5 * P+(ij) V_ij^Q
+    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ij)", nQ, naoccB, naoccB);
+    V = std::make_shared<Tensor2d>("V (Q|ij)", nQ, naoccB, naoccB);
+    V->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(V, 0.5);
+    V.reset();
+
+    // G_ij^Q -= 0.5 * P+(ij) 2*V'_ij^Q
+    V = std::make_shared<Tensor2d>("Vp (Q|ij)", nQ, naoccB, naoccB);
+    V->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(V, -1.0);
+    V.reset();
+
+    // symmetrize
+    G->symmetrize3(G);
+    G->scale(2.0);
+    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|oo)", nQ, noccB, noccB);
+    G2->set3_act_oo(nfrzc, G);
+    G.reset();
+    G2->write(psio_, PSIF_DFOCC_DENS);
+    if (print_ > 3) G2->print();
+    G2.reset();
+
+    /////////////////////////////////
+    //// OV-Block ///////////////////
+    /////////////////////////////////
+
+    //// Alpha BLock ////////////////
+
+    // G_IA^Q = 0.5 * T_IA^Q
+    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IA)", nQ, naoccA, navirA);
+    T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
+    T->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(T, 0.5);
+    T.reset();
+
+    // G_IA^Q += 0.5 * L_IA^Q
+    T = std::make_shared<Tensor2d>("L2 (Q|IA)", nQ, naoccA, navirA);
+    T->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(T, 0.5);
+    T.reset();
+
+    // G_IA^Q += 0.5 * 2*y_IA^Q
+    T = std::make_shared<Tensor2d>("Y (Q|IA)", nQ, naoccA, navirA);
+    T->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(T, 1.0);
+    T.reset();
+
+    // G_IA^Q -= 0.5 * \sum(M) T_MA^Q G_IM
+    T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
+    T->read(psio_, PSIF_DFOCC_AMPS);
+    G->contract233(false, false, naoccA, navirA, GijA, T, -0.5, 1.0);
+
+    // G_IA^Q += 0.5 * \sum(E) T_IE^Q G_EA
+    G->contract(false, false, nQ * naoccA, navirA, navirA, T, GabA, 0.5, 1.0);
+    T.reset();
+
+    // G_IA^Q += 0.5 * \sum(ME) T(IM,AE) (G_EM^Q - G_ME^Q)
+    U = std::make_shared<Tensor2d>("G (Q|AI)", nQ, navirA, naoccA);
+    U->read(psio_, PSIF_DFOCC_AMPS);
+    T = std::make_shared<Tensor2d>("Temp (Q|IA)", nQ, naoccA, navirA);
+    T->swap_3index_col(U);
+    U.reset();
+    U = std::make_shared<Tensor2d>("G (Q|IA)", nQ, naoccA, navirA);
+    U->read(psio_, PSIF_DFOCC_AMPS);
+    T->axpy(U, -1.0);
+    U.reset();
+    Tau = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
+    Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+    U = std::make_shared<Tensor2d>("T2 (ME|IA)", naoccA, navirA, naoccA, navirA);
+    U->sort(2413, Tau, 1.0, 0.0);
+    Tau.reset();
+    G->gemm(false, false, T, U, 0.5, 1.0);
+    U.reset();
+    T.reset();
+
+    // G_IA^Q += 0.5 * \sum(me) T(Im,Ae) (Gt_em^Q - Gt_me^Q)
+    U = std::make_shared<Tensor2d>("G (Q|ai)", nQ, navirB, naoccB);
+    U->read(psio_, PSIF_DFOCC_AMPS);
+    T = std::make_shared<Tensor2d>("Temp (Q|ia)", nQ, naoccB, navirB);
+    T->swap_3index_col(U);
+    U.reset();
+    U = std::make_shared<Tensor2d>("G (Q|ia)", nQ, naoccB, navirB);
+    U->read(psio_, PSIF_DFOCC_AMPS);
+    T->axpy(U, -1.0);
+    U.reset();
+    Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+    Tau->read(psio_, PSIF_DFOCC_AMPS);
+    U = std::make_shared<Tensor2d>("T2 (me|IA)", naoccB, navirB, naoccA, navirA);
+    U->sort(2413, Tau, 1.0, 0.0);
+    Tau.reset();
+    G->gemm(false, false, T, U, 0.5, 1.0);
+    U.reset();
+    T.reset();
+
+    // Form overall OV Block
+    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OV)", nQ, noccA, nvirA);
+    G2->set3_act_ov(nfrzc, naoccA, navirA, nvirA, G);
+    G.reset();
+    G2->write(psio_, PSIF_DFOCC_DENS);
+    if (print_ > 3) G2->print();
+
+    // Form G_vo^Q
+    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VO)", nQ, nvirA, noccA);
+    G->swap_3index_col(G2);
+    G2.reset();
+    G->write(psio_, PSIF_DFOCC_DENS);
+    if (print_ > 3) G->print();
+    G.reset();
+
+    //// Beta BLock  ////////////////
+
+    // G_ia^Q = 0.5 * T_ia^Q
+    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ia)", nQ, naoccB, navirB);
+    T = std::make_shared<Tensor2d>("T2 (Q|ia)", nQ, naoccB, navirB);
+    T->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(T, 0.5);
+    T.reset();
+    // G_ia^Q += 0.5 * L_ia^Q
+    T = std::make_shared<Tensor2d>("L2 (Q|ia)", nQ, naoccB, navirB);
+    T->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(T, 0.5);
+    T.reset();
+    // G_ia^Q += 0.5 * 2*y_ia^Q
+    T = std::make_shared<Tensor2d>("Y (Q|ia)", nQ, naoccB, navirB);
+    T->read(psio_, PSIF_DFOCC_AMPS);
+    G->axpy(T, 1.0);
+    T.reset();
+
+    // G_ia^Q -= 0.5 * \sum(m) T_ma^Q G_im
+    T = std::make_shared<Tensor2d>("T2 (Q|ia)", nQ, naoccB, navirB);
+    T->read(psio_, PSIF_DFOCC_AMPS);
+    G->contract233(false, false, naoccB, navirB, GijB, T, -0.5, 1.0);
+
+    // G_ia^Q += 0.5 * \sum(e) T_ie^Q G_ea
+    G->contract(false, false, nQ * naoccB, navirB, navirB, T, GabB, 0.5, 1.0);
+    T.reset();
+
+    // G_ia^Q += 0.5 * \sum(me) T(im,ae) (G_em^Q - G_me^Q)
+    U = std::make_shared<Tensor2d>("G (Q|ai)", nQ, navirB, naoccB);
+    U->read(psio_, PSIF_DFOCC_AMPS);
+    T = std::make_shared<Tensor2d>("Temp (Q|ia)", nQ, naoccB, navirB);
+    T->swap_3index_col(U);
+    U.reset();
+    U = std::make_shared<Tensor2d>("G (Q|ia)", nQ, naoccB, navirB);
+    U->read(psio_, PSIF_DFOCC_AMPS);
+    T->axpy(U, -1.0);
+    U.reset();
+    Tau = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
+    Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+    U = std::make_shared<Tensor2d>("T2 (me|ia)", naoccB, navirB, naoccB, navirB);
+    U->sort(2413, Tau, 1.0, 0.0);
+    Tau.reset();
+    G->gemm(false, false, T, U, 0.5, 1.0);
+    U.reset();
+    T.reset();
+
+    // G_ia^Q += 0.5 * \sum(ME) T(Mi,Ea) (G_EM^Q - G_ME^Q)
+    U = std::make_shared<Tensor2d>("G (Q|AI)", nQ, navirA, naoccA);
+    U->read(psio_, PSIF_DFOCC_AMPS);
+    T = std::make_shared<Tensor2d>("Temp (Q|IA)", nQ, naoccA, navirA);
+    T->swap_3index_col(U);
+    U.reset();
+    U = std::make_shared<Tensor2d>("G (Q|IA)", nQ, naoccA, navirA);
+    U->read(psio_, PSIF_DFOCC_AMPS);
+    T->axpy(U, -1.0);
+    U.reset();
+    Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+    Tau->read(psio_, PSIF_DFOCC_AMPS);
+    U = std::make_shared<Tensor2d>("T2 (ME|ia)", naoccA, navirA, naoccB, navirB);
+    U->sort(1324, Tau, 1.0, 0.0);
+    Tau.reset();
+    G->gemm(false, false, T, U, 0.5, 1.0);
+    U.reset();
+    T.reset();
+
+    // Form overall OV Block
+    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ov)", nQ, noccB, nvirB);
+    G2->set3_act_ov(nfrzc, naoccB, navirB, nvirB, G);
+    G.reset();
+    G2->write(psio_, PSIF_DFOCC_DENS);
+    if (print_ > 3) G2->print();
+
+    // Form G_vo^Q
+    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|vo)", nQ, nvirB, noccB);
+    G->swap_3index_col(G2);
+    G2.reset();
+    G->write(psio_, PSIF_DFOCC_DENS);
+    if (print_ > 3) G->print();
+    G.reset();
+
+    /////////////////////////////////
+    //// VV-Block ///////////////////
+    /////////////////////////////////
+
+    //// Alpha BLock ////////////////
+
+    // G_AB^Q = P+(AB) V_AB^Q
+    V = std::make_shared<Tensor2d>("V (Q|AB)", nQ, navirA, navirA);
+    V->read(psio_, PSIF_DFOCC_AMPS);
+    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|AB)", nQ, navirA, navirA);
+    G->axpy(V, -1.0);
+    V.reset();
+
+    // PPL
+    ccd_tpdm_pplA(G, "T2");
+
+    // SYMMETRIZE
+    G->symmetrize3(G);
+    G->scale(2.0);
+    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VV)", nQ, nvirA, nvirA);
+    G2->set3_act_vv(G);
+    G.reset();
+    G2->write(psio_, PSIF_DFOCC_DENS, true, true);
+    if (print_ > 3) G2->print();
+    G2.reset();
+
+    //// Beta BLock ////////////////
+
+    // G_ab^Q -= P+(ab) V_ab^Q
+    V = std::make_shared<Tensor2d>("V (Q|ab)", nQ, navirB, navirB);
+    V->read(psio_, PSIF_DFOCC_AMPS);
+    G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ab)", nQ, navirB, navirB);
+    G->axpy(V, -1.0);
+    V.reset();
+
+    // PPL
+    ccd_tpdm_pplB(G, "T2");
+
+    // symmetrize
+    G->symmetrize3(G);
+    G->scale(2.0);
+    G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|vv)", nQ, nvirB, nvirB);
+    G2->set3_act_vv(G);
+    G.reset();
+    G2->write(psio_, PSIF_DFOCC_DENS, true, true);
+    if (print_ > 3) G2->print();
+
+ }// else if (reference_ == "UNRESTRICTED")
+    timer_off("tpdm");
+}  // end ccd_tpdm
+
+//======================================================================
+//    PPL Alpha
+//======================================================================
+void DFOCC::ccd_tpdm_pplA(SharedTensor2d& G, std::string amps) {
+
+    SharedTensor2d T, T2, L2, Tau, X, Y, Z, V, U, L, G2;
+    SharedTensor2d T1, Ts, Ta, Vs, Va, S, A;
+
+        // G_AB^Q += P+(ab) 1/2\sum(EF) V_AEBF b_EF^Q
+        // V_AEBF = 1/2 \sum(MN) L_MN^AE T_MN^BF
+        // Read b_EF^Q
         bQabA = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|AB)", nQ, navirA, navirA);
         bQabA->read(psio_, PSIF_DFOCC_INTS, true, true);
 
-        // (+)Ut(mn, ae) = 1/2 (Ut_mn^ae + Ut_nm^ae) * (2 - \delta_{mn})
-        // (-)Ut(mn, ae) = 1/2 (Ut_mn^ae - Ut_nm^ae) * (2 - \delta_{mn})
-        T = std::make_shared<Tensor2d>("Ut2 (IA|JB)", naoccA, navirA, naoccA, navirA);
-        T->read_symm(psio_, PSIF_DFOCC_AMPS);
-        U = std::make_shared<Tensor2d>("Ut2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-        U->sort(1324, T, 1.0, 0.0);
-        T.reset();
-        Ts = std::make_shared<Tensor2d>("(+)Ut [I>=J|A>=B]", ntri_ijAA, ntri_abAA);
+        // (-)Tt(mn, ae) = 1/2 (L_mn^ae - L_nm^ae) * (2 - \delta_{mn})
+        T1 = std::make_shared<Tensor2d>("L2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
+        T1->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
         Ta = std::make_shared<Tensor2d>("(-)Ut [I>=J|A>=B]", ntri_ijAA, ntri_abAA);
-        Ts->symm_row_packed4(U);
-        Ta->antisymm_row_packed4(U);
-        U.reset();
+        Ta->antisymm_row_packed4(T1);
 
-        // Symmetric & Anti-symmetric contributions
-        U = std::make_shared<Tensor2d>("T2 (IA|JB)", naoccA, navirA, naoccA, navirA);
-        U->read_symm(psio_, PSIF_DFOCC_AMPS);
-        Tau = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-        Tau->sort(1324, U, 1.0, 0.0);
-        U.reset();
-        Vs = std::make_shared<Tensor2d>("(+)T[B] (F,M>=N)", navirA, ntri_ijAA);
+        // Anti-symmetric contributions
+        if (amps == "T2") {
+            T2 = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
+            T2->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+        }
+        else if (amps == "Tau") {
+            Tau = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
+            Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+            T2 = std::make_shared<Tensor2d>("Tau <IJ|AB>", naoccA, naoccA, navirA, navirA);
+            uccsd_tau_amps(naoccA, naoccA, navirA, navirA, T2, Tau, t1A, t1A);
+            Tau.reset();
+        }
+        else {
+             throw std::logic_error("ccd_tpdm_pplA ---> Unrecognized amps, it should be T2 or Tau ! \n");
+        }
         Va = std::make_shared<Tensor2d>("(-)T[B] (F,M>=N)", navirA, ntri_ijAA);
-        S = std::make_shared<Tensor2d>("S[B] (F,A>=E)", navirA, ntri_abAA);
         A = std::make_shared<Tensor2d>("A[B] (F,A>=E)", navirA, ntri_abAA);
         V = std::make_shared<Tensor2d>("V[B] (A,EF)", navirA, navirA, navirA);
         X = std::make_shared<Tensor2d>("TPDM[B] (Q|A)", nQ, navirA);
         // Main loop
         for (int b = 0; b < navirA; ++b) {
-// Form (+)Tau[b](f, m>=n)
+// Form (+)T[b](f, m>=n)
 #pragma omp parallel for
             for (int m = 0; m < naoccA; ++m) {
                 for (int n = 0; n <= m; ++n) {
@@ -184,17 +574,14 @@ void DFOCC::ccd_tpdm() {
                     int nm = m + (n * naoccA);
                     for (int f = 0; f < navirA; ++f) {
                         int bf = f + (b * navirA);
-                        double value1 = 0.5 * (Tau->get(mn, bf) + Tau->get(nm, bf));
-                        double value2 = 0.5 * (Tau->get(mn, bf) - Tau->get(nm, bf));
-                        Vs->set(f, mn2, value1);
+                        double value2 = 0.5 * (T2->get(mn, bf) - T2->get(nm, bf));
                         Va->set(f, mn2, value2);
                     }
                 }
             }
 
-            // Form S[b](f,a>=e) = \sum(m>=n) (+)Ut(m>=n,a>=e) * Tau[b](f,m>=n)
-            S->contract(false, false, navirA, ntri_abAA, ntri_ijAA, Vs, Ts, 1.0, 0.0);
-            A->contract(false, false, navirA, ntri_abAA, ntri_ijAA, Va, Ta, 1.0, 0.0);
+            // Form A[b](f,a>=e) = 1/2 \sum(m>=n) (+)Tt(m>=n,a>=e) * T[b](f,m>=n)
+            A->contract(false, false, navirA, ntri_abAA, ntri_ijAA, Va, Ta, 0.5, 0.0);
 
 // Form V[b](a,ef)
 #pragma omp parallel for
@@ -204,14 +591,14 @@ void DFOCC::ccd_tpdm() {
                     for (int f = 0; f < navirA; ++f) {
                         int ef = ab_idxAA->get(e, f);
                         int perm1 = (a > e) ? 1 : -1;
-                        double value = S->get(f, ae) + (perm1 * A->get(f, ae));
+                        double value = perm1 * A->get(f, ae);
                         V->set(a, ef, value);
                     }
                 }
             }
 
-            // G2[b](Q,a) = \sum(ef) b(Q,ef) * V[b](a,ef)
-            X->gemm(false, true, bQabA, V, 1.0, 0.0);
+            // G2[b](Q,a) = 1/2\sum(ef) b(Q,ef) * V[b](a,ef)
+            X->gemm(false, true, bQabA, V, 0.5, 0.0);
 
 // Form G2
 #pragma omp parallel for
@@ -222,457 +609,75 @@ void DFOCC::ccd_tpdm() {
                 }
             }
         }
-        Tau.reset();
-        Ts.reset();
+        T1.reset();
+        T2.reset();
         Ta.reset();
-        Vs.reset();
         Va.reset();
-        S.reset();
         A.reset();
         X.reset();
         V.reset();
         bQabA.reset();
 
-        // symmetrize
-        G->symmetrize3(G);
-        G->scale(2.0);
-        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VV)", nQ, nvirA, nvirA);
-        G2->set3_act_vv(G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS, true, true);
-        if (print_ > 3) G2->print();
-        G2.reset();
+        // G_AB^Q += P+(AB) 1/2 \sum(ef) V_AeBf b_ef^Q
+        // V_AeBf = \sum(Mn) L_Mn^Ae T_Mn^Bf
+        // Read b_ef^Q
+        bQabB = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|ab)", nQ, navirB, navirB);
+        bQabB->read(psio_, PSIF_DFOCC_INTS, true, true);
 
-    }  // end if (reference_ == "RESTRICTED")
-
-    // UHF
-    else if (reference_ == "UNRESTRICTED") {
-        SharedTensor2d T, T2, L2, Tau, X, Y, Z, V, U, L, G, G2;
-        SharedTensor2d T1, Ts, Ta, Vs, Va, S, A;
-        // std::cout << "TPDM is starting \n";
-
-        /////////////////////////////////
-        //// OO-Block ///////////////////
-        /////////////////////////////////
-
-        //// Alpha BLock ////////////////
-
-        // G_IJ^Q += 0.5 * P+(IJ) V_IJ^Q
-        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IJ)", nQ, naoccA, naoccA);
-        V = std::make_shared<Tensor2d>("V (Q|IJ)", nQ, naoccA, naoccA);
-        V->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(V, 0.5);
-        V.reset();
-
-        // G_IJ^Q -= 0.5 * P+(IJ) 2*V'_IJ^Q
-        V = std::make_shared<Tensor2d>("Vp (Q|IJ)", nQ, naoccA, naoccA);
-        V->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(V, -1.0);
-        V.reset();
-
-        // SYMMETRIZE
-        G->symmetrize3(G);
-        G->scale(2.0);
-        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OO)", nQ, noccA, noccA);
-        G2->set3_act_oo(nfrzc, G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS);
-        if (print_ > 3) G2->print();
-        G2.reset();
-
-        //// Beta BLock  ////////////////
-
-        // G_ij^Q += 0.5 * P+(ij) V_ij^Q
-        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ij)", nQ, naoccB, naoccB);
-        V = std::make_shared<Tensor2d>("V (Q|ij)", nQ, naoccB, naoccB);
-        V->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(V, 0.5);
-        V.reset();
-
-        // G_ij^Q -= 0.5 * P+(ij) 2*V'_ij^Q
-        V = std::make_shared<Tensor2d>("Vp (Q|ij)", nQ, naoccB, naoccB);
-        V->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(V, -1.0);
-        V.reset();
-
-        // symmetrize
-        G->symmetrize3(G);
-        G->scale(2.0);
-        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|oo)", nQ, noccB, noccB);
-        G2->set3_act_oo(nfrzc, G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS);
-        if (print_ > 3) G2->print();
-        G2.reset();
-
-        /////////////////////////////////
-        //// OV-Block ///////////////////
-        /////////////////////////////////
-
-        //// Alpha BLock ////////////////
-
-        // G_IA^Q = 0.5 * T_IA^Q
-        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|IA)", nQ, naoccA, navirA);
-        T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
-        T->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(T, 0.5);
-        T.reset();
-
-        // G_IA^Q += 0.5 * L_IA^Q
-        T = std::make_shared<Tensor2d>("L2 (Q|IA)", nQ, naoccA, navirA);
-        T->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(T, 0.5);
-        T.reset();
-
-        // G_IA^Q += 0.5 * 2*y_IA^Q
-        T = std::make_shared<Tensor2d>("Y (Q|IA)", nQ, naoccA, navirA);
-        T->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(T, 1.0);
-        T.reset();
-
-        // G_IA^Q -= 0.5 * \sum(M) T_MA^Q G_IM
-        T = std::make_shared<Tensor2d>("T2 (Q|IA)", nQ, naoccA, navirA);
-        T->read(psio_, PSIF_DFOCC_AMPS);
-        G->contract233(false, false, naoccA, navirA, GijA, T, -0.5, 1.0);
-
-        // G_IA^Q += 0.5 * \sum(E) T_IE^Q G_EA
-        G->contract(false, false, nQ * naoccA, navirA, navirA, T, GabA, 0.5, 1.0);
-        T.reset();
-
-        // G_IA^Q += 0.5 * \sum(ME) T(IM,AE) (G_EM^Q - G_ME^Q)
-        U = std::make_shared<Tensor2d>("G (Q|AI)", nQ, navirA, naoccA);
-        U->read(psio_, PSIF_DFOCC_AMPS);
-        T = std::make_shared<Tensor2d>("Temp (Q|IA)", nQ, naoccA, navirA);
-        T->swap_3index_col(U);
-        U.reset();
-        U = std::make_shared<Tensor2d>("G (Q|IA)", nQ, naoccA, navirA);
-        U->read(psio_, PSIF_DFOCC_AMPS);
-        T->axpy(U, -1.0);
-        U.reset();
-        Tau = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-        Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-        U = std::make_shared<Tensor2d>("T2 (ME|IA)", naoccA, navirA, naoccA, navirA);
-        U->sort(2413, Tau, 1.0, 0.0);
-        Tau.reset();
-        G->gemm(false, false, T, U, 0.5, 1.0);
-        U.reset();
-        T.reset();
-
-        // G_IA^Q += 0.5 * \sum(me) T(Im,Ae) (Gt_em^Q - Gt_me^Q)
-        U = std::make_shared<Tensor2d>("G (Q|ai)", nQ, navirB, naoccB);
-        U->read(psio_, PSIF_DFOCC_AMPS);
-        T = std::make_shared<Tensor2d>("Temp (Q|ia)", nQ, naoccB, navirB);
-        T->swap_3index_col(U);
-        U.reset();
-        U = std::make_shared<Tensor2d>("G (Q|ia)", nQ, naoccB, navirB);
-        U->read(psio_, PSIF_DFOCC_AMPS);
-        T->axpy(U, -1.0);
-        U.reset();
-        Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-        Tau->read(psio_, PSIF_DFOCC_AMPS);
-        U = std::make_shared<Tensor2d>("T2 (me|IA)", naoccB, navirB, naoccA, navirA);
-        U->sort(2413, Tau, 1.0, 0.0);
-        Tau.reset();
-        G->gemm(false, false, T, U, 0.5, 1.0);
-        U.reset();
-        T.reset();
-
-        // Form overall OV Block
-        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|OV)", nQ, noccA, nvirA);
-        G2->set3_act_ov(nfrzc, naoccA, navirA, nvirA, G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS);
-        if (print_ > 3) G2->print();
-
-        // Form G_vo^Q
-        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VO)", nQ, nvirA, noccA);
-        G->swap_3index_col(G2);
-        G2.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-        if (print_ > 3) G->print();
-        G.reset();
-
-        //// Beta BLock  ////////////////
-
-        // G_ia^Q = 0.5 * T_ia^Q
-        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ia)", nQ, naoccB, navirB);
-        T = std::make_shared<Tensor2d>("T2 (Q|ia)", nQ, naoccB, navirB);
-        T->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(T, 0.5);
-        T.reset();
-        // G_ia^Q += 0.5 * L_ia^Q
-        T = std::make_shared<Tensor2d>("L2 (Q|ia)", nQ, naoccB, navirB);
-        T->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(T, 0.5);
-        T.reset();
-        // G_ia^Q += 0.5 * 2*y_ia^Q
-        T = std::make_shared<Tensor2d>("Y (Q|ia)", nQ, naoccB, navirB);
-        T->read(psio_, PSIF_DFOCC_AMPS);
-        G->axpy(T, 1.0);
-        T.reset();
-
-        // G_ia^Q -= 0.5 * \sum(m) T_ma^Q G_im
-        T = std::make_shared<Tensor2d>("T2 (Q|ia)", nQ, naoccB, navirB);
-        T->read(psio_, PSIF_DFOCC_AMPS);
-        G->contract233(false, false, naoccB, navirB, GijB, T, -0.5, 1.0);
-
-        // G_ia^Q += 0.5 * \sum(e) T_ie^Q G_ea
-        G->contract(false, false, nQ * naoccB, navirB, navirB, T, GabB, 0.5, 1.0);
-        T.reset();
-
-        // G_ia^Q += 0.5 * \sum(me) T(im,ae) (G_em^Q - G_me^Q)
-        U = std::make_shared<Tensor2d>("G (Q|ai)", nQ, navirB, naoccB);
-        U->read(psio_, PSIF_DFOCC_AMPS);
-        T = std::make_shared<Tensor2d>("Temp (Q|ia)", nQ, naoccB, navirB);
-        T->swap_3index_col(U);
-        U.reset();
-        U = std::make_shared<Tensor2d>("G (Q|ia)", nQ, naoccB, navirB);
-        U->read(psio_, PSIF_DFOCC_AMPS);
-        T->axpy(U, -1.0);
-        U.reset();
-        Tau = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
-        Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-        U = std::make_shared<Tensor2d>("T2 (me|ia)", naoccB, navirB, naoccB, navirB);
-        U->sort(2413, Tau, 1.0, 0.0);
-        Tau.reset();
-        G->gemm(false, false, T, U, 0.5, 1.0);
-        U.reset();
-        T.reset();
-
-        // G_ia^Q += 0.5 * \sum(ME) T(Mi,Ea) (G_EM^Q - G_ME^Q)
-        U = std::make_shared<Tensor2d>("G (Q|AI)", nQ, navirA, naoccA);
-        U->read(psio_, PSIF_DFOCC_AMPS);
-        T = std::make_shared<Tensor2d>("Temp (Q|IA)", nQ, naoccA, navirA);
-        T->swap_3index_col(U);
-        U.reset();
-        U = std::make_shared<Tensor2d>("G (Q|IA)", nQ, naoccA, navirA);
-        U->read(psio_, PSIF_DFOCC_AMPS);
-        T->axpy(U, -1.0);
-        U.reset();
-        Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-        Tau->read(psio_, PSIF_DFOCC_AMPS);
-        U = std::make_shared<Tensor2d>("T2 (ME|ia)", naoccA, navirA, naoccB, navirB);
-        U->sort(1324, Tau, 1.0, 0.0);
-        Tau.reset();
-        G->gemm(false, false, T, U, 0.5, 1.0);
-        U.reset();
-        T.reset();
-
-        // Form overall OV Block
-        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ov)", nQ, noccB, nvirB);
-        G2->set3_act_ov(nfrzc, naoccB, navirB, nvirB, G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS);
-        if (print_ > 3) G2->print();
-
-        // Form G_vo^Q
-        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|vo)", nQ, nvirB, noccB);
-        G->swap_3index_col(G2);
-        G2.reset();
-        G->write(psio_, PSIF_DFOCC_DENS);
-        if (print_ > 3) G->print();
-        G.reset();
-
-        /////////////////////////////////
-        //// VV-Block ///////////////////
-        /////////////////////////////////
-
-        //// Alpha BLock ////////////////
-
-        // G_AB^Q = P+(AB) V_AB^Q
-        V = std::make_shared<Tensor2d>("V (Q|AB)", nQ, navirA, navirA);
-        V->read(psio_, PSIF_DFOCC_AMPS);
-        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|AB)", nQ, navirA, navirA);
-        G->axpy(V, -1.0);
-        V.reset();
-
-        // PPL
-        ccd_tpdm_pplA(G, "T2");
-
-        // SYMMETRIZE
-        G->symmetrize3(G);
-        G->scale(2.0);
-        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|VV)", nQ, nvirA, nvirA);
-        G2->set3_act_vv(G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS, true, true);
-        if (print_ > 3) G2->print();
-        G2.reset();
-
-        //// Beta BLock ////////////////
-
-        // G_ab^Q -= P+(ab) V_ab^Q
-        V = std::make_shared<Tensor2d>("V (Q|ab)", nQ, navirB, navirB);
-        V->read(psio_, PSIF_DFOCC_AMPS);
-        G = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|ab)", nQ, navirB, navirB);
-        G->axpy(V, -1.0);
-        V.reset();
-
-        // PPL
-        ccd_tpdm_pplB(G, "T2");
-
-        // symmetrize
-        G->symmetrize3(G);
-        G->scale(2.0);
-        G2 = std::make_shared<Tensor2d>("Correlation 3-Index TPDM (Q|vv)", nQ, nvirB, nvirB);
-        G2->set3_act_vv(G);
-        G.reset();
-        G2->write(psio_, PSIF_DFOCC_DENS, true, true);
-        if (print_ > 3) G2->print();
-
-    }  // else if (reference_ == "UNRESTRICTED")
-    timer_off("tpdm");
-}  // end ccd_tpdm
-
-//======================================================================
-//    PPL Alpha
-//======================================================================
-void DFOCC::ccd_tpdm_pplA(SharedTensor2d& G, std::string amps) {
-    SharedTensor2d T, T2, L2, Tau, X, Y, Z, V, U, L, G2;
-    SharedTensor2d T1, Ts, Ta, Vs, Va, S, A;
-
-    // G_AB^Q += P+(ab) 1/2\sum(EF) V_AEBF b_EF^Q
-    // V_AEBF = 1/2 \sum(MN) L_MN^AE T_MN^BF
-    // Read b_EF^Q
-    bQabA = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|AB)", nQ, navirA, navirA);
-    bQabA->read(psio_, PSIF_DFOCC_INTS, true, true);
-
-    // (-)Tt(mn, ae) = 1/2 (L_mn^ae - L_nm^ae) * (2 - \delta_{mn})
-    T1 = std::make_shared<Tensor2d>("L2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-    T1->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-    Ta = std::make_shared<Tensor2d>("(-)Ut [I>=J|A>=B]", ntri_ijAA, ntri_abAA);
-    Ta->antisymm_row_packed4(T1);
-
-    // Anti-symmetric contributions
-    if (amps == "T2") {
-        T2 = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-        T2->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-    } else if (amps == "Tau") {
-        Tau = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-        Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-        T2 = std::make_shared<Tensor2d>("Tau <IJ|AB>", naoccA, naoccA, navirA, navirA);
-        uccsd_tau_amps(naoccA, naoccA, navirA, navirA, T2, Tau, t1A, t1A);
-        Tau.reset();
-    } else {
-        throw std::logic_error("ccd_tpdm_pplA ---> Unrecognized amps, it should be T2 or Tau ! \n");
-    }
-    Va = std::make_shared<Tensor2d>("(-)T[B] (F,M>=N)", navirA, ntri_ijAA);
-    A = std::make_shared<Tensor2d>("A[B] (F,A>=E)", navirA, ntri_abAA);
-    V = std::make_shared<Tensor2d>("V[B] (A,EF)", navirA, navirA, navirA);
-    X = std::make_shared<Tensor2d>("TPDM[B] (Q|A)", nQ, navirA);
-    // Main loop
-    for (int b = 0; b < navirA; ++b) {
-// Form (+)T[b](f, m>=n)
-#pragma omp parallel for
-        for (int m = 0; m < naoccA; ++m) {
-            for (int n = 0; n <= m; ++n) {
-                int mn2 = index2(m, n);
-                int mn = n + (m * naoccA);
-                int nm = m + (n * naoccA);
-                for (int f = 0; f < navirA; ++f) {
-                    int bf = f + (b * navirA);
-                    double value2 = 0.5 * (T2->get(mn, bf) - T2->get(nm, bf));
-                    Va->set(f, mn2, value2);
-                }
-            }
+        T1 = std::make_shared<Tensor2d>("L2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+        T1->read(psio_, PSIF_DFOCC_AMPS);
+        if (amps == "T2") {
+            T2 = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+            T2->read(psio_, PSIF_DFOCC_AMPS);
         }
-
-        // Form A[b](f,a>=e) = 1/2 \sum(m>=n) (+)Tt(m>=n,a>=e) * T[b](f,m>=n)
-        A->contract(false, false, navirA, ntri_abAA, ntri_ijAA, Va, Ta, 0.5, 0.0);
-
-// Form V[b](a,ef)
-#pragma omp parallel for
-        for (int a = 0; a < navirA; ++a) {
-            for (int e = 0; e < navirA; ++e) {
-                int ae = index2(a, e);
-                for (int f = 0; f < navirA; ++f) {
-                    int ef = ab_idxAA->get(e, f);
-                    int perm1 = (a > e) ? 1 : -1;
-                    double value = perm1 * A->get(f, ae);
-                    V->set(a, ef, value);
-                }
-            }
+        else if (amps == "Tau") {
+            Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+            Tau->read(psio_, PSIF_DFOCC_AMPS);
+            T2 = std::make_shared<Tensor2d>("Tau <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+            uccsd_tau_amps_OS(naoccA, naoccB, navirA, navirB, T2, Tau, t1A, t1B);
+            Tau.reset();
         }
-
-        // G2[b](Q,a) = 1/2\sum(ef) b(Q,ef) * V[b](a,ef)
-        X->gemm(false, true, bQabA, V, 0.5, 0.0);
-
-// Form G2
-#pragma omp parallel for
-        for (int Q = 0; Q < nQ; ++Q) {
-            for (int a = 0; a < navirA; ++a) {
-                int ab = ab_idxAA->get(a, b);
-                G->add(Q, ab, X->get(Q, a));
-            }
+        else {
+             throw std::logic_error("ccd_tpdm_pplA ---> Unrecognized amps, it should be T2 or Tau ! \n");
         }
-    }
-    T1.reset();
-    T2.reset();
-    Ta.reset();
-    Va.reset();
-    A.reset();
-    X.reset();
-    V.reset();
-    bQabA.reset();
-
-    // G_AB^Q += P+(AB) 1/2 \sum(ef) V_AeBf b_ef^Q
-    // V_AeBf = \sum(Mn) L_Mn^Ae T_Mn^Bf
-    // Read b_ef^Q
-    bQabB = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|ab)", nQ, navirB, navirB);
-    bQabB->read(psio_, PSIF_DFOCC_INTS, true, true);
-
-    T1 = std::make_shared<Tensor2d>("L2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-    T1->read(psio_, PSIF_DFOCC_AMPS);
-    if (amps == "T2") {
-        T2 = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-        T2->read(psio_, PSIF_DFOCC_AMPS);
-    } else if (amps == "Tau") {
-        Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-        Tau->read(psio_, PSIF_DFOCC_AMPS);
-        T2 = std::make_shared<Tensor2d>("Tau <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-        uccsd_tau_amps_OS(naoccA, naoccB, navirA, navirB, T2, Tau, t1A, t1B);
-        Tau.reset();
-    } else {
-        throw std::logic_error("ccd_tpdm_pplA ---> Unrecognized amps, it should be T2 or Tau ! \n");
-    }
-    Ts = std::make_shared<Tensor2d>("T[B] (Mn,f)", naoccA * naoccB, navirB);
-    V = std::make_shared<Tensor2d>("V[B] (A,ef)", navirA, navirB * navirB);
-    X = std::make_shared<Tensor2d>("TPDM[B] (Q|A)", nQ, navirA);
-    // Main loop
-    for (int b = 0; b < navirA; ++b) {
+        Ts = std::make_shared<Tensor2d>("T[B] (Mn,f)", naoccA * naoccB, navirB);
+        V = std::make_shared<Tensor2d>("V[B] (A,ef)", navirA, navirB * navirB);
+        X = std::make_shared<Tensor2d>("TPDM[B] (Q|A)", nQ, navirA);
+        // Main loop
+        for (int b = 0; b < navirA; ++b) {
 // Form (+)T[B](Mn,f)
 #pragma omp parallel for
-        for (int m = 0; m < naoccA; ++m) {
-            for (int n = 0; n < naoccB; ++n) {
-                int mn = n + (m * naoccB);
-                for (int f = 0; f < navirB; ++f) {
-                    int bf = f + (b * navirB);
-                    Ts->set(mn, f, T2->get(mn, bf));
+            for (int m = 0; m < naoccA; ++m) {
+                for (int n = 0; n < naoccB; ++n) {
+                    int mn = n + (m * naoccB);
+                    for (int f = 0; f < navirB; ++f) {
+                        int bf = f + (b * navirB);
+                        Ts->set(mn, f, T2->get(mn, bf));
+                    }
                 }
             }
-        }
 
-        // Form V[B](A,ef) = \sum(Mn) L(Mn,Ae) T[B](Mn,f)
-        V->contract(true, false, navirA * navirB, navirB, naoccA * naoccB, T1, Ts, 1.0, 0.0);
+            // Form V[B](A,ef) = \sum(Mn) L(Mn,Ae) T[B](Mn,f)
+            V->contract(true, false, navirA * navirB, navirB, naoccA * naoccB, T1, Ts, 1.0, 0.0);
 
-        // G2[B](Q,A) = 1/2\sum(ef) b(Q,ef) * V[B](A,ef)
-        X->gemm(false, true, bQabB, V, 0.5, 0.0);
+            // G2[B](Q,A) = 1/2\sum(ef) b(Q,ef) * V[B](A,ef)
+            X->gemm(false, true, bQabB, V, 0.5, 0.0);
 
 // Form G2
 #pragma omp parallel for
-        for (int Q = 0; Q < nQ; ++Q) {
-            for (int a = 0; a < navirA; ++a) {
-                int ab = ab_idxAA->get(a, b);
-                G->add(Q, ab, X->get(Q, a));
+            for (int Q = 0; Q < nQ; ++Q) {
+                for (int a = 0; a < navirA; ++a) {
+                    int ab = ab_idxAA->get(a, b);
+                    G->add(Q, ab, X->get(Q, a));
+                }
             }
-        }
-    }  // main b-loop
-    T1.reset();
-    T2.reset();
-    Ts.reset();
-    X.reset();
-    V.reset();
-    bQabB.reset();
+        }// main b-loop
+        T1.reset();
+        T2.reset();
+        Ts.reset();
+        X.reset();
+        V.reset();
+        bQabB.reset();
 
 }  // end ccd_tpdm_pplA
 
@@ -680,167 +685,173 @@ void DFOCC::ccd_tpdm_pplA(SharedTensor2d& G, std::string amps) {
 //    PPL Beta
 //======================================================================
 void DFOCC::ccd_tpdm_pplB(SharedTensor2d& G, std::string amps) {
+
     SharedTensor2d T, T2, L2, Tau, X, Y, Z, V, U, L, G2;
     SharedTensor2d T1, Ts, Ta, Vs, Va, S, A;
 
-    // G_ab^Q += P+(ab) 1/2 \sum(ef) V_aebf b_ef^Q
-    // V_aebf = 1/2 \sum(MN) L_mn^ae T_mn^bf
-    // Read b_ef^Q
-    bQabB = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|ab)", nQ, navirB, navirB);
-    bQabB->read(psio_, PSIF_DFOCC_INTS, true, true);
+        // G_ab^Q += P+(ab) 1/2 \sum(ef) V_aebf b_ef^Q
+        // V_aebf = 1/2 \sum(MN) L_mn^ae T_mn^bf
+        // Read b_ef^Q
+        bQabB = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|ab)", nQ, navirB, navirB);
+        bQabB->read(psio_, PSIF_DFOCC_INTS, true, true);
 
-    // (-)Tt(mn, ae) = 1/2 (T_mn^ae - T_nm^ae) * (2 - \delta_{mn})
-    T1 = std::make_shared<Tensor2d>("L2 <ij|ab>", naoccB, naoccB, navirB, navirB);
-    T1->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-    Ta = std::make_shared<Tensor2d>("(-)Ut [i>=j|a>=b]", ntri_ijBB, ntri_abBB);
-    Ta->antisymm_row_packed4(T1);
+        // (-)Tt(mn, ae) = 1/2 (T_mn^ae - T_nm^ae) * (2 - \delta_{mn})
+        T1 = std::make_shared<Tensor2d>("L2 <ij|ab>", naoccB, naoccB, navirB, navirB);
+        T1->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+        Ta = std::make_shared<Tensor2d>("(-)Ut [i>=j|a>=b]", ntri_ijBB, ntri_abBB);
+        Ta->antisymm_row_packed4(T1);
 
-    // Anti-symmetric contributions
-    if (amps == "T2") {
-        T2 = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
-        T2->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-    } else if (amps == "Tau") {
-        Tau = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
-        Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
-        T2 = std::make_shared<Tensor2d>("Tau <ij|ab>", naoccB, naoccB, navirB, navirB);
-        uccsd_tau_amps(naoccB, naoccB, navirB, navirB, T2, Tau, t1B, t1B);
-        Tau.reset();
-    } else {
-        throw std::logic_error("ccd_tpdm_pplB --> Unrecognized amps, it should be T2 or Tau ! \n");
-    }
-    Va = std::make_shared<Tensor2d>("(-)T[b] (f,m>=n)", navirB, ntri_ijBB);
-    A = std::make_shared<Tensor2d>("A[b] (f,a>=e)", navirB, ntri_abBB);
-    V = std::make_shared<Tensor2d>("V[b] (a,ef)", navirB, navirB, navirB);
-    X = std::make_shared<Tensor2d>("TPDM[b] (Q|a)", nQ, navirB);
-    // Main loop
-    for (int b = 0; b < navirB; ++b) {
+        // Anti-symmetric contributions
+        if (amps == "T2") {
+            T2 = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
+            T2->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+        }
+        else if (amps == "Tau") {
+            Tau = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
+            Tau->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
+            T2 = std::make_shared<Tensor2d>("Tau <ij|ab>", naoccB, naoccB, navirB, navirB);
+            uccsd_tau_amps(naoccB, naoccB, navirB, navirB, T2, Tau, t1B, t1B);
+            Tau.reset();
+        }
+        else {
+             throw std::logic_error("ccd_tpdm_pplB ---> Unrecognized amps, it should be T2 or Tau ! \n");
+        }
+        Va = std::make_shared<Tensor2d>("(-)T[b] (f,m>=n)", navirB, ntri_ijBB);
+        A = std::make_shared<Tensor2d>("A[b] (f,a>=e)", navirB, ntri_abBB);
+        V = std::make_shared<Tensor2d>("V[b] (a,ef)", navirB, navirB, navirB);
+        X = std::make_shared<Tensor2d>("TPDM[b] (Q|a)", nQ, navirB);
+        // Main loop
+        for (int b = 0; b < navirB; ++b) {
 // Form (+)T[b](f, m>=n)
 #pragma omp parallel for
-        for (int m = 0; m < naoccB; ++m) {
-            for (int n = 0; n <= m; ++n) {
-                int mn2 = index2(m, n);
-                int mn = n + (m * naoccB);
-                int nm = m + (n * naoccB);
-                for (int f = 0; f < navirB; ++f) {
-                    int bf = f + (b * navirB);
-                    double value2 = 0.5 * (T2->get(mn, bf) - T2->get(nm, bf));
-                    Va->set(f, mn2, value2);
+            for (int m = 0; m < naoccB; ++m) {
+                for (int n = 0; n <= m; ++n) {
+                    int mn2 = index2(m, n);
+                    int mn = n + (m * naoccB);
+                    int nm = m + (n * naoccB);
+                    for (int f = 0; f < navirB; ++f) {
+                        int bf = f + (b * navirB);
+                        double value2 = 0.5 * (T2->get(mn, bf) - T2->get(nm, bf));
+                        Va->set(f, mn2, value2);
+                    }
                 }
             }
-        }
 
-        // Form A[b](f,a>=e) = 1/2 \sum(m>=n) (+)Tt(m>=n,a>=e) * T[b](f,m>=n)
-        A->contract(false, false, navirB, ntri_abBB, ntri_ijBB, Va, Ta, 0.5, 0.0);
+            // Form A[b](f,a>=e) = 1/2 \sum(m>=n) (+)Tt(m>=n,a>=e) * T[b](f,m>=n)
+            A->contract(false, false, navirB, ntri_abBB, ntri_ijBB, Va, Ta, 0.5, 0.0);
 
 // Form V[b](a,ef)
 #pragma omp parallel for
-        for (int a = 0; a < navirB; ++a) {
-            for (int e = 0; e < navirB; ++e) {
-                int ae = index2(a, e);
-                for (int f = 0; f < navirB; ++f) {
-                    int ef = ab_idxBB->get(e, f);
-                    int perm1 = (a > e) ? 1 : -1;
-                    double value = perm1 * A->get(f, ae);
-                    V->set(a, ef, value);
+            for (int a = 0; a < navirB; ++a) {
+                for (int e = 0; e < navirB; ++e) {
+                    int ae = index2(a, e);
+                    for (int f = 0; f < navirB; ++f) {
+                        int ef = ab_idxBB->get(e, f);
+                        int perm1 = (a > e) ? 1 : -1;
+                        double value = perm1 * A->get(f, ae);
+                        V->set(a, ef, value);
+                    }
                 }
             }
-        }
 
-        // G2[b](Q,a) = 1/2\sum(ef) b(Q,ef) * V[b](a,ef)
-        X->gemm(false, true, bQabB, V, 0.5, 0.0);
+            // G2[b](Q,a) = 1/2\sum(ef) b(Q,ef) * V[b](a,ef)
+            X->gemm(false, true, bQabB, V, 0.5, 0.0);
 
 // Form G2
 #pragma omp parallel for
-        for (int Q = 0; Q < nQ; ++Q) {
-            for (int a = 0; a < navirB; ++a) {
-                int ab = ab_idxBB->get(a, b);
-                G->add(Q, ab, X->get(Q, a));
-            }
-        }
-    }
-    T1.reset();
-    T2.reset();
-    Ta.reset();
-    Va.reset();
-    A.reset();
-    X.reset();
-    V.reset();
-    bQabB.reset();
-
-    // G_ab^Q += P+(ab) 1/2 \sum(ef) V_EaFb b_EF^Q
-    // V_EaFb = \sum(Mn) L_Mn^Ea T_Mn^Fb
-    // Read b_EF^Q
-    bQabA = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|AB)", nQ, navirA, navirA);
-    bQabA->read(psio_, PSIF_DFOCC_INTS, true, true);
-
-    T1 = std::make_shared<Tensor2d>("L2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-    T1->read(psio_, PSIF_DFOCC_AMPS);
-    if (amps == "T2") {
-        T2 = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-        T2->read(psio_, PSIF_DFOCC_AMPS);
-    } else if (amps == "Tau") {
-        Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-        Tau->read(psio_, PSIF_DFOCC_AMPS);
-        T2 = std::make_shared<Tensor2d>("Tau <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-        uccsd_tau_amps_OS(naoccA, naoccB, navirA, navirB, T2, Tau, t1A, t1B);
-        Tau.reset();
-    } else {
-        throw std::logic_error("ccd_tpdm_pplB ---> Unrecognized amps, it should be T2 or Tau ! \n");
-    }
-    Ts = std::make_shared<Tensor2d>("T[b] (Mn,F)", naoccA * naoccB, navirA);
-    V = std::make_shared<Tensor2d>("V[b] (Ea,F)", navirA * navirB, navirA);
-    Vs = std::make_shared<Tensor2d>("V[b] (EF,a)", navirA * navirA, navirB);
-    X = std::make_shared<Tensor2d>("TPDM[b] (Q|a)", nQ, navirB);
-    // Main loop
-    for (int b = 0; b < navirB; ++b) {
-// Form (+)T[b](Mn,F)
-#pragma omp parallel for
-        for (int m = 0; m < naoccA; ++m) {
-            for (int n = 0; n < naoccB; ++n) {
-                int mn = n + (m * naoccB);
-                for (int f = 0; f < navirA; ++f) {
-                    int fb = (f * navirB) + b;
-                    Ts->set(mn, f, T2->get(mn, fb));
+            for (int Q = 0; Q < nQ; ++Q) {
+                for (int a = 0; a < navirB; ++a) {
+                    int ab = ab_idxBB->get(a, b);
+                    G->add(Q, ab, X->get(Q, a));
                 }
             }
         }
+        T1.reset();
+        T2.reset();
+        Ta.reset();
+        Va.reset();
+        A.reset();
+        X.reset();
+        V.reset();
+        bQabB.reset();
 
-        // Form V[b](Ea,F) = \sum(Mn) L(Mn,Ea) T[b](Mn,F)
-        V->gemm(true, false, T1, Ts, 1.0, 0.0);
+        // G_ab^Q += P+(ab) 1/2 \sum(ef) V_EaFb b_EF^Q
+        // V_EaFb = \sum(Mn) L_Mn^Ea T_Mn^Fb
+        // Read b_EF^Q
+        bQabA = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|AB)", nQ, navirA, navirA);
+        bQabA->read(psio_, PSIF_DFOCC_INTS, true, true);
+
+        T1 = std::make_shared<Tensor2d>("L2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+        T1->read(psio_, PSIF_DFOCC_AMPS);
+        if (amps == "T2") {
+            T2 = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+            T2->read(psio_, PSIF_DFOCC_AMPS);
+        }
+        else if (amps == "Tau") {
+            Tau = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+            Tau->read(psio_, PSIF_DFOCC_AMPS);
+            T2 = std::make_shared<Tensor2d>("Tau <Ij|Ab>", naoccA, naoccB, navirA, navirB);
+            uccsd_tau_amps_OS(naoccA, naoccB, navirA, navirB, T2, Tau, t1A, t1B);
+            Tau.reset();
+        }
+        else {
+             throw std::logic_error("ccd_tpdm_pplB ---> Unrecognized amps, it should be T2 or Tau ! \n");
+        }
+        Ts = std::make_shared<Tensor2d>("T[b] (Mn,F)", naoccA * naoccB, navirA);
+        V = std::make_shared<Tensor2d>("V[b] (Ea,F)", navirA * navirB, navirA);
+        Vs = std::make_shared<Tensor2d>("V[b] (EF,a)", navirA * navirA, navirB);
+        X = std::make_shared<Tensor2d>("TPDM[b] (Q|a)", nQ, navirB);
+        // Main loop
+        for (int b = 0; b < navirB; ++b) {
+// Form (+)T[b](Mn,F)
+#pragma omp parallel for
+            for (int m = 0; m < naoccA; ++m) {
+                for (int n = 0; n < naoccB; ++n) {
+                    int mn = n + (m * naoccB);
+                    for (int f = 0; f < navirA; ++f) {
+                        int fb = (f * navirB) + b;
+                        Ts->set(mn, f, T2->get(mn, fb));
+                    }
+                }
+            }
+
+            // Form V[b](Ea,F) = \sum(Mn) L(Mn,Ea) T[b](Mn,F)
+            V->gemm(true, false, T1, Ts, 1.0, 0.0);
 
 // Form Vs[b](EF,a)
 #pragma omp parallel for
-        for (int e = 0; e < navirA; ++e) {
-            for (int f = 0; f < navirA; ++f) {
-                int ef = ab_idxAA->get(e, f);
-                for (int a = 0; a < navirB; ++a) {
-                    int ea = (e * navirB) + a;
-                    Vs->set(ef, a, V->get(ea, f));
+            for (int e = 0; e < navirA; ++e) {
+                for (int f = 0; f < navirA; ++f) {
+                    int ef = ab_idxAA->get(e, f);
+                    for (int a = 0; a < navirB; ++a) {
+                        int ea = (e * navirB) + a;
+                        Vs->set(ef, a, V->get(ea, f));
+                    }
                 }
             }
-        }
 
-        // G2[b](Q,a) = 1/2 \sum(EF) b(Q,EF) * Vs[b](EF,a)
-        X->gemm(false, false, bQabA, Vs, 0.5, 0.0);
+            // G2[b](Q,a) = 1/2 \sum(EF) b(Q,EF) * Vs[b](EF,a)
+            X->gemm(false, false, bQabA, Vs, 0.5, 0.0);
 
 // Form G2
 #pragma omp parallel for
-        for (int Q = 0; Q < nQ; ++Q) {
-            for (int a = 0; a < navirB; ++a) {
-                int ab = ab_idxBB->get(a, b);
-                G->add(Q, ab, X->get(Q, a));
+            for (int Q = 0; Q < nQ; ++Q) {
+                for (int a = 0; a < navirB; ++a) {
+                    int ab = ab_idxBB->get(a, b);
+                    G->add(Q, ab, X->get(Q, a));
+                }
             }
         }
-    }
-    T1.reset();
-    T2.reset();
-    Ts.reset();
-    X.reset();
-    V.reset();
-    Vs.reset();
-    bQabA.reset();
+        T1.reset();
+        T2.reset();
+        Ts.reset();
+        X.reset();
+        V.reset();
+        Vs.reset();
+        bQabA.reset();
 
 }  // end ccd_tpdm_pplB
+
 
 }  // namespace dfoccwave
 }  // namespace psi

--- a/psi4/src/psi4/dfocc/idp.cc
+++ b/psi4/src/psi4/dfocc/idp.cc
@@ -144,9 +144,7 @@ void DFOCC::idp() {
         }  // end if nidpA != 0
 
         else if (nidpA == 0) {
-            outfile->Printf("\tThere is not any non-redundant orbital rotation pair! \n");
-            tstop();
-            exit(EXIT_SUCCESS);
+            throw std::logic_error("There is are no non-redundant orbital rotation pairs! \n");
         }
 
     }  // end if (reference_ == "RESTRICTED")
@@ -184,9 +182,7 @@ void DFOCC::idp() {
         outfile->Printf("\tNumber of beta independent-pairs :%3d\n", nidpB);
 
         if (nidpA == 0 && nidpB == 0) {
-            outfile->Printf("\tThere is not any non-redundant orbital rotation pair! \n");
-            tstop();
-            exit(EXIT_SUCCESS);
+            throw std::logic_error("There are no non-redundant orbital rotation pairs! \n");
         }
 
         if (nidpA > 0) {

--- a/psi4/src/psi4/dfocc/lccd_W_intr.cc
+++ b/psi4/src/psi4/dfocc/lccd_W_intr.cc
@@ -938,7 +938,7 @@ void DFOCC::lccd_WabefT2AB() {
     T->read(psio_, PSIF_DFOCC_AMPS);
 
     // malloc
-    //J = std::make_shared<Tensor2d>("J[A] <E|bf>", navirA, navirB * navirB);
+    // J = std::make_shared<Tensor2d>("J[A] <E|bf>", navirA, navirB * navirB);
     J = std::make_shared<Tensor2d>("J[A] <E|b>=f>", navirA, ntri_abBB);
     I = std::make_shared<Tensor2d>("I[A] <b|Ef>", navirB, navirA * navirB);
     X = std::make_shared<Tensor2d>("T[A] <b|Ij>", navirB, naoccA * naoccB);
@@ -964,8 +964,8 @@ void DFOCC::lccd_WabefT2AB() {
         for (int b = 0; b < navirB; ++b) {
             for (int e = 0; e < navirA; ++e) {
                 for (int f = 0; f < navirB; ++f) {
-                    //int bf = f + (b * navirB);
-                    int bf = index2(b,f);
+                    // int bf = f + (b * navirB);
+                    int bf = index2(b, f);
                     int ef = ab_idxAB->get(e, f);
                     I->set(b, ef, J->get(e, bf));
                 }
@@ -1019,13 +1019,10 @@ void DFOCC::cc_WabefT2AA(std::string amps) {
     // (-)T(ij, ab) = 1/2 (T_ij^ab - T_ji^ab) * (2 - \delta_{ab})
     if (amps == "L") {
         X = std::make_shared<Tensor2d>("L2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-    }
-    else if (amps == "T") {
+    } else if (amps == "T") {
         X = std::make_shared<Tensor2d>("T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-    }
-    else {
-        std::cout << "cc_W_abefT2AA --> unrecognized AMPS, it can be T or L \n";
-        exit(1);
+    } else {
+        throw std::logic_error("cc_W_abefT2AA --> unrecognized AMPS, it can be T or L \n");
     }
     X->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
     T = std::make_shared<Tensor2d>("(-)T [I>=J|A>=B]", ntri_ijAA, ntri_abAA);
@@ -1088,13 +1085,10 @@ void DFOCC::cc_WabefT2AA(std::string amps) {
     // T(ia,jb) <-- A(a>=b,i>=j)
     if (amps == "L") {
         Tnew = std::make_shared<Tensor2d>("New L2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-    }
-    else if (amps == "T") {
+    } else if (amps == "T") {
         Tnew = std::make_shared<Tensor2d>("New T2 <IJ|AB>", naoccA, naoccA, navirA, navirA);
-    }
-    else {
-        std::cout << "cc_W_abefT2AA --> unrecognized AMPS, it can be T or L \n";
-        exit(1);
+    } else {
+        throw std::logic_error("cc_W_abefT2AA --> unrecognized AMPS, it can be T or L \n");
     }
     Tnew->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
 #pragma omp parallel for
@@ -1136,13 +1130,10 @@ void DFOCC::cc_WabefT2BB(std::string amps) {
     // (-)T(ij, ab) = 1/2 (T_ij^ab - T_ji^ab) * (2 - \delta_{ab})
     if (amps == "L") {
         X = std::make_shared<Tensor2d>("L2 <ij|ab>", naoccB, naoccB, navirB, navirB);
-    }
-    else if (amps == "T") {
+    } else if (amps == "T") {
         X = std::make_shared<Tensor2d>("T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
-    }
-    else {
-        std::cout << "cc_W_abefT2AA --> unrecognized AMPS, it can be T or L \n";
-        exit(1);
+    } else {
+        throw std::logic_error("cc_W_abefT2AA --> unrecognized AMPS, it can be T or L \n");
     }
     X->read_anti_symm(psio_, PSIF_DFOCC_AMPS);
     T = std::make_shared<Tensor2d>("(-)T [I>=J|A>=B]", ntri_ijBB, ntri_abBB);
@@ -1205,11 +1196,9 @@ void DFOCC::cc_WabefT2BB(std::string amps) {
     // T(ia,jb) <-- A(a>=b,i>=j)
     if (amps == "L") {
         Tnew = std::make_shared<Tensor2d>("New L2 <ij|ab>", naoccB, naoccB, navirB, navirB);
-    }
-    else if (amps == "T") {
+    } else if (amps == "T") {
         Tnew = std::make_shared<Tensor2d>("New T2 <ij|ab>", naoccB, naoccB, navirB, navirB);
-    }
-    else {
+    } else {
         std::cout << "cc_W_abefT2AA --> unrecognized AMPS, it can be T or L \n";
         exit(1);
     }
@@ -1252,26 +1241,23 @@ void DFOCC::cc_WabefT2AB(std::string amps) {
     bQabB = std::make_shared<Tensor2d>("DF_BASIS_CC B (Q|ab)", nQ, ntri_abBB);
     bQabB->read(psio_, PSIF_DFOCC_INTS);
 
-
     // t_Ij^Ab <= \sum_{Ef} T_Ij^Ef <Ab|Ef>
     if (amps == "L") {
         Tnew = std::make_shared<Tensor2d>("New L2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
         Tnew->read(psio_, PSIF_DFOCC_AMPS);
         T = std::make_shared<Tensor2d>("L2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-    }
-    else if (amps == "T") {
+    } else if (amps == "T") {
         Tnew = std::make_shared<Tensor2d>("New T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
         Tnew->read(psio_, PSIF_DFOCC_AMPS);
         T = std::make_shared<Tensor2d>("T2 <Ij|Ab>", naoccA, naoccB, navirA, navirB);
-    }
-    else {
+    } else {
         std::cout << "cc_W_abefT2AA --> unrecognized AMPS, it can be T or L \n";
         exit(1);
     }
     T->read(psio_, PSIF_DFOCC_AMPS);
 
     // malloc
-    //J = std::make_shared<Tensor2d>("J[A] <E|bf>", navirA, navirB * navirB);
+    // J = std::make_shared<Tensor2d>("J[A] <E|bf>", navirA, navirB * navirB);
     J = std::make_shared<Tensor2d>("J[A] <E|b>=f>", navirA, ntri_abBB);
     I = std::make_shared<Tensor2d>("I[A] <b|Ef>", navirB, navirA * navirB);
     X = std::make_shared<Tensor2d>("T[A] <b|Ij>", navirB, naoccA * naoccB);
@@ -1297,8 +1283,8 @@ void DFOCC::cc_WabefT2AB(std::string amps) {
         for (int b = 0; b < navirB; ++b) {
             for (int e = 0; e < navirA; ++e) {
                 for (int f = 0; f < navirB; ++f) {
-                    //int bf = f + (b * navirB);
-                    int bf = index2(b,f);
+                    // int bf = f + (b * navirB);
+                    int bf = index2(b, f);
                     int ef = ab_idxAB->get(e, f);
                     I->set(b, ef, J->get(e, bf));
                 }
@@ -1337,7 +1323,6 @@ void DFOCC::cc_WabefT2AB(std::string amps) {
     timer_off("WabefT2");
 
 }  // end cc_WabefT2AB
-
 
 }  // namespace dfoccwave
 }  // namespace psi

--- a/psi4/src/psi4/dfocc/qchf.cc
+++ b/psi4/src/psi4/dfocc/qchf.cc
@@ -351,9 +351,7 @@ void DFOCC::idp_hf() {
         }  // end if nidpA != 0
 
         else if (nidpA == 0) {
-            outfile->Printf("\tThere is not any non-redundant orbital rotation pair! \n");
-            tstop();
-            exit(EXIT_SUCCESS);
+            throw std::logic_error("There are no non-redundant orbital rotation pairs! \n");
         }
 
     }  // end if (reference_ == "RESTRICTED")
@@ -368,9 +366,7 @@ void DFOCC::idp_hf() {
         nidpB += nvirB * noccB;
 
         if (nidpA == 0 && nidpB == 0) {
-            outfile->Printf("\tThere is not any non-redundant orbital rotation pair! \n");
-            tstop();
-            exit(EXIT_SUCCESS);
+            throw std::logic_error("There are no non-redundant orbital rotation pairs! \n");
         }
 
         if (nidpA > 0) {

--- a/psi4/src/psi4/dfocc/tensors.cc
+++ b/psi4/src/psi4/dfocc/tensors.cc
@@ -333,14 +333,13 @@ double Tensor1d::xay(const SharedTensor2d &a, const SharedTensor1d &y) {
 }  //
 
 SharedTensor2d Tensor1d::to_2d(int row, int col) {
-  if (row*col != dim1_) {
-      printf("Tensor1d-->to_2d dimensisons are not consistent!");
-      exit(1);
-  }
-  auto temp = std::make_shared<Tensor2d>("Temp", row, col);
-  C_DCOPY(dim1_, A1d_, 1, temp->A2d_[0], 1);
-  return temp;
-} //
+    if (row * col != dim1_) {
+        throw std::logic_error("Tensor1d-->to_2d dimensisons are not consistent!\n");
+    }
+    auto temp = std::make_shared<Tensor2d>("Temp", row, col);
+    C_DCOPY(dim1_, A1d_, 1, temp->A2d_[0], 1);
+    return temp;
+}  //
 
 void Tensor1d::axpy(const SharedTensor1d &a, double alpha) {
     size_t length = (size_t)dim1_;
@@ -839,7 +838,7 @@ void Tensor2d::gemm(bool transa, bool transb, const SharedTensor2d &a, const Sha
 
     // C(m,n) = \sum(k) A(m,k) B(k,n)
     if (!transa && !transb) {
-        if (m != a->dim1()  || n != b->dim2() || a->dim2() != b->dim1()) {
+        if (m != a->dim1() || n != b->dim2() || a->dim2() != b->dim1()) {
             outfile->Printf("\tTensor2d::gemm dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::gemm dimensions are NOT consistent!");
         }
@@ -847,7 +846,7 @@ void Tensor2d::gemm(bool transa, bool transb, const SharedTensor2d &a, const Sha
 
     // C(m,n) = \sum(k) A(m,k) B(n,k)
     else if (!transa && transb) {
-        if (m != a->dim1()  || n != b->dim1() || a->dim2() != b->dim2()) {
+        if (m != a->dim1() || n != b->dim1() || a->dim2() != b->dim2()) {
             outfile->Printf("\tTensor2d::gemm dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::gemm dimensions are NOT consistent!");
         }
@@ -855,7 +854,7 @@ void Tensor2d::gemm(bool transa, bool transb, const SharedTensor2d &a, const Sha
 
     // C(m,n) = \sum(k) A(k,m) B(k,n)
     else if (transa && !transb) {
-        if (m != a->dim2()  || n != b->dim2() || a->dim1() != b->dim1()) {
+        if (m != a->dim2() || n != b->dim2() || a->dim1() != b->dim1()) {
             outfile->Printf("\tTensor2d::gemm dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::gemm dimensions are NOT consistent!");
         }
@@ -863,7 +862,7 @@ void Tensor2d::gemm(bool transa, bool transb, const SharedTensor2d &a, const Sha
 
     // C(m,n) = \sum(k) A(k,m) B(n,k)
     else if (transa && transb) {
-        if (m != a->dim2()  || n != b->dim1() || a->dim1() != b->dim2()) {
+        if (m != a->dim2() || n != b->dim1() || a->dim1() != b->dim2()) {
             outfile->Printf("\tTensor2d::gemm dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::gemm dimensions are NOT consistent!");
         }
@@ -934,14 +933,18 @@ void Tensor2d::contract323(bool transa, bool transb, int m, int n, const SharedT
     // contract323: C[Q](m,n) = \sum_{k} A[Q](m,k) * B(k,n). Note: contract332 should be called with beta=1.0
     // Check C[Q](m,n)
     if (m * n != dim2_) {
-        outfile->Printf("\tTensor2d::contract323 the m*n value is NOT consistent with the col dimension of the Tensor C!\n");
-        throw PSIEXCEPTION("Tensor2d::contract323 the m*n value is NOT consistent with the col dimension of the Tensor C!");
+        outfile->Printf(
+            "\tTensor2d::contract323 the m*n value is NOT consistent with the col dimension of the Tensor C!\n");
+        throw PSIEXCEPTION(
+            "Tensor2d::contract323 the m*n value is NOT consistent with the col dimension of the Tensor C!");
     }
 
     // Check A[Q](m,k)
     if (m * k != a->dim2()) {
-        outfile->Printf("\tTensor2d::contract323 the m*k value is NOT consistent with the col dimension of the Tensor A!\n");
-        throw PSIEXCEPTION("Tensor2d::contract323 the m*k value is NOT consistent with the col dimension of the Tensor A!");
+        outfile->Printf(
+            "\tTensor2d::contract323 the m*k value is NOT consistent with the col dimension of the Tensor A!\n");
+        throw PSIEXCEPTION(
+            "Tensor2d::contract323 the m*k value is NOT consistent with the col dimension of the Tensor A!");
     }
 
     // Check B(k,n)
@@ -972,8 +975,10 @@ void Tensor2d::contract233(bool transa, bool transb, int m, int n, const SharedT
     // contract233: C[Q](m,n) = \sum_{k} A(m,k) * B[Q](k,n)
     // Check C[Q](m,n)
     if (m * n != dim2_) {
-        outfile->Printf("\tTensor2d::contract233 the m*n value is NOT consistent with the col dimension of the Tensor C!\n");
-        throw PSIEXCEPTION("Tensor2d::contract233 the m*n value is NOT consistent with the col dimension of the Tensor C!");
+        outfile->Printf(
+            "\tTensor2d::contract233 the m*n value is NOT consistent with the col dimension of the Tensor C!\n");
+        throw PSIEXCEPTION(
+            "Tensor2d::contract233 the m*n value is NOT consistent with the col dimension of the Tensor C!");
     }
 
     // Check A(m,k)
@@ -984,8 +989,10 @@ void Tensor2d::contract233(bool transa, bool transb, int m, int n, const SharedT
 
     // Check B[Q](k,n)
     if (n * k != b->dim2()) {
-        outfile->Printf("\tTensor2d::contract233 the n*k value is NOT consistent with the col dimension of the Tensor B!\n");
-        throw PSIEXCEPTION("Tensor2d::contract233 the n*k value is NOT consistent with the col dimension of the Tensor B!");
+        outfile->Printf(
+            "\tTensor2d::contract233 the n*k value is NOT consistent with the col dimension of the Tensor B!\n");
+        throw PSIEXCEPTION(
+            "Tensor2d::contract233 the n*k value is NOT consistent with the col dimension of the Tensor B!");
     }
 
     if (m && n && k) {
@@ -1017,18 +1024,22 @@ void Tensor2d::contract332(bool transa, bool transb, int k, const SharedTensor2d
 
     // Check A[Q](m,k)
     if (m * k != a->dim2()) {
-        outfile->Printf("\tTensor2d::contract332 the m*k value is NOT consistent with the col dimension of the Tensor A!\n");
-        throw PSIEXCEPTION("Tensor2d::contract332 the m*k value is NOT consistent with the col dimension of the Tensor A!");
+        outfile->Printf(
+            "\tTensor2d::contract332 the m*k value is NOT consistent with the col dimension of the Tensor A!\n");
+        throw PSIEXCEPTION(
+            "Tensor2d::contract332 the m*k value is NOT consistent with the col dimension of the Tensor A!");
     }
 
     // Check B[Q](k,n)
     if (n * k != b->dim2()) {
-        outfile->Printf("\tTensor2d::contract332 the n*k value is NOT consistent with the col dimension of the Tensor B!\n");
-        throw PSIEXCEPTION("Tensor2d::contract332 the n*k value is NOT consistent with the col dimension of the Tensor B!");
+        outfile->Printf(
+            "\tTensor2d::contract332 the n*k value is NOT consistent with the col dimension of the Tensor B!\n");
+        throw PSIEXCEPTION(
+            "Tensor2d::contract332 the n*k value is NOT consistent with the col dimension of the Tensor B!");
     }
 
     if (m && n && k) {
-        //#pragma omp parallel for
+        // #pragma omp parallel for
         for (int Q = 0; Q < a->dim1(); Q++) {
             C_DGEMM(ta, tb, m, n, k, alpha, a->A2d_[Q], nca, b->A2d_[Q], ncb, beta, A2d_[0], ncc);
         }
@@ -1268,8 +1279,9 @@ void Tensor2d::contract424(int target_x, int target_y, const SharedTensor2d &a, 
 
 }  //
 
-//CSB contract two four-index tensors to a two-index tensor. The target index specifies the number of the "surviving" index
-// i.e. the one that is not contracted
+// CSB contract two four-index tensors to a two-index tensor. The target index specifies the number of the "surviving"
+// index
+//  i.e. the one that is not contracted
 void Tensor2d::contract442(int target_a, int target_b, const SharedTensor2d &a, const SharedTensor2d &b, double alpha,
                            double beta) {
     char ta;
@@ -2111,7 +2123,7 @@ void Tensor2d::read(std::shared_ptr<psi::PSIO> psio, size_t fileno) {
 }
 
 void Tensor2d::read(std::shared_ptr<psi::PSIO> psio, const std::string &label, size_t fileno) {
-    //Check to see if the file is open
+    // Check to see if the file is open
     bool already_open = false;
     if (psio->open_check(fileno))
         already_open = true;
@@ -2265,7 +2277,7 @@ bool Tensor2d::read(PSIO *psio, int itap, const char *label, int dim) {
     double **Asq = block_matrix(dim, dim);
     memset(Asq[0], 0, sizeof(double) * dim * dim);
     tri_to_sq(mybuffer, Asq, dim);
-    delete [] mybuffer;
+    delete[] mybuffer;
 
     set(Asq);
     free_block(Asq);
@@ -2281,7 +2293,7 @@ bool Tensor2d::read(std::shared_ptr<psi::PSIO> psio, int itap, const char *label
     double **Asq = block_matrix(dim, dim);
     memset(Asq[0], 0, sizeof(double) * dim * dim);
     tri_to_sq(mybuffer, Asq, dim);
-    delete [] mybuffer;
+    delete[] mybuffer;
 
     set(Asq);
     free_block(Asq);
@@ -2479,7 +2491,7 @@ void Tensor2d::to_pointer(double *A) {
 
 void Tensor2d::mgs() {
     double rmgs1, rmgs2;
-    //#pragma omp parallel for
+    // #pragma omp parallel for
     for (int k = 0; k < dim1_; k++) {  // loop-1
         rmgs1 = 0.0;
 
@@ -2533,30 +2545,30 @@ void Tensor2d::gs() {
 ** Returns: 1 if a vector is added to A, 0 otherwise
 */
 int Tensor2d::gs_add(int rows, SharedTensor1d v) {
-   double dotval, normval ;
-   int i, I ;
-   int cols = dim2_;
-   double NORM_TOL = 1.0E-5;
+    double dotval, normval;
+    int i, I;
+    int cols = dim2_;
+    double NORM_TOL = 1.0E-5;
 
-   for (i=0; i<rows; i++) {
+    for (i = 0; i < rows; i++) {
         dotval = C_DDOT(cols, A2d_[i], 1, v->A1d_, 1);
-        for (I=0; I<cols; I++) {
-	     v->subtract(I, dotval * A2d_[i][I]);
+        for (I = 0; I < cols; I++) {
+            v->subtract(I, dotval * A2d_[i][I]);
         }
-   }
+    }
 
-   // dot_arr(v, v, cols, &normval) ;
-   normval = C_DDOT(cols, v->A1d_, 1, v->A1d_, 1);
-   normval = std::sqrt(normval) ;
+    // dot_arr(v, v, cols, &normval) ;
+    normval = C_DDOT(cols, v->A1d_, 1, v->A1d_, 1);
+    normval = std::sqrt(normval);
 
-   if (normval < NORM_TOL)
-      return(0) ;
-   else {
-      //if (A2d_[rows] == NULL) A2d_[rows] = init_array(cols) ;
-      if (A2d_[rows] == NULL) A2d_[rows] = new double[cols] ;
-      for (I=0; I<cols; I++) A2d_[rows][I] = v->get(I) / normval ;
-      return(1) ;
-      }
+    if (normval < NORM_TOL)
+        return (0);
+    else {
+        // if (A2d_[rows] == NULL) A2d_[rows] = init_array(cols) ;
+        if (A2d_[rows] == NULL) A2d_[rows] = new double[cols];
+        for (I = 0; I < cols; I++) A2d_[rows][I] = v->get(I) / normval;
+        return (1);
+    }
 }  //
 
 double *Tensor2d::row_vector(int n) {
@@ -2580,7 +2592,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     int d4 = A->d4_;
 
     if (sort_type == 1243) {
-        if (d1_ != d1 || d2_ != d2 || d3_ != d4  || d4_ != d3 ) {
+        if (d1_ != d1 || d2_ != d2 || d3_ != d4 || d4_ != d3) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2600,7 +2612,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 1324) {
-        if (d1_ != d1 || d2_ != d3 || d3_ != d2  || d4_ != d4 ) {
+        if (d1_ != d1 || d2_ != d3 || d3_ != d2 || d4_ != d4) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2621,7 +2633,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 1342) {
-        if (d1_ != d1 || d2_ != d3 || d3_ != d4  || d4_ != d2 ) {
+        if (d1_ != d1 || d2_ != d3 || d3_ != d4 || d4_ != d2) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2642,7 +2654,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 1423) {
-        if (d1_ != d1 || d2_ != d4 || d3_ != d2  || d4_ != d3 ) {
+        if (d1_ != d1 || d2_ != d4 || d3_ != d2 || d4_ != d3) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2663,7 +2675,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 1432) {
-        if (d1_ != d1 || d2_ != d4 || d3_ != d3  || d4_ != d2 ) {
+        if (d1_ != d1 || d2_ != d4 || d3_ != d3 || d4_ != d2) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2684,7 +2696,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 2134) {
-        if (d1_ != d2 || d2_ != d1 || d3_ != d3  || d4_ != d4 ) {
+        if (d1_ != d2 || d2_ != d1 || d3_ != d3 || d4_ != d4) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2704,7 +2716,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 2143) {
-        if (d1_ != d2 || d2_ != d1 || d3_ != d4  || d4_ != d3 ) {
+        if (d1_ != d2 || d2_ != d1 || d3_ != d4 || d4_ != d3) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2725,7 +2737,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 2314) {
-        if (d1_ != d2 || d2_ != d3 || d3_ != d1  || d4_ != d4 ) {
+        if (d1_ != d2 || d2_ != d3 || d3_ != d1 || d4_ != d4) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2746,7 +2758,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 2341) {
-        if (d1_ != d2 || d2_ != d3 || d3_ != d4  || d4_ != d1 ) {
+        if (d1_ != d2 || d2_ != d3 || d3_ != d4 || d4_ != d1) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2767,7 +2779,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 2413) {
-        if (d1_ != d2 || d2_ != d4 || d3_ != d1  || d4_ != d3 ) {
+        if (d1_ != d2 || d2_ != d4 || d3_ != d1 || d4_ != d3) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2788,7 +2800,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 2431) {
-        if (d1_ != d2 || d2_ != d4 || d3_ != d3  || d4_ != d1 ) {
+        if (d1_ != d2 || d2_ != d4 || d3_ != d3 || d4_ != d1) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2809,7 +2821,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 3124) {
-        if (d1_ != d3 || d2_ != d1 || d3_ != d2  || d4_ != d4 ) {
+        if (d1_ != d3 || d2_ != d1 || d3_ != d2 || d4_ != d4) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2830,7 +2842,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 3142) {
-        if (d1_ != d3 || d2_ != d1 || d3_ != d4  || d4_ != d2 ) {
+        if (d1_ != d3 || d2_ != d1 || d3_ != d4 || d4_ != d2) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2851,7 +2863,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 3214) {
-        if (d1_ != d3 || d2_ != d2 || d3_ != d1  || d4_ != d4 ) {
+        if (d1_ != d3 || d2_ != d2 || d3_ != d1 || d4_ != d4) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2872,7 +2884,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 3241) {
-        if (d1_ != d3 || d2_ != d2 || d3_ != d4  || d4_ != d1 ) {
+        if (d1_ != d3 || d2_ != d2 || d3_ != d4 || d4_ != d1) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2893,7 +2905,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 3412) {
-        if (d1_ != d3 || d2_ != d4 || d3_ != d1  || d4_ != d2 ) {
+        if (d1_ != d3 || d2_ != d4 || d3_ != d1 || d4_ != d2) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2912,7 +2924,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 3421) {
-        if (d1_ != d3 || d2_ != d4 || d3_ != d2  || d4_ != d1 ) {
+        if (d1_ != d3 || d2_ != d4 || d3_ != d2 || d4_ != d1) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2932,7 +2944,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 4123) {
-        if (d1_ != d4 || d2_ != d1 || d3_ != d2  || d4_ != d3 ) {
+        if (d1_ != d4 || d2_ != d1 || d3_ != d2 || d4_ != d3) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2953,7 +2965,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 4132) {
-        if (d1_ != d4 || d2_ != d1 || d3_ != d3  || d4_ != d2 ) {
+        if (d1_ != d4 || d2_ != d1 || d3_ != d3 || d4_ != d2) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2974,7 +2986,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 4213) {
-        if (d1_ != d4 || d2_ != d2 || d3_ != d1  || d4_ != d3 ) {
+        if (d1_ != d4 || d2_ != d2 || d3_ != d1 || d4_ != d3) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2995,7 +3007,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 4231) {
-        if (d1_ != d4 || d2_ != d2 || d3_ != d3  || d4_ != d1 ) {
+        if (d1_ != d4 || d2_ != d2 || d3_ != d3 || d4_ != d1) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -3016,7 +3028,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 4312) {
-        if (d1_ != d4 || d2_ != d3 || d3_ != d1  || d4_ != d2 ) {
+        if (d1_ != d4 || d2_ != d3 || d3_ != d1 || d4_ != d2) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -3036,7 +3048,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 4321) {
-        if (d1_ != d4 || d2_ != d3 || d3_ != d2  || d4_ != d1 ) {
+        if (d1_ != d4 || d2_ != d3 || d3_ != d2 || d4_ != d1) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -3292,7 +3304,7 @@ void Tensor2d::reg_denom(int frzc, int occ, const SharedTensor2d &fock, double r
                 for (int b = 0; b < avir; b++) {
                     double dijab = dija - fock->A2d_[b + occ][b + occ];
                     int ab = col_idx_[a][b];
-                    A2d_[ij][ab] /= dijab;    //SB A2d_ refers to the respective property of Tensor2d... this->Ad2
+                    A2d_[ij][ab] /= dijab;  // SB A2d_ refers to the respective property of Tensor2d... this->Ad2
                 }
             }
         }

--- a/psi4/src/psi4/dfocc/tensors.cc
+++ b/psi4/src/psi4/dfocc/tensors.cc
@@ -333,13 +333,13 @@ double Tensor1d::xay(const SharedTensor2d &a, const SharedTensor1d &y) {
 }  //
 
 SharedTensor2d Tensor1d::to_2d(int row, int col) {
-    if (row * col != dim1_) {
-        throw std::logic_error("Tensor1d-->to_2d dimensisons are not consistent!\n");
-    }
-    auto temp = std::make_shared<Tensor2d>("Temp", row, col);
-    C_DCOPY(dim1_, A1d_, 1, temp->A2d_[0], 1);
-    return temp;
-}  //
+  if (row*col != dim1_) {
+      throw std::logic_error("Tensor1d-->to_2d dimensions are not consistent!\n");
+  }
+  auto temp = std::make_shared<Tensor2d>("Temp", row, col);
+  C_DCOPY(dim1_, A1d_, 1, temp->A2d_[0], 1);
+  return temp;
+} //
 
 void Tensor1d::axpy(const SharedTensor1d &a, double alpha) {
     size_t length = (size_t)dim1_;
@@ -838,7 +838,7 @@ void Tensor2d::gemm(bool transa, bool transb, const SharedTensor2d &a, const Sha
 
     // C(m,n) = \sum(k) A(m,k) B(k,n)
     if (!transa && !transb) {
-        if (m != a->dim1() || n != b->dim2() || a->dim2() != b->dim1()) {
+        if (m != a->dim1()  || n != b->dim2() || a->dim2() != b->dim1()) {
             outfile->Printf("\tTensor2d::gemm dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::gemm dimensions are NOT consistent!");
         }
@@ -846,7 +846,7 @@ void Tensor2d::gemm(bool transa, bool transb, const SharedTensor2d &a, const Sha
 
     // C(m,n) = \sum(k) A(m,k) B(n,k)
     else if (!transa && transb) {
-        if (m != a->dim1() || n != b->dim1() || a->dim2() != b->dim2()) {
+        if (m != a->dim1()  || n != b->dim1() || a->dim2() != b->dim2()) {
             outfile->Printf("\tTensor2d::gemm dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::gemm dimensions are NOT consistent!");
         }
@@ -854,7 +854,7 @@ void Tensor2d::gemm(bool transa, bool transb, const SharedTensor2d &a, const Sha
 
     // C(m,n) = \sum(k) A(k,m) B(k,n)
     else if (transa && !transb) {
-        if (m != a->dim2() || n != b->dim2() || a->dim1() != b->dim1()) {
+        if (m != a->dim2()  || n != b->dim2() || a->dim1() != b->dim1()) {
             outfile->Printf("\tTensor2d::gemm dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::gemm dimensions are NOT consistent!");
         }
@@ -862,7 +862,7 @@ void Tensor2d::gemm(bool transa, bool transb, const SharedTensor2d &a, const Sha
 
     // C(m,n) = \sum(k) A(k,m) B(n,k)
     else if (transa && transb) {
-        if (m != a->dim2() || n != b->dim1() || a->dim1() != b->dim2()) {
+        if (m != a->dim2()  || n != b->dim1() || a->dim1() != b->dim2()) {
             outfile->Printf("\tTensor2d::gemm dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::gemm dimensions are NOT consistent!");
         }
@@ -933,18 +933,14 @@ void Tensor2d::contract323(bool transa, bool transb, int m, int n, const SharedT
     // contract323: C[Q](m,n) = \sum_{k} A[Q](m,k) * B(k,n). Note: contract332 should be called with beta=1.0
     // Check C[Q](m,n)
     if (m * n != dim2_) {
-        outfile->Printf(
-            "\tTensor2d::contract323 the m*n value is NOT consistent with the col dimension of the Tensor C!\n");
-        throw PSIEXCEPTION(
-            "Tensor2d::contract323 the m*n value is NOT consistent with the col dimension of the Tensor C!");
+        outfile->Printf("\tTensor2d::contract323 the m*n value is NOT consistent with the col dimension of the Tensor C!\n");
+        throw PSIEXCEPTION("Tensor2d::contract323 the m*n value is NOT consistent with the col dimension of the Tensor C!");
     }
 
     // Check A[Q](m,k)
     if (m * k != a->dim2()) {
-        outfile->Printf(
-            "\tTensor2d::contract323 the m*k value is NOT consistent with the col dimension of the Tensor A!\n");
-        throw PSIEXCEPTION(
-            "Tensor2d::contract323 the m*k value is NOT consistent with the col dimension of the Tensor A!");
+        outfile->Printf("\tTensor2d::contract323 the m*k value is NOT consistent with the col dimension of the Tensor A!\n");
+        throw PSIEXCEPTION("Tensor2d::contract323 the m*k value is NOT consistent with the col dimension of the Tensor A!");
     }
 
     // Check B(k,n)
@@ -975,10 +971,8 @@ void Tensor2d::contract233(bool transa, bool transb, int m, int n, const SharedT
     // contract233: C[Q](m,n) = \sum_{k} A(m,k) * B[Q](k,n)
     // Check C[Q](m,n)
     if (m * n != dim2_) {
-        outfile->Printf(
-            "\tTensor2d::contract233 the m*n value is NOT consistent with the col dimension of the Tensor C!\n");
-        throw PSIEXCEPTION(
-            "Tensor2d::contract233 the m*n value is NOT consistent with the col dimension of the Tensor C!");
+        outfile->Printf("\tTensor2d::contract233 the m*n value is NOT consistent with the col dimension of the Tensor C!\n");
+        throw PSIEXCEPTION("Tensor2d::contract233 the m*n value is NOT consistent with the col dimension of the Tensor C!");
     }
 
     // Check A(m,k)
@@ -989,10 +983,8 @@ void Tensor2d::contract233(bool transa, bool transb, int m, int n, const SharedT
 
     // Check B[Q](k,n)
     if (n * k != b->dim2()) {
-        outfile->Printf(
-            "\tTensor2d::contract233 the n*k value is NOT consistent with the col dimension of the Tensor B!\n");
-        throw PSIEXCEPTION(
-            "Tensor2d::contract233 the n*k value is NOT consistent with the col dimension of the Tensor B!");
+        outfile->Printf("\tTensor2d::contract233 the n*k value is NOT consistent with the col dimension of the Tensor B!\n");
+        throw PSIEXCEPTION("Tensor2d::contract233 the n*k value is NOT consistent with the col dimension of the Tensor B!");
     }
 
     if (m && n && k) {
@@ -1024,22 +1016,18 @@ void Tensor2d::contract332(bool transa, bool transb, int k, const SharedTensor2d
 
     // Check A[Q](m,k)
     if (m * k != a->dim2()) {
-        outfile->Printf(
-            "\tTensor2d::contract332 the m*k value is NOT consistent with the col dimension of the Tensor A!\n");
-        throw PSIEXCEPTION(
-            "Tensor2d::contract332 the m*k value is NOT consistent with the col dimension of the Tensor A!");
+        outfile->Printf("\tTensor2d::contract332 the m*k value is NOT consistent with the col dimension of the Tensor A!\n");
+        throw PSIEXCEPTION("Tensor2d::contract332 the m*k value is NOT consistent with the col dimension of the Tensor A!");
     }
 
     // Check B[Q](k,n)
     if (n * k != b->dim2()) {
-        outfile->Printf(
-            "\tTensor2d::contract332 the n*k value is NOT consistent with the col dimension of the Tensor B!\n");
-        throw PSIEXCEPTION(
-            "Tensor2d::contract332 the n*k value is NOT consistent with the col dimension of the Tensor B!");
+        outfile->Printf("\tTensor2d::contract332 the n*k value is NOT consistent with the col dimension of the Tensor B!\n");
+        throw PSIEXCEPTION("Tensor2d::contract332 the n*k value is NOT consistent with the col dimension of the Tensor B!");
     }
 
     if (m && n && k) {
-        // #pragma omp parallel for
+        //#pragma omp parallel for
         for (int Q = 0; Q < a->dim1(); Q++) {
             C_DGEMM(ta, tb, m, n, k, alpha, a->A2d_[Q], nca, b->A2d_[Q], ncb, beta, A2d_[0], ncc);
         }
@@ -1279,9 +1267,8 @@ void Tensor2d::contract424(int target_x, int target_y, const SharedTensor2d &a, 
 
 }  //
 
-// CSB contract two four-index tensors to a two-index tensor. The target index specifies the number of the "surviving"
-// index
-//  i.e. the one that is not contracted
+//CSB contract two four-index tensors to a two-index tensor. The target index specifies the number of the "surviving" index
+// i.e. the one that is not contracted
 void Tensor2d::contract442(int target_a, int target_b, const SharedTensor2d &a, const SharedTensor2d &b, double alpha,
                            double beta) {
     char ta;
@@ -2123,7 +2110,7 @@ void Tensor2d::read(std::shared_ptr<psi::PSIO> psio, size_t fileno) {
 }
 
 void Tensor2d::read(std::shared_ptr<psi::PSIO> psio, const std::string &label, size_t fileno) {
-    // Check to see if the file is open
+    //Check to see if the file is open
     bool already_open = false;
     if (psio->open_check(fileno))
         already_open = true;
@@ -2277,7 +2264,7 @@ bool Tensor2d::read(PSIO *psio, int itap, const char *label, int dim) {
     double **Asq = block_matrix(dim, dim);
     memset(Asq[0], 0, sizeof(double) * dim * dim);
     tri_to_sq(mybuffer, Asq, dim);
-    delete[] mybuffer;
+    delete [] mybuffer;
 
     set(Asq);
     free_block(Asq);
@@ -2293,7 +2280,7 @@ bool Tensor2d::read(std::shared_ptr<psi::PSIO> psio, int itap, const char *label
     double **Asq = block_matrix(dim, dim);
     memset(Asq[0], 0, sizeof(double) * dim * dim);
     tri_to_sq(mybuffer, Asq, dim);
-    delete[] mybuffer;
+    delete [] mybuffer;
 
     set(Asq);
     free_block(Asq);
@@ -2491,7 +2478,7 @@ void Tensor2d::to_pointer(double *A) {
 
 void Tensor2d::mgs() {
     double rmgs1, rmgs2;
-    // #pragma omp parallel for
+    //#pragma omp parallel for
     for (int k = 0; k < dim1_; k++) {  // loop-1
         rmgs1 = 0.0;
 
@@ -2545,30 +2532,30 @@ void Tensor2d::gs() {
 ** Returns: 1 if a vector is added to A, 0 otherwise
 */
 int Tensor2d::gs_add(int rows, SharedTensor1d v) {
-    double dotval, normval;
-    int i, I;
-    int cols = dim2_;
-    double NORM_TOL = 1.0E-5;
+   double dotval, normval ;
+   int i, I ;
+   int cols = dim2_;
+   double NORM_TOL = 1.0E-5;
 
-    for (i = 0; i < rows; i++) {
+   for (i=0; i<rows; i++) {
         dotval = C_DDOT(cols, A2d_[i], 1, v->A1d_, 1);
-        for (I = 0; I < cols; I++) {
-            v->subtract(I, dotval * A2d_[i][I]);
+        for (I=0; I<cols; I++) {
+	     v->subtract(I, dotval * A2d_[i][I]);
         }
-    }
+   }
 
-    // dot_arr(v, v, cols, &normval) ;
-    normval = C_DDOT(cols, v->A1d_, 1, v->A1d_, 1);
-    normval = std::sqrt(normval);
+   // dot_arr(v, v, cols, &normval) ;
+   normval = C_DDOT(cols, v->A1d_, 1, v->A1d_, 1);
+   normval = std::sqrt(normval) ;
 
-    if (normval < NORM_TOL)
-        return (0);
-    else {
-        // if (A2d_[rows] == NULL) A2d_[rows] = init_array(cols) ;
-        if (A2d_[rows] == NULL) A2d_[rows] = new double[cols];
-        for (I = 0; I < cols; I++) A2d_[rows][I] = v->get(I) / normval;
-        return (1);
-    }
+   if (normval < NORM_TOL)
+      return(0) ;
+   else {
+      //if (A2d_[rows] == NULL) A2d_[rows] = init_array(cols) ;
+      if (A2d_[rows] == NULL) A2d_[rows] = new double[cols] ;
+      for (I=0; I<cols; I++) A2d_[rows][I] = v->get(I) / normval ;
+      return(1) ;
+      }
 }  //
 
 double *Tensor2d::row_vector(int n) {
@@ -2592,7 +2579,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     int d4 = A->d4_;
 
     if (sort_type == 1243) {
-        if (d1_ != d1 || d2_ != d2 || d3_ != d4 || d4_ != d3) {
+        if (d1_ != d1 || d2_ != d2 || d3_ != d4  || d4_ != d3 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2612,7 +2599,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 1324) {
-        if (d1_ != d1 || d2_ != d3 || d3_ != d2 || d4_ != d4) {
+        if (d1_ != d1 || d2_ != d3 || d3_ != d2  || d4_ != d4 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2633,7 +2620,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 1342) {
-        if (d1_ != d1 || d2_ != d3 || d3_ != d4 || d4_ != d2) {
+        if (d1_ != d1 || d2_ != d3 || d3_ != d4  || d4_ != d2 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2654,7 +2641,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 1423) {
-        if (d1_ != d1 || d2_ != d4 || d3_ != d2 || d4_ != d3) {
+        if (d1_ != d1 || d2_ != d4 || d3_ != d2  || d4_ != d3 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2675,7 +2662,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 1432) {
-        if (d1_ != d1 || d2_ != d4 || d3_ != d3 || d4_ != d2) {
+        if (d1_ != d1 || d2_ != d4 || d3_ != d3  || d4_ != d2 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2696,7 +2683,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 2134) {
-        if (d1_ != d2 || d2_ != d1 || d3_ != d3 || d4_ != d4) {
+        if (d1_ != d2 || d2_ != d1 || d3_ != d3  || d4_ != d4 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2716,7 +2703,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 2143) {
-        if (d1_ != d2 || d2_ != d1 || d3_ != d4 || d4_ != d3) {
+        if (d1_ != d2 || d2_ != d1 || d3_ != d4  || d4_ != d3 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2737,7 +2724,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 2314) {
-        if (d1_ != d2 || d2_ != d3 || d3_ != d1 || d4_ != d4) {
+        if (d1_ != d2 || d2_ != d3 || d3_ != d1  || d4_ != d4 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2758,7 +2745,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 2341) {
-        if (d1_ != d2 || d2_ != d3 || d3_ != d4 || d4_ != d1) {
+        if (d1_ != d2 || d2_ != d3 || d3_ != d4  || d4_ != d1 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2779,7 +2766,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 2413) {
-        if (d1_ != d2 || d2_ != d4 || d3_ != d1 || d4_ != d3) {
+        if (d1_ != d2 || d2_ != d4 || d3_ != d1  || d4_ != d3 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2800,7 +2787,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 2431) {
-        if (d1_ != d2 || d2_ != d4 || d3_ != d3 || d4_ != d1) {
+        if (d1_ != d2 || d2_ != d4 || d3_ != d3  || d4_ != d1 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2821,7 +2808,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 3124) {
-        if (d1_ != d3 || d2_ != d1 || d3_ != d2 || d4_ != d4) {
+        if (d1_ != d3 || d2_ != d1 || d3_ != d2  || d4_ != d4 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2842,7 +2829,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 3142) {
-        if (d1_ != d3 || d2_ != d1 || d3_ != d4 || d4_ != d2) {
+        if (d1_ != d3 || d2_ != d1 || d3_ != d4  || d4_ != d2 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2863,7 +2850,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 3214) {
-        if (d1_ != d3 || d2_ != d2 || d3_ != d1 || d4_ != d4) {
+        if (d1_ != d3 || d2_ != d2 || d3_ != d1  || d4_ != d4 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2884,7 +2871,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 3241) {
-        if (d1_ != d3 || d2_ != d2 || d3_ != d4 || d4_ != d1) {
+        if (d1_ != d3 || d2_ != d2 || d3_ != d4  || d4_ != d1 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2905,7 +2892,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 3412) {
-        if (d1_ != d3 || d2_ != d4 || d3_ != d1 || d4_ != d2) {
+        if (d1_ != d3 || d2_ != d4 || d3_ != d1  || d4_ != d2 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2924,7 +2911,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 3421) {
-        if (d1_ != d3 || d2_ != d4 || d3_ != d2 || d4_ != d1) {
+        if (d1_ != d3 || d2_ != d4 || d3_ != d2  || d4_ != d1 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2944,7 +2931,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 4123) {
-        if (d1_ != d4 || d2_ != d1 || d3_ != d2 || d4_ != d3) {
+        if (d1_ != d4 || d2_ != d1 || d3_ != d2  || d4_ != d3 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2965,7 +2952,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 4132) {
-        if (d1_ != d4 || d2_ != d1 || d3_ != d3 || d4_ != d2) {
+        if (d1_ != d4 || d2_ != d1 || d3_ != d3  || d4_ != d2 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -2986,7 +2973,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 4213) {
-        if (d1_ != d4 || d2_ != d2 || d3_ != d1 || d4_ != d3) {
+        if (d1_ != d4 || d2_ != d2 || d3_ != d1  || d4_ != d3 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -3007,7 +2994,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 4231) {
-        if (d1_ != d4 || d2_ != d2 || d3_ != d3 || d4_ != d1) {
+        if (d1_ != d4 || d2_ != d2 || d3_ != d3  || d4_ != d1 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -3028,7 +3015,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 4312) {
-        if (d1_ != d4 || d2_ != d3 || d3_ != d1 || d4_ != d2) {
+        if (d1_ != d4 || d2_ != d3 || d3_ != d1  || d4_ != d2 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -3048,7 +3035,7 @@ void Tensor2d::sort(int sort_type, const SharedTensor2d &A, double alpha, double
     }
 
     else if (sort_type == 4321) {
-        if (d1_ != d4 || d2_ != d3 || d3_ != d2 || d4_ != d1) {
+        if (d1_ != d4 || d2_ != d3 || d3_ != d2  || d4_ != d1 ) {
             outfile->Printf("\tTensor2d::sort dimensions are NOT consistent!\n");
             throw PSIEXCEPTION("Tensor2d::sort dimensions are NOT consistent!");
         }
@@ -3304,7 +3291,7 @@ void Tensor2d::reg_denom(int frzc, int occ, const SharedTensor2d &fock, double r
                 for (int b = 0; b < avir; b++) {
                     double dijab = dija - fock->A2d_[b + occ][b + occ];
                     int ab = col_idx_[a][b];
-                    A2d_[ij][ab] /= dijab;  // SB A2d_ refers to the respective property of Tensor2d... this->Ad2
+                    A2d_[ij][ab] /= dijab;    //SB A2d_ refers to the respective property of Tensor2d... this->Ad2
                 }
             }
         }

--- a/psi4/src/psi4/libciomr/block_matrix.cc
+++ b/psi4/src/psi4/libciomr/block_matrix.cc
@@ -80,18 +80,16 @@ namespace psi {
 
     A = new double *[n];
     if (A == nullptr) {
-        outfile->Printf("block_matrix: trouble allocating memory \n");
-        outfile->Printf("n = %ld\n", n);
-        throw PSIEXCEPTION("Could not allocate memory in block_matrix! Tried to allocate " +
-                           std::to_string(n * sizeof(double *)) + " bytes.");
+        std::ostringstream oss;
+        oss << "block_matrix: trouble allocating memory, n = " << n << "\n";
+        throw PSIEXCEPTION(oss.str());
     }
 
     B = new double[n * m];
     if (B == nullptr) {
-        outfile->Printf("block_matrix: trouble allocating memory \n");
-        outfile->Printf("m = %ld\n", m);
-        throw PSIEXCEPTION("Could not allocate memory in block_matrix! Tried to allocate " +
-                           std::to_string(n * m * sizeof(double)) + " bytes.");
+        std::ostringstream oss;
+        oss << "block_matrix: trouble allocating memory, n = " << n << " m = " << m << "\n";
+        throw PSIEXCEPTION(oss.str());
     }
     memset(static_cast<void *>(B), 0, m * n * sizeof(double));
 
@@ -112,9 +110,7 @@ namespace psi {
         size += page_offset; /* Adjust size with page_offset */
 
         if (mlock(addr, size)) { /* Lock the memory */
-            outfile->Printf("block_matrix: trouble locking memory \n");
-            fflush(stderr);
-            exit(PSI_RETURN_FAILURE);
+            throw std::runtime_error("block_matrix: trouble locking memory \n");
         }
 
         addr = (char *)A;
@@ -126,9 +122,7 @@ namespace psi {
         size += page_offset; /* Adjust size with page_offset */
 
         if (mlock(addr, size)) { /* Lock the memory */
-            outfile->Printf("block_matrix: trouble locking memory \n");
-            fflush(stderr);
-            exit(PSI_RETURN_FAILURE);
+            throw std::runtime_error("block_matrix: trouble locking memory \n");
         }
     }
 #endif

--- a/psi4/src/psi4/libciomr/init_array.cc
+++ b/psi4/src/psi4/libciomr/init_array.cc
@@ -54,11 +54,11 @@ double *init_array(size_t size) {
     double *array;
 
     if ((array = (double *)malloc(size * (size_t)sizeof(double))) == nullptr) {
-        outfile->Printf("init_array: trouble allocating memory \n");
-        outfile->Printf("size = %ld\n", size);
-        exit(PSI_RETURN_FAILURE);
+        std::ostringstream oss;
+        oss << "init_array: trouble allocating memory, size = " << size << "\n";
+        throw std::runtime_error(oss.str());
     }
     memset(array, 0, size * (size_t)sizeof(double));
     return (array);
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libciomr/init_matrix.cc
+++ b/psi4/src/psi4/libciomr/init_matrix.cc
@@ -44,15 +44,15 @@
 namespace psi {
 
 /**
-*  WARNING: Psi 3 init/free_matrix routines deprecated
-*  by Robert Parrish, robparrish@gmail.com
-*
-*  block_matrix() replaces this routine
-*
-*  the signature of this method remains the same
-*
-*  June 22, 2010
-**/
+ *  WARNING: Psi 3 init/free_matrix routines deprecated
+ *  by Robert Parrish, robparrish@gmail.com
+ *
+ *  block_matrix() replaces this routine
+ *
+ *  the signature of this method remains the same
+ *
+ *  June 22, 2010
+ **/
 /*!
 ** init_matrix(): Initialize an nxm matrix of doubles and return a pointer to
 ** the first row.  Note that this does not form a matrix which is
@@ -74,16 +74,16 @@ double **init_matrix(size_t n, size_t m) {
 
     //  if ((A = (double **) malloc(n * (size_t)sizeof(double *)))==nullptr) {
     if ((A = new double *[n]) == nullptr) {
-        outfile->Printf("block_matrix: trouble allocating memory \n");
-        outfile->Printf("n = %ld\n", n);
-        exit(PSI_RETURN_FAILURE);
+        std::ostringstream oss;
+        oss << "block_matrix: trouble allocating memory, n = " << n << "\n";
+        throw std::runtime_error(oss.str());
     }
 
     //  if ((B = (double *) malloc(m*n * (size_t)sizeof(double)))==nullptr) {
     if ((B = new double[n * m]) == nullptr) {
-        outfile->Printf("block_matrix: trouble allocating memory \n");
-        outfile->Printf("m = %ld\n", m);
-        exit(PSI_RETURN_FAILURE);
+        std::ostringstream oss;
+        oss << "block_matrix: trouble allocating memory, n = " << n << " m = " << m << "\n";
+        throw std::runtime_error(oss.str());
     }
 
     // bzero is not in the C standard, use memset instead.
@@ -95,44 +95,18 @@ double **init_matrix(size_t n, size_t m) {
     }
 
     return (A);
-    // <<<<<<<<<<<<<<<<<<<<<
-    // BEGIN DEPRECATED CODE
-    // <<<<<<<<<<<<<<<<<<<<<
-
-    /**
-    double **array=nullptr;
-    size_t i;
-
-    if ((array = (double **) malloc(n*(size_t)sizeof(double *)))
-      ==nullptr) {
-      outfile->Printf("init_matrix: trouble allocating memory \n");
-      outfile->Printf("n = %ld\n",n);
-      exit(PSI_RETURN_FAILURE);
-    }
-
-    for (i = 0; i < n; i++) {
-      if ((array[i] = (double *) malloc(m*(size_t)sizeof(double)))
-        ==nullptr) {
-        outfile->Printf("init_matrix: trouble allocating memory \n");
-        outfile->Printf("i = %ld m = %ld\n",i,m);
-        exit(PSI_RETURN_FAILURE);
-      }
-      bzero(array[i],m*(size_t)sizeof(double));
-    }
-    return(array);
-    **/
 }
 
 /**
-*  WARNING: Psi 3 init/free_matrix routines deprecated
-*  by Robert Parrish, robparrish@gmail.com
-*
-*  use block_matrix allocation/free calls instead
-*
-*  the signature of this method remains the same
-*
-*  June 22, 2010
-**/
+ *  WARNING: Psi 3 init/free_matrix routines deprecated
+ *  by Robert Parrish, robparrish@gmail.com
+ *
+ *  use block_matrix allocation/free calls instead
+ *
+ *  the signature of this method remains the same
+ *
+ *  June 22, 2010
+ **/
 /*!
 ** free_matrix(): Free a 2D matrix allocated with init_matrix().
 **
@@ -160,4 +134,4 @@ void free_matrix(double **array, size_t /*size*/) {
     free(array);
   **/
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libciomr/int_array.cc
+++ b/psi4/src/psi4/libciomr/int_array.cc
@@ -40,6 +40,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <sstream>
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 namespace psi {
@@ -63,9 +64,9 @@ PSI_API int *init_int_array(int size) {
     int *array;
 
     if ((array = (int *)malloc(sizeof(int) * size)) == nullptr) {
-        outfile->Printf("init_array:  trouble allocating memory \n");
-        outfile->Printf("size = %d\n", size);
-        exit(PSI_RETURN_FAILURE);
+        std::ostringstream oss;
+        oss << "init_array: trouble allocating memory, size = " << size << "\n";
+        throw std::runtime_error(oss.str());
     }
     memset(array, 0, sizeof(int) * size);
     return (array);
@@ -102,15 +103,15 @@ PSI_API int **init_int_matrix(int rows, int cols) {
     int i;
 
     if ((array = (int **)malloc(sizeof(int *) * rows)) == nullptr) {
-        outfile->Printf("init_int_matrix: trouble allocating memory \n");
-        outfile->Printf("rows = %d\n", rows);
-        exit(PSI_RETURN_FAILURE);
+        std::ostringstream oss;
+        oss << "init_array: trouble allocating memory, rows = " << rows << "\n";
+        throw std::runtime_error(oss.str());
     }
 
     if ((array[0] = (int *)malloc(sizeof(int) * cols * rows)) == nullptr) {
-        outfile->Printf("init_int_matrix: trouble allocating memory \n");
-        outfile->Printf("rows = %d, cols = %d", rows, cols);
-        exit(PSI_RETURN_FAILURE);
+        std::ostringstream oss;
+        oss << "init_array: trouble allocating memory, rows = " << rows << " cols = " << cols << "\n";
+        throw std::runtime_error(oss.str());
     }
     for (i = 1; i < rows; i++) {
         array[i] = array[i - 1] + cols;
@@ -192,4 +193,4 @@ L200:
     ii = kk;
     goto L200;
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libciomr/long_int_array.cc
+++ b/psi4/src/psi4/libciomr/long_int_array.cc
@@ -62,9 +62,9 @@ long int *init_long_int_array(int size) {
     long int *array;
 
     if ((array = (long int *)malloc(sizeof(long int) * size)) == nullptr) {
-        outfile->Printf("init_array:  trouble allocating memory \n");
-        outfile->Printf("size = %d\n", size);
-        exit(PSI_RETURN_FAILURE);
+        std::ostringstream oss;
+        oss << "init_array: trouble allocating memory, size = " << size << "\n";
+        throw std::runtime_error(oss.str());
     }
     memset(array, 0, sizeof(long int) * size);
     return (array);
@@ -86,11 +86,11 @@ PSI_API size_t *init_size_t_array(int size) {
     size_t *array;
 
     if ((array = (size_t *)malloc(sizeof(size_t) * size)) == nullptr) {
-        outfile->Printf("init_size_t_array:  trouble allocating memory \n");
-        outfile->Printf("size = %d\n", size);
-        exit(PSI_RETURN_FAILURE);
+        std::ostringstream oss;
+        oss << "init_size_t_array: trouble allocating memory, size = " << size << "\n";
+        throw std::runtime_error(oss.str());
     }
     memset(array, 0, sizeof(size_t) * size);
     return (array);
 }
-}
+}  // namespace psi

--- a/psi4/src/psi4/libcubeprop/csg.cc
+++ b/psi4/src/psi4/libcubeprop/csg.cc
@@ -260,9 +260,7 @@ void CubicScalarGrid::write_cube_file(double* v, const std::string& name, const 
 
     // Is filepath a valid directory?
     if (filesystem::path(filepath_).make_absolute().is_directory() == false) {
-        printf("Filepath \"%s\" is not valid.  Please create this directory.\n", filepath_.c_str());
-        outfile->Printf("Filepath \"%s\" is not valid.  Please create this directory.\n", filepath_.c_str());
-        exit(Failure);
+        throw std::runtime_error("Filepath \"" + filepath_ + "\" is not valid.  Please create this directory.\n");
     }
 
     FILE* fh = fopen(ss.str().c_str(), "w");
@@ -642,17 +640,17 @@ void CubicScalarGrid::compute_difference(std::shared_ptr<Matrix> C, const std::v
     double* vp = v->pointer();
     add_orbitals(&v_tp[0], C2);
     for (int i = 0; i < npoints_; i++) {
-         if (square) {
-             v->set(0, i, (v_t->get(0,i) - v_t->get(1,i))*(v_t->get(0,i) + v_t->get(1,i)));
-         } else {
-             v->set(0, i, (v_t->get(0,i) - v_t->get(1,i)));
-         }
+        if (square) {
+            v->set(0, i, (v_t->get(0, i) - v_t->get(1, i)) * (v_t->get(0, i) + v_t->get(1, i)));
+        } else {
+            v->set(0, i, (v_t->get(0, i) - v_t->get(1, i)));
+        }
     }
     std::pair<double, double> isocontour_range = compute_isocontour_range(&vp[0], 2.0);
     double density_percent = 100.0 * options_.get_double("CUBEPROP_ISOCONTOUR_THRESHOLD");
     std::stringstream comment;
-    comment << ". Isocontour range for " << density_percent << "% of the density: (" << isocontour_range.first
-            << "," << isocontour_range.second << ")";
+    comment << ". Isocontour range for " << density_percent << "% of the density: (" << isocontour_range.first << ","
+            << isocontour_range.second << ")";
     // Write to disk
     write_gen_file(&vp[0], label, type, comment.str());
 }
@@ -707,12 +705,12 @@ std::string CubicScalarGrid::ecp_header() {
         std::stringstream ecp_ncore;
         for (int A = 0; A < mol_->natom(); A++) {
             if (primary_->n_ecp_core(mol_->label(A)) > 0) {
-                ecp_atoms << A+1 << "[" << mol_->symbol(A) << "], ";
+                ecp_atoms << A + 1 << "[" << mol_->symbol(A) << "], ";
                 ecp_ncore << primary_->n_ecp_core(mol_->label(A)) << ", ";
             }
         }
-        ecp_head << ecp_atoms.str().substr(0,ecp_atoms.str().length()-2) << ") electrons ("
-                 << ecp_ncore.str().substr(0,ecp_ncore.str().length()-2) << ").";
+        ecp_head << ecp_atoms.str().substr(0, ecp_atoms.str().length() - 2) << ") electrons ("
+                 << ecp_ncore.str().substr(0, ecp_ncore.str().length() - 2) << ").";
     }
     return ecp_head.str();
 }

--- a/psi4/src/psi4/libmints/chartab.cc
+++ b/psi4/src/psi4/libmints/chartab.cc
@@ -168,8 +168,6 @@ void CharacterTable::common_init() {
     // rotation axis (nt), and the number of irreps (nirrep_)
 
     if (!symb.length()) {
-        // ExEnv::errn() << "CharacterTable::CharacterTable: null point group" << endl;
-        // exit(1);
         throw PSIEXCEPTION("CharacterTable::CharacterTable: null point group");
     }
 

--- a/psi4/src/psi4/libmints/erd_eri.cc
+++ b/psi4/src/psi4/libmints/erd_eri.cc
@@ -85,16 +85,14 @@ ERDTwoElectronInt::ERDTwoElectronInt(const IntegralFactory *integral, int deriv,
     try {
         tformbuf_ = new double[max_cart];
     } catch (std::bad_alloc &e) {
-        outfile->Printf("Error allocating tformbuf_.\n%s\n", e.what());
-        exit(EXIT_FAILURE);
+        throw std::bad_alloc("Error allocating tformbuf_.\n" + e.what());
     }
     memset(tformbuf_, 0, sizeof(double) * max_cart);
 
     try {
         target_ = new double[max_cart];
     } catch (std::bad_alloc &e) {
-        outfile->Printf("Error allocating target_.\n%s\n", e.what());
-        exit(EXIT_FAILURE);
+        throw std::bad_alloc("Error allocating target_.\n" + e.what());
     }
     memset(target_, 0, sizeof(double) * max_cart);
 
@@ -159,16 +157,14 @@ ERDTwoElectronInt::ERDTwoElectronInt(const IntegralFactory *integral, int deriv,
     try {
         dscratch_ = new double[d_buffer_size_];
     } catch (std::bad_alloc &e) {
-        outfile->Printf("Error allocating dscratch_.\n%s\n", e.what());
-        exit(EXIT_FAILURE);
+        throw std::bad_alloc("Error allocating dscratch_.\n" + e.what());
     }
     memset(dscratch_, 0, sizeof(double) * d_buffer_size_);
 
     try {
         iscratch_ = new F_INT[i_buffer_size_];
     } catch (std::bad_alloc &e) {
-        outfile->Printf("Error allocating iscratch.\n%s\n", e.what());
-        exit(EXIT_FAILURE);
+        throw std::bad_alloc("Error allocating iscratch_.\n" + e.what());
     }
 
     normalize_basis();

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -1129,8 +1129,7 @@ SharedMatrix Wavefunction::basis_projection(SharedMatrix C_A, Dimension noccpi, 
         double *work = init_array(lwork);
         int stat = C_DSYEV('v', 'u', nocc, T[0], nocc, eigval, work, lwork);
         if (stat != 0) {
-            outfile->Printf("C_DSYEV failed\n");
-            exit(PSI_RETURN_FAILURE);
+            throw std::runtime_error("C_DSYEV failed\n");
         }
         delete[] work;
 

--- a/psi4/src/psi4/libmoinfo/model_space_build.cc
+++ b/psi4/src/psi4/libmoinfo/model_space_build.cc
@@ -125,15 +125,16 @@ void ModelSpace::build() {
     }
 
     if (determinants.size() == 0) {
-        outfile->Printf("\n\n  No reference found in the model space");
-        outfile->Printf("\n  Please check the following:");
-        outfile->Printf("\n  1) Definition of FROZEN_DOCC, RESTRICTED_DOCC, ACTIVE, and FROZEN_UOCC");
-        //    outfile->Printf("\n  1) Definition of FOCC, DOCC, ACTV, and FVIR");
-        outfile->Printf("\n  2) Symmetry of the wavefunction");
-        outfile->Printf("\n  3) Charge and multiplicity");
-        outfile->Printf("\n\n  Ending the computation.\n");
+        std::string message =
+            "\n\n  No reference found in the model space"
+            "\n  Please check the following:"
+            "\n  1) Definition of FROZEN_DOCC, RESTRICTED_DOCC, ACTIVE, and FROZEN_UOCC"
+            "\n  2) Symmetry of the wavefunction"
+            "\n  3) Charge and multiplicity"
+            "\n\n  Ending the computation.\n";
+        outfile->Printf(message);
 
-        exit(PSI_RETURN_FAILURE);
+        throw std::logic_error(message);
     }
 }
 

--- a/psi4/src/psi4/libmoinfo/moinfo_base.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.cc
@@ -65,7 +65,7 @@ void MOInfoBase::startup() {
     compute_ioff();
 }
 
-void MOInfoBase::cleanup() {} 
+void MOInfoBase::cleanup() {}
 
 void MOInfoBase::read_data() {
     nirreps = ref_wfn.nirrep();
@@ -110,10 +110,8 @@ void MOInfoBase::read_mo_space(int nirreps_ref, int& n, intvec& mo, std::string 
         mo.assign(nirreps_ref, 0);
         n = 0;
         if (read) {
-            outfile->Printf("\n\n  libmoinfo has found a redundancy in the input keywords %s , please fix it!",
-                            labels.c_str());
-
-            exit(1);
+            throw std::runtime_error("libmoinfo has found a redundancy in the input keywords " + labels +
+                                     ", please fix it!\n");
         } else {
             read = true;
         }
@@ -123,12 +121,10 @@ void MOInfoBase::read_mo_space(int nirreps_ref, int& n, intvec& mo, std::string 
                 n += mo[i];
             }
         } else {
-            outfile->Printf(
-                "\n\n  The size of the %s array (%d) does not match the number of irreps (%d), please fix the input "
-                "file",
-                label_vec[k].c_str(), size, nirreps_ref);
-
-            exit(1);
+            std::ostringstream oss;
+            oss << "The size of the " << label_vec[k] << " array (" << size << ") does not match the number of irreps ("
+                << nirreps_ref << "), please fix the input\n";
+            throw std::runtime_error(oss.str());
         }
     }
 }
@@ -162,8 +158,9 @@ void MOInfoBase::correlate(char* ptgrp, int irrep, int& nirreps_old, int& nirrep
     else if (strcmp(ptgrp, "D2h") == 0)
         nirreps_old = 8;
     else {
-        outfile->Printf("point group %s unknown.\n", ptgrp);
-        exit(1);
+        std::ostringstream oss;
+        oss << "point group " << ptgrp << " is not recognized.\n";
+        throw std::logic_error(oss.str());
     }
 
     arr = new int[nirreps_old];

--- a/psi4/src/psi4/libmoinfo/moinfo_model_space.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_model_space.cc
@@ -181,15 +181,15 @@ void MOInfo::build_model_space() {
     }
 
     if (references.size() == 0) {
-        outfile->Printf("\n\n  MOInfo found no reference in the model space");
-        outfile->Printf("\n  Please check the following:");
-        outfile->Printf("\n  1) Definition of FROZEN_DOCC, RESTRICTED_DOCC, ACTIVE, and FROZEN_UOCC");
-        //        outfile->Printf("\n  1) Definition of FOCC, DOCC, ACTV, and FVIR");
-        outfile->Printf("\n  2) Symmetry of the wavefunction");
-        outfile->Printf("\n  3) Charge and multiplicity");
-        outfile->Printf("\n\n  PSIMRCC will end the computation.\n");
-
-        exit(PSI_RETURN_FAILURE);
+        std::string message =
+            "\n\n  No reference found in the model space"
+            "\n  Please check the following:"
+            "\n  1) Definition of FROZEN_DOCC, RESTRICTED_DOCC, ACTIVE, and FROZEN_UOCC"
+            "\n  2) Symmetry of the wavefunction"
+            "\n  3) Charge and multiplicity"
+            "\n\n  Ending the computation.\n";
+        outfile->Printf(message);
+        throw std::logic_error(message);
     }
 }
 

--- a/psi4/src/psi4/libpsi4util/PsiOutStream.cc
+++ b/psi4/src/psi4/libpsi4util/PsiOutStream.cc
@@ -89,4 +89,5 @@ void PsiOutStream::Printf(const char* format, ...) {
 }
 void PsiOutStream::Printf(std::string fp) { (*stream_) << fp << std::flush; }
 
-}  // End Psi Namespace
+void PsiOutStream::Flush() { stream_->flush(); }
+}  // namespace psi

--- a/psi4/src/psi4/libpsi4util/PsiOutStream.h
+++ b/psi4/src/psi4/libpsi4util/PsiOutStream.h
@@ -50,6 +50,7 @@ class PSI_API PsiOutStream {
     void Printf(const char* fmt, ...);
     void Printf(std::string fp);
     void MakeBanner(std::string header);
+    void Flush();
 
     std::ostream* stream() { return stream_; }
 
@@ -66,5 +67,5 @@ class PSI_API PsiOutStream {
     // }
 };
 
-}  // End Psi namespace
+}  // namespace psi
 #endif

--- a/psi4/src/psi4/libpsio/init.cc
+++ b/psi4/src/psi4/libpsio/init.cc
@@ -62,8 +62,7 @@ PSIO::PSIO() {
     state_ = 1;
 
     if (psio_unit == nullptr) {
-        ::fprintf(stderr, "Error in PSIO_INIT()!\n");
-        exit(_error_exit_code_);
+      throw std::runtime_error("Error in PSIO_INIT()!\n");
     }
 
     for (i = 0; i < PSIO_MAXUNIT; i++) {
@@ -115,16 +114,14 @@ int psio_init() {
         auto temp = std::make_shared<PSIO>();
         _default_psio_lib_ = temp;
         if (_default_psio_lib_ == 0) {
-            ::fprintf(stderr, "LIBPSIO::init() -- failed to allocate the memory");
-            exit(PSIO::_error_exit_code_);
+          throw std::runtime_error("LIBPSIO::init() -- failed to allocate the memory\n");
         }
     }
     if (_default_psio_manager_.get() == 0) {
         auto temp = std::make_shared<PSIOManager>();
         _default_psio_manager_ = temp;
         if (_default_psio_manager_ == 0) {
-            ::fprintf(stderr, "LIBPSIO::init() -- failed to allocate the memory");
-            exit(PSIO::_error_exit_code_);
+          throw std::runtime_error("LIBPSIO::init() -- failed to allocate the memory\n");
         }
     }
 

--- a/psi4/src/psi4/libpsio/init.cc
+++ b/psi4/src/psi4/libpsio/init.cc
@@ -48,7 +48,6 @@ std::shared_ptr<PSIO> _default_psio_lib_;
 std::shared_ptr<PSIOManager> _default_psio_manager_;
 std::string PSIO::default_namespace_;
 
-int PSIO::_error_exit_code_ = 1;
 psio_address PSIO_ZERO = {0, 0};
 
 PSIO::PSIO() {
@@ -62,7 +61,7 @@ PSIO::PSIO() {
     state_ = 1;
 
     if (psio_unit == nullptr) {
-      throw std::runtime_error("Error in PSIO_INIT()!\n");
+        throw std::runtime_error("Error in PSIO_INIT()!\n");
     }
 
     for (i = 0; i < PSIO_MAXUNIT; i++) {
@@ -114,14 +113,14 @@ int psio_init() {
         auto temp = std::make_shared<PSIO>();
         _default_psio_lib_ = temp;
         if (_default_psio_lib_ == 0) {
-          throw std::runtime_error("LIBPSIO::init() -- failed to allocate the memory\n");
+            throw std::runtime_error("LIBPSIO::init() -- failed to allocate the memory\n");
         }
     }
     if (_default_psio_manager_.get() == 0) {
         auto temp = std::make_shared<PSIOManager>();
         _default_psio_manager_ = temp;
         if (_default_psio_manager_ == 0) {
-          throw std::runtime_error("LIBPSIO::init() -- failed to allocate the memory\n");
+            throw std::runtime_error("LIBPSIO::init() -- failed to allocate the memory\n");
         }
     }
 

--- a/psi4/src/psi4/libpsio/psio.hpp
+++ b/psi4/src/psi4/libpsio/psio.hpp
@@ -52,7 +52,7 @@ extern PSI_API std::shared_ptr<PSIOManager> _default_psio_manager_;
     Now supports a .psirc and interactive file placement
    */
 class PSI_API PSIOManager {
-private:
+   private:
     /// Default path for unspec'd file numbers. Defaults to /tmp/
     std::string default_path_;
     /// Specific paths for arbitrary file numbers
@@ -66,56 +66,57 @@ private:
     std::set<std::string> retained_files_;
 
     std::string pid_;
-public:
+
+   public:
     /// Default constructor (does nothing)
     PSIOManager();
     /// Default destructor (does nothing)
     ~PSIOManager();
 
     /**
-            * Mirror the current delete-able files to "psi.clean"
-            **/
+     * Mirror the current delete-able files to "psi.clean"
+     **/
     void mirror_to_disk();
     /**
-            * Build from "psi.clean"
-            **/
+     * Build from "psi.clean"
+     **/
     void build_from_disk();
 
     /**
-            * Set the default path for files to be stored
-            * \param path full path to scratch
-            */
-    void set_default_path(const std::string& path);
+     * Set the default path for files to be stored
+     * \param path full path to scratch
+     */
+    void set_default_path(const std::string &path);
     /**
-            * Set the path for specific file numbers
-            * \param fileno PSI4 file number
-            * \param path full path to file-specific scratch
-            */
-    void set_specific_path(int fileno, const std::string& path);
+     * Set the path for specific file numbers
+     * \param fileno PSI4 file number
+     * \param path full path to file-specific scratch
+     */
+    void set_specific_path(int fileno, const std::string &path);
     /**
-            * Set the specific file number to be retained
-            * \param fileno PSI4 file number
-            * \param retain keep or not? (Allows override)
-            */
+     * Set the specific file number to be retained
+     * \param fileno PSI4 file number
+     * \param retain keep or not? (Allows override)
+     */
     void set_specific_retention(int fileno, bool retain);
     /**
-            * Inquire whether a specific file number is set to be retained
-            * \param fileno PSI4 file number
-            * \return keeping or not?
-            */
+     * Inquire whether a specific file number is set to be retained
+     * \param fileno PSI4 file number
+     * \return keeping or not?
+     */
     bool get_specific_retention(int fileno);
 
     /**
-            * Get the path for a specific file number
-            * \param fileno PSI4 file number
-            * \return the appropriate full path
-            */
+     * Get the path for a specific file number
+     * \param fileno PSI4 file number
+     * \return the appropriate full path
+     */
     std::string get_file_path(int fileno);
 
     /**
-      * Returns the default path.
-      * \return the default path.
-      */
+     * Returns the default path.
+     * \return the default path.
+     */
     std::string get_default_path() { return default_path_; }
 
     /**
@@ -126,10 +127,10 @@ public:
     void write_scratch_file(const std::string &full_path, const std::string &text);
 
     /**
-            * Record the opening of a file
-            * \param full_path filename
-            */
-    void open_file(const std::string & full_path, int fileno);
+     * Record the opening of a file
+     * \param full_path filename
+     */
+    void open_file(const std::string &full_path, int fileno);
     /**
             * Record the opening of a file
             * \param fileno PSI4 file number
@@ -137,45 +138,45 @@ public:
             * \param keep TRUE : the file is closed and retained by PSIO
                           FALSE: the file is closed and deleted by PSIO
             */
-    void close_file(const std::string & full_path, int fileno, bool keep);
+    void close_file(const std::string &full_path, int fileno, bool keep);
     /**
-            * Move a file from one location to another, retaining status
-            * Useful for changing namespaces
-            * \param old_full_path old filename
-            * \param new_full_path new filename
-            */
-    void move_file(const std::string & old_full_path, const std::string & new_full_path);
+     * Move a file from one location to another, retaining status
+     * Useful for changing namespaces
+     * \param old_full_path old filename
+     * \param new_full_path new filename
+     */
+    void move_file(const std::string &old_full_path, const std::string &new_full_path);
     /**
-            * Mark a file to be retained after a psiclean operation, ie for use in
-            * a later computation
-            * \param full_path filename
-            * \param retain keep or not? (Allows override)
-            */
-    void mark_file_for_retention(const std::string & full_path, bool retain);
+     * Mark a file to be retained after a psiclean operation, ie for use in
+     * a later computation
+     * \param full_path filename
+     * \param retain keep or not? (Allows override)
+     */
+    void mark_file_for_retention(const std::string &full_path, bool retain);
     /**
-            * Print the current status of PSI4 files
-            * \param out file to print to
-            */
+     * Print the current status of PSI4 files
+     * \param out file to print to
+     */
     void print(std::string out = "outfile");
     /**
-            * Print the current status of PSI4 files
-            */
+     * Print the current status of PSI4 files
+     */
     void print_out() { print("outfile"); }
     /**
-            * Execute the psiclean protocol, deleting all recorded files
-            * except for those currently marked for retention.
-            *
-            * Those files marked for retention are not deleted, and their
-            * traces in the files_ set and retained_files set remain.
-            * Deleted files are removed from the files_ set.
-            *
-            * This is useful for intermediate calls to psiclean
-            */
+     * Execute the psiclean protocol, deleting all recorded files
+     * except for those currently marked for retention.
+     *
+     * Those files marked for retention are not deleted, and their
+     * traces in the files_ set and retained_files set remain.
+     * Deleted files are removed from the files_ set.
+     *
+     * This is useful for intermediate calls to psiclean
+     */
     void psiclean();
     /**
-            * Clean from disk-mirrored image after crash
-            * NOT to be called during regular computation
-            **/
+     * Clean from disk-mirrored image after crash
+     * NOT to be called during regular computation
+     **/
     void crashclean();
     /// The one and (should be) only instance of PSIOManager for a PSI4 instance
     static std::shared_ptr<PSIOManager> shared_object();
@@ -193,14 +194,12 @@ public:
 
    */
 class PSI_API PSIO {
-public:
+   public:
     PSIO();
     ~PSIO();
 
     /// return 1 if activated
-    int state() {
-        return state_;
-    }
+    int state() { return state_; }
     /**
        set keyword kwd describing some aspect of configuration of PSIO file unit
        to value kwdval. kwdgrp specifies the keyword group (useful values are: "DEFAULT", "PSI", and the name of
@@ -210,21 +209,20 @@ public:
 
        PSIO understands the following keywords: "name" (specifies the prefix for the filename,
        i.e. if name is set to "psi" then unit 35 will be named "psi.35"), "nvolume" (number of files over which
-       to stripe this unit, cannot be greater than PSIO_MAXVOL), "volumeX", where X is a positive integer less than or equal to
-       the value of "nvolume".
+       to stripe this unit, cannot be greater than PSIO_MAXVOL), "volumeX", where X is a positive integer less than or
+       equal to the value of "nvolume".
        */
-    void filecfg_kwd(const char* kwdgrp, const char* kwd, int unit,
-                     const char* kwdval);
+    void filecfg_kwd(const char *kwdgrp, const char *kwd, int unit, const char *kwdval);
     /// returns the keyword value. If not defined, returns empty string.
-    const std::string& filecfg_kwd(const char* kwdgrp, const char* kwd,
-                                   int unit);
+    const std::string &filecfg_kwd(const char *kwdgrp, const char *kwd, int unit);
 
     /// moves a file from old_unit to new_unit
-    void rename_file(size_t old_unit,size_t new_unit);
+    void rename_file(size_t old_unit, size_t new_unit);
 
     /// check if a psi unit already exists or not
     bool exists(size_t unit);
-    /// open unit. status can be PSIO_OPEN_OLD (if existing file is to be opened) or PSIO_OPEN_NEW if new file should be open
+    /// open unit. status can be PSIO_OPEN_OLD (if existing file is to be opened) or PSIO_OPEN_NEW if new file should be
+    /// open
     void open(size_t unit, int status);
     /// close unit. if keep == 0, will remove the file, else keep it
     void close(size_t unit, int keep);
@@ -235,73 +233,68 @@ public:
     /// return 1 if unit is open
     int open_check(size_t unit);
     /** Reads data from within a TOC entry from a PSI file.
-       **
-       **  \param unit   = The PSI unit number used to identify the file to all
-       **                  read and write functions.
-       **  \param key    = The TOC keyword identifying the desired entry.
-       **  \param buffer = The buffer to store the data as it is read.
-       **  \param size   = The number of bytes to read.
-       **  \param start  = The entry-relative starting page/offset of the desired data.
-       **  \param end    = A pointer to the entry-relative page/offset for the next
-       **                  byte after the end of the read request.
-       */
-    void read(size_t unit, const char *key, char *buffer, size_t size,
-              psio_address start, psio_address *end);
+     **
+     **  \param unit   = The PSI unit number used to identify the file to all
+     **                  read and write functions.
+     **  \param key    = The TOC keyword identifying the desired entry.
+     **  \param buffer = The buffer to store the data as it is read.
+     **  \param size   = The number of bytes to read.
+     **  \param start  = The entry-relative starting page/offset of the desired data.
+     **  \param end    = A pointer to the entry-relative page/offset for the next
+     **                  byte after the end of the read request.
+     */
+    void read(size_t unit, const char *key, char *buffer, size_t size, psio_address start, psio_address *end);
     /** Writes data to a TOC entry in a PSI file.
-       **
-       **  \param unit    = The PSI unit number used to identify the file to all read
-       **                   and write functions.
-       **  \param key     = The TOC keyword identifying the desired entry.
-       **  \param buffer  = The buffer from which the data is written.
-       **  \param size    = The number of bytes to write.
-       **  \param start   = The entry-relative starting page/offset to write the data.
-       **  \param end     = A pointer to the entry-relative page/offset for the next
-       **                   byte after the end of the write request.
-       */
-    void write(size_t unit, const char *key, char *buffer, size_t size,
-               psio_address start, psio_address *end);
+     **
+     **  \param unit    = The PSI unit number used to identify the file to all read
+     **                   and write functions.
+     **  \param key     = The TOC keyword identifying the desired entry.
+     **  \param buffer  = The buffer from which the data is written.
+     **  \param size    = The number of bytes to write.
+     **  \param start   = The entry-relative starting page/offset to write the data.
+     **  \param end     = A pointer to the entry-relative page/offset for the next
+     **                   byte after the end of the write request.
+     */
+    void write(size_t unit, const char *key, char *buffer, size_t size, psio_address start, psio_address *end);
 
     void read_entry(size_t unit, const char *key, char *buffer, size_t size);
     void write_entry(size_t unit, const char *key, char *buffer, size_t size);
 
     /** Zeros out a double precision array in a PSI file.
-       ** Typically used before striping out a transposed array
-       **  Total fill size is rows*cols*sizeof(double)
-       **  Buffer memory of cols*sizeof(double) is used
-       **
-       **  \param unit    = The PSI unit number used to identify the file
-       **  \param key     = The TOC keyword identifying the desired entry.
-       **  \param rows    = The number of rows in the full array
-       **  \param cols    = The number of columnss in the full array
-       **
-       */
+     ** Typically used before striping out a transposed array
+     **  Total fill size is rows*cols*sizeof(double)
+     **  Buffer memory of cols*sizeof(double) is used
+     **
+     **  \param unit    = The PSI unit number used to identify the file
+     **  \param key     = The TOC keyword identifying the desired entry.
+     **  \param rows    = The number of rows in the full array
+     **  \param cols    = The number of columnss in the full array
+     **
+     */
     void zero_disk(size_t unit, const char *key, size_t rows, size_t cols);
 
     /** Central function for all reads and writes on a PSIO unit.
-       **
-       ** \param unit    = The PSI unit number.
-       ** \param buffer  = The buffer containing the bytes for the read/write event.
-       ** \param address = the PSIO global address for the start of the read/write.
-       ** \param size    = The number of bytes to read/write.
-       ** \param wrt      = Indicates if the call is to read (0) or write (0) the input data.
-       **
-       */
-    void rw(size_t unit, char *buffer, psio_address address, size_t size,
-            int wrt);
+     **
+     ** \param unit    = The PSI unit number.
+     ** \param buffer  = The buffer containing the bytes for the read/write event.
+     ** \param address = the PSIO global address for the start of the read/write.
+     ** \param size    = The number of bytes to read/write.
+     ** \param wrt      = Indicates if the call is to read (0) or write (0) the input data.
+     **
+     */
+    void rw(size_t unit, char *buffer, psio_address address, size_t size, int wrt);
 
     /// Delete all TOC entries after the given key. If a blank key is given, the entire TOC will be wiped.
     void tocclean(size_t unit, const char *key);
     /// Print the table of contents for the given unit
     void tocprint(size_t unit);
     /// Scans the TOC for a particular keyword and returns either a pointer to the entry or nullptr to the caller.
-    psio_tocentry* tocscan(size_t unit, const char *key);
+    psio_tocentry *tocscan(size_t unit, const char *key);
     /// Checks the TOC to see if a particular keyword exists there or not
     bool tocentry_exists(size_t unit, const char *key);
-    ///  Write the table of contents for file number 'unit'. NB: This function should NOT call psio_error because the latter calls it!
+    ///  Write the table of contents for file number 'unit'. NB: This function should NOT call psio_error because the
+    ///  latter calls it!
     void tocwrite(size_t unit);
-
-    /// Upon catastrophic failure, the library will exit() with this code. The default is 1, but can be overridden.
-    static int _error_exit_code_;
 
     /// Set the current namespace (for PREFIX.NAMESPACE.UNIT file numbering)
     static void set_default_namespace(const std::string &_ns) { default_namespace_ = _ns; }
@@ -310,13 +303,13 @@ public:
     static std::string get_default_namespace() { return default_namespace_; }
 
     /// Change file FILENO from NS1 to NS2
-    static void change_file_namespace(size_t fileno, const std::string & ns1, const std::string & ns2);
+    static void change_file_namespace(size_t fileno, const std::string &ns1, const std::string &ns2);
 
     /// Return the global shared object
     static std::shared_ptr<PSIO> shared_object();
 
-    void rewind_toclen(const size_t unit); // Seek the stream of the vol[0] of a unit to its beginning.
-    size_t rd_toclen(size_t unit); // Read the length of the TOC for a given unit directly from the file.
+    void rewind_toclen(const size_t unit);  // Seek the stream of the vol[0] of a unit to its beginning.
+    size_t rd_toclen(size_t unit);          // Read the length of the TOC for a given unit directly from the file.
 
     /// grab the filename of unit and strdup into name.
     void get_filename(size_t unit, char **name, bool remove_namespace = false);
@@ -324,7 +317,7 @@ public:
     /// delete a specific TOC entry (only deletes entry, not data)
     bool tocdel(size_t unit, const char *key);
 
-private:
+   private:
     /// vector of units
     psio_ud *psio_unit;
 
@@ -334,7 +327,7 @@ private:
     /// Current default namespace (for PREFIX.NAMESPACE.UNIT numbering)
     static std::string default_namespace_;
 
-    typedef std::map<std::string,std::string> KWDMap;
+    typedef std::map<std::string, std::string> KWDMap;
     /// library configuration is described by a set of keywords
     KWDMap files_keywords_;
 
@@ -352,18 +345,18 @@ private:
     /// return the last TOC entry
     psio_tocentry *toclast(size_t unit);
 
-    size_t toclen(size_t unit); // Compute the length of the TOC for a given unit using the in-core TOC list.
-    void wt_toclen(size_t unit, size_t toclen); // Write the length of the TOC for a given unit directly to the file.
-    
+    size_t toclen(size_t unit);  // Compute the length of the TOC for a given unit using the in-core TOC list.
+    void wt_toclen(size_t unit, size_t toclen);  // Write the length of the TOC for a given unit directly to the file.
+
     /// Read the table of contents for file number 'unit'.
     void tocread(size_t unit);
 
     friend class AIO_Handler;
 
-public:
+   public:
     void set_pid(const std::string &pid) { pid_ = pid; }
 };
 
-}
+}  // namespace psi
 
 #endif /* header guard */

--- a/psi4/src/psi4/mcscf/sblock_matrix.cc
+++ b/psi4/src/psi4/mcscf/sblock_matrix.cc
@@ -40,7 +40,8 @@ namespace mcscf {
 
 SBlockMatrix::SBlockMatrix() : block_matrix_(nullptr) {}
 
-SBlockMatrix::SBlockMatrix(std::string label, int nirreps, size_t*& rows_size, size_t*& cols_size) : block_matrix_(nullptr) {
+SBlockMatrix::SBlockMatrix(std::string label, int nirreps, size_t*& rows_size, size_t*& cols_size)
+    : block_matrix_(nullptr) {
     block_matrix_ = new BlockMatrix(label, nirreps, rows_size, cols_size);
     block_matrix_->add_reference();
 }
@@ -50,7 +51,8 @@ SBlockMatrix::SBlockMatrix(std::string label, int nirreps, int*& rows_size, int*
     block_matrix_->add_reference();
 }
 
-SBlockMatrix::SBlockMatrix(std::string label, int nirreps, vecint& rows_size, vecint& cols_size) : block_matrix_(nullptr) {
+SBlockMatrix::SBlockMatrix(std::string label, int nirreps, vecint& rows_size, vecint& cols_size)
+    : block_matrix_(nullptr) {
     block_matrix_ = new BlockMatrix(label, nirreps, rows_size, cols_size);
     block_matrix_->add_reference();
 }
@@ -135,9 +137,8 @@ double dot(SBlockMatrix& A, SBlockMatrix& B) {
 
 void SBlockMatrix::check(const char* cstr) {
     if (!is_allocated()) {
-        outfile->Printf("\n\n  Error: SBlockMatrix operation '%s' is using an uninitialized matrix", cstr);
-
-        exit(PSI_RETURN_FAILURE);
+        throw std::runtime_error("Error: SBlockMatrix operation '" + std::string(cstr) +
+                                 "' is using an uninitialized matrix\n");
     }
 }
 

--- a/psi4/src/psi4/mcscf/sblock_vector.cc
+++ b/psi4/src/psi4/mcscf/sblock_vector.cc
@@ -80,9 +80,8 @@ SBlockVector& SBlockVector::operator=(const SBlockVector& src) {
 
 void SBlockVector::check(const char* cstr) {
     if (!is_allocated()) {
-        outfile->Printf("\n\n  Error: SBlockVector operation '%s' is using an uninitialized matrix", cstr);
-
-        exit(PSI_RETURN_FAILURE);
+        throw std::runtime_error("Error: SBlockVector operation '" + std::string(cstr) +
+                                 "' is using an uninitialized matrix\n");
     }
 }
 

--- a/psi4/src/psi4/mcscf/scf.cc
+++ b/psi4/src/psi4/mcscf/scf.cc
@@ -96,10 +96,7 @@ void SCF::startup() {
         same_a_b_orbs_ = true;
         same_a_b_dens_ = false;
         if (moinfo_scf->get_guess_occupation()) {
-            printf("\n  ERROR:  MCSCF cannot guess the active orbital occupation\n");
-            outfile->Printf("\n\n  MCSCF cannot guess the active orbital occupation\n");
-
-            exit(1);
+            throw std::runtime_error("MCSCF cannot guess the active orbital occupation\n");
         }
     }
 

--- a/psi4/src/psi4/mcscf/scf_iterate_scf_equations.cc
+++ b/psi4/src/psi4/mcscf/scf_iterate_scf_equations.cc
@@ -135,10 +135,9 @@ void SCF::iterate_scf_equations() {
         }
 
         if (cycle > options_.get_int("MAXITER")) {
-            outfile->Printf("\n\n  The calculation did not converge in %d cycles", options_.get_int("MAXITER"));
-            outfile->Printf("\n  Quitting MCSCF.\n");
-
-            exit(1);
+            std::ostringstream oss;
+            oss << "The calculation did not converge in " << options_.get_int("MAXITER") << " cycles.\n";
+            throw std::runtime_error(oss.str());
         }
 
         cycle++;

--- a/psi4/src/psi4/occ/idp.cc
+++ b/psi4/src/psi4/occ/idp.cc
@@ -97,9 +97,7 @@ void OCCWave::idp() {
         }  // end if nidpA != 0
 
         else if (nidpA == 0) {
-            outfile->Printf("\tThere is not any non-redundant orbital rotation pair! \n");
-            tstop();
-            exit(EXIT_SUCCESS);
+            throw std::logic_error("There are no non-redundant orbital rotation pairs! \n");
         }
 
     }  // end if (reference_ == "RESTRICTED")
@@ -125,9 +123,7 @@ void OCCWave::idp() {
         outfile->Printf("\tNumber of beta independent-pairs :%3d\n", nidpB);
 
         if (nidpA == 0 && nidpB == 0) {
-            outfile->Printf("\tThere is not any non-redundant orbital rotation pair! \n");
-            tstop();
-            exit(EXIT_SUCCESS);
+            throw std::logic_error("There are no non-redundant orbital rotation pairs! \n");
         }
 
         if (nidpA != 0) {
@@ -215,5 +211,5 @@ void OCCWave::idp() {
     }  // end if (reference_ == "UNRESTRICTED")
 
 }  // end of main
-}
-}  // End Namespaces
+}  // namespace occwave
+}  // namespace psi

--- a/psi4/src/psi4/psimrcc/blas_compatibile.cc
+++ b/psi4/src/psi4/psimrcc/blas_compatibile.cc
@@ -61,8 +61,8 @@ bool CCOperation::compatible_dot() {
     if (!same) {
         outfile->Printf("\n\nSolve couldn't perform the operation ");
         print_operation();
-
-        exit(1);
+        outfile->Flush();
+        throw std::runtime_error("Solve could not perform an operation, see log file for details\n");
     }
     return (same);
 }
@@ -94,8 +94,8 @@ bool CCOperation::compatible_element_by_element() {
         if ((B_left != C_left) || (B_right != C_right)) {
             outfile->Printf("\n\nSolve couldn't perform the operation ");
             print_operation();
-
-            exit(1);
+            outfile->Flush();
+            throw std::runtime_error("Solve could not perform an operation, see log file for details\n");
         }
     }
     return (same);
@@ -138,8 +138,8 @@ bool CCOperation::compatible_contract() {
     if (B_contracted != C_contracted) {
         outfile->Printf("\n\nSolve couldn't perform the operation ");
         print_operation();
-
-        exit(1);
+        outfile->Flush();
+        throw std::runtime_error("Solve could not perform an operation, see log file for details\n");
     }
     return (same);
 }

--- a/psi4/src/psi4/psimrcc/blas_parser.cc
+++ b/psi4/src/psi4/psimrcc/blas_parser.cc
@@ -159,10 +159,7 @@ double get_number(const std::string& str) {
         if (unsigned_numerator.size() * denominator.size() != 0) {
             value = to_double(numerator) / to_double(denominator);
         } else {
-            outfile->Printf("\n\nSolve couldn't parse the numerical factor %s\n\n", str.c_str());
-            outfile->Printf("\n\nCritical Breakdown of the Program. Blame the programmers!!!\n\n");
-
-            exit(1);
+            throw std::runtime_error("Solve couldn't parse the numerical factor " + str + ".\n");
         }
 
     } else {

--- a/psi4/src/psi4/psimrcc/idmrpt2.cc
+++ b/psi4/src/psi4/psimrcc/idmrpt2.cc
@@ -115,10 +115,9 @@ double IDMRPT2::compute_energy() {
         old_energy = current_energy;
 
         if (cycle > options_.get_int("MAXITER")) {
-            outfile->Printf("\n\n\tThe calculation did not converge in %d cycles\n\tQuitting PSIMRCC\n",
-                            options_.get_int("MAXITER"));
-
-            exit(1);
+            std::ostringstream oss;
+            oss << "The calculation did not converge in " << options_.get_int("MAXITER") << " cycles.\n";
+            throw std::runtime_error(oss.str());
         }
         cycle++;
     }

--- a/psi4/src/psi4/psimrcc/index.cc
+++ b/psi4/src/psi4/psimrcc/index.cc
@@ -116,10 +116,8 @@ void CCIndex::init() {
             make_three_index();
             break;
         default: {
-            outfile->Printf("\n\n\tThe CCIndex class cannot handle %s because there are more than three indices!!!\n\n",
-                            label.c_str());
-
-            exit(1);
+            throw std::logic_error("The CCIndex class cannot handle " + label +
+                                   "  because there are more than three indices!\n");
         }
     }
 }
@@ -274,9 +272,7 @@ void CCIndex::make_two_index() {
 
 void CCIndex::make_three_index() {
     if (label.find(">") != std::string::npos) {
-        outfile->Printf("\n\n\tThe CCIndex class cannot handle restricted loops for triplets!!!\n\n");
-
-        exit(1);
+        throw std::logic_error("The CCIndex class cannot handle restricted loops for triplets!\n");
     }
 
     std::vector<std::vector<short>> pairs;  // The pairs ordered as a vector

--- a/psi4/src/psi4/psimrcc/matrix_addressing.cc
+++ b/psi4/src/psi4/psimrcc/matrix_addressing.cc
@@ -72,10 +72,7 @@ double CCMatrix::get_two_address_element(short p, short q) {
         // Case C
         return (matrix[left->get_tuple_irrep(p)][left->get_tuple_rel_index(p)][right->get_tuple_rel_index(q)]);
     }
-    outfile->Printf("\n\n\tdouble CCMatrix::get_two_address_element(int p, int q) Critical Error!!!");
-
-    exit(1);
-    return (0.0);
+    throw std::logic_error("double CCMatrix::get_two_address_element(int p, int q) critical error!\n");
 }
 
 /**
@@ -186,10 +183,7 @@ double CCMatrix::get_four_address_element(short p, short q, short r, short s) {
         // Case C
         return (matrix[right->get_tuple_irrep(s)][left->get_tuple_rel_index(p, q, r)][right->get_tuple_rel_index(s)]);
     }
-    outfile->Printf("\n\n\tdouble CCMatrix::get_four_address_element(int p, int q, int r, int s) Critical Error!!!");
-
-    exit(1);
-    return (0.0);
+    throw std::logic_error("double CCMatrix::get_four_address_element(int p, int q, int r, int s) critical error!\n");
 }
 
 void CCMatrix::set_four_address_element(short p, short q, short r, short s, double value) {
@@ -633,32 +627,6 @@ void CCMatrix::add_six_address_element_Pi_jk_Pa_bc(short i, short j, short k, sh
     matrix[irrep][jik][cba] += value;
     matrix[irrep][kji][cba] += value;
 }
-
-/*
-double CCMatrix::get_two_address_element_check(short p, short q)
-{
-  if(left->get_nelements() == 2){
-    // Case A
-    outfile->Printf("double CCMatrix::get_two_address_element_check(int p, int q) Case A non implemented");
-
-    exit(1);
-  }else if (left->get_nelements() == 0){
-    // Case B
-    outfile->Printf("double CCMatrix::get_two_address_element_check(int p, int q) Case B non implemented");
-
-    exit(1);
-  }else if (left->get_nelements() == 1){
-    // Case C
-    if((left->get_tuple_rel_index(p)!=-1) && (right->get_tuple_rel_index(q)!=-1))
-      return(matrix[left->get_tuple_irrep(p)][left->get_tuple_rel_index(p)][right->get_tuple_rel_index(q)]);
-    else return(0.0);
-  }
-  outfile->Printf("\n\n\tdouble CCMatrix::get_two_address_element_check(int p, int q) Critical Error!!!");
-
-  exit(1);
-  return(0.0);
-}
-*/
 
 }  // namespace psimrcc
 }  // namespace psi

--- a/psi4/src/psi4/psimrcc/matrix_memory_and_io.cc
+++ b/psi4/src/psi4/psimrcc/matrix_memory_and_io.cc
@@ -95,17 +95,15 @@ void CCMatrix::allocate_block(int h) {
                 matrix[h] = block_matrix(left_pairpi[h], right_pairpi[h]);
                 wfn_->free_memory_ -= memorypi2[h];
             } else {
-                outfile->Printf("\n\nNot enough memory to allocate irrep %d of %s\n", h, label.c_str());
-
-                exit(1);
+                std::ostringstream oss;
+                oss << "Not enough memory to allocate irrep " << h << " of " << label << "\n";
+                throw std::runtime_error(oss.str());
             }
         } else {
-            outfile->Printf(
-                "\n\nCCMatrix::allocate_block(): You are trying to allocate irrep %d of %s when is already "
-                "allocated!!!\n",
-                h, label.c_str());
-
-            exit(EXIT_FAILURE);
+            std::ostringstream oss;
+            oss << "CCMatrix::allocate_block(): You are trying to allocate irrep " << h << " of " << label
+                << " when it is already allocated!\n";
+            throw std::logic_error(oss.str());
         }
     }
 }
@@ -295,9 +293,7 @@ size_t CCMatrix::read_strip_from_disk(int h, int strip, double *buffer) {
     if (block_sizepi[h] > 0) {
         // for generic matrices read the entire symmetry block on disk
         if (!is_integral()) {
-            outfile->Printf("\nMatrix %s is not stored in strips!!!", label.c_str());
-
-            exit(EXIT_FAILURE);
+            throw std::logic_error("\nMatrix " + label + " is not stored in strips!\n");
         } else {
             // Read the number of strips
             int nstrips = 0;

--- a/psi4/src/psi4/psimrcc/mp2_ccsd.cc
+++ b/psi4/src/psi4/psimrcc/mp2_ccsd.cc
@@ -138,10 +138,9 @@ double MP2_CCSD::compute_energy() {
         old_energy = current_energy;
 
         if (cycle > options_.get_int("MAXITER")) {
-            outfile->Printf("\n\n\tThe calculation did not converge in %d cycles\n\tQuitting PSIMRCC\n",
-                            options_.get_int("MAXITER"));
-
-            exit(1);
+            std::ostringstream oss;
+            oss << "The calculation did not converge in " << options_.get_int("MAXITER") << " cycles.\n";
+            throw std::runtime_error(oss.str());
         }
         cycle++;
     }

--- a/psi4/src/psi4/psimrcc/mrcc_compute.cc
+++ b/psi4/src/psi4/psimrcc/mrcc_compute.cc
@@ -96,10 +96,9 @@ double CCMRCC::compute_energy() {
         }
 
         if (cycle > options_.get_int("MAXITER")) {
-            outfile->Printf("\n\n\tThe calculation did not converge in %d cycles\n\tQuitting PSIMRCC\n",
-                            options_.get_int("MAXITER"));
-
-            exit(1);
+            std::ostringstream oss;
+            oss << "The calculation did not converge in " << options_.get_int("MAXITER") << " cycles.\n";
+            throw std::runtime_error(oss.str());
         }
         cycle++;
     }

--- a/psi4/src/psi4/psimrcc/operation_compute.cc
+++ b/psi4/src/psi4/psimrcc/operation_compute.cc
@@ -205,8 +205,8 @@ void CCOperation::zero_target_block(int h) {
 void CCOperation::fail_to_compute() {
     outfile->Printf("\n\nSolve couldn't perform the operation ");
     print_operation();
-
-    exit(EXIT_FAILURE);
+    outfile->Flush();
+    throw std::runtime_error("Solve could not perform an operation (see log file for details).\n");
 }
 
 //   Timer zero_timer;

--- a/psi4/src/psi4/psimrcc/transform_block.cc
+++ b/psi4/src/psi4/psimrcc/transform_block.cc
@@ -74,13 +74,11 @@ int CCTransform::read_tei_mo_integrals_block(int first_irrep) {
 }
 
 /**
- * Allocate as many blocks of the tei_mo array and exit(EXIT_FAILURE) if there is not enough space
+ * Allocate as many blocks of the tei_mo array and throw error if there is not enough space
  */
 int CCTransform::allocate_tei_mo_block(int first_irrep) {
     if (first_irrep > wfn_->nirrep()) {
-        outfile->Printf("\n    Transform: allocate_tei_mo_block() was called with first_irrep > nirreps !");
-
-        exit(EXIT_FAILURE);
+        throw std::runtime_error("Transform: allocate_tei_mo_block() was called with first_irrep > nirreps !\n");
     }
 
     size_t available_transform_memory =
@@ -107,9 +105,7 @@ int CCTransform::allocate_tei_mo_block(int first_irrep) {
     }
     outfile->Printf("\n    Integrals from irreps %d -> %d will be read in core", first_irrep, last_irrep - 1);
     if (first_irrep == last_irrep) {
-        outfile->Printf("\n    CCTransform: allocate_tei_mo_block() has not enough memory!");
-
-        exit(EXIT_FAILURE);
+        throw std::runtime_error("CCTransform: allocate_tei_mo_block() does not have enough memory!\n");
     }
     first_irrep_in_core = first_irrep;
     last_irrep_in_core = last_irrep;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
As discussed in #2997 and #3117, no debugging information is produced in many places in Psi4. I believe this is because of improper calls to `exit()`, which is a remnant of the C history of Psi. #3117 replaces the calls to `exit()` with `throw`s in libdpd. This PR replaces the calls in the rest of Psi4.

Sorry for the verbose changes; I ran clang-format on the files since my editor's indentation doesn't match that in Psi4.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Obsoleted calls to `exit()` have been replaced by exceptions, which should better guarantee the passing of error messages to the end user.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Spurious calls to `exit()` have been removed in favor of exceptions, which should better guarantee error messages getting through to the user.

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
