### PR TITLE
Pass frozen-core information from SAPT(DFT) to FISAPT dispersion

### DIFF
--- a/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
@@ -271,11 +271,11 @@ def df_mp2_fisapt_dispersion(wfn, primary, auxiliary, cache, nfrozen_A, nfrozen_
 
     # If frozen core, trim the appropriate matrices and vectors. We can do it with NumPy slicing.
     if nfrozen_A > 0:
-        matrix_cache["Caocc0A"] = psi4.core.Matrix.from_array(np.asarray(matrix_cache["Caocc0A"])[:,nfrozen_A:])
-        vector_cache["eps_aocc0A"] = psi4.core.Vector.from_array(np.asarray(vector_cache["eps_aocc0A"])[nfrozen_A:])
+        matrix_cache["Caocc0A"] = core.Matrix.from_array(np.asarray(matrix_cache["Caocc0A"])[:,nfrozen_A:])
+        vector_cache["eps_aocc0A"] = core.Vector.from_array(np.asarray(vector_cache["eps_aocc0A"])[nfrozen_A:])
     if nfrozen_B > 0:
-        matrix_cache["Caocc0B"] = psi4.core.Matrix.from_array(np.asarray(matrix_cache["Caocc0B"])[:,nfrozen_B:])
-        vector_cache["eps_aocc0B"] = psi4.core.Vector.from_array(np.asarray(vector_cache["eps_aocc0B"])[nfrozen_B:])
+        matrix_cache["Caocc0B"] = core.Matrix.from_array(np.asarray(matrix_cache["Caocc0B"])[:,nfrozen_B:])
+        vector_cache["eps_aocc0B"] = core.Vector.from_array(np.asarray(vector_cache["eps_aocc0B"])[nfrozen_B:])
 
     wfn.set_basisset("DF_BASIS_SAPT", auxiliary)
     fisapt = core.FISAPT(wfn)

--- a/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
@@ -249,7 +249,7 @@ def df_fdds_dispersion(primary, auxiliary, cache, is_hybrid, x_alpha, leg_points
     return {"Disp20,FDDS (unc)": Disp20_uc, "Disp20": Disp20_c}
 
 
-def df_mp2_fisapt_dispersion(wfn, primary, auxiliary, cache, do_print=True):
+def df_mp2_fisapt_dispersion(wfn, primary, auxiliary, cache, nfrozen_A, nfrozen_B, do_print=True):
 
     if do_print:
         core.print_out("\n  ==> E20 Dispersion (MP2) <== \n\n")
@@ -268,6 +268,14 @@ def df_mp2_fisapt_dispersion(wfn, primary, auxiliary, cache, do_print=True):
     df_vector_keys = ["eps_occ_A", "eps_vir_A", "eps_occ_B", "eps_vir_B"]
     df_vfisapt_keys = ["eps_aocc0A", "eps_vir0A", "eps_aocc0B", "eps_vir0B"]
     vector_cache = {fkey: cache[ckey] for ckey, fkey in zip(df_vector_keys, df_vfisapt_keys)}
+
+    # If frozen core, trim the appropriate matrices and vectors. We can do it with NumPy slicing.
+    if nfrozen_A > 0:
+        matrix_cache["Caocc0A"] = psi4.core.Matrix.from_array(np.asarray(matrix_cache["Caocc0A"])[:,nfrozen_A:])
+        vector_cache["eps_aocc0A"] = psi4.core.Vector.from_array(np.asarray(vector_cache["eps_aocc0A"])[nfrozen_A:])
+    if nfrozen_B > 0:
+        matrix_cache["Caocc0B"] = psi4.core.Matrix.from_array(np.asarray(matrix_cache["Caocc0B"])[:,nfrozen_B:])
+        vector_cache["eps_aocc0B"] = psi4.core.Vector.from_array(np.asarray(vector_cache["eps_aocc0B"])[nfrozen_B:])
 
     wfn.set_basisset("DF_BASIS_SAPT", auxiliary)
     fisapt = core.FISAPT(wfn)

--- a/psi4/driver/procrouting/sapt/sapt_proc.py
+++ b/psi4/driver/procrouting/sapt/sapt_proc.py
@@ -446,11 +446,20 @@ def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None,
             x_alpha = 0.0
         fdds_disp = sapt_mp2_terms.df_fdds_dispersion(primary_basis, aux_basis, cache, is_hybrid, x_alpha)
         data.update(fdds_disp)
+        nfrozen_A = 0
+        nfrozen_B = 0
         core.timer_off("FDDS disp")
+    else:
+# this is where we actually need to figure out the number of frozen-core orbitals
+# if SAPT_DFT_MP2_DISP_ALG == FISAPT, the code will not figure it out on its own
+        nfrozen_A = wfn_A.basisset().n_frozen_core(core.get_global_option("FREEZE_CORE"),wfn_A.molecule())
+        nfrozen_B = wfn_B.basisset().n_frozen_core(core.get_global_option("FREEZE_CORE"),wfn_B.molecule())
+        
     
     core.timer_on("MP2 disp")
     if core.get_option("SAPT", "SAPT_DFT_MP2_DISP_ALG") == "FISAPT":
-        mp2_disp = sapt_mp2_terms.df_mp2_fisapt_dispersion(wfn_A, primary_basis, aux_basis, cache, do_print=True)
+        mp2_disp = sapt_mp2_terms.df_mp2_fisapt_dispersion(wfn_A, primary_basis, aux_basis, 
+                                                           cache, nfrozen_A, nfrozen_B, do_print=True)
     else:
         mp2_disp = sapt_mp2_terms.df_mp2_sapt_dispersion(dimer_wfn,
                                                          wfn_A,


### PR DESCRIPTION
## Description
When SAPT(DFT) is used with `SAPT_DFT_FUNCTIONAL == 'HF'` to run SAPT0, two pathways for dispersion and exchange-dispersion calculations are possible, through the SAPT0-SAPT2+3 code (requested by `set SAPT_DFT_MP2_DISP_ALG SAPT`) or through the FISAPT code (`set SAPT_DFT_MP2_DISP_ALG FISAPT`). However, in the latter case, the calculation forgot to freeze the core as requested. This PR should preserve frozen-core in this specific situation.

This fixes https://github.com/psi4/psi4/issues/3141. It's quite likely that the FISAPT pathway can be faster (thanks to @carolinesargent for extensive testing), that's why we want to fix it.


## Questions
- [ ] I assumed no frozen core is ever needed for true SAPT(DFT). Is that valid? 

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
