### PR TITLE
Add missing basis set to nbody example in docs

### DIFF
--- a/doc/sphinxman/source/nbody.rst
+++ b/doc/sphinxman/source/nbody.rst
@@ -50,6 +50,10 @@ The nbody function computes counterpoise-corrected (CP), non-CP (noCP), and Vali
 
 **Examples :** ::
 
+    set {
+      basis def2-svp
+    }
+
     # Counterpoise corrected CCSD(T) energies for the Helium dimer
     molecule mol {
       He


### PR DESCRIPTION
## Description

The example in https://psicode.org/psi4manual/master/nbody.html is not copy-pasteable as-is, it's missing a basis set.  I picked something small and not horrible so it finishes in a reasonable amount of time.

## Status
- [x] Ready for review
- [ ] Ready for merge
