### PR TITLE
Small Refactor of Exception Call Stack Size

### DIFF
--- a/psi4/src/psi4/libpsi4util/exception.cc
+++ b/psi4/src/psi4/libpsi4util/exception.cc
@@ -33,8 +33,8 @@
 #include <cxxabi.h>
 #endif
 
+#include <array>
 #include <cstdlib>
-#include <vector>
 
 namespace psi {
 
@@ -49,13 +49,14 @@ PsiException::PsiException(std::string msg, const char *_file, int _line) noexce
 // Disable stack trace printing on Windows
 #ifndef _MSC_VER
 
-    std::vector<void *> Stack(5);
+    constexpr size_t stacksize = 5;
+    std::array<void *, stacksize> Stack;
     char **strings;
-    int size = backtrace(&Stack[0], 5);
+    int size = backtrace(Stack.data(), stacksize);
     int status = -1;
 
-    message << "The most recent " << (size < 5 ? size : 5) << " function calls were:" << std::endl << std::endl;
-    strings = backtrace_symbols(&Stack[0], size);
+    message << "The most recent " << (size < stacksize ? size : stacksize) << " function calls were:" << std::endl << std::endl;
+    strings = backtrace_symbols(Stack.data(), size);
 
     for (int i = 0; i < size; i++) {
         // This part from https://panthema.net/2008/0901-stacktrace-demangled/


### PR DESCRIPTION
## Description
This PR makes small changes to the `PsiException` class, specifically regarding the printout of the function call stack upon throwing. Now, the number of functions included in the printed call stack during exception printout is tied to a singular variable, instead of being scattered about in multiple places. The goal is to allow easier control of the function call stack size during printout for debugging purposes, if desired. 

There are a couple small cleanups here and there as well.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [X] N/A

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [X] All separate instances of function call stack printout sizes have been replaced with a single variable definition.
- [X] The `Stack` variable now uses a `std::array` instead of a `std::vector`.
- [X] Uses of `&Stack[0]` have been replaced with `Stack.data()`.

## Questions
- [X] N/A

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [x] Ready for merge
