### PR TITLE
MintsHelper: OMP on helper and getter fxns

### DIFF
--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -81,11 +81,11 @@ class PSI_API MintsHelper {
     /// In-core builds spin eri's
     SharedMatrix mo_spin_eri_helper(SharedMatrix Iso, int n1, int n2);
 
-    SharedMatrix ao_helper(const std::string& label, std::shared_ptr<TwoBodyAOInt> ints);
+    SharedMatrix ao_helper(const std::string& label, std::vector<std::shared_ptr<TwoBodyAOInt>> ints);
     SharedMatrix ao_shell_getter(const std::string& label, std::shared_ptr<TwoBodyAOInt> ints, int M, int N, int P,
                                  int Q);
 
-    SharedMatrix ao_3coverlap_helper(const std::string& label, std::shared_ptr<ThreeCenterOverlapInt> ints);
+    SharedMatrix ao_3coverlap_helper(const std::string& label, std::vector<std::shared_ptr<ThreeCenterOverlapInt>> ints);
 
     void common_init();
 


### PR DESCRIPTION
## Description
Adds OpenMP threading to AO/MO two-electron integrals and AO three-center overlap integrals.
Response to Issue #3071 and python script to show it worked below.

Code Snippet:
```
psi4.core.timer_on("Thread 8")
psi4.set_num_threads(8)

mints = psi4.core.MintsHelper(wfn.basisset())

test_one_body_ao_computer = mints.ao_kinetic(conv, aux)
test_ao_helper = mints.ao_eri(conv, aux, conv, aux)
test_ao_shell_getter = mints.ao_eri_shell(5, 3, 2, 4)
test_ao_3coverlap_helper = mints.ao_3coverlap(conv, conv, aux)
test_mo_helper = mints.mo_eri(Co, Cv, Co, Cv)
test_mo_spin_helper = mints.mo_spin_eri(Co, Cv)
psi4.core.timer_off("Thread 8")

psi4.core.timer_on("Thread 1")
psi4.set_num_threads(1)

mints = psi4.core.MintsHelper(wfn.basisset())

ref_one_body_ao_computer = mints.ao_kinetic(conv, aux)
ref_ao_helper = mints.ao_eri(conv, aux, conv, aux)
ref_ao_shell_getter = mints.ao_eri_shell(5, 3, 2, 4)
ref_ao_3coverlap_helper = mints.ao_3coverlap(conv, conv, aux)
ref_mo_helper = mints.mo_eri(Co, Cv, Co, Cv)
ref_mo_spin_helper = mints.mo_spin_eri(Co, Cv)
psi4.core.timer_off("Thread 1")
```

Outputs:
```
Test 1:  True
Test 2:  True
Test 3:  True
Test 4:  True
Test 5:  True
Test 6:  True
                     User      System        Wall        Calls
Thread 8     :    164.900u      1.467s     15.559w      1 calls
Thread 1     :    150.083u      1.283s     89.410w      1 calls
```

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [X] Speeds up computation of integrals

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [X] Adds a lot of `omp parallel for`
- [X] Makes input require `std::vector<std::shared_ptr<TwoBodyAOInt>>`
- [X] Rearranges where 3coverlap is so that it isn't sandwiched btwn the two body ints

## Checklist
- [X] No new tests
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)
- [X] Passed both pytest and ctest "quick" tests

## Status
- [X] Ready for review
- [X] Ready for merge
