### PR TITLE
Enabling SCF calculations with arbitrary external potential

### DIFF
--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -309,7 +309,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
             self.H().add(Vefp)
 
         SCFE = 0.0
-        self.clear_external_potentials()
+#       self.clear_external_potentials()
 
         # Two-electron contribution to Fock matrix from self.jk()
         core.timer_on("HF: Form G")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
A one-line change to enable an SCF calculation with an arbitrary one-electron matrix `X` added to the Fock matrix via `wfn.push_back_external_potential(X)`. Fixes #3227.

## Questions
- [x] Is this the right way to accomplish this goal (computing SCF with an extra 1-electron operator added to the Fock matrix)?
- [x] Does this mess up PCM/DDX/PE in any way? (It shouldn't).

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
