### PR TITLE
Add creation of Eigen::Map representations of Psi4 matrices

### DIFF
--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -438,7 +438,7 @@ std::vector<Eigen::Map<Eigen::MatrixXd>> Matrix::eigen_maps() {
         eigen_maps.emplace_back(get_pointer(h), rowdim(h), coldim(h));
     } 
     
-    return std::move(eigen_maps);
+    return eigen_maps;
 }
 
 void Matrix::alloc() {

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -404,6 +404,41 @@ void Matrix::copy(const Matrix &cp) { copy(&cp); }
 
 void Matrix::copy(const SharedMatrix &cp) { copy(cp.get()); }
 
+// produces an Eigen::Map object mapping to the matrix data buffer 
+// of a matrix with a single irrep 
+Eigen::Map<Eigen::MatrixXd> Matrix::eigen_map() {
+    // Sanity checks
+    // only works for C1 symmetry at the moment
+    // could be improved if symmetry is utilized in JK builds in the future
+    if (nirrep() != 1) {
+        throw PSIEXCEPTION("Psi4::Matrix must be in C1 symmetry to be transformed into Eigen::MatrixXd!");
+    }
+
+    // create Eigen matrix "map" using Psi4 matrix data array directly
+    return std::move(
+        Eigen::Map<Eigen::MatrixXd>(
+            get_pointer(), nrow(), ncol()
+        )
+    );
+}
+
+// produces Eigen::Maps object mapping to the matrix data buffer
+// of a matrix with multiple irreps 
+// NOTE: this impl for mapping Psi4 matrices to Eigen maps
+// is currently experimental, as it is unused in the code 
+// currently
+std::vector<Eigen::Map<Eigen::MatrixXd>> Matrix::eigen_maps() {
+    std::vector<Eigen::Map<Eigen::MatrixXd>> eigen_maps;
+    eigen_maps.reserve(nirrep());
+
+    for (int h = 0; h != nirrep(); ++h) {
+        eigen_maps.emplace_back(get_pointer(h), rowdim(h), coldim(h));
+    } 
+    
+    // create Eigen matrix "map" using Psi4 matrix data array directly
+    return std::move(eigen_maps);
+}
+
 void Matrix::alloc() {
     if (matrix_) release();
 

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -431,11 +431,12 @@ std::vector<Eigen::Map<Eigen::MatrixXd>> Matrix::eigen_maps() {
     std::vector<Eigen::Map<Eigen::MatrixXd>> eigen_maps;
     eigen_maps.reserve(nirrep());
 
+    // create Eigen matrix "map"s for each irrep, 
+    // using Psi4 matrix data array directly
     for (int h = 0; h != nirrep(); ++h) {
         eigen_maps.emplace_back(get_pointer(h), rowdim(h), coldim(h));
     } 
     
-    // create Eigen matrix "map" using Psi4 matrix data array directly
     return std::move(eigen_maps);
 }
 

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -407,11 +407,12 @@ void Matrix::copy(const SharedMatrix &cp) { copy(cp.get()); }
 // produces an Eigen::Map object mapping to the matrix data buffer 
 // of a matrix with a single irrep 
 Eigen::Map<Eigen::MatrixXd> Matrix::eigen_map() {
-    // Sanity checks
-    // only works for C1 symmetry at the moment
-    // could be improved if symmetry is utilized in JK builds in the future
+    // this function only works with matrices with a single irrep 
     if (nirrep() != 1) {
-        throw PSIEXCEPTION("Psi4::Matrix must be in C1 symmetry to be transformed into Eigen::MatrixXd!");
+        std::string message = "Matrix::eigen_map() called, but matrix only has one irrep! ";
+        message += "Use Matrix::eigen_maps() instead."; 
+        
+        throw PSIEXCEPTION(message); 
     }
 
     // create Eigen matrix "map" using Psi4 matrix data array directly

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -36,6 +36,8 @@
 
 #include "dimension.h"
 
+#include <eigen3/Eigen/Core>
+
 namespace psi {
 
 struct dpdfile2;
@@ -49,6 +51,7 @@ class Dimension;
 class Molecule;
 class Vector3;
 class Matrix;
+
 using SharedMatrix = std::shared_ptr<Matrix>;
 
 enum diagonalize_order { evals_only_ascending = 0, ascending = 1, evals_only_descending = 2, descending = 3 };
@@ -271,6 +274,10 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     void copy(const Matrix& cp);
     void copy(const Matrix* cp);
     /** @} */
+
+    /// returns an Eigen::Map object to the underlying matrix data buffer
+    Eigen::Map<Eigen::MatrixXd> eigen_map();
+    std::vector<Eigen::Map<Eigen::MatrixXd>> eigen_maps();
 
     /**
     ** For a matrix of 3D vectors (ncol==3), rotate a set of points around an


### PR DESCRIPTION
## Description
This is something I have been working on as part of the upcoming Psi4-GauXC interface; but it seems to be of interest for other use cases, so I will be adding it here as a separate PR.

What this change does, is it adds two new member functions to the `Psi4::Matrix`  class, `eigen_map()`  and `eigen_maps()` . Both of these functions serve the same purpose - take the Psi4 matrix in question and return a representation of said matrix through Eigen's `Map` objects. The `Eigen::Map` class acts the same way as a normal `Eigen::Matrix` object, but uses an external array as its data buffer rather than an internal data buffer. The `eigen_map()` and `eigen_maps()` functions, then, return Eigen matrix-like objects that directly link with the Psi4 matrix data buffer of the Psi4 matrix for which the function was called. This provides an efficient fashion by which to utilize Psi4 matrices in contexts which require Eigen constructs, with no data deepcopying or Eigen-to-Psi4 back-conversions required.

There is a key difference between the two functions. `eigen_map()`  assumes that the matrix has a single irrep, and returns a single `Eigen::Map` object. `eigen_maps()` , on the other hand, is used for matrices with multiple irreps, and returns a `std::vector` of `Eigen::Map` objects, each `Map` in the `vector` corresponding to one irrep of the Psi4 matrix.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [X] Adds two new functions, `eigen_map()` and `eigen_maps()`, usable in Psi4 plugins and downstream programs, that return  a formulation of the calling `Psi::Matrix` object, that is usable in contexts where `Eigen::Matrix` objects are required/desired.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [X] Adds two new member functions to `Psi4::Matrix`, `eigen_map()` and `eigen_maps()`, that return `Eigen::Map` representations of the Psi4 matrix object.

## Questions
- [X] N/A

## Notes
- [X] I did look into forward declaring the necessary Eigen classes, but forward declaring `Eigen::Map` turns out to be a bit ugly, as it is a class template that, to forward declare, ends up requiring forward declarations for other Eigen classes and enums (such as `Stride` and `AlignmentType`) that aren't specifically necessary for the Psi4 use case. Therefore, I have skipped forward declarations here.
- [X] I can confirm the correctness of the `eigen_map()` function, as I have implemented these PR changes into my Psi-GauXC interface, wherein `eigen_map()` replaces the original formulation I used for the equivalent result. `eigen_maps()`, however, is currently untested as there is no current use case for it yet, and should thus be considered experimental. 

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge