### PR TITLE
Least Squares Tensor Hypercontraction (LS-THC) for ERIs (Part 1)

### DIFF
--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -741,3 +741,8 @@ Bibliography
    *J. Chem. Phys.* **154**, 064103 (2021).
    https://doi.org/10.1063/5.0040021
 
+.. [Parrish:2012:224106]
+   R. M. Parrish, E. G. Hohenstein, T. J. Martinez, C. D. Sherrill
+   *J. Chem. Phys.* **137**, 224106 (2012).
+   https://doi.org/10.1063/1.4768233
+

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -73,6 +73,7 @@
 #include "psi4/libmints/dipole.h"
 #include "psi4/libmints/overlap.h"
 #include "psi4/libmints/sieve.h"
+#include "psi4/libmints/thc_eri.h"
 #include "psi4/libpsi4util/libpsi4util.h"
 #include <string>
 
@@ -1738,6 +1739,18 @@ void export_mints(py::module& m) {
             return sho;
         },
         "The solid harmonics setting of Libint2 currently active for Psi4");
+
+    py::class_<LS_THC_Computer, std::shared_ptr<LS_THC_Computer>>(m, "LS_THC_Computer",
+            "Computer class for grid-based tensor hypercontraction (THC) of two-electron integrals (Parrish 2012)")
+            .def(py::init([] (std::shared_ptr<Molecule> mol, std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary) {
+                    return new LS_THC_Computer(mol, primary, auxiliary, Process::environment.options); 
+                    }))
+            .def("compute_thc_factorization", &LS_THC_Computer::compute_thc_factorization, "Compute the THC (x1, x2, Z, x3, x4) factors through grid based LS-THC")
+            .def("get_x1", &LS_THC_Computer::get_x1, "Returns x1 factor from LS-THC factorization")
+            .def("get_x2", &LS_THC_Computer::get_x2, "Returns x2 factor from LS-THC factorization")
+            .def("get_x3", &LS_THC_Computer::get_x3, "Returns x3 factor from LS-THC factorization")
+            .def("get_x4", &LS_THC_Computer::get_x4, "Returns x4 factor from LS-THC factorization")
+            .def("get_Z", &LS_THC_Computer::get_Z, "Returns Z factor from LS-THC factorization");
 
     // when psi4 requires >=v2.8.0
     // m.def("libint2_supports", [](const std::string& comp) { return libint2::supports(comp); },

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -46,6 +46,7 @@ list(APPEND sources
   erd_eri.cc
   angularmomentum.cc
   orthog.cc
+  thc_eri.cc
   )
 
 # l2intf is a listing of all the files that include libint2's boys.h include (which is included in L2's engine.h).  they must

