### PR TITLE
Support all W integrals

### DIFF
--- a/psi4/src/psi4/libmints/rel_potential.cc
+++ b/psi4/src/psi4/libmints/rel_potential.cc
@@ -65,6 +65,7 @@ RelPotentialInt::RelPotentialInt(std::vector<SphericalTransform>& st, std::share
             {bs1_->molecule()->x(A), bs1_->molecule()->y(A), bs1_->molecule()->z(A)}});
     }
 
+    set_chunks(4);
     engine0_ = std::make_unique<libint2::Engine>(libint2::Operator::opVop, max_nprim, max_am, 0);
     engine0_->set_params(params);
     // If you want derivatives of these integrals, just take the code from potential.cc's constructor


### PR DESCRIPTION
## Description
`RelPotentialInt` and associated integral classes now expose all four W integral types instead of just the W0 integrals.

This PR seems way too easy. @brianz98, please let me know if there are issues. Obligatory @fevangelista and @dnascimento13 pings.

## User API & Changelog headlines

- [x] `RelPotentialInt` and associated integral classes now expose all four W integral types instead of just the W0 integrals.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Changes `RelPotentialInt` to expose W0, Wx, Wy, and Wz integrals.

## Questions
- [x] Any objections to changing an existing integral type rather than creating a new one?
- [x] Any documentation edits needed?
- [x] Do any of the users need the derivative integrals?

## Checklist
- [ ] Are any tests necessary?
- [x] `ctest -L x2c` passes, in addition to standard tests

## Status
- [x] Ready for review
- [ ] Ready for merge
