### PR TITLE
test docs build

### DIFF
--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -304,7 +304,7 @@ data:
     conda:
       channel: conda-forge
       name: dftd3-python
-      constraint: null
+      constraint: ">=1.0"
       cmake:
         CMAKE_PROGRAM_PATH: ${CONDA_PREFIX}/bin
       cmake_note: "Primarily OTF runtime detected. With package present, CMake detection only relevant for CTest."
@@ -755,7 +755,7 @@ data:
     conda:
       channel: conda-forge
       name: pybind11
-      constraint: ">=2.10.*"
+      constraint: ">=2.10.*,<2.12.0"
       constraint_note: "Particularly for docs until FixedSize typing percolates upstream."
       cmake:
         pybind11_DIR:

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -1410,10 +1410,10 @@ data:
       host: github
       account: Einsums
       name: Einsums
-      commit: v0.3
+      commit: v0.4
     #cmake:
     #  name:
-    #  constraint: 0.3
+    #  constraint: 0.4
     #  target: Einsums::einsums
     #  components:
     #  ENABLE_Einsums

--- a/external/upstream/einsums/CMakeLists.txt
+++ b/external/upstream/einsums/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(${ENABLE_Einsums})
-    find_package(Einsums 0.3 CONFIG)
+    find_package(Einsums 0.4 CONFIG)
 
     if(TARGET Einsums::einsums)
         get_property(_loc TARGET Einsums::einsums PROPERTY LOCATION)

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -135,7 +135,7 @@ else()
 endif()
 
 if(${ENABLE_Einsums})
-    find_package(Einsums 0.3 CONFIG REQUIRED)
+    find_package(Einsums 0.4 CONFIG REQUIRED)
     get_property(_loc TARGET Einsums::einsums PROPERTY LOCATION)
     list(APPEND _addons ${_loc})
     message(STATUS "${Cyan}Using Einsums${ColourReset}: ${_loc} (version ${Einsums_VERSION})")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->


## Dev notes & details
- [x] fix CI by pointing to the new einsums 0.4 (since it's using SameMinorVersion)
- [x] fix Mac ecosys GHA by requiring newest dftd3-python. I'm not sure why it was using ~0.6, but that wasn't compatible with the new 3c methods.
- [x] there's something going wrong in the docs build with the new 3.12 pybind11 so constrain to 3.11. see if htis goes away in later versions

```
writing output... [100%] tutorial
/home/runner/work/psi4/psi4/code/objdir/doc/sphinxman/docstring of psi4.core.PyCapsule.nuclear_repulsion_energy:1: WARNING: py:class reference target not found: Annotated[list[float], FixedSize(3)]
/home/runner/work/psi4/psi4/code/objdir/doc/sphinxman/docstring of psi4.core.PyCapsule.nuclear_repulsion_energy_deriv1:1: WARNING: py:class reference target not found: Annotated[list[float], FixedSize(3)]
/home/runner/work/psi4/psi4/code/objdir/doc/sphinxman/docstring of psi4.core.PyCapsule.matrix:1: WARNING: py:class reference target not found: Annotated[list[Annotated[list[float], FixedSize(3)]], FixedSize(3)]
/home/runner/work/psi4/psi4/code/objdir/doc/sphinxman/docstring of psi4.core.PyCapsule.get_dipole_field_strength:1: WARNING: py:class reference target not found: Annotated[list[float], FixedSize(3)]
generating indices... genindex py-modindex done
copying linked files... 
```

## Status
- [x] Ready for review
- [x] Ready for merge
