### PR TITLE
Fix many compiler warnings

### DIFF
--- a/psi4/src/psi4/dct/dct_density_UHF.cc
+++ b/psi4/src/psi4/dct/dct_density_UHF.cc
@@ -1164,7 +1164,7 @@ void DCTSolver::compute_unrelaxed_separable_density_VVVV() {
 
 Matrix DCTSolver::construct_oo_density(const Matrix& occtau, const Matrix& virtau, const Matrix& kappa,
                                        const Matrix& C) {
-    auto opdm = Matrix("MO basis OPDM", nirrep_, nmopi_, nmopi_);
+    auto opdm = Matrix("MO basis OPDM", nmopi_, nmopi_);
 
     auto occdim = occtau.rowspi();
     auto virdim = virtau.rowspi();

--- a/psi4/src/psi4/dct/dct_df_operations.cc
+++ b/psi4/src/psi4/dct/dct_df_operations.cc
@@ -968,7 +968,7 @@ void DCTSolver::build_DF_tensors_RHF() {
     build_gbarlambda_RHF_v3mem();
 
     // Build Tau matrix in MO basis (All)
-    mo_tauA_ = Matrix("MO basis Tau", nirrep_, nmopi_, nmopi_);
+    mo_tauA_ = Matrix("MO basis Tau", nmopi_, nmopi_);
 #pragma omp parallel for
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < naoccpi_[h]; ++i) {
@@ -1142,10 +1142,8 @@ void DCTSolver::build_gbarGamma_RHF() {
 #endif
 
     // Form gamma<R|S> = kappa<R|S> + tau<R|S>
-    mo_gammaA_ = Matrix("MO-basis Gamma", nirrep_, nmopi_, nmopi_);
-    //    mo_gammaA_->copy(kappa_mo_a_);
-    //    mo_gammaA_->add(mo_tauA_);
-    mo_gbarGamma_A_ = Matrix("MO-basis Gbar*Gamma", nirrep_, nmopi_, nmopi_);
+    mo_gammaA_ = Matrix("MO-basis Gamma", nmopi_, nmopi_);
+    mo_gbarGamma_A_ = Matrix("MO-basis Gbar*Gamma", nmopi_, nmopi_);
     mo_gammaA_.copy(mo_tauA_);
     mo_gammaA_.add(kappa_mo_a_);
 
@@ -1258,7 +1256,7 @@ void DCTSolver::build_DF_tensors_UHF() {
 
     // Build Tau matrix in MO basis (All)
     // Alpha-Alpha
-    mo_tauA_ = Matrix("MO basis Tau Alpha", nirrep_, nmopi_, nmopi_);
+    mo_tauA_ = Matrix("MO basis Tau Alpha", nmopi_, nmopi_);
 #pragma omp parallel for
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < naoccpi_[h]; ++i) {
@@ -1277,7 +1275,7 @@ void DCTSolver::build_DF_tensors_UHF() {
     }
 
     // Beta-Beta
-    mo_tauB_ = Matrix("MO basis Tau Beta", nirrep_, nmopi_, nmopi_);
+    mo_tauB_ = Matrix("MO basis Tau Beta", nmopi_, nmopi_);
 #pragma omp parallel for
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < nboccpi_[h]; ++i) {
@@ -1701,10 +1699,10 @@ void DCTSolver::build_gbarGamma_UHF() {
 #endif
 
     // Form gamma<R|S> = kappa<R|S> + tau<R|S>
-    mo_gammaA_ = Matrix("MO-basis Gamma Alpha", nirrep_, nmopi_, nmopi_);
-    mo_gbarGamma_A_ = Matrix("MO-basis Gbar_Gamma_A", nirrep_, nmopi_, nmopi_);
-    mo_gammaB_ = Matrix("MO-basis Gamma Beta", nirrep_, nmopi_, nmopi_);
-    mo_gbarGamma_B_ = Matrix("MO-basis Gbar_Gamma_B", nirrep_, nmopi_, nmopi_);
+    mo_gammaA_ = Matrix("MO-basis Gamma Alpha", nmopi_, nmopi_);
+    mo_gbarGamma_A_ = Matrix("MO-basis Gbar_Gamma_A", nmopi_, nmopi_);
+    mo_gammaB_ = Matrix("MO-basis Gamma Beta", nmopi_, nmopi_);
+    mo_gbarGamma_B_ = Matrix("MO-basis Gbar_Gamma_B", nmopi_, nmopi_);
 
     mo_gammaA_.copy(mo_tauA_);
     mo_gammaA_.add(kappa_mo_a_);

--- a/psi4/src/psi4/dct/dct_gradient_RHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_RHF.cc
@@ -363,9 +363,9 @@ void DCTSolver::compute_lagrangian_VV_RHF(bool separate_gbargamma) {
 void DCTSolver::compute_ewdm_odc_RHF() {
     dpdfile2 X_OV, X_VO, X_OO, X_VV;
 
-    Matrix aW("Energy-weighted density matrix (Alpha)", nirrep_, nmopi_, nmopi_);
+    Matrix aW("Energy-weighted density matrix (Alpha)", nmopi_, nmopi_);
 
-    auto a_opdm = Matrix("MO basis OPDM (Alpha)", nirrep_, nmopi_, nmopi_);
+    auto a_opdm = Matrix("MO basis OPDM (Alpha)", nmopi_, nmopi_);
 
     const int *alpha_corr_to_pitzer = _ints->alpha_corr_to_pitzer();
     auto *alpha_pitzer_to_corr = new int[nmo_];

--- a/psi4/src/psi4/dct/dct_gradient_UHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_UHF.cc
@@ -249,10 +249,10 @@ void DCTSolver::compute_gradient_UHF() {
 
 void DCTSolver::dc06_response_init() {
     // Allocate memory for the global objects
-    aocc_ptau_ = Matrix("MO basis Perturbed Tau (Alpha Occupied)", nirrep_, naoccpi_, naoccpi_);
-    bocc_ptau_ = Matrix("MO basis Perturbed Tau (Beta Occupied)", nirrep_, nboccpi_, nboccpi_);
-    avir_ptau_ = Matrix("MO basis Perturbed Tau (Alpha Virtual)", nirrep_, navirpi_, navirpi_);
-    bvir_ptau_ = Matrix("MO basis Perturbed Tau (Beta Virtual)", nirrep_, nbvirpi_, nbvirpi_);
+    aocc_ptau_ = Matrix("MO basis Perturbed Tau (Alpha Occupied)", naoccpi_, naoccpi_);
+    bocc_ptau_ = Matrix("MO basis Perturbed Tau (Beta Occupied)", nboccpi_, nboccpi_);
+    avir_ptau_ = Matrix("MO basis Perturbed Tau (Alpha Virtual)", navirpi_, navirpi_);
+    bvir_ptau_ = Matrix("MO basis Perturbed Tau (Beta Virtual)", nbvirpi_, nbvirpi_);
 
     // Transform the two-electron integrals to the (VO|OO) and (OV|VV) subspaces in chemists' notation
 
@@ -3550,8 +3550,8 @@ void DCTSolver::compute_lagrangian_VV(bool separate_gbargamma) {
 void DCTSolver::compute_ewdm_dc() {
     dpdfile2 zI_OV, zI_VO, X_OV, X_VO, zI_OO, zI_VV, X_OO, X_VV;
 
-    Matrix aW("Energy-weighted density matrix (Alpha)", nirrep_, nmopi_, nmopi_);
-    Matrix bW("Energy-weighted density matrix (Beta)", nirrep_, nmopi_, nmopi_);
+    Matrix aW("Energy-weighted density matrix (Alpha)", nmopi_, nmopi_);
+    Matrix bW("Energy-weighted density matrix (Beta)", nmopi_, nmopi_);
 
     const int *alpha_corr_to_pitzer = _ints->alpha_corr_to_pitzer();
     auto *alpha_pitzer_to_corr = new int[nmo_];
@@ -4430,11 +4430,11 @@ void DCTSolver::compute_ewdm_dc() {
 void DCTSolver::compute_ewdm_odc() {
     dpdfile2 X_OV, X_VO, X_OO, X_VV;
 
-    Matrix aW("Energy-weighted density matrix (Alpha)", nirrep_, nmopi_, nmopi_);
-    Matrix bW("Energy-weighted density matrix (Beta)", nirrep_, nmopi_, nmopi_);
+    Matrix aW("Energy-weighted density matrix (Alpha)", nmopi_, nmopi_);
+    Matrix bW("Energy-weighted density matrix (Beta)", nmopi_, nmopi_);
 
-    auto a_opdm = std::make_shared<Matrix>("MO basis OPDM (Alpha)", nirrep_, nmopi_, nmopi_);
-    auto b_opdm = std::make_shared<Matrix>("MO basis OPDM (Beta)", nirrep_, nmopi_, nmopi_);
+    auto a_opdm = std::make_shared<Matrix>("MO basis OPDM (Alpha)", nmopi_, nmopi_);
+    auto b_opdm = std::make_shared<Matrix>("MO basis OPDM (Beta)", nmopi_, nmopi_);
 
     const int *alpha_corr_to_pitzer = _ints->alpha_corr_to_pitzer();
     auto *alpha_pitzer_to_corr = new int[nmo_];

--- a/psi4/src/psi4/dct/dct_intermediates_RHF.cc
+++ b/psi4/src/psi4/dct/dct_intermediates_RHF.cc
@@ -253,8 +253,8 @@ void DCTSolver::form_density_weighted_fock_RHF() {
     global_dpd_->file2_init(&T_VV, PSIF_DCT_DPD, 0, ID('V'), ID('V'), "Tau <V|V>");
 
     // Copy Tau in MO basis from the DPD library
-    auto a_tau_mo = Matrix("Alpha Tau in the MO basis", nirrep_, nmopi_, nmopi_);
-    auto b_tau_mo = Matrix("Beta Tau in the MO basis", nirrep_, nmopi_, nmopi_);
+    auto a_tau_mo = Matrix("Alpha Tau in the MO basis", nmopi_, nmopi_);
+    auto b_tau_mo = Matrix("Beta Tau in the MO basis", nmopi_, nmopi_);
 
     a_tau_mo.set_block(slices_.at("ACTIVE_OCC_A"), Matrix(&T_OO));
     a_tau_mo.set_block(slices_.at("ACTIVE_VIR_A"), Matrix(&T_VV));

--- a/psi4/src/psi4/dct/dct_intermediates_UHF.cc
+++ b/psi4/src/psi4/dct/dct_intermediates_UHF.cc
@@ -507,8 +507,8 @@ void DCTSolver::form_density_weighted_fock() {
     global_dpd_->file2_init(&T_vv, PSIF_DCT_DPD, 0, ID('v'), ID('v'), "Tau <v|v>");
 
     // Copy Tau in MO basis from the DPD library
-    auto a_tau_mo = Matrix("Alpha Tau in the MO basis", nirrep_, nmopi_, nmopi_);
-    auto b_tau_mo = Matrix("Beta Tau in the MO basis", nirrep_, nmopi_, nmopi_);
+    auto a_tau_mo = Matrix("Alpha Tau in the MO basis", nmopi_, nmopi_);
+    auto b_tau_mo = Matrix("Beta Tau in the MO basis", nmopi_, nmopi_);
 
     a_tau_mo.set_block(slices_.at("ACTIVE_OCC_A"), Matrix(&T_OO));
     a_tau_mo.set_block(slices_.at("ACTIVE_VIR_A"), Matrix(&T_VV));
@@ -520,8 +520,8 @@ void DCTSolver::form_density_weighted_fock() {
     global_dpd_->file2_close(&T_VV);
     global_dpd_->file2_close(&T_vv);
 
-    auto a_evecs = std::make_shared<Matrix>("Tau Eigenvectors (Alpha)", nirrep_, nmopi_, nmopi_);
-    auto b_evecs = std::make_shared<Matrix>("Tau Eigenvectors (Beta)", nirrep_, nmopi_, nmopi_);
+    auto a_evecs = std::make_shared<Matrix>("Tau Eigenvectors (Alpha)", nmopi_, nmopi_);
+    auto b_evecs = std::make_shared<Matrix>("Tau Eigenvectors (Beta)", nmopi_, nmopi_);
     auto a_evals = std::make_shared<Vector>("Tau Eigenvalues (Alpha)",  nmopi_);
     auto b_evals = std::make_shared<Vector>("Tau Eigenvalues (Beta)", nmopi_);
 

--- a/psi4/src/psi4/dct/dct_memory.cc
+++ b/psi4/src/psi4/dct/dct_memory.cc
@@ -77,37 +77,37 @@ void DCTSolver::init() {
         {"ACTIVE_VIR_B",  Slice(nbetapi_, nbetapi_ + nbvirpi_)}
     };
 
-    aocc_c_ = std::make_shared<Matrix>("Alpha Occupied MO Coefficients", nirrep_, nsopi_, naoccpi_);
-    bocc_c_ = std::make_shared<Matrix>("Beta Occupied MO Coefficients", nirrep_, nsopi_, nboccpi_);
-    avir_c_ = std::make_shared<Matrix>("Alpha Virtual MO Coefficients", nirrep_, nsopi_, navirpi_);
-    bvir_c_ = std::make_shared<Matrix>("Beta Virtual MO Coefficients", nirrep_, nsopi_, nbvirpi_);
-    scf_error_a_ = std::make_shared<Matrix>("Alpha SCF Error Vector", nirrep_, nsopi_, nsopi_);
-    scf_error_b_ = std::make_shared<Matrix>("Beta SCF Error Vector", nirrep_, nsopi_, nsopi_);
+    aocc_c_ = std::make_shared<Matrix>("Alpha Occupied MO Coefficients", nsopi_, naoccpi_);
+    bocc_c_ = std::make_shared<Matrix>("Beta Occupied MO Coefficients", nsopi_, nboccpi_);
+    avir_c_ = std::make_shared<Matrix>("Alpha Virtual MO Coefficients", nsopi_, navirpi_);
+    bvir_c_ = std::make_shared<Matrix>("Beta Virtual MO Coefficients", nsopi_, nbvirpi_);
+    scf_error_a_ = std::make_shared<Matrix>("Alpha SCF Error Vector", nsopi_, nsopi_);
+    scf_error_b_ = std::make_shared<Matrix>("Beta SCF Error Vector", nsopi_, nsopi_);
     Fa_ = reference_wavefunction_->Fa()->clone();
     Fb_ = reference_wavefunction_->Fb()->clone();
-    Ftilde_a_ = std::make_shared<Matrix>("Alpha MO Ftilde Matrix", nirrep_, nmopi_, nmopi_);
-    Ftilde_b_ = std::make_shared<Matrix>("Beta MO Ftilde Matrix", nirrep_, nmopi_, nmopi_);
-    Ca_ = std::make_shared<Matrix>("Alpha MO Coefficients", nirrep_, nsopi_, nsopi_);
-    Cb_ = std::make_shared<Matrix>("Beta MO Coefficients", nirrep_, nsopi_, nsopi_);
-    moFa_ = std::make_shared<Matrix>("Alpha MO Fock Matrix", nirrep_, nmopi_, nmopi_);
-    moFb_ = std::make_shared<Matrix>("Beta MO Fock Matrix", nirrep_, nmopi_, nmopi_);
-    old_ca_ = std::make_shared<Matrix>("Old Alpha MO Coefficients", nirrep_, nsopi_, nsopi_);
-    old_cb_ = std::make_shared<Matrix>("Old Beta MO Coefficients", nirrep_, nsopi_, nsopi_);
-    kappa_so_a_ = std::make_shared<Matrix>("Alpha Kappa Matrix", nirrep_, nsopi_, nsopi_);
-    kappa_so_b_ = std::make_shared<Matrix>("Beta Kappa Matrix", nirrep_, nsopi_, nsopi_);
-    ao_s_ = std::make_shared<Matrix>("SO Basis Overlap Integrals", nirrep_, nsopi_, nsopi_);
-    so_h_ = Matrix("SO basis one-electron integrals", nirrep_, nsopi_, nsopi_);
-    s_half_inv_ = std::make_shared<Matrix>("SO Basis Inverse Square Root Overlap Matrix", nirrep_, nsopi_, nsopi_);
+    Ftilde_a_ = std::make_shared<Matrix>("Alpha MO Ftilde Matrix", nmopi_, nmopi_);
+    Ftilde_b_ = std::make_shared<Matrix>("Beta MO Ftilde Matrix", nmopi_, nmopi_);
+    Ca_ = std::make_shared<Matrix>("Alpha MO Coefficients", nsopi_, nsopi_);
+    Cb_ = std::make_shared<Matrix>("Beta MO Coefficients", nsopi_, nsopi_);
+    moFa_ = std::make_shared<Matrix>("Alpha MO Fock Matrix", nmopi_, nmopi_);
+    moFb_ = std::make_shared<Matrix>("Beta MO Fock Matrix", nmopi_, nmopi_);
+    old_ca_ = std::make_shared<Matrix>("Old Alpha MO Coefficients", nsopi_, nsopi_);
+    old_cb_ = std::make_shared<Matrix>("Old Beta MO Coefficients", nsopi_, nsopi_);
+    kappa_so_a_ = std::make_shared<Matrix>("Alpha Kappa Matrix", nsopi_, nsopi_);
+    kappa_so_b_ = std::make_shared<Matrix>("Beta Kappa Matrix", nsopi_, nsopi_);
+    ao_s_ = std::make_shared<Matrix>("SO Basis Overlap Integrals", nsopi_, nsopi_);
+    so_h_ = Matrix("SO basis one-electron integrals", nsopi_, nsopi_);
+    s_half_inv_ = std::make_shared<Matrix>("SO Basis Inverse Square Root Overlap Matrix", nsopi_, nsopi_);
     epsilon_a_ = std::make_shared<Vector>(nsopi_);
     epsilon_b_ = std::make_shared<Vector>(nsopi_);
-    kappa_mo_a_ = std::make_shared<Matrix>("MO basis Kappa (Alpha)", nirrep_, nmopi_, nmopi_);
-    kappa_mo_b_ = std::make_shared<Matrix>("MO basis Kappa (Beta)", nirrep_, nmopi_, nmopi_);
-    tau_so_a_ = std::make_shared<Matrix>("Alpha Tau Matrix", nirrep_, nsopi_, nsopi_);
-    tau_so_b_ = std::make_shared<Matrix>("Beta Tau Matrix", nirrep_, nsopi_, nsopi_);
-    aocc_tau_ = Matrix("MO basis Tau (Alpha Occupied)", nirrep_, naoccpi_, naoccpi_);
-    bocc_tau_ = Matrix("MO basis Tau (Beta Occupied)", nirrep_, nboccpi_, nboccpi_);
-    avir_tau_ = Matrix("MO basis Tau (Alpha Virtual)", nirrep_, navirpi_, navirpi_);
-    bvir_tau_ = Matrix("MO basis Tau (Beta Virtual)", nirrep_, nbvirpi_, nbvirpi_);
+    kappa_mo_a_ = std::make_shared<Matrix>("MO basis Kappa (Alpha)", nmopi_, nmopi_);
+    kappa_mo_b_ = std::make_shared<Matrix>("MO basis Kappa (Beta)", nmopi_, nmopi_);
+    tau_so_a_ = std::make_shared<Matrix>("Alpha Tau Matrix", nsopi_, nsopi_);
+    tau_so_b_ = std::make_shared<Matrix>("Beta Tau Matrix", nsopi_, nsopi_);
+    aocc_tau_ = Matrix("MO basis Tau (Alpha Occupied)", naoccpi_, naoccpi_);
+    bocc_tau_ = Matrix("MO basis Tau (Beta Occupied)", nboccpi_, nboccpi_);
+    avir_tau_ = Matrix("MO basis Tau (Alpha Virtual)", navirpi_, navirpi_);
+    bvir_tau_ = Matrix("MO basis Tau (Beta Virtual)", nbvirpi_, nbvirpi_);
 
     // Compute MO offsets
     aocc_off_ = std::vector<int>(nirrep_);
@@ -182,9 +182,9 @@ void DCTSolver::init() {
     ao_s_->copy(mintshelper_->so_overlap());
 
     // Form S^(-1/2) matrix
-    Matrix eigvec(nirrep_, nsopi_, nsopi_);
-    Matrix eigtemp(nirrep_, nsopi_, nsopi_);
-    Matrix eigtemp2(nirrep_, nsopi_, nsopi_);
+    Matrix eigvec(nsopi_, nsopi_);
+    Matrix eigtemp(nsopi_, nsopi_);
+    Matrix eigtemp2(nsopi_, nsopi_);
     Vector eigval(nsopi_);
     ao_s_->diagonalize(eigvec, eigval);
     // Convert the eigenvales to 1/sqrt(eigenvalues)

--- a/psi4/src/psi4/dct/dct_oo_RHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_RHF.cc
@@ -86,7 +86,7 @@ void DCTSolver::run_simult_dct_oo_RHF() {
         if (options_.get_str("DCT_TYPE") == "DF" && options_.get_str("AO_BASIS") == "NONE") {
             build_DF_tensors_RHF();
 
-            auto mo_h = Matrix("MO-based H", nirrep_, nmopi_, nmopi_);
+            auto mo_h = Matrix("MO-based H", nmopi_, nmopi_);
             mo_h.copy(so_h_);
             mo_h.transform(Ca_);
 
@@ -622,7 +622,7 @@ void DCTSolver::compute_orbital_rotation_jacobi_RHF() {
 
     // Determine the orbital rotation step
     // Alpha spin
-    auto X_a = Matrix("Alpha orbital step", nirrep_, nmopi_, nmopi_);
+    auto X_a = Matrix("Alpha orbital step", nmopi_, nmopi_);
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < naoccpi_[h]; ++i) {
             for (int a = naoccpi_[h]; a < nmopi_[h]; ++a) {

--- a/psi4/src/psi4/dct/dct_oo_UHF.cc
+++ b/psi4/src/psi4/dct/dct_oo_UHF.cc
@@ -79,11 +79,11 @@ void DCTSolver::run_simult_dct_oo() {
         if (options_.get_str("DCT_TYPE") == "DF" && options_.get_str("AO_BASIS") == "NONE") {
             build_DF_tensors_UHF();
 
-            auto mo_h_A = Matrix("MO-based H Alpha", nirrep_, nmopi_, nmopi_);
+            auto mo_h_A = Matrix("MO-based H Alpha", nmopi_, nmopi_);
             mo_h_A.copy(so_h_);
             mo_h_A.transform(Ca_);
 
-            auto mo_h_B = Matrix("MO-based H Beta", nirrep_, nmopi_, nmopi_);
+            auto mo_h_B = Matrix("MO-based H Beta", nmopi_, nmopi_);
             mo_h_B.copy(so_h_);
             mo_h_B.transform(Cb_);
 
@@ -918,7 +918,7 @@ void DCTSolver::compute_orbital_rotation_jacobi() {
 
     // Determine the orbital rotation step
     // Alpha spin
-    auto X_a = Matrix("Alpha orbital step", nirrep_, nmopi_, nmopi_);
+    auto X_a = Matrix("Alpha orbital step", nmopi_, nmopi_);
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < naoccpi_[h]; ++i) {
             for (int a = naoccpi_[h]; a < nmopi_[h]; ++a) {
@@ -931,7 +931,7 @@ void DCTSolver::compute_orbital_rotation_jacobi() {
     }
 
     // Beta spin
-    auto X_b = Matrix("Beta orbital step", nirrep_, nmopi_, nmopi_);
+    auto X_b = Matrix("Beta orbital step", nmopi_, nmopi_);
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < nboccpi_[h]; ++i) {
             for (int a = nboccpi_[h]; a < nmopi_[h]; ++a) {

--- a/psi4/src/psi4/dct/dct_qc.cc
+++ b/psi4/src/psi4/dct/dct_qc.cc
@@ -1884,7 +1884,7 @@ void DCTSolver::compute_orbital_rotation_nr() {
     int orbitals_address = 0;
     int idpcount = 0;
     // Alpha spin
-    auto X_a = Matrix("Alpha orbital step", nirrep_, nmopi_, nmopi_);
+    auto X_a = Matrix("Alpha orbital step", nmopi_, nmopi_);
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < naoccpi_[h]; ++i) {
             for (int a = 0; a < navirpi_[h]; ++a) {
@@ -1900,7 +1900,7 @@ void DCTSolver::compute_orbital_rotation_nr() {
     }
 
     // Beta spin
-    auto X_b = Matrix("Beta orbital step", nirrep_, nmopi_, nmopi_);
+    auto X_b = Matrix("Beta orbital step", nmopi_, nmopi_);
     for (int h = 0; h < nirrep_; ++h) {
         for (int i = 0; i < nboccpi_[h]; ++i) {
             for (int a = 0; a < nbvirpi_[h]; ++a) {

--- a/psi4/src/psi4/dct/dct_relaxed_density_UHF.cc
+++ b/psi4/src/psi4/dct/dct_relaxed_density_UHF.cc
@@ -740,10 +740,10 @@ void DCTSolver::compute_relaxed_density_VVVV() {
 }
 
 void DCTSolver::dc06_compute_relaxed_density_1PDM() {
-    auto a_opdm = std::make_shared<Matrix>("MO basis OPDM (Alpha)", nirrep_, nmopi_, nmopi_);
-    auto b_opdm = std::make_shared<Matrix>("MO basis OPDM (Beta)", nirrep_, nmopi_, nmopi_);
-    auto a_zia = Matrix("MO basis Orbital Response (Alpha)", nirrep_, nmopi_, nmopi_);
-    auto b_zia = Matrix("MO basis Orbital Response (Beta)", nirrep_, nmopi_, nmopi_);
+    auto a_opdm = std::make_shared<Matrix>("MO basis OPDM (Alpha)", nmopi_, nmopi_);
+    auto b_opdm = std::make_shared<Matrix>("MO basis OPDM (Beta)", nmopi_, nmopi_);
+    auto a_zia = Matrix("MO basis Orbital Response (Alpha)", nmopi_, nmopi_);
+    auto b_zia = Matrix("MO basis Orbital Response (Beta)", nmopi_, nmopi_);
 
     dpdfile2 z_OV;
 

--- a/psi4/src/psi4/dct/dct_scf_RHF.cc
+++ b/psi4/src/psi4/dct/dct_scf_RHF.cc
@@ -448,8 +448,8 @@ double DCTSolver::compute_scf_error_vector_RHF() {
 
     size_t nElements = 0;
     double sumOfSquares = 0.0;
-    auto tmp1 = Matrix("tmp1", nirrep_, nsopi_, nsopi_);
-    auto tmp2 = Matrix("tmp2", nirrep_, nsopi_, nsopi_);
+    auto tmp1 = Matrix("tmp1", nsopi_, nsopi_);
+    auto tmp2 = Matrix("tmp2", nsopi_, nsopi_);
     // form FDS
     tmp1.gemm(false, false, 1.0, kappa_so_a_, ao_s_, 0.0);
     scf_error_a_->gemm(false, false, 1.0, Fa_, tmp1, 0.0);

--- a/psi4/src/psi4/dct/dct_scf_UHF.cc
+++ b/psi4/src/psi4/dct/dct_scf_UHF.cc
@@ -57,8 +57,8 @@ namespace dct {
 bool DCTSolver::correct_mo_phases(bool dieOnError) {
     dct_timer_on("DCTSolver::correct_mo_phases()");
 
-    Matrix temp("temp", nirrep_, nsopi_, nmopi_);
-    Matrix overlap("Old - New Overlap", nirrep_, nmopi_, nmopi_);
+    Matrix temp("temp", nsopi_, nmopi_);
+    Matrix overlap("Old - New Overlap", nmopi_, nmopi_);
 
     bool error = correct_mo_phase_spincase(temp, overlap, *old_ca_, *Ca_, dieOnError);
     error = error && correct_mo_phase_spincase(temp, overlap, *old_cb_, *Cb_, dieOnError);
@@ -166,8 +166,8 @@ double DCTSolver::compute_scf_error_vector() {
 
     size_t nElements = 0;
     double sumOfSquares = 0.0;
-    auto tmp1 = Matrix("tmp1", nirrep_, nsopi_, nsopi_);
-    auto tmp2 = Matrix("tmp2", nirrep_, nsopi_, nsopi_);
+    auto tmp1 = Matrix("tmp1", nsopi_, nsopi_);
+    auto tmp2 = Matrix("tmp2", nsopi_, nsopi_);
     // form FDS
     tmp1.gemm(false, false, 1.0, kappa_so_a_, ao_s_, 0.0);
     scf_error_a_->gemm(false, false, 1.0, Fa_, tmp1, 0.0);
@@ -741,7 +741,7 @@ void DCTSolver::update_fock() {
     moFb_->transform(Cb_);
 
     // We already have the gbar * tau contraction computed, so let's just add it in.
-    auto moG_tau = Matrix("GGamma in the MO basis", nirrep_, nmopi_, nmopi_);
+    auto moG_tau = Matrix("GGamma in the MO basis", nmopi_, nmopi_);
 
     // Alpha occupied
     global_dpd_->file2_init(&Gtau, PSIF_DCT_DPD, 0, ID('O'), ID('O'), "GGamma <O|O>");

--- a/psi4/src/psi4/dct/dct_tau_RHF.cc
+++ b/psi4/src/psi4/dct/dct_tau_RHF.cc
@@ -120,10 +120,10 @@ void DCTSolver::build_tau_R() {
 
     // Iteratively compute the exact Tau
 
-    auto aocc_tau_old = Matrix("MO basis Tau (Alpha Occupied, old)", nirrep_, naoccpi_, naoccpi_);
-    auto avir_tau_old = Matrix("MO basis Tau (Alpha Virtual, old)", nirrep_, navirpi_, navirpi_);
-    auto aocc_d = Matrix("Non-idempotency of OPDM (Alpha Occupied, old)", nirrep_, naoccpi_, naoccpi_);
-    auto avir_d = Matrix("Non-idempotency of OPDM (Alpha Virtual, old)", nirrep_, navirpi_, navirpi_);
+    auto aocc_tau_old = Matrix("MO basis Tau (Alpha Occupied, old)", naoccpi_, naoccpi_);
+    auto avir_tau_old = Matrix("MO basis Tau (Alpha Virtual, old)", navirpi_, navirpi_);
+    auto aocc_d = Matrix("Non-idempotency of OPDM (Alpha Occupied, old)", naoccpi_, naoccpi_);
+    auto avir_d = Matrix("Non-idempotency of OPDM (Alpha Virtual, old)", navirpi_, navirpi_);
 
     bool converged = false;
     bool failed = false;

--- a/psi4/src/psi4/libmints/factory.cc
+++ b/psi4/src/psi4/libmints/factory.cc
@@ -110,7 +110,7 @@ std::unique_ptr<Matrix> MatrixFactory::create_matrix(int symmetry) { return std:
 /// Returns a new Matrix object with default dimensions
 SharedMatrix MatrixFactory::create_shared_matrix() const { return std::make_shared<Matrix>(nirrep_, rowspi_, colspi_); }
 
-void MatrixFactory::create_matrix(Matrix& mat, int symmetry) { mat.init(nirrep_, rowspi_, colspi_, "", symmetry); }
+void MatrixFactory::create_matrix(Matrix& mat, int symmetry) { mat.init(rowspi_, colspi_, "", symmetry); }
 
 /// Returns a new Matrix object named name with default dimensions
 std::unique_ptr<Matrix> MatrixFactory::create_matrix(std::string name, int symmetry) {
@@ -130,7 +130,7 @@ SharedMatrix MatrixFactory::create_shared_matrix(const std::string& name, int ro
 }
 
 void MatrixFactory::create_matrix(Matrix& mat, std::string name, int symmetry) {
-    mat.init(nirrep_, rowspi_, colspi_, name, symmetry);
+    mat.init(rowspi_, colspi_, name, symmetry);
 }
 
 /// Returns a new Vector object with default dimensions


### PR DESCRIPTION
## Description
Fixes many compiler warnings by no longer passing redundant arguments to Matrix constructors.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Fixes 83 compiler warnings, 81 of which were coming from `dct`.

## Checklist
- [x] quick tests and dct tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
