### PR TITLE
test einsums env solving

### DIFF
--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -1420,8 +1420,8 @@ data:
     conda:
       channel: conda-forge
       name: einsums
-      constraint: "=*=mkl*"
-      # todo: tie einsums variant to libblas selection, rather than mkl constraint above.
+      constraint: null
+      # add a mkl constraint like "=*=mkl*" if the solver doesn't select correctly. (won't work for osx-arm64)
       aux_build_names:
         - range-v3
         - zlib


### PR DESCRIPTION
## Description
First we had to constrain einsums to the openblas variant on linux to get the env to solve b/c the most recent libblas wasn't available for MKL 2023. Then that got fixed on c-f and we could use the mkl variant. But that as a constraint, of course, won't work on Mac Silicon, which doesn't have MKL. It'd be cleanest if the solver handled it, so I'm giving the no-constraint a try.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
