### PR TITLE
fix CI

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -9,15 +9,16 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      gcc_10:
-        CXX_COMPILER: 'g++-10'
+      gcc_11:
+        CXX_COMPILER: 'g++-11'
         PYTHON_VER: '3.8'
-        C_COMPILER: 'gcc-10'
+        C_COMPILER: 'gcc-11'
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'
-        APT_INSTALL: 'gfortran gcc-10 g++-10'
+        APT_INSTALL: 'gfortran gcc-11 g++-11'
         vmImage: 'ubuntu-20.04'
         PYTEST_MARKER_EXPR: "quick"
+        ENABLE_Einsums: 'ON'
 
       gcc_latest:
         CXX_COMPILER: 'g++'
@@ -28,6 +29,7 @@ jobs:
         APT_INSTALL: 'gfortran'
         vmImage: 'ubuntu-latest'
         PYTEST_MARKER_EXPR: 'api and not stdsuite and not (smoke or quick or medlong or long)'
+        ENABLE_Einsums: 'ON'
 
       clang_latest:
         CXX_COMPILER: 'clang++'
@@ -38,6 +40,7 @@ jobs:
         APT_INSTALL: 'gfortran clang-6.0'
         vmImage: 'ubuntu-20.04'
         PYTEST_MARKER_EXPR: 'cli and not (smoke or quick or medlong or long)'
+        ENABLE_Einsums: 'OFF'
 
   pool:
     vmImage: $(vmImage)
@@ -131,7 +134,7 @@ jobs:
         -D CMAKE_Fortran_COMPILER=${F_COMPILER} \
         -D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
         -D ENABLE_PLUGIN_TESTING=ON \
-        -D ENABLE_Einsums=ON \
+        -D ENABLE_Einsums=${ENABLE_Einsums} \
         -D ENABLE_IntegratorXX=ON \
         -D ENABLE_gauxc=ON \
         -D FORCE_PEDANTIC=ON \

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -18,7 +18,7 @@ jobs:
         APT_INSTALL: 'gfortran gcc-11 g++-11'
         vmImage: 'ubuntu-22.04'
         PYTEST_MARKER_EXPR: "quick"
-        ENABLE_Einsums: 'ON'
+        ENABLE_EINSUMS: "ON"
 
       gcc_latest:
         CXX_COMPILER: 'g++'
@@ -29,7 +29,7 @@ jobs:
         APT_INSTALL: 'gfortran'
         vmImage: 'ubuntu-latest'
         PYTEST_MARKER_EXPR: 'api and not stdsuite and not (smoke or quick or medlong or long)'
-        ENABLE_Einsums: 'ON'
+        ENABLE_EINSUMS: "ON"
 
       clang_latest:
         CXX_COMPILER: 'clang++'
@@ -40,7 +40,7 @@ jobs:
         APT_INSTALL: 'gfortran clang-6.0'
         vmImage: 'ubuntu-20.04'
         PYTEST_MARKER_EXPR: 'cli and not (smoke or quick or medlong or long)'
-        ENABLE_Einsums: 'OFF'
+        ENABLE_EINSUMS: "OFF"
 
   pool:
     vmImage: $(vmImage)
@@ -134,7 +134,7 @@ jobs:
         -D CMAKE_Fortran_COMPILER=${F_COMPILER} \
         -D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
         -D ENABLE_PLUGIN_TESTING=ON \
-        -D ENABLE_Einsums="${ENABLE_Einsums}" \
+        -D ENABLE_Einsums="${ENABLE_EINSUMS}" \
         -D ENABLE_IntegratorXX=ON \
         -D ENABLE_gauxc=ON \
         -D FORCE_PEDANTIC=ON \

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -134,7 +134,7 @@ jobs:
         -D CMAKE_Fortran_COMPILER=${F_COMPILER} \
         -D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
         -D ENABLE_PLUGIN_TESTING=ON \
-        -D ENABLE_Einsums=${ENABLE_Einsums} \
+        -D ENABLE_Einsums="${ENABLE_Einsums}" \
         -D ENABLE_IntegratorXX=ON \
         -D ENABLE_gauxc=ON \
         -D FORCE_PEDANTIC=ON \

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,7 +16,7 @@ jobs:
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'
         APT_INSTALL: 'gfortran gcc-11 g++-11'
-        vmImage: 'ubuntu-20.04'
+        vmImage: 'ubuntu-22.04'
         PYTEST_MARKER_EXPR: "quick"
         ENABLE_Einsums: 'ON'
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Einsums v0.6 needs gcc 11 or clang 16. don't want to bump psi4 requirements for opt'l dep, so bump gcc from 10->11 and don't build w/clang (currently 11). note that azure matrix vars like this _must_ be all caps to register.

## Status
- [x] Ready for review
- [x] Ready for merge
