### PR TITLE
Eliminate casting of Dimension objects to pointers within libmoinfo

### DIFF
--- a/psi4/src/psi4/libmoinfo/moinfo.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo.cc
@@ -112,7 +112,11 @@ void MOInfo::read_info() {
     nmo = ref_wfn.nmo();
     compute_number_of_electrons();
     scf_energy = ref_wfn.energy();
-    mopi = convert_int_array_to_vector(nirreps, ref_wfn.nmopi());
+    if (nirreps != ref_wfn.nmopi().n())
+        throw PSIEXCEPTION(
+            "MOInfo::read_info(): Suspicious condition! The number of irreps in the reference wavefunction is not "
+            "equal to the size of the number of MOs per irrep array.");
+    mopi = ref_wfn.nmopi().blocks();
     SharedMatrix matCa = ref_wfn.Ca();
     scf = block_matrix(get_nso(), nmo);
     size_t soOffset = 0;
@@ -244,9 +248,21 @@ void MOInfo::read_mo_spaces() {
         intvec fvir_ref;
 
         // Read the dimensioning information for the subgroup from the wfn object
-        focc_ref = convert_int_array_to_vector(nirreps, ref_wfn.frzcpi());
-        docc_ref = convert_int_array_to_vector(nirreps, ref_wfn.doccpi());
-        actv_ref = convert_int_array_to_vector(nirreps, ref_wfn.soccpi());
+        if (nirreps != ref_wfn.frzcpi().n())
+            throw PSIEXCEPTION(
+                "MOInfo::read_mo_spaces(): Suspicious condition! The number of irreps in the reference wavefunction is not "
+                "equal to the size of the number of frozen core orbitals per irrep array.");
+        if (nirreps != ref_wfn.doccpi().n())
+            throw PSIEXCEPTION(
+                "MOInfo::read_mo_spaces(): Suspicious condition! The number of irreps in the reference wavefunction is not "
+                "equal to the size of the DOCC per irrep array.");
+        if (nirreps != ref_wfn.soccpi().n())
+            throw PSIEXCEPTION(
+                "MOInfo::read_mo_spaces(): Suspicious condition! The number of irreps in the reference wavefunction is not "
+                "equal to the size of the SOCC per irrep array.");
+        focc_ref = ref_wfn.frzcpi().blocks();
+        docc_ref = ref_wfn.doccpi().blocks();
+        actv_ref = ref_wfn.soccpi().blocks();
         for (int h = 0; h < nirreps; h++) docc_ref[h] -= focc_ref[h];
         nfocc = std::accumulate(focc_ref.begin(), focc_ref.end(), 0);
         ndocc = std::accumulate(docc_ref.begin(), docc_ref.end(), 0);
@@ -285,9 +301,21 @@ void MOInfo::read_mo_spaces() {
         // For a single-point only
         outfile->Printf("\n  For a single-point only");
 
-        focc = convert_int_array_to_vector(nirreps, ref_wfn.frzcpi());
-        docc = convert_int_array_to_vector(nirreps, ref_wfn.doccpi());
-        actv = convert_int_array_to_vector(nirreps, ref_wfn.soccpi());
+        if (nirreps != ref_wfn.frzcpi().n())
+            throw PSIEXCEPTION(
+                "MOInfo::read_mo_spaces(): Suspicious condition! The number of irreps in the reference wavefunction is not "
+                "equal to the size of the number of frozen core orbitals per irrep array.");
+        if (nirreps != ref_wfn.doccpi().n())
+            throw PSIEXCEPTION(
+                "MOInfo::read_mo_spaces(): Suspicious condition! The number of irreps in the reference wavefunction is not "
+                "equal to the size of the DOCC per irrep array.");
+        if (nirreps != ref_wfn.soccpi().n())
+            throw PSIEXCEPTION(
+                "MOInfo::read_mo_spaces(): Suspicious condition! The number of irreps in the reference wavefunction is not "
+                "equal to the size of the SOCC per irrep array.");
+        focc = ref_wfn.frzcpi().blocks();
+        docc = ref_wfn.doccpi().blocks();
+        actv = ref_wfn.soccpi().blocks();
 
         for (int h = 0; h < nirreps; h++) docc[h] -= focc[h];
 

--- a/psi4/src/psi4/libmoinfo/moinfo.h
+++ b/psi4/src/psi4/libmoinfo/moinfo.h
@@ -191,6 +191,7 @@ class MOInfo : public MOInfoBase {
     double get_sign_internal_excitation(int i, int j);
 
    private:
+    void read_mo_spaces_check_irrepcnt();
     void read_info();
     void read_mo_spaces();
     void compute_mo_mappings();

--- a/psi4/src/psi4/libmoinfo/moinfo_base.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.cc
@@ -126,9 +126,4 @@ void MOInfoBase::print_mo_space(int n, const intvec& mo, const std::string& labe
     outfile->Printf("  %3d", n);
 }
 
-intvec MOInfoBase::convert_int_array_to_vector(int n, const int* array) {
-    // Read an integer array and save as a STL vector
-    return intvec(array, array + n);
-}
-
 }  // namespace psi

--- a/psi4/src/psi4/libmoinfo/moinfo_base.cc
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.cc
@@ -59,7 +59,14 @@ void MOInfoBase::read_data() {
     nirreps = ref_wfn.nirrep();
     nso = ref_wfn.nso();
     // Read sopi and save as a STL vector
-    sopi = convert_int_array_to_vector(nirreps, ref_wfn.nsopi());
+    if (ref_wfn.nirrep() != ref_wfn.nsopi().n()) {
+        const std::string msg =
+            "MOInfoBase::read_data(): Suspicious condition! The number of irreps in the reference wavefunction is not "
+            "equal to the size of the number of SOs per irrep array. Invalid ref_wfn?\n";
+        outfile->Printf(msg.c_str());
+        throw PSIEXCEPTION(msg);
+    }
+    sopi = ref_wfn.nsopi().blocks();
     irr_labs = ref_wfn.molecule()->irrep_labels();
     nuclear_energy = ref_wfn.molecule()->nuclear_repulsion_energy(ref_wfn.get_dipole_field_strength());
 }

--- a/psi4/src/psi4/libmoinfo/moinfo_base.h
+++ b/psi4/src/psi4/libmoinfo/moinfo_base.h
@@ -110,7 +110,6 @@ class MOInfoBase {
     void compute_number_of_electrons();
     void read_mo_space(const int nirreps_ref, int& n, intvec& mo, const std::string& labels);
     void print_mo_space(int nmo, const intvec& mo, const std::string& labels);
-    intvec convert_int_array_to_vector(int n, const int* array);
 
     Wavefunction& ref_wfn;
     Options& options;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This is the third PR in the `libmoinfo` series, following #3101 and #3155.
Currently, `libmoinfo` is calling the `intvec convert_int_array_to_vector(int n, const int* array)` to initialize some of its `std::vector<int>` members by copying the innards of `Dimension` objects. Unfortunately this is happening through the rather inelegant mechanism of implicitly calling `Dimension::operator const int*() const`, which is set to be removed eventually.

This PR replaces all calls of `convert_int_array_to_vector` in `libmoinfo` with simple assignment-initialization. Now, this could in theory lead to a change in behavior, as the former only copies the first `n` elements of the array inside the Dimension object instead of the entire thing, but in practice that does not seem to be happening. As far as I can tell, for trouble to happen it would require an internally inconsistent `Wavefunction` object or `libmoinfo` trying to use only a subset of the irreps.

Nevertheless, I have added checks to ensure that any condition that would lead to an unpredictable change in behavior after this PR, results in a crash instead. I don't think it should ever happen, but internal consistency checks are probably not a bad idea anyways.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] None

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Replace all calls of `convert_int_array_to_vector` in `libmoinfo` with simple assignment-initialization
- [x] Add internal consistency checks to guard against possible hazards
- [x] Remove now-unused function `MOInfoBase::convert_int_array_to_vector`

## Questions
-  If everyone else is confident that the checks are redundant I _could_ remove them.

## Checklist
- [x] No new features
- [x] No new errors in the full test suite

## Status
- [x] Ready for review
- [x] Ready for merge
