### PR TITLE
Modernize relativistic potential

### DIFF
--- a/external/upstream/libint2/CMakeLists.txt
+++ b/external/upstream/libint2/CMakeLists.txt
@@ -32,20 +32,22 @@
 # * Libraries of different AM are not hot-swappable in a Psi4 build, but they only require a relinking.
 # [Jan 2024]
 # * As of v1.9, Psi4 can use an upstream v2.8 Libint2. This is a libtool+cmake build, so `find_package(Libint2 ... COMPONENTS ...)` has no components to check.
+# [Apr 2024]
+# * As of now, Psi4 needs v2.8.1 or higher for relativistic integral support.
 
 find_package(
   Libint2
-  2.7.2
+  2.8.1
   CONFIG
-  COMPONENTS
-    sss
-    CXX_ho
-    impure_sh
-    "eri_c4_d0_l${MAX_AM_ERI}" eri_c3_d0_l4 eri_c2_d0_l4 onebody_d0_l4
-     eri_c4_d1_l2              eri_c3_d1_l3 eri_c2_d1_l3 onebody_d1_l3
-                                                         onebody_d2_l3
-  OPTIONAL_COMPONENTS
-     eri_c4_d2_l2              eri_c3_d2_l3 eri_c2_d2_l3
+#  COMPONENTS
+#    sss
+#    CXX_ho
+#    impure_sh
+#    "eri_c4_d0_l${MAX_AM_ERI}" eri_c3_d0_l4 eri_c2_d0_l4 onebody_d0_l4
+#     eri_c4_d1_l2              eri_c3_d1_l3 eri_c2_d1_l3 onebody_d1_l3
+#                                                         onebody_d2_l3
+#  OPTIONAL_COMPONENTS
+#     eri_c4_d2_l2              eri_c3_d2_l3 eri_c2_d2_l3
   )
 
 # If L2 v2.8.1 (1) exported CMake components and (2) libint2-config.cmake actually

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -177,18 +177,18 @@ endif()
 
 find_package(
   Libint2
-  2.7.2
+  2.8.1
   CONFIG
   REQUIRED
-  COMPONENTS
-    sss
-    CXX_ho
-    impure_sh
-    "eri_c4_d0_l${MAX_AM_ERI}" eri_c3_d0_l4 eri_c2_d0_l4 onebody_d0_l4
-     eri_c4_d1_l2              eri_c3_d1_l3 eri_c2_d1_l3 onebody_d1_l3
-                                                         onebody_d2_l3
-  OPTIONAL_COMPONENTS
-     eri_c4_d2_l2              eri_c3_d2_l3 eri_c2_d2_l3
+#  COMPONENTS
+#    sss
+#    CXX_ho
+#    impure_sh
+#    "eri_c4_d0_l${MAX_AM_ERI}" eri_c3_d0_l4 eri_c2_d0_l4 onebody_d0_l4
+#     eri_c4_d1_l2              eri_c3_d1_l3 eri_c2_d1_l3 onebody_d1_l3
+#                                                         onebody_d2_l3
+#  OPTIONAL_COMPONENTS
+#     eri_c4_d2_l2              eri_c3_d2_l3 eri_c2_d2_l3
   )
 get_property(_loc TARGET Libint2::int2 PROPERTY LOCATION)
 # defer until upstream provides full-dress targets get_property(Libint2_VERSION TARGET Libint2::int2 PROPERTY Libint2_VERSION)

--- a/psi4/src/psi4/libmints/rel_potential.cc
+++ b/psi4/src/psi4/libmints/rel_potential.cc
@@ -31,11 +31,9 @@
 #include "psi4/libmints/integral.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/molecule.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
 
-#include <libint2/shell.h>
 #include <libint2/engine.h>
-
-#include <algorithm>
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
@@ -44,7 +42,6 @@
 ;
 using namespace psi;
 