--- a/psi4/src/psi4/libmints/thc_eri.cc
+++ b/psi4/src/psi4/libmints/thc_eri.cc
@@ -300,6 +300,7 @@ void LS_THC_Computer::compute_thc_factorization() {
 
     x1_ = std::make_shared<Matrix>(npoints, nbf);
 
+    // Parrish 2012, Equation 29
     size_t point_idx = 0;
     for (auto& block : grid.blocks()) {
         auto w = block->w();
@@ -324,6 +325,7 @@ void LS_THC_Computer::compute_thc_factorization() {
     
     timer_on("LS-THC: Form E");
 
+    // Parrish 2012, Equations 33-35
     SharedMatrix E_PQ = use_df_ ? build_E_df() : build_E_exact();
 
     timer_off("LS-THC: Form E");
@@ -333,6 +335,7 @@ void LS_THC_Computer::compute_thc_factorization() {
     SharedMatrix S_Qq = std::make_shared<Matrix>(npoints, npoints);
     SharedMatrix S_temp = linalg::doublet(x1_, x1_, false, true);
 
+    // Parrish 2012, Equation 28
 #pragma omp parallel for
     for (size_t p = 0; p < npoints; ++p) {
         for (size_t q = 0; q < npoints; ++q) {
@@ -340,6 +343,7 @@ void LS_THC_Computer::compute_thc_factorization() {
         }
     }
 
+    // Parrish 2012, Equation 30
     int nremoved = 0;
     SharedMatrix S_Qq_inv = S_Qq->pseudoinverse(options_.get_double("LS_THC_S_EPSILON"), nremoved);
 
@@ -347,6 +351,7 @@ void LS_THC_Computer::compute_thc_factorization() {
 
     timer_on("LS-THC: Form Z");
 
+    // Parrish 2012, Equation 36
     Z_PQ_ = linalg::triplet(S_Qq_inv, E_PQ, S_Qq_inv);
 
     timer_off("LS-THC: Form Z");

--- a/psi4/src/psi4/libmints/thc_eri.cc
+++ b/psi4/src/psi4/libmints/thc_eri.cc
@@ -87,7 +87,6 @@ SharedMatrix LS_THC_Computer::build_E_exact() {
     std::vector<std::shared_ptr<TwoBodyAOInt>> eri_computers(nthreads);
 
     eri_computers[0] = std::shared_ptr<TwoBodyAOInt>(factory.eri());
-#pragma omp parallel for
     for (int thread = 1; thread < nthreads; ++thread) {
         eri_computers[thread] = std::shared_ptr<TwoBodyAOInt>(eri_computers[0]->clone());
     }
@@ -194,7 +193,6 @@ SharedMatrix LS_THC_Computer::build_E_df() {
     std::vector<std::shared_ptr<TwoBodyAOInt>> eri_computers(nthreads);
 
     eri_computers[0] = std::shared_ptr<TwoBodyAOInt>(factory.eri());
-#pragma omp parallel for
     for (int thread = 1; thread < nthreads; ++thread) {
         eri_computers[thread] = std::shared_ptr<TwoBodyAOInt>(eri_computers[0]->clone());
     }

--- a/psi4/src/psi4/libmints/thc_eri.cc
+++ b/psi4/src/psi4/libmints/thc_eri.cc
@@ -1,0 +1,210 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2024 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include "thc_eri.h"
+#include "basisset.h"
+#include "mintshelper.h"
+#include "integral.h"
+
+#include "psi4/libqt/qt.h"
+#include "psi4/libfock/cubature.h"
+#include "psi4/lib3index/dftensor.h"
+
+#include <algorithm>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace psi {
+
+THC_Computer::THC_Computer(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> primary, Options& options) :
+    molecule_(molecule), primary_(primary), options_(options) {}
+
+THC_Computer::~THC_Computer() {}
+
+LS_THC_Computer::LS_THC_Computer(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> primary, 
+                                    std::shared_ptr<BasisSet> auxiliary, Options& options) : THC_Computer(molecule, primary, options) {
+    auxiliary_ = auxiliary;
+}
+
+LS_THC_Computer::~LS_THC_Computer() {}
+
+SharedMatrix LS_THC_Computer::build_E_exact() {
+    /**
+     * Parrish et al. 2012 Procedure 2
+    */
+
+    throw PSIEXCEPTION("Error: Build E exact has not been implemented for LS-THC! Buy poor Andy a coffee!");
+}
+
+SharedMatrix LS_THC_Computer::build_E_df() {
+    /**
+     * Parrish et al. 2012 Procedure 3
+    */
+    
+    size_t nbf = primary_->nbf();
+    size_t naux = auxiliary_->nbf();
+    size_t rank = x1_->nrow();
+
+    int nthreads = 1;
+#ifdef _OPENMP
+    nthreads = Process::environment.get_n_threads();
+#endif
+
+    auto zero = BasisSet::zero_ao_basis_set();
+    IntegralFactory factory(auxiliary_, zero, primary_, primary_);
+    std::vector<std::shared_ptr<TwoBodyAOInt>> eri_computers(nthreads);
+
+    eri_computers[0] = std::shared_ptr<TwoBodyAOInt>(factory.eri());
+#pragma omp parallel for
+    for (int thread = 1; thread < nthreads; ++thread) {
+        eri_computers[thread] = std::shared_ptr<TwoBodyAOInt>(eri_computers[0]->clone());
+    }
+
+    size_t nshell_aux = auxiliary_->nshell();
+    size_t nshellpair = eri_computers[0]->shell_pairs().size();
+    size_t nshelltriplet = nshell_aux * nshellpair;
+
+    SharedMatrix E_temp = std::make_shared<Matrix>(rank, naux);
+
+#pragma omp parallel for
+    for (size_t MNP = 0; MNP < nshelltriplet; ++MNP) {
+
+        size_t MN = MNP % nshellpair;
+        size_t P = MNP / nshellpair;
+        int thread = 0;
+#ifdef _OPENMP
+        thread = omp_get_thread_num();
+#endif
+        auto bra = eri_computers[thread]->shell_pairs()[MN];
+        size_t M = bra.first;
+        size_t N = bra.second;
+
+        int np = auxiliary_->shell(P).nfunction();
+        int pstart = auxiliary_->shell(P).function_index();
+        int nm = primary_->shell(M).nfunction();
+        int mstart = primary_->shell(M).function_index();
+        int nn = primary_->shell(N).nfunction();
+        int nstart = primary_->shell(N).function_index();
+
+        // TODO: Implement screening to make this more efficient
+        eri_computers[thread]->compute_shell(P, 0, M, N);
+        const auto &buffer = eri_computers[thread]->buffers()[0];
+
+        double prefactor = (M == N) ? 1.0 : 2.0;
+
+        for (size_t r = 0; r < rank; ++r) {
+            for (size_t p = pstart, index = 0; p < pstart + np; ++p) {
+                for (size_t m = mstart; m < mstart + nm; ++m) {
+                    for (size_t n = nstart; n < nstart + nn; ++n, ++index) {
+#pragma omp atomic
+                        (*E_temp)(r, p) += prefactor * buffer[index] * (*x1_)(r, m) * (*x1_)(r, n);
+                    } // end n
+                } // end m
+            } // end p
+        } // end r
+    } // end MNP
+
+    FittingMetric J_metric_obj(auxiliary_, true);
+    J_metric_obj.form_fitting_metric();
+    auto J_metric = J_metric_obj.get_metric();
+    
+    int nremoved = 0;
+    auto Jinv = J_metric->pseudoinverse(1.0e-14, nremoved);
+
+    return linalg::triplet(E_temp, Jinv, E_temp, false, false, true);
+}
+
+void LS_THC_Computer::compute_thc_factorization() {
+    /**
+     * Parrish et al. 2012 Procedure 1
+    */
+
+    size_t nbf = primary_->nbf();
+
+    timer_on("LS-THC: Build Grid");
+
+    DFTGrid grid(molecule_, primary_, options_);
+    size_t npoints = grid.npoints();
+
+    x1_ = std::make_shared<Matrix>(npoints, nbf);
+
+    size_t point_idx = 0;
+    for (auto& block : grid.blocks()) {
+        auto w = block->w();
+        auto x = block->x();
+        auto y = block->y();
+        auto z = block->z();
+
+#pragma omp parallel for
+        for (size_t p = 0; p < block->npoints(); ++p) {
+            primary_->compute_phi(&(*x1_)(point_idx + p, 0), x[p], y[p], z[p]);
+            x1_->scale_row(0, point_idx + p, std::pow(w[p], 0.25));
+        }
+
+        point_idx += block->npoints();
+    }
+
+    x2_ = x1_;
+    x3_ = x1_;
+    x4_ = x1_;
+
+    timer_off("LS-THC: Build Grid");
+    
+    timer_on("LS-THC: Form E");
+
+    SharedMatrix E_PQ = options_.get_bool("LS_THC_DF") ? build_E_df() : build_E_exact();
+
+    timer_off("LS-THC: Form E");
+
+    timer_on("LS-THC: Form S");
+
+    SharedMatrix S_Qq = std::make_shared<Matrix>(npoints, npoints);
+    SharedMatrix S_temp = linalg::doublet(x1_, x1_, false, true);
+
+#pragma omp parallel for
+    for (size_t p = 0; p < npoints; ++p) {
+        for (size_t q = 0; q < npoints; ++q) {
+            (*S_Qq)(p, q) = (*S_temp)(p, q) * (*S_temp)(p, q);
+        }
+    }
+
+    int nremoved = 0;
+    SharedMatrix S_Qq_inv = S_Qq->pseudoinverse(1.0e-10, nremoved);
+
+    timer_off("LS-THC: Form S");
+
+    timer_on("LS-THC: Form Z");
+
+    Z_PQ_ = linalg::triplet(S_Qq_inv, E_PQ, S_Qq_inv);
+
+    timer_off("LS-THC: Form Z");
+}
+
+}

--- a/psi4/src/psi4/libmints/thc_eri.cc
+++ b/psi4/src/psi4/libmints/thc_eri.cc
@@ -72,10 +72,8 @@ void LS_THC_Computer::print_header() {
     outfile->Printf("\n\n");
 }
 
+/// @brief Builds the E intermediate using exact four-center two-electron integrals (Parrish et al. 2012 procedure 2)
 SharedMatrix LS_THC_Computer::build_E_exact() {
-    /**
-     * Parrish et al. 2012 Procedure 2
-    */
 
     size_t nbf = primary_->nbf();
     size_t rank = x1_->nrow();
@@ -171,6 +169,7 @@ SharedMatrix LS_THC_Computer::build_E_exact() {
     return E_PQ;
 }
 
+/// @brief Builds the E intermediate using the DF/RI approximation for ERIs (Parrish et al. 2012 procedure 3)
 SharedMatrix LS_THC_Computer::build_E_df() {
     /**
      * Parrish et al. 2012 Procedure 3
@@ -247,17 +246,16 @@ SharedMatrix LS_THC_Computer::build_E_df() {
     FittingMetric J_metric_obj(auxiliary_, true);
     J_metric_obj.form_fitting_metric();
     auto J_metric = J_metric_obj.get_metric();
-    
+
+    /// 1.0e-14 is around machine epsilon
     int nremoved = 0;
     auto Jinv = J_metric->pseudoinverse(1.0e-14, nremoved);
 
     return linalg::triplet(E_temp, Jinv, E_temp, false, false, true);
 }
 
+/// @brief Factors ERIs into a product of two-index tensors through LS-THC algorithm (Parrish et al. 2012 Procedure 1)
 void LS_THC_Computer::compute_thc_factorization() {
-    /**
-     * Parrish et al. 2012 Procedure 1
-    */
 
     use_df_ = options_.get_bool("LS_THC_DF");
     

--- a/psi4/src/psi4/libmints/thc_eri.h
+++ b/psi4/src/psi4/libmints/thc_eri.h
@@ -1,0 +1,90 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2024 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#ifndef PSI4_SRC_LIBMINTS_LS_THC_H_
+#define PSI4_SRC_LIBMINTS_LS_THC_H_
+
+#include "basisset.h"
+#include "matrix.h"
+
+#include <vector>
+
+namespace psi {
+
+class THC_Computer {
+   protected:
+    // The molecule to evaluate the THC factors
+    std::shared_ptr<Molecule> molecule_;
+    // The primary basis set
+    std::shared_ptr<BasisSet> primary_;
+
+    // THC Factor for first index
+    SharedMatrix x1_;
+    // THC Factor for second index
+    SharedMatrix x2_;
+    // THC Factor for third index
+    SharedMatrix x3_;
+    // THC Factor for fourth index
+    SharedMatrix x4_;
+    // THC connecting factor
+    SharedMatrix Z_IJ_;
+
+   public:
+    THC_Computer(std::shared_ptr<Molecule> molecule);
+    virtual ~THC_Computer();
+
+    /// Compute THC Factors
+    void compute_thc_factorization();
+
+    /// Returns the molecule the THC factors are evaluated on
+    std::shared_ptr<Molecule> molecule() const { return molecule_; }
+    /// Returns the THC factor for the first index
+    SharedMatrix get_x1() const { return x1_; }
+    /// Returns the THC factor for the second index
+    SharedMatrix get_x2() const { return x2_; }
+    /// Returns the THC factor for the third index
+    SharedMatrix get_x3() const { return x3_; }
+    /// Returns the THC factor for the fourth index
+    SharedMatrix get_x4() const { return x4_; }
+
+};
+
+// Least Squares Tensor Hypercontraction
+class LS_THC_Computer : public THC_Computer {
+   protected:
+    /// Parrish LS-THC Algorithm X
+    void build_E_df();
+    /// Parrish LS-THC Algorithm Y
+    void build_E_exact();
+
+   public:
+    LS_THC_Computer(std::shared_ptr<Molecule> molecule);
+    ~LS_THC_Computer() override;
+};
+
+}

--- a/psi4/src/psi4/libmints/thc_eri.h
+++ b/psi4/src/psi4/libmints/thc_eri.h
@@ -81,10 +81,17 @@ class THC_Computer {
 };
 
 // Least Squares Tensor Hypercontraction
+// Derived from work of Parrish et al. 2012 (doi: 10.1063/1.4768233)
 class LS_THC_Computer : public THC_Computer {
    protected:
+    /// Use DF integrals to perform LS-THC ?
+    bool use_df_;
+    
     /// Auxiliary basis set (null if not using DF approximation)
     std::shared_ptr<BasisSet> auxiliary_;
+
+    /// Print options and other info for LS-THC decomposition
+    void print_header();
 
     /// Parrish LS-THC Procedure 2
     SharedMatrix build_E_exact();
@@ -92,6 +99,7 @@ class LS_THC_Computer : public THC_Computer {
     SharedMatrix build_E_df();
 
    public:
+    LS_THC_Computer(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> primary, Options& options);
     LS_THC_Computer(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary, Options& options);
     ~LS_THC_Computer() override;
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -284,6 +284,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     /*- Pruning scheme for LS-THC grids !expert -*/
     options.add_str("LS_THC_PRUNING_SCHEME", "ROBUST", 
                         "ROBUST TREUTLER NONE FLAT P_GAUSSIAN D_GAUSSIAN P_SLATER D_SLATER LOG_GAUSSIAN LOG_SLATER NONE");
+    /*- Tolerance for pseudoinversion of grid point overlap matrix (Parrish 2012 eq. 30) !expert -*/
+    options.add_double("LS_THC_S_EPSILON", 1.0E-10);
 
     /// MBIS Options (libmints/oeprop.cc)
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -269,7 +269,12 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     /*- How many NOONS to print -- used in libscf_solver/uhf.cc and libmints/oeprop.cc -*/
     options.add_str("PRINT_NOONS", "3");
 
-    ///MBIS Options (libmints/oeprop.cc)
+    /// Tensor Hypercontration (THC) Options (libmints/thc_eri.cc)
+
+    /*- Use DF approximation when computing LS-THC factorization? -*/
+    options.add_bool("LS_THC_DF", true);
+
+    /// MBIS Options (libmints/oeprop.cc)
 
     /*- Maximum Number of MBIS Iterations -*/
     options.add_int("MBIS_MAXITER", 500);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -273,6 +273,17 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
 
     /*- Use DF approximation when computing LS-THC factorization? -*/
     options.add_bool("LS_THC_DF", true);
+    /*- Number of spherical points in LS-THC grid -*/
+    options.add_int("LS_THC_SPHERICAL_POINTS", 50);
+    /*- Number of radial points in LS-THC grid -*/
+    options.add_int("LS_THC_RADIAL_POINTS", 10);
+    /*- Screening criteria for basis function values on LS-THC grids !expert -*/
+    options.add_double("LS_THC_BASIS_TOLERANCE", 1.0E-10);
+    /*- Grid weights cutoff for LS-THC grids !expert -*/
+    options.add_double("LS_THC_WEIGHTS_TOLERANCE", 1.0E-12);
+    /*- Pruning scheme for LS-THC grids !expert -*/
+    options.add_str("LS_THC_PRUNING_SCHEME", "ROBUST", 
+                        "ROBUST TREUTLER NONE FLAT P_GAUSSIAN D_GAUSSIAN P_SLATER D_SLATER LOG_GAUSSIAN LOG_SLATER NONE");
 
     /// MBIS Options (libmints/oeprop.cc)
 

--- a/tests/pytests/test_thc_eri.py
+++ b/tests/pytests/test_thc_eri.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+import psi4
+
+pytestmark = [pytest.mark.psi, pytest.mark.quick]
+
+@pytest.mark.smoke
+def test_ls_thc_df():
+    mol = psi4.geometry("""
+    0 1
+    O
+    H 1 0.96
+    H 1 0.96 2 104.5
+    symmetry c1
+    """)
+
+    psi4.set_options({'basis' : 'cc-pVDZ',
+                    'ls_thc_df' : True,
+                    'dft_radial_points': 10,
+                    'dft_spherical_points': 26,
+                    'dft_weights_tolerance': 1.0e-12})
+
+    e, wfn = psi4.energy('scf', return_wfn=True)
+
+    primary = wfn.basisset()
+    aux = psi4.core.BasisSet.build(mol, "DF_BASIS_SCF", "", "RIFIT", "cc-pVDZ")
+
+    ls_thc_computer = psi4.core.LS_THC_Computer(mol, primary, aux)
+    ls_thc_computer.compute_thc_factorization()
+
+    # THC-Factored ERI
+    Z_PQ = np.array(ls_thc_computer.get_Z())
+    x1 = np.array(ls_thc_computer.get_x1())
+    I_guess_thc = np.einsum('pu,pv,pq,qr,qt->uvrt', x1, x1, Z_PQ, x1, x1, optimize=True)
+
+    mints = psi4.core.MintsHelper(primary)
+    zero = psi4.core.BasisSet.zero_ao_basis_set()
+
+    # AO 3-index ERIs
+    Ppq = np.squeeze(mints.ao_eri(aux, zero, primary, primary))
+    J_PQ = np.squeeze(mints.ao_eri(aux, zero, aux, zero))
+    J_PQ_inv = np.linalg.pinv(J_PQ)
+    I_guess_df = np.einsum('Ppq,PQ,Qrs->pqrs', Ppq, J_PQ_inv, Ppq, optimize=True)
+
+    # AO 4-index ERIs
+    I = np.array(mints.ao_eri(primary, primary, primary, primary))
+
+    assert(np.linalg.norm((I_guess_thc-I).flatten()) < 0.153)
+    assert(np.linalg.norm((I_guess_df-I).flatten()) < 0.152)

--- a/tests/pytests/test_thc_eri.py
+++ b/tests/pytests/test_thc_eri.py
@@ -1,4 +1,5 @@
 import numpy as np
+from utils import compare
 import pytest
 
 import psi4
@@ -47,8 +48,8 @@ def test_ls_thc_df():
     # AO 4-index ERIs
     I = np.array(mints.ao_eri(primary, primary, primary, primary))
 
-    assert(np.sqrt(np.average(np.square(I_guess_thc-I))) < 3e-4)
-    assert(np.sqrt(np.average(np.square(I_guess_df-I))) < 3e-4)
+    assert compare(True, np.sqrt(np.average(np.square(I_guess_thc-I))) < 3e-4, 'LS_THC_DF ERIs accurate')
+    assert compare(True, np.sqrt(np.average(np.square(I_guess_df-I))) < 3e-4, 'DF ERIs accurate')  
 
 @pytest.mark.smoke
 def test_ls_thc_exact():
@@ -84,4 +85,4 @@ def test_ls_thc_exact():
     mints = psi4.core.MintsHelper(primary)
     I = np.array(mints.ao_eri(primary, primary, primary, primary))
 
-    assert(np.sqrt(np.average(np.square(I_guess_thc-I))) < 1e-4)
+    assert compare(True, np.sqrt(np.average(np.square(I_guess_thc-I))) < 1e-4, 'LS_THC_exact ERIs accurate')


### PR DESCRIPTION
## Description
In this PR, we implement a pilot version of least squares tensor hypercontraction (LS-THC)... factoring 4-index ERIs (O(N^4)) into two-index quantities (i.e. $(mn|rs) = x_{m}^{P}x_{n}^{P}Z^{PQ}x_{r}^{Q}x_{s}^{Q}$). In the LS-THC formulation, $P$ and $Q$ are derived from grid points, and

$x_{m}^{P} = w_{P}^{\frac{1}{4}} \phi_{m}(x_{P}, y_{P}, z_{P})$,
$E^{PQ} = x_{m}^{P}x_{n}^{P}(mn|rs)x_{r}^{Q}x_{s}^{Q}$
$S^{PP'} = (x_{m}^{P}x_{m}^{P'})^{2}$
$Z^{PQ} = (S^{PP'})^{-1} E^{P'Q'} (S^{QQ'})^{-1}$

This is based off of the work of [Parrish et al. (2012)](https://pubs.aip.org/aip/jcp/article/137/22/224106/194901/Tensor-hypercontraction-II-Least-squares)

These quantities can be constructed integral-direct and non-iteratively. No four or even three-index quantities are stored, thereby allowing for the future development of efficient, low-memory quantum chemistry algorithms in Psi.

This is a PR in a series of planned PRs that will involve:
1.) LS-THC-JK (integral-direct SCF without recomputing ERIs every iteration and faster K construction)
2.) LS-THC-MP2
3.) Local grid implementation of LS-THC to allow for use in local correlation methods (DLPNO-MP2, DLPNO-CCSD/(T))

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Added Python interface (Pybind) for building LS-THC quantities that allow for rapid prototyping of new methods involving THC
- [x] Developed infrastructure for the development of alternate ways to perform THC (i.e. PF-THC)

## Dev notes & details
- [x] Implemented LS-THC C/Py-side for future QC methods

## Questions
- [x] Is this the proper way to export this object Py-side?

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
