### PR TITLE
Opt options

### DIFF
--- a/doc/sphinxman/source/optking.rst
+++ b/doc/sphinxman/source/optking.rst
@@ -281,8 +281,7 @@ For bends, the corresponding keyword is "frozen_bend".
     breaking, while Cartesian constraints are active, symmetrization cannot occur and
     an error will be raised, prompting you to restart the job.
 
-* As a shortcut, the entire set of dihedral angles can be frozen. A subset can then be unfrozen if
-desired.
+* As a shortcut, the entire set of dihedral angles can be frozen. A subset can then be unfrozen if desired.
 
 .. code-block:: none
 

--- a/doc/sphinxman/source/optking.rst
+++ b/doc/sphinxman/source/optking.rst
@@ -281,6 +281,17 @@ For bends, the corresponding keyword is "frozen_bend".
     breaking, while Cartesian constraints are active, symmetrization cannot occur and
     an error will be raised, prompting you to restart the job.
 
+* As a shortcut, the entire set of dihedral angles can be frozen. A subset can then be unfrozen if
+desired.
+
+.. code-block:: none
+
+	set {
+		freeze_all_dihedrals true
+		unfreeze_dihedrals "1 2 3 4"
+	}
+
+
 * To scan the potential energy surface by optimizing at several fixed values
   of the dihedral angle of HOOH.
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2700,8 +2700,12 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- Geometry optimization coordinates to use.
             REDUNDANT and INTERNAL are synonyms and the default.
             CARTESIAN uses only cartesian coordinates.
-            BOTH uses both redundant and cartesian coordinates.  -*/
+            BOTH uses both redundant and cartesian coordinates.
+            CUSTOM is not fully implemented yet - expected optking 0.3.1  -*/
         options.add_str("OPT_COORDINATES", "INTERNAL", "REDUNDANT INTERNAL CARTESIAN BOTH CUSTOM");
+        /*- A string formatted as a dicitonary containing a set of coordinates. Coordinates can be
+            appended to Optking's coordinate set or used on their own - expected optking 0.3.1. -*/
+        options.add_str("CUSTOM_COORDS", "")
         /*- Do follow the initial RFO vector after the first step? -*/
         options.add_bool("RFO_FOLLOW_ROOT", false);
         /*- Root for RFO to follow, 0 being lowest (for a minimum) -*/
@@ -2757,6 +2761,10 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- Specify range for the out-of-plane angles between atoms to be constrained to (eq. value specified)
             analogous to the old FIXED_<COORD> keyword-*/
         options.add_str("RANGED_OOFP", "");
+        /*- Freeze ALL dihedral angles -*/
+        options.add_bool("FREEZE_ALL_DIHEDRALS", false)
+        /*- Unfreeze a subset of dihedrals - meant for use with freeze_all_dihedrals -*/
+        options.add_str("UNFREEZE_DIHEDRALS", "")
 
         /*- Specify formula for external forces for the distance between atoms -*/
         options.add_str("EXT_FORCE_DISTANCE", "");

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2705,7 +2705,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_str("OPT_COORDINATES", "INTERNAL", "REDUNDANT INTERNAL CARTESIAN BOTH CUSTOM");
         /*- A string formatted as a dicitonary containing a set of coordinates. Coordinates can be
             appended to Optking's coordinate set or used on their own - expected optking 0.3.1. -*/
-        options.add_str("CUSTOM_COORDS", "")
+        options.add_str("CUSTOM_COORDS", "");
         /*- Do follow the initial RFO vector after the first step? -*/
         options.add_bool("RFO_FOLLOW_ROOT", false);
         /*- Root for RFO to follow, 0 being lowest (for a minimum) -*/
@@ -2762,9 +2762,9 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
             analogous to the old FIXED_<COORD> keyword-*/
         options.add_str("RANGED_OOFP", "");
         /*- Freeze ALL dihedral angles -*/
-        options.add_bool("FREEZE_ALL_DIHEDRALS", false)
+        options.add_bool("FREEZE_ALL_DIHEDRALS", false);
         /*- Unfreeze a subset of dihedrals - meant for use with freeze_all_dihedrals -*/
-        options.add_str("UNFREEZE_DIHEDRALS", "")
+        options.add_str("UNFREEZE_DIHEDRALS", "");
 
         /*- Specify formula for external forces for the distance between atoms -*/
         options.add_str("EXT_FORCE_DISTANCE", "");


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Adds optking keywords missed in #3204. For users, if these options are needed with an older version of Psi4, they can be passed through `psi4.optimize(..., 'optimizer_keywords'=)` to optking. Features require `optking >= 0.3.0`

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Adds shortcut for freezing all dihedrals in a molecule `freeze_all_dihedrals` and `unfreeze_dihedrals` 

## Checklist
- [x] Ran -L opt subset
- [x] keywords checked explicitly in optking's tests  

## Status
- [x] Ready for review
- [ ] Ready for merge
