### PR TITLE
Least Squares Tensor Hypercontraction (LS-THC) for ERIs (Part 2): Grid Pruning

### DIFF
--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -746,3 +746,7 @@ Bibliography
 .. not yet referenced    *J. Chem. Phys.* **137**, 224106 (2012).
 .. not yet referenced    https://doi.org/10.1063/1.4768233
 
+.. [Matthews:2020:1382]
+   D. A. Matthews
+   *J. Chem. Theory Comput.* **16**, 1382 (2020).
+   https://doi.org/10.1021/acs.jctc.9b01205

--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -746,7 +746,7 @@ Bibliography
 .. not yet referenced    *J. Chem. Phys.* **137**, 224106 (2012).
 .. not yet referenced    https://doi.org/10.1063/1.4768233
 
-.. [Matthews:2020:1382]
-   D. A. Matthews
-   *J. Chem. Theory Comput.* **16**, 1382 (2020).
-   https://doi.org/10.1021/acs.jctc.9b01205
+.. not yet referenced [Matthews:2020:1382]
+.. not yet referenced   D. A. Matthews
+.. not yet referenced   *J. Chem. Theory Comput.* **16**, 1382 (2020).
+.. not yet referenced   https://doi.org/10.1021/acs.jctc.9b01205

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -2052,7 +2052,7 @@ void Matrix::pivoted_cholesky(double tol, std::vector<std::vector<int>> &pivot) 
 
         // Perform decomposition. Since the matrix is symmetric, row vs column major ordering makes no difference.
         int rank;
-        int err = C_DPSTRF('L', rowspi_[h], matrix_[h][0], rowspi_[h], pivot[h].data(), &rank, tol, work.data());
+        int err = C_DPSTRF('U', rowspi_[h], matrix_[h][0], rowspi_[h], pivot[h].data(), &rank, tol, work.data());
         nchol[h] = rank;
 
         // Fix pivots, Fortran to C
@@ -2076,18 +2076,18 @@ void Matrix::pivoted_cholesky(double tol, std::vector<std::vector<int>> &pivot) 
     }
 
     // Properly sized return matrix
