### PR TITLE
'python' may not be available, use the same Python to run the tests

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -116,7 +116,7 @@ elif os.path.isfile(infile.replace(".dat", ".py")):
     else:
         os.environ["PYTHONPATH"] = psilibdir
     outfile = os.path.dirname(infile) + os.path.sep + outfile
-    pyexitcode = backtick(["python", infile, " > ", outfile])
+    pyexitcode = backtick([sys.executable, infile, " > ", outfile])
 else:
     raise Exception("\n\nError: Input file %s not found\n" % infile)
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
On the Fedora build system, `python` is not available which causes tests to fail.
This patch fixes this issue for good.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
