### PR TITLE
Replace SplitJK method-specific functions with typecasts

### DIFF
--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -248,7 +248,7 @@ jobs:
         workingDirectory: $(Build.BinariesDirectory)/build
 
       - script: |
-          objdump.exe -p D:/a/*/b/install/lib/psi4/core.*.pyd | grep dll
+          objdump.exe -p $(Build.BinariesDirectory)/install/lib/psi4/core.*.pyd | grep dll
         displayName: "Library dependencies"
 
       # Test (ctest)

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -248,7 +248,7 @@ jobs:
         workingDirectory: $(Build.BinariesDirectory)/build
 
       - script: |
-          objdump.exe -p D:/a/1/b/install/lib/psi4/core.*.pyd | grep dll
+          objdump.exe -p D:/a/*/b/install/lib/psi4/core.*.pyd | grep dll
         displayName: "Library dependencies"
 
       # Test (ctest)

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -301,7 +301,7 @@ void CompositeJK::compute_JK() {
         timer_on("CompositeJK: " + k_algo_->name());
 
         if (k_algo_->name() == "COSX") {
-            std::string gridname = get_COSX_grid(); 
+            std::string gridname = get_COSX_grid();
             timer_on("COSX " + gridname + " Grid");
         }
 
@@ -312,7 +312,7 @@ void CompositeJK::compute_JK() {
         }
 
         if (k_algo_->name() == "COSX") {
-            std::string gridname = get_COSX_grid(); 
+            std::string gridname = get_COSX_grid();
             timer_off("COSX " + gridname + " Grid");
         }
 

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -348,7 +348,7 @@ std::string CompositeJK::get_COSX_grid() {
         auto k_algo_derived = std::dynamic_pointer_cast<COSK>(k_algo_); 
         return k_algo_derived->get_grid(); 
     } else {
-        throw PSIEXCEPTION("CompositeJK::set_COSX_grid() was called, but COSX is not selected in SCF_TYPE!");
+        throw PSIEXCEPTION("CompositeJK::get_COSX_grid() was called, but COSX is not selected in SCF_TYPE!");
     }
 }
 

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -52,7 +52,6 @@ using namespace psi;
 
 namespace psi {
 
-
 CompositeJK::CompositeJK(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary, Options& options) : JK(primary), auxiliary_(auxiliary), options_(options) {
     timer_on("CompositeJK: Setup");
     common_init(); 
@@ -302,7 +301,7 @@ void CompositeJK::compute_JK() {
         timer_on("CompositeJK: " + k_algo_->name());
 
         if (k_algo_->name() == "COSX") {
-            std::string gridname = k_algo_->get_COSX_grid();
+            std::string gridname = get_COSX_grid(); 
             timer_on("COSX " + gridname + " Grid");
         }
 
@@ -313,7 +312,7 @@ void CompositeJK::compute_JK() {
         }
 
         if (k_algo_->name() == "COSX") {
-            std::string gridname = k_algo_->get_COSX_grid();
+            std::string gridname = get_COSX_grid(); 
             timer_off("COSX " + gridname + " Grid");
         }
 
@@ -332,5 +331,25 @@ void CompositeJK::compute_JK() {
 }
 
 void CompositeJK::postiterations() {}
+
+// => Method-specific knobs go here <= //
+
+void CompositeJK::set_COSX_grid(std::string current_grid) { 
+    if (k_algo_->name() == "COSX") {
+        auto k_algo_derived = std::dynamic_pointer_cast<COSK>(k_algo_); 
+        k_algo_derived->set_grid(current_grid); 
+    } else {
+        throw PSIEXCEPTION("CompositeJK::set_COSX_grid() was called, but COSX is not selected in SCF_TYPE!");
+    }
+}
+
+std::string CompositeJK::get_COSX_grid() { 
+    if (k_algo_->name() == "COSX") {
+        auto k_algo_derived = std::dynamic_pointer_cast<COSK>(k_algo_); 
+        return k_algo_derived->get_grid(); 
+    } else {
+        throw PSIEXCEPTION("CompositeJK::set_COSX_grid() was called, but COSX is not selected in SCF_TYPE!");
+    }
+}
 
 }  // namespace psi

--- a/psi4/src/psi4/libfock/SplitJK.h
+++ b/psi4/src/psi4/libfock/SplitJK.h
@@ -126,17 +126,6 @@ class PSI_API SplitJK {
     * print name of method
     */
     virtual std::string name() = 0;
-
-    /**
-    * Method-specific knobs, if necessary
-    */
-    virtual void set_COSX_grid(std::string current_grid) {
-        throw PSIEXCEPTION("SplitJK::set_COSX_grid was called, but COSX is not being used!");
-    }
-
-    virtual std::string get_COSX_grid() {
-        throw PSIEXCEPTION("SplitJK::get_COSX_grid was called, but COSX is not being used!");
-    };
 };
 
 // ==> Start SplitJK Coulomb (J) Algorithms here <== //
@@ -307,8 +296,8 @@ class PSI_API COSK : public SplitJK {
     std::string name() override { return "COSX"; }
 
     // setter/getter for the COSX grid used for this SCF iteration
-    void set_COSX_grid(std::string current_grid) override { current_grid_ = current_grid; };
-    std::string get_COSX_grid() override { return current_grid_; };
+    void set_grid(std::string current_grid) { current_grid_ = current_grid; };
+    std::string get_grid() { return current_grid_; };
 };
 
 }

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1300,8 +1300,8 @@ class PSI_API CompositeJK : public JK {
     * Knobs for getting and setting current COSX grid for this SCF iteration, if COSX is used
     * throws by default, if COSX is not used
     */
-    void set_COSX_grid(std::string current_grid) { return k_algo_->set_COSX_grid(current_grid); }
-    std::string get_COSX_grid() { return k_algo_->get_COSX_grid(); }
+    void set_COSX_grid(std::string current_grid); 
+    std::string get_COSX_grid(); 
 
     /**
     * Print header information regarding JK

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1298,10 +1298,10 @@ class PSI_API CompositeJK : public JK {
 
     /**
     * Knobs for getting and setting current COSX grid for this SCF iteration, if COSX is used
-    * throws by default, if COSX is not used
+    * throws if COSX is not used
     */
-    void set_COSX_grid(std::string current_grid); 
-    std::string get_COSX_grid(); 
+    void set_COSX_grid(std::string current_grid);
+    std::string get_COSX_grid();
 
     /**
     * Print header information regarding JK


### PR DESCRIPTION
## Description
This PR was motivated by a comment by @andyj10224 in PR https://github.com/psi4/psi4/pull/3150, pointing out that implementing method-specific setters/getters in `SplitJK` could more elegantly and sensibly be performed via downcasting. While the comment in that PR addressed knobs specific to `snLinK`, it is also applicable to other methods within the CompositeJK framework. This PR fixes that, replacing all instances of method-specific setters/getters in the base `SplitJK` class with downcasting to call the needed function at the derived-class level.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [X] Renames `COSK::set_COSX_grid` and `COSK::get_COSX_grid` functions to `COSK::set_grid` and `COSK::get_grid`, respectively.
- [X] Removes `SplitJK::set_COSX_grid` and `SplitJK::get_COSX_grid` functions. 

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [X] Removes `SplitJK::set_COSX_grid` and `SplitJK::get_COSX_grid` functions, localizing their presence to the `COSK` class.
- [X] Replaces utilizations of the above with usage of downcasting in the `CompositeJK::set_COSX_grid` and `CompositeJK::get_COSX_grid` functions.

## Questions
- [X] N/A

## Checklist
- [X] Tests added for any new features
- [X] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [ ] Ready for merge
