### PR TITLE
Change CompositeJK::name() Behavior

### DIFF
--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1287,8 +1287,8 @@ class PSI_API CompositeJK : public JK {
     void clear_D_prev() { D_prev_.clear();}
 
     // => Knobs <= //
-    std::string name() override { return "CompositeJK"; }
-
+    std::string name() override { return j_algo_->name() + "+" + k_algo_->name(); }
+ 
     /**
     * Set to do K tasks
     * @param do_K do K matrices or not,


### PR DESCRIPTION
## Description
Here's another JK mini-PR. This one seems to be of interest in multiple future JK-related developments (such as https://github.com/psi4/psi4/pull/3158), so I figured it would be good to add it on its own.

This PR changes the behavior of `CompositeJK::name()` so that, instead of returning the value "CompositeJK", it returns the names of the underlying `SplitJK` algorithms used. Additionally, using this feature, a new test has been added to `test_compositejk.py`, testing to make sure that proper composite algorithm pairs are called, given an input `SCF_TYPE=J_ALGO + K_ALGO`.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [X] Improves behavior of the `CompositeJK::name()` function.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [X] `CompositeJK::name()` now returns the combined names of the substituent `SplitJK` components rather than "CompositeJK".
- [X] Adds new test to ensure proper calling of CompositeJK algorithm pairs.

## Questions
- [X] N/A

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [x] Ready for merge
