### PR TITLE
Opt options

### DIFF
--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -149,6 +149,10 @@ Bibliography
    Bofill,
    *J. Comp. Chem.* **15**, 1-11 (1994).
 
+.. [Besalu:1998:265]
+   Besalú, E., Bofill, J.,
+   *Theor Chem Acc* **100**, 265–274 (1998)
+
 .. [Piecuch:1999:6103]
    P. Piecuch, S. A. Kicharski, and R. J. Bartlett,
    *J. Chem. Phys.* **110**, 6103 (1999).

--- a/doc/sphinxman/source/optking.rst
+++ b/doc/sphinxman/source/optking.rst
@@ -171,7 +171,7 @@ Transition States and Reaction Paths
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Optking currently has two transition state algorithms. The current default is the
-newer RS_I_RFO algorithm [Besalu:1998:265]. The old algorithm can be used by setting
+newer RS_I_RFO algorithm [Besalu:1998:265]_ . The old algorithm can be used by setting
 `STEP_TYPE P_RFO` for `OPT_TYPE TS`
 
 * Calculate a starting Hessian and optimize the "transition state" of

--- a/doc/sphinxman/source/optking.rst
+++ b/doc/sphinxman/source/optking.rst
@@ -170,6 +170,10 @@ The Hessian may be computed during an optimization using the
 Transition States and Reaction Paths
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Optking currently has two transition state algorithms. The current default is the
+newer RS_I_RFO algorithm [Besalu:1998:265]. The old algorithm can be used by setting
+`STEP_TYPE P_RFO` for `OPT_TYPE TS`
+
 * Calculate a starting Hessian and optimize the "transition state" of
   linear water (note that without a reasonable starting geometry and
   Hessian, such a straightforward search often fails)::

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2696,12 +2696,12 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- Specifies minimum search, transition-state search, or IRC following -*/
         options.add_str("OPT_TYPE", "MIN", "MIN TS IRC");
         /*- Geometry optimization step type, either Newton-Raphson or Rational Function Optimization -*/
-        options.add_str("STEP_TYPE", "RFO", "RFO P_RFO NR SD LINESEARCH");
+        options.add_str("STEP_TYPE", "RFO", "RFO RS_I_RFO P_RFO NR SD LINESEARCH");
         /*- Geometry optimization coordinates to use.
             REDUNDANT and INTERNAL are synonyms and the default.
             CARTESIAN uses only cartesian coordinates.
             BOTH uses both redundant and cartesian coordinates.  -*/
-        options.add_str("OPT_COORDINATES", "INTERNAL", "REDUNDANT INTERNAL CARTESIAN BOTH");
+        options.add_str("OPT_COORDINATES", "INTERNAL", "REDUNDANT INTERNAL CARTESIAN BOTH CUSTOM");
         /*- Do follow the initial RFO vector after the first step? -*/
         options.add_bool("RFO_FOLLOW_ROOT", false);
         /*- Root for RFO to follow, 0 being lowest (for a minimum) -*/


### PR DESCRIPTION
## Description
Adds new optking options to `read_options.cc`. Adds soon to be added `OPT_COORDINATES CUSTOM` option.

## User API & Changelog headlines
- [x] Default TS search algorithm is now RS_I_RFO

## Checklist
- [x] opt16 now by default tests with RS_I_RFO (old algorithm still tested by optking's test suite)
- [x] `-L opt`

## Status
- [x] Ready for review
- [ ] Ready for merge
