### PR TITLE
Ghost atom and ECPs bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ TEST
 */test.py
 */test.dat
 install*
+objdir_p4dev
 
 # Other random files people have added.
 svn_source
@@ -159,3 +160,13 @@ GTAGS
 GPATH
 GRTAGS
 Pipfile.lock
+
+# FIles created by psi4-path-advisor.py
+cache_p4dev.cmake
+env_p4dev.yaml
+
+# Psi4 installation
+bin
+lib
+include
+share

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -166,7 +166,7 @@ def _pybuild_basis(
         atom_basis_list = []
         for atbs in basisdict:
             atommol = core.Molecule.from_dict(atbs['molecule'])
-            lmbs = core.BasisSet.construct_from_pydict(atommol, atbs, puream)
+            lmbs = core.BasisSet.construct_from_pydict(atommol, atbs, puream, False)
             atom_basis_list.append(lmbs)
         return atom_basis_list
     if isinstance(resolved_target, str):

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -87,7 +87,7 @@ using namespace pybind11::literals;
  * @param forced_puream Force puream or not
  **/
 std::shared_ptr<BasisSet> construct_basisset_from_pydict(const std::shared_ptr<Molecule>& mol, py::dict& pybs,
-                                                         const int forced_puream) {
+                                                         const int forced_puream, bool skip_ghost_ecps = true) {
     std::string key = pybs["key"].cast<std::string>();
     std::string name = pybs["name"].cast<std::string>();
     std::string label = pybs["blend"].cast<std::string>();
@@ -153,6 +153,19 @@ std::shared_ptr<BasisSet> construct_basisset_from_pydict(const std::shared_ptr<M
             std::string atomlabel = atominfo[0].cast<std::string>();
             std::string hash = atominfo[1].cast<std::string>();
             int ncore = atominfo[2].cast<int>();
+            bool addecpforatom = true;
+            // We do NOT want to load ECPs when atom is GHOST!
+            //
+            // Tha atom loop always goes over all atoms in a geometry,
+            // also for SAD guess, when the 'mol' object contains only one atom.
+            // In such case loop index 'atom' goes beyond the scope of atoms list in the 'mol' object.
+            // Therefore, calling 'mol->Z(atom)' in such case raises an error and the program crashes.
+            if (skip_ghost_ecps) {
+                if (mol->Z(atom) == 0.0) {
+                    // We should be here only whent it is not SAD and it is GHOST
+                    addecpforatom = false;
+                }
+            }
             for (int atomshells = 3; atomshells < py::len(atominfo); ++atomshells) {
                 // Each shell entry has p primitives that look like
                 // [ angmom, [ [ e1, c1, r1 ], [ e2, c2, r2 ], ...., [ ep, cp, rp ] ] ]
@@ -168,10 +181,14 @@ std::shared_ptr<BasisSet> construct_basisset_from_pydict(const std::shared_ptr<M
                     coefficients.push_back(primitiveinfo[1].cast<double>());
                     ns.push_back(primitiveinfo[2].cast<int>());
                 }
+                if (addecpforatom) {
                 vec_shellinfo.push_back(ShellInfo(am, coefficients, exponents, ns));
+                }
             }
             basis_atom_ncore[name][atomlabel] = ncore;
+            if (addecpforatom) {
             basis_atom_ecpshell[name][atomlabel] = vec_shellinfo;
+            }
             totalncore += ncore;
         }
     }
@@ -1232,7 +1249,8 @@ void export_mints(py::module& m) {
         .def("max_function_per_shell", &BasisSet::max_function_per_shell,
              "The max number of basis functions in a shell")
         .def("max_nprimitive", &BasisSet::max_nprimitive, "The max number of primitives in a shell")
-        .def_static("construct_from_pydict", &construct_basisset_from_pydict, "docstring")
+        .def_static("construct_from_pydict", &construct_basisset_from_pydict, "docstring", 
+                    py::arg("mol"), py::arg("pybs"), py::arg("forced_puream"), py::arg("skip_ghost_ecps")=true)
         .def("compute_phi", [](BasisSet& basis, double x, double y, double z) {
             auto phi_ao = new std::vector<double>(basis.nbf());
             auto capsule = py::capsule(phi_ao, [](void *phi_ao) { delete reinterpret_cast<std::vector<double>*>(phi_ao); });


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Fix for the bug described in [issue  #1968](https://github.com/psi4/psi4/issues/1968) about incorrectly loading ECPs for ghosted atoms.


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] Calculations using ghosted atoms that contain ECPs in the basis set can now be executed properly.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] When loading basis functions we check if we should skip loading ECPs (`skip_ghost_ecps`) and if `true` then we check if an atom is a ghost (`mol->Z(atom) == 0.0`). If yes we do not load ECPs fot it.
- [ ] Added optional boolean argument `skip_ghost_ecps` for `construct_basisset_from_pydict` function. The default is `true`, we set it `false` for atomistic calculations (like SAD guess).

## Questions
- [ ] Should I have any?

## Checklist
- [ ] Minimal working example
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
