### PR TITLE
Throw PSIEXCEPTION instead of calling abort() in detci

### DIFF
--- a/psi4/src/psi4/detci/import_vector.cc
+++ b/psi4/src/psi4/detci/import_vector.cc
@@ -82,15 +82,15 @@ void CIWavefunction::parse_import_vector(SlaterDetSet *sdset, int *ialplist, int
 
     /* now figure out how the frozen stuff is going to map */
     if (CalcInfo_->num_drc_orbs > alphastrings->ndrc || CalcInfo_->num_drc_orbs > betastrings->ndrc) {
-        outfile->Printf(
-            "(parse_import_vector): Can't drop more orbitals now"
-            " than in the imported guess!\n");
-        abort();
+        const std::string msg = "(parse_import_vector): Can't drop more orbitals now than in the imported guess!\n";
+        outfile->Printf(msg.c_str());
+        throw PSIEXCEPTION(msg);
     }
 
     if (alphastrings->ndrc != betastrings->ndrc) {
-        outfile->Printf("(parse_import_vector): alpha ndrc != beta ndrc!\n");
-        abort();
+        const std::string msg = "(parse_import_vector): alpha ndrc != beta ndrc!\n";
+        outfile->Printf(msg.c_str());
+        throw PSIEXCEPTION(msg);
     }
 
     new_alphastr_list = init_int_array(alphastrings->size);
@@ -117,11 +117,12 @@ void CIWavefunction::parse_import_vector(SlaterDetSet *sdset, int *ialplist, int
         /* figure out what block we're in */
         j = CIblks_->decode[ialplist[i]][ibetlist[i]];
         if (j == -1) {
-            outfile->Printf("Import vector: can't find CI block!\n");
-            outfile->Printf("Determinant number %d\n", i);
-            outfile->Printf("\nialplist=%d, ialpidx=%d, ibetlist=%d, ibetidx=%d\n", ialplist[i], ialpidx[i],
-                            ibetlist[i], ibetidx[i]);
-            abort();
+            const std::string msg =
+                "Import vector: can't find CI block!\nDeterminant number " + std::to_string(i) +
+                "\nialplist=" + std::to_string(ialplist[i]) + ", ialpidx=" + std::to_string(ialpidx[i]) +
+                ", ibetlist=" + std::to_string(ibetlist[i]) + ", ibetidx=" + std::to_string(ibetidx[i]) + "\n";
+            outfile->Printf(msg.c_str());
+            throw PSIEXCEPTION(msg);
         } else
             blknums[i] = j;
     } /* end loop over determinants */
@@ -166,11 +167,9 @@ void stringset_translate_addr(StringSet *sset, int new_nel, int new_ndrc, int *p
     }
 
     if (num_former_drc + old_nel > new_nel) {
-        outfile->Printf(
-            "(stringset_translate_addr): num_former_drc + old_nel"
-            " > new_nel!\n");
-
-        abort();
+        const std::string msg = "(stringset_translate_addr): num_former_drc + old_nel > new_nel!\n";
+        outfile->Printf(msg.c_str());
+        throw PSIEXCEPTION(msg);
     }
 
     tmpocc = init_int_array(new_nel);
@@ -192,12 +191,10 @@ void stringset_translate_addr(StringSet *sset, int new_nel, int new_ndrc, int *p
         }
 
         if (l != new_nel) {
-            outfile->Printf(
-                "(stringset_translate_addr): Imported string has wrong"
-                " number of electrons, %d vs. %d\n",
-                l, new_nel);
-
-            abort();
+            const std::string msg = "(stringset_translate_addr): Imported string has wrong number of electrons, " +
+                                    std::to_string(l) + " vs. " + std::to_string(new_nel) + "\n";
+            outfile->Printf(msg.c_str());
+            throw PSIEXCEPTION(msg);
         }
 
         new_idx[s] = og_lex_addr(Graph, tmpocc, new_nel, &(new_list[s]));

--- a/psi4/src/psi4/detci/params.cc
+++ b/psi4/src/psi4/detci/params.cc
@@ -498,24 +498,23 @@ void CIWavefunction::get_parameters(Options &options) {
     if (Parameters_->filter_guess == 1) {
         Parameters_->filter_guess_sign = options.get_int("FILTER_GUESS_SIGN");
         if (Parameters_->filter_guess_sign != 1 && Parameters_->filter_guess_sign != -1) {
-            outfile->Printf("FILTER_GUESS_SIGN should be 1 or -1 !\n");
-            abort();
+            const std::string msg = "FILTER_GUESS_SIGN should be 1 or -1 !\n";
+            outfile->Printf(msg.c_str());
+            throw PSIEXCEPTION(msg);
         }
 
         if (options["FILTER_GUESS_DET1"].size() != 2) {
-            outfile->Printf(
-                "Need to specify FILTER_GUESS_DET1 = "
-                "(alphastr betastr)\n");
-            abort();
+            const std::string msg = "Need to specify FILTER_GUESS_DET1 = (alphastr betastr)\n";
+            outfile->Printf(msg.c_str());
+            throw PSIEXCEPTION(msg);
         }
         Parameters_->filter_guess_Ia = options["FILTER_GUESS_DET1"][0].to_integer();
         Parameters_->filter_guess_Ib = options["FILTER_GUESS_DET1"][1].to_integer();
 
         if (options["FILTER_GUESS_DET2"].size() != 2) {
-            outfile->Printf(
-                "Need to specify FILTER_GUESS_DET2 = "
-                "(alphastr betastr)\n");
-            abort();
+            const std::string msg = "Need to specify FILTER_GUESS_DET2 = (alphastr betastr)\n";
+            outfile->Printf(msg.c_str());
+            throw PSIEXCEPTION(msg);
         }
         Parameters_->filter_guess_Ja = options["FILTER_GUESS_DET2"][0].to_integer();
         Parameters_->filter_guess_Jb = options["FILTER_GUESS_DET2"][1].to_integer();
@@ -532,10 +531,9 @@ void CIWavefunction::get_parameters(Options &options) {
     Parameters_->filter_zero_det = 0;
     if (options["FILTER_ZERO_DET"].has_changed()) {
         if (options["FILTER_ZERO_DET"].size() != 2) {
-            outfile->Printf(
-                "Need to specify FILTER_ZERO_DET = "
-                "(alphastr betastr)\n");
-            abort();
+            const std::string msg = "Need to specify FILTER_ZERO_DET = (alphastr betastr)\n";
+            outfile->Printf(msg.c_str());
+            throw PSIEXCEPTION(msg);
         }
         Parameters_->filter_zero_det = 1;
         Parameters_->filter_zero_det_Ia = options["FILTER_ZERO_DET"][0].to_integer();
@@ -607,21 +605,20 @@ void CIWavefunction::get_parameters(Options &options) {
         Parameters_->follow_vec_Ibc.resize(i);
         Parameters_->follow_vec_Iaridx.resize(i);
         Parameters_->follow_vec_Ibridx.resize(i);
+        const std::string err_msg = "Need format FOLLOW_VECTOR = [ [[alphastr_i, betastr_i], coeff_i], ... ]\n";
 
         /* now parse each piece */
         for (i = 0; i < Parameters_->follow_vec_num; i++) {
             int isize = options["FOLLOW_VECTOR"][i].size();
             if (isize != 2) {
-                outfile->Printf("Need format FOLLOW_VECTOR = \n");
-                outfile->Printf("  [ [[alphastr_i, betastr_i], coeff_i], ... ] \n");
-                abort();
+                outfile->Printf(err_msg.c_str());
+                throw PSIEXCEPTION(err_msg);
             }
 
             int iisize = options["FOLLOW_VECTOR"][i][0].size();
             if (iisize != 2) {
-                outfile->Printf("Need format FOLLOW_VECTOR = \n");
-                outfile->Printf("  [ [[alphastr_i, betastr_i], coeff_i], ... ] \n");
-                abort();
+                outfile->Printf(err_msg.c_str());
+                throw PSIEXCEPTION(err_msg);
             }
 
             Parameters_->follow_vec_Ia[i] = options["FOLLOW_VECTOR"][i][0][0].to_integer();

--- a/psi4/src/psi4/detci/params.cc
+++ b/psi4/src/psi4/detci/params.cc
@@ -631,7 +631,7 @@ void CIWavefunction::get_parameters(Options &options) {
             Parameters_->follow_vec_coef[i] = options["FOLLOW_VECTOR"][i][1].to_double();
 
         } /* end loop over parsing */
-    }     /* end follow vector stuff */
+    } /* end follow vector stuff */
 
     /* make sure SA weights add up to 1.0 */
     for (i = 0, junk = 0.0; i < Parameters_->average_num; i++) {
@@ -688,7 +688,8 @@ void CIWavefunction::print_parameters() {
                     Parameters_->nprint);
     outfile->Printf("    NUM ROOTS      =   %6d      ICORE         =   %6d\n", Parameters_->num_roots,
                     Parameters_->icore);
-    outfile->Printf("    PRINT LVL      =   %6lu      FCI           =   %6s\n", print_, Parameters_->fci ? "YES" : "NO");
+    outfile->Printf("    PRINT LVL      =   %6lu      FCI           =   %6s\n", print_,
+                    Parameters_->fci ? "YES" : "NO");
     outfile->Printf("    R CONV         = %6.2e      MIXED         =   %6s\n", Parameters_->convergence,
                     Parameters_->mixed ? "YES" : "NO");
     outfile->Printf("    E CONV         = %6.2e      MIXED4        =   %6s\n", Parameters_->energy_convergence,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Detci still has a few places where error termination is effected through printf+abort(). This PR replaces the calls to abort() in with `throw PSIEXCEPTION(msg)`.

The rest of the codebase has more of this pattern, those are subject to future PRs to keep this one small.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] A few error terminations in the detci module now print a more detailed error information to the console, instead of just the error message in the output file.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Calls to `abort()` in detci are replaced with `throw PSIEXCEPTION(msg)`, where `msg` is the relevant error message taken from the context of the `abort()`

## Checklist
- [x] No new features
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