-    auto L = std::make_shared<Matrix>("Cholesky decomposed matrix", nirrep_, rowspi_, nchol);
-    L->zero();
+    auto U = std::make_shared<Matrix>("Cholesky decomposed matrix", nirrep_, rowspi_, nchol);
+    U->zero();
     for (int h = 0; h < nirrep_; ++h) {
         for (int m = 0; m < rowspi_[h]; ++m) {
-            for (int n = 0; n < std::min(m + 1, nchol[h]); ++n) {
+            for (int n = m; n < nchol[h]; ++n) {
                 // Psi4 stores matrices as row major, LAPACK as column major
-                L->set(h, m, n, get(h, n, m));
+                U->set(h, m, n, get(h, n, m));
             }
         }
     }
     // Switch to the properly sized matrix
-    *this = *L;
+    *this = *U;
 }
 
 SharedMatrix Matrix::partial_cholesky_factorize(double delta, bool throw_if_negative) {

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -2052,12 +2052,8 @@ void Matrix::pivoted_cholesky(double tol, std::vector<std::vector<int>> &pivot, 
 
         // Perform decomposition. Since the matrix is symmetric, row vs column major ordering makes no difference.
         int rank;
-        int err; 
-        if (upper) {
-            err = C_DPSTRF('U', rowspi_[h], matrix_[h][0], rowspi_[h], pivot[h].data(), &rank, tol, work.data());
-        } else {
-            err = C_DPSTRF('L', rowspi_[h], matrix_[h][0], rowspi_[h], pivot[h].data(), &rank, tol, work.data());
-        }
+        int err = C_DPSTRF(upper ? 'U' : 'L', rowspi_[h], matrix_[h][0], rowspi_[h], pivot[h].data(), &rank, tol, work.data());
+        
         nchol[h] = rank;
 
         // Fix pivots, Fortran to C
@@ -2081,6 +2077,8 @@ void Matrix::pivoted_cholesky(double tol, std::vector<std::vector<int>> &pivot, 
     }
 
     // Properly sized return matrix
+    Dimension zero(nirrep_);
+
     if (upper) {
         auto U = std::make_shared<Matrix>("Cholesky decomposed matrix", nirrep_, rowspi_, nchol);
         U->zero();

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -2028,7 +2028,7 @@ void Matrix::cholesky_factorize() {
     zero_upper();
 }
 
-void Matrix::pivoted_cholesky(double tol, std::vector<std::vector<int>> &pivot) {
+void Matrix::pivoted_cholesky(double tol, std::vector<std::vector<int>> &pivot, bool upper) {
     if (symmetry_) {
         throw PSIEXCEPTION("Matrix::pivoted_cholesky: Matrix is non-totally symmetric.");
     }
@@ -2052,7 +2052,12 @@ void Matrix::pivoted_cholesky(double tol, std::vector<std::vector<int>> &pivot) 
 
         // Perform decomposition. Since the matrix is symmetric, row vs column major ordering makes no difference.
         int rank;
-        int err = C_DPSTRF('U', rowspi_[h], matrix_[h][0], rowspi_[h], pivot[h].data(), &rank, tol, work.data());
+        int err; 
+        if (upper) {
+            err = C_DPSTRF('U', rowspi_[h], matrix_[h][0], rowspi_[h], pivot[h].data(), &rank, tol, work.data());
+        } else {
+            err = C_DPSTRF('L', rowspi_[h], matrix_[h][0], rowspi_[h], pivot[h].data(), &rank, tol, work.data());
+        }
         nchol[h] = rank;
 
         // Fix pivots, Fortran to C
@@ -2076,18 +2081,33 @@ void Matrix::pivoted_cholesky(double tol, std::vector<std::vector<int>> &pivot) 
     }
 
     // Properly sized return matrix
-    auto U = std::make_shared<Matrix>("Cholesky decomposed matrix", nirrep_, rowspi_, nchol);
-    U->zero();
-    for (int h = 0; h < nirrep_; ++h) {
-        for (int m = 0; m < rowspi_[h]; ++m) {
-            for (int n = m; n < nchol[h]; ++n) {
-                // Psi4 stores matrices as row major, LAPACK as column major
-                U->set(h, m, n, get(h, n, m));
+    if (upper) {
+        auto U = std::make_shared<Matrix>("Cholesky decomposed matrix", nirrep_, rowspi_, nchol);
+        U->zero();
+        for (int h = 0; h < nirrep_; ++h) {
+            for (int m = 0; m < rowspi_[h]; ++m) {
+                for (int n = m; n < nchol[h]; ++n) {
+                    // Psi4 stores matrices as row major, LAPACK as column major
+                    U->set(h, m, n, get(h, n, m));
+                }
             }
         }
+        // Switch to the properly sized matrix
+        *this = *U;
+    } else {
+        auto L = std::make_shared<Matrix>("Cholesky decomposed matrix", nirrep_, rowspi_, nchol);
+        L->zero();
+        for (int h = 0; h < nirrep_; ++h) {
+            for (int m = 0; m < rowspi_[h]; ++m) {
+                for (int n = 0; n < std::min(m + 1, nchol[h]); ++n) {
+                    // Psi4 stores matrices as row major, LAPACK as column major
+                    L->set(h, m, n, get(h, n, m));
+                }
+            }
+        }
+        // Switch to the properly sized matrix
+        *this = *L;
     }
-    // Switch to the properly sized matrix
-    *this = *U;
 }
 
 SharedMatrix Matrix::partial_cholesky_factorize(double delta, bool throw_if_negative) {

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -967,7 +967,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * This is the block version of the algorithm, calling Level 3
      * BLAS (dpstrf).
      */
-    void pivoted_cholesky(double tol, std::vector<std::vector<int>>& pivot);
+    void pivoted_cholesky(double tol, std::vector<std::vector<int>>& pivot, bool upper=false);
 
     /*! Computes the inverse of a real symmetric positive definite
      *  matrix A using the Cholesky factorization A = L*L**T

--- a/psi4/src/psi4/libmints/thc_eri.cc
+++ b/psi4/src/psi4/libmints/thc_eri.cc
@@ -274,7 +274,7 @@ SharedMatrix LS_THC_Computer::prune_grid() {
     auto Stp = S_temp->pointer();
 
     // Parrish 2012, Equation 28
-#pragma omp parallel for
+#pragma omp parallel for collapse(2) schedule(guided)
     for (size_t p = 0; p < npoints; ++p) {
         for (size_t q = 0; q < npoints; ++q) {
             S_Qq_p[p][q] = Stp[p][q] * Stp[p][q];
@@ -290,10 +290,13 @@ SharedMatrix LS_THC_Computer::prune_grid() {
 
     // Update factor matrix
     auto x1_new = std::make_shared<Matrix>(rank, nbf);
-#pragma omp parallel for
+    auto x1_newp = x1_new->pointer();
+    auto x1p = x1_->pointer();
+
+#pragma omp parallel for collapse(2) schedule(guided)
     for (size_t r = 0; r < rank; ++r) {
         for (size_t u = 0; u < nbf; ++u) {
-            (*x1_new)(r, u) = (*x1_)(pivot[0][r], u);
+            x1_newp[r][u] = x1p[pivot[0][r]][u];
         }
     }
     x1_ = x1_new;

--- a/psi4/src/psi4/libmints/thc_eri.cc
+++ b/psi4/src/psi4/libmints/thc_eri.cc
@@ -259,6 +259,51 @@ SharedMatrix LS_THC_Computer::build_E_df() {
     return linalg::triplet(E_temp, Jinv, E_temp, false, false, true);
 }
 
+/// @brief Drastically reduces the size of the grid using pivoted Cholesky decomposition (Parrish et al. 2012 procedure 2)
+SharedMatrix LS_THC_Computer::prune_grid() {
+
+    outfile->Printf("    Pruning grid using pivoted Cholesky (Matthews 2020)...\n");
+
+    size_t npoints = x1_->nrow();
+    size_t nbf = x1_->ncol();
+
+    SharedMatrix S_Qq = std::make_shared<Matrix>(npoints, npoints);
+    SharedMatrix S_temp = linalg::doublet(x1_, x1_, false, true);
+
+    auto S_Qq_p = S_Qq->pointer();
+    auto Stp = S_temp->pointer();
+
+    // Parrish 2012, Equation 28
+#pragma omp parallel for
+    for (size_t p = 0; p < npoints; ++p) {
+        for (size_t q = 0; q < npoints; ++q) {
+            S_Qq_p[p][q] = Stp[p][q] * Stp[p][q];
+        }
+    }
+
+    std::vector<std::vector<int>> pivot;
+    S_Qq->pivoted_cholesky(PSI_ZERO, pivot);
+
+    // Update S_Qq (returned as upper Cholesky factor of dimension (npoints, rank))
+    S_Qq = linalg::doublet(S_Qq, S_Qq, true, false);
+    size_t rank = S_Qq->nrow();
+
+    // Update factor matrix
+    auto x1_new = std::make_shared<Matrix>(rank, nbf);
+#pragma omp parallel for
+    for (size_t r = 0; r < rank; ++r) {
+        for (size_t u = 0; u < nbf; ++u) {
+            (*x1_new)(r, u) = (*x1_)(pivot[0][r], u);
+        }
+    }
+    x1_ = x1_new;
+
+    outfile->Printf("      Initial Rank (From Grid)      : %6d \n", npoints);
+    outfile->Printf("      Final Rank (Pivoted Cholesky) : %6d \n\n", rank);
+
+    return S_Qq;
+}
+
 /// @brief Factors ERIs into a product of two-index tensors through LS-THC algorithm (Parrish et al. 2012 Procedure 1)
 void LS_THC_Computer::compute_thc_factorization() {
 
@@ -320,11 +365,20 @@ void LS_THC_Computer::compute_thc_factorization() {
         point_idx += block->npoints();
     }
 
+    timer_off("LS-THC: Build Grid");
+
+    timer_on("LS-THC: Prune Grid");
+
+    // Matthews 2020
+    auto S_Qq = prune_grid();
+    size_t rank = S_Qq->nrow();
+
+    // In AO basis, all factors are equal
     x2_ = x1_;
     x3_ = x1_;
     x4_ = x1_;
 
-    timer_off("LS-THC: Build Grid");
+    timer_off("LS-THC: Prune Grid");
     
     timer_on("LS-THC: Form E");
 
@@ -333,27 +387,13 @@ void LS_THC_Computer::compute_thc_factorization() {
 
     timer_off("LS-THC: Form E");
 
-    timer_on("LS-THC: Form S");
-
-    SharedMatrix S_Qq = std::make_shared<Matrix>(npoints, npoints);
-    SharedMatrix S_temp = linalg::doublet(x1_, x1_, false, true);
-
-    auto S_Qq_p = S_Qq->pointer();
-    auto Stp = S_temp->pointer();
-
-    // Parrish 2012, Equation 28
-#pragma omp parallel for
-    for (size_t p = 0; p < npoints; ++p) {
-        for (size_t q = 0; q < npoints; ++q) {
-            S_Qq_p[p][q] = Stp[p][q] * Stp[p][q];
-        }
-    }
+    timer_on("LS-THC: S Pseudoinverse");
 
     // Parrish 2012, Equation 30
     int nremoved = 0;
     SharedMatrix S_Qq_inv = S_Qq->pseudoinverse(options_.get_double("LS_THC_S_EPSILON"), nremoved);
 
-    timer_off("LS-THC: Form S");
+    timer_off("LS-THC: S Pseudoinverse");
 
     timer_on("LS-THC: Form Z");
 
@@ -363,10 +403,11 @@ void LS_THC_Computer::compute_thc_factorization() {
     timer_off("LS-THC: Form Z");
 
     outfile->Printf("    Tensor Hypercontraction Complete! \n\n");
-    outfile->Printf("    Number of Grid Points (Rank) : %6d (%3d per atom)\n\n", npoints, npoints / molecule_->natom());
+    outfile->Printf("    (Initial) Number of Grid Points : %6d (%3d per atom)\n", npoints, npoints / molecule_->natom());
+    outfile->Printf("    (Final) Number of Grid Points   : %6d (%3d per atom)\n\n", rank, rank / molecule_->natom());
     outfile->Printf("    Memory Required to Store Exact Integrals : %6.3f [GiB]\n", (nbf * (nbf + 1) / 2) * (nbf * (nbf + 1) / 2 + 1) / 2 * pow(2.0, -30) * sizeof(double));
     if (auxiliary_) outfile->Printf("    Memory Required to Store DF Integrals : %6.3f [GiB]\n", auxiliary_->nbf() * nbf * (nbf + 1) / 2 * pow(2.0, -30) * sizeof(double));
-    outfile->Printf("    Memory Required in LS-THC factored form  : %6.3f [GiB]\n\n", (npoints * (npoints + nbf)) * pow(2.0, -30) * sizeof(double));
+    outfile->Printf("    Memory Required in LS-THC factored form  : %6.3f [GiB]\n\n", (rank * (rank + nbf)) * pow(2.0, -30) * sizeof(double));
 }
 
 }

--- a/psi4/src/psi4/libmints/thc_eri.cc
+++ b/psi4/src/psi4/libmints/thc_eri.cc
@@ -282,7 +282,7 @@ SharedMatrix LS_THC_Computer::prune_grid() {
     }
 
     std::vector<std::vector<int>> pivot;
-    S_Qq->pivoted_cholesky(PSI_ZERO, pivot);
+    S_Qq->pivoted_cholesky(PSI_ZERO, pivot, true);
 
     // Update S_Qq (returned as upper Cholesky factor of dimension (npoints, rank))
     S_Qq = linalg::doublet(S_Qq, S_Qq, true, false);

--- a/psi4/src/psi4/libmints/thc_eri.h
+++ b/psi4/src/psi4/libmints/thc_eri.h
@@ -98,6 +98,7 @@ class LS_THC_Computer : public THC_Computer {
     /// Parrish LS-THC Procedure 3
     SharedMatrix build_E_df();
     /// Matthews 2020 SI Page 5 (returns S matrix using rank-reduced grid)
+    /// doi: 10.1021/acs.jctc.9b01205
     SharedMatrix prune_grid();
 
    public:

--- a/psi4/src/psi4/libmints/thc_eri.h
+++ b/psi4/src/psi4/libmints/thc_eri.h
@@ -97,6 +97,8 @@ class LS_THC_Computer : public THC_Computer {
     SharedMatrix build_E_exact();
     /// Parrish LS-THC Procedure 3
     SharedMatrix build_E_df();
+    /// Matthews 2020 SI Page 5 (returns S matrix using rank-reduced grid)
+    SharedMatrix prune_grid();
 
    public:
     LS_THC_Computer(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> primary, Options& options);


### PR DESCRIPTION
## Description
This PR implements the grid pruning scheme of Matthews (https://pubs.acs.org/doi/10.1021/acs.jctc.9b01205), applying a pivoted Cholesky decomposition to the S matrix to remove linear dependencies and drastically reduce the number of grid points. Per @PhillCli's comments on #3157, taking the pseudoinverse of the S matrix can be costly, and this PR fixes that problem! The final rank appears to be _mostly_ invariant to grid size, but only to the molecule/basis set (results in tables below)

| System | Radial, Spherical Points | Initial Rank | Final Rank |
| ------------- | ------------- | ------------- | ------------- |
| Water/cc-pVDZ  | (25, 50) | 2605 | 280 |
| Water/cc-pVDZ  | (50, 86) | 8739 | 280 |
| Water/cc-pVTZ  | (25, 50) | 2630 | 1184 |
| Water/cc-pVTZ  | (50, 86) | 8774 | 1328 |
| Benzene/cc-pVDZ | (25, 50) | 9831 | 3124 |
| Benzene/cc-pVDZ | (50, 86) | 32588 | 3414 |

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Drastically reduction of the rank of the intermediates in a THC factorization

## Questions
- [x] The pivoted Cholesky algorithm presented by Matthews requires the upper triangular form. I modified the algorithm in matrix.cc to the upper triangular form because `Matrix::pivoted_cholesky` is not called elsewhere. Is this okay?

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