-// Initialize potential_recur_ to +1 basis set angular momentum
 RelPotentialInt::RelPotentialInt(std::vector<SphericalTransform>& st, std::shared_ptr<BasisSet> bs1,
                                  std::shared_ptr<BasisSet> bs2, int deriv)
     : OneBodyAOInt(st, bs1, bs2, deriv) {
@@ -52,50 +49,37 @@ RelPotentialInt::RelPotentialInt(std::vector<SphericalTransform>& st, std::share
         throw PSIEXCEPTION("RelPotentialInt: deriv > 0 is not supported.");
     }
 
+    if (bs1 != bs2) {
+        outfile->Printf("*********************************************************************************************************************\n");
+        outfile->Printf("When computing potential integrals with different bra and ket basis, the atom definition is taken from the bra basis.\n");
+        outfile->Printf("*********************************************************************************************************************\n");
+    }
+
     int max_am = std::max(basis1()->max_am(), basis2()->max_am());
     int max_nprim = std::max(basis1()->max_nprimitive(), basis2()->max_nprimitive());
-    engine2_ = std::make_unique<libint2::Engine>(libint2::Operator::nuclear, max_nprim, max_am, 2);
 
-    buffer_ = new double[INT_NCART(max_am) * INT_NCART(max_am)];
-    buffers_.resize(1);
-    buffers_[0] = buffer_;
-}
-
-RelPotentialInt::~RelPotentialInt() {
-    delete[] buffer_;
-}
-
-/*
- * This code was originally written by Prakash in the Evangelista lab, but modified
- * by Andy Simmonett to use Libint2.  We need to compute  <p mu |1/r-C | p nu > where
- * p is the del operator; these are easily obtained from second derivative integrals.
-*/
-void RelPotentialInt::compute_pair(const libint2::Shell& s1, const libint2::Shell& s2) {
-    size_t size = s1.size() * s2.size();
-    ::memset(buffer_, 0, size * sizeof(double));
-
-    // If we only add one center, C, at a time, Libint2 is more memory efficient because
-    // it creates buffers corresponding to each external point charge..  It also yields
-    // predictable ordering of integral buffers, which are organized as follows...
-    //
-    //   0    1    2    3    4    5    6    7    8    9   10
-    // AxAx AxAy AxAz AxBx AxBy AxBz AxCx AxCy AxCz AyAy AyAz
-    //  11   12   13   14   15   16   17   18   19   20  ....
-    // AyBx AyBy AyBz AyCx AyCy AyCz AzAz AzBx AzBy AzBz ....
-    //
-    const auto &results = engine2_->results();
+    // Setup the initial field of partial charges
+    std::vector<std::pair<double, std::array<double, 3>>> params;
     for (int A = 0; A < bs1_->molecule()->natom(); A++) {
-        const auto &mol = *bs1_->molecule();
-        // Setup the initial field of partial charges
-        engine2_->set_params(std::vector<std::pair<double, std::array<double, 3>>>{{mol.Z(A),{mol.x(A), mol.y(A), mol.z(A)}}});
-        engine2_->compute(s1, s2);
-        // Add AxBx
-        std::transform(buffer_, buffer_+size, results[3], buffer_, std::plus<>{});
-        // Add AyBy
-        std::transform(buffer_, buffer_+size, results[12], buffer_, std::plus<>{});
-        // Add AzBz
-        std::transform(buffer_, buffer_+size, results[20], buffer_, std::plus<>{});
+        params.push_back({
+            (double)bs1_->molecule()->Z(A),
+            {bs1_->molecule()->x(A), bs1_->molecule()->y(A), bs1_->molecule()->z(A)}});
     }
+
+    engine0_ = std::make_unique<libint2::Engine>(libint2::Operator::opVop, max_nprim, max_am, 0);
+    engine0_->set_params(params);
+    // If you want derivatives of these integrals, just take the code from potential.cc's constructor
+    // and change out the operator-type. We don't have these integrals now for want of a use case.
+
+    buffer_ = nullptr;
+    buffers_.resize(nchunk_);
+}
+
+void RelPotentialInt::set_charge_field(const std::vector<std::pair<double, std::array<double, 3>>>& Zxyz) {
+    engine0_->set_params(Zxyz);
+    if (engine1_) engine1_->set_params(Zxyz);
+    if (engine2_) engine2_->set_params(Zxyz);
+    Zxyz_ = Zxyz;
 }
 
 RelPotentialSOInt::RelPotentialSOInt(const std::shared_ptr<OneBodyAOInt>& aoint,

--- a/psi4/src/psi4/libmints/rel_potential.h
+++ b/psi4/src/psi4/libmints/rel_potential.h
@@ -51,23 +51,16 @@ class CdSalcList;
 class RelPotentialInt : public OneBodyAOInt {
 
    protected:
+    /// The charges and locations that define the external potential
+    std::vector<std::pair<double, std::array<double, 3>>> Zxyz_;
 
-    /// Matrix of coordinates/charges of partial charges
-    SharedMatrix Zxyz_;
-
-    /// Computes integrals between two shell objects.
-    void compute_pair(const libint2::Shell&, const libint2::Shell&) override;
    public:
     /// Constructor. Assumes nuclear centers/charges as the potential
     RelPotentialInt(std::vector<SphericalTransform>&, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
                     int deriv = 0);
-    ~RelPotentialInt() override;
 
     /// Set the field of charges
-    void set_charge_field(SharedMatrix Zxyz) { Zxyz_ = Zxyz; }
-
-    /// Get the field of charges
-    SharedMatrix charge_field() const { return Zxyz_; }
+    void set_charge_field(const std::vector<std::pair<double, std::array<double, 3>>>& Zxyz);
 };
 
 class RelPotentialSOInt : public OneBodySOInt {


### PR DESCRIPTION
## Description
Paying off an old IOU. I'll get to what Francesco and Daniel Nascimento need after this PR is in.


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] `RelPotentialInt` now has the same charge field API as `PotentialInt` and should be faster

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `RelPotentialInt` now delegates construction of W0 integrals to Libint
- [x] `RelPotentialInt` now has the same charge field API as `PotentialInt` 

## Checklist
- [x] `ctest -L x2c` passes

## Status
- [x] Ready for review
- [x] Ready for merge
