### PR TITLE
fix: slience annoying print outs in ip fitting jobs

### DIFF
--- a/psi4/driver/driver.py
+++ b/psi4/driver/driver.py
@@ -521,7 +521,7 @@ def energy(name, **kwargs):
             shutil.copy(item, targetfile)
 
     logger.info(f"Compute energy(): method={lowername}, basis={core.get_global_option('BASIS').lower()}, molecule={molecule.name()}, nre={'w/EFP' if hasattr(molecule, 'EFP') else molecule.nuclear_repulsion_energy()}")
-    logger.debug("w/EFP" if hasattr(molecule, "EFP") else pp.pformat(molecule.to_dict()))
+    logger.debug("w/EFP" if hasattr(molecule, "EFP") else pp.pformat(molecule.to_dict(quiet=kwargs.get("quiet", False))))
     wfn = procedures['energy'][lowername](lowername, molecule=molecule, **kwargs)
     logger.info(f"Return energy(): {core.variable('CURRENT ENERGY')}")
 

--- a/psi4/driver/frac.py
+++ b/psi4/driver/frac.py
@@ -560,7 +560,7 @@ def ip_fitting(name: Union[str, Callable], omega_l: float = 0.05, omega_r: float
         copy_file_to_scratch(read180, 'psi', 'ot', 180)
     core.set_local_option("SCF", "DF_INTS_IO", "SAVE")
     E, wfn = driver.energy('scf', dft_functional=name, return_wfn=True, molecule=molecule,
-                           banner='IP Fitting SCF: Burn-in', **kwargs)
+                           banner='IP Fitting SCF: Burn-in', quiet=True, **kwargs)
     core.set_local_option("SCF", "DF_INTS_IO", "LOAD")
 
     if not wfn.functional().is_x_lrc():
@@ -609,7 +609,7 @@ def ip_fitting(name: Union[str, Callable], omega_l: float = 0.05, omega_r: float
     molecule.set_molecular_charge(charge0)
     molecule.set_multiplicity(mult0)
     E0r, wfn = driver.energy('scf', dft_functional=name, return_wfn=True, molecule=molecule,
-                             banner='IP Fitting SCF: Neutral, Right Endpoint', **kwargs)
+                             banner='IP Fitting SCF: Neutral, Right Endpoint', quiet=True, **kwargs)
     eps_a = wfn.epsilon_a()
     eps_b = wfn.epsilon_b()
     if Nb == 0:
@@ -629,7 +629,7 @@ def ip_fitting(name: Union[str, Callable], omega_l: float = 0.05, omega_r: float
     molecule.set_molecular_charge(charge1)
     molecule.set_multiplicity(mult1)
     E1r = driver.energy('scf', dft_functional=name, molecule=molecule,
-                               banner='IP Fitting SCF: Cation, Right Endpoint', **kwargs)
+                               banner='IP Fitting SCF: Cation, Right Endpoint', quiet=True, **kwargs)
     core.IO.change_file_namespace(180, "ot", "cation")
 
     IPr = E1r - E0r
@@ -659,7 +659,7 @@ def ip_fitting(name: Union[str, Callable], omega_l: float = 0.05, omega_r: float
     core.set_global_option("DOCC", [Nb])
     core.set_global_option("SOCC", [Na - Nb])
     E0l, wfn = driver.energy('scf', dft_functional=name, return_wfn=True, molecule=molecule,
-                             banner='IP Fitting SCF: Neutral, Left Endpoint', **kwargs)
+                             banner='IP Fitting SCF: Neutral, Left Endpoint', quiet=True, **kwargs)
     eps_a = wfn.epsilon_a()
     eps_b = wfn.epsilon_b()
     if Nb == 0:
@@ -678,7 +678,7 @@ def ip_fitting(name: Union[str, Callable], omega_l: float = 0.05, omega_r: float
     core.set_global_option("DOCC", [Nb1])
     core.set_global_option("SOCC", [Na1 - Nb1])
     E1l = driver.energy('scf', dft_functional=name, molecule=molecule,
-                        banner='IP Fitting SCF: Cation, Left Endpoint', **kwargs)
+                        banner='IP Fitting SCF: Cation, Left Endpoint', quiet=True, **kwargs)
     core.IO.change_file_namespace(180, "ot", "cation")
 
     IPl = E1l - E0l
@@ -715,7 +715,7 @@ def ip_fitting(name: Union[str, Callable], omega_l: float = 0.05, omega_r: float
         core.set_global_option("DOCC", [Nb])
         core.set_global_option("SOCC", [Na - Nb])
         E0, wfn = driver.energy('scf', dft_functional=name, return_wfn=True, molecule=molecule,
-                                banner='IP Fitting SCF: Neutral, Omega = {:11.3E}'.format(omega), **kwargs)
+                                banner='IP Fitting SCF: Neutral, Omega = {:11.3E}'.format(omega), quiet=True, **kwargs)
         eps_a = wfn.epsilon_a()
         eps_b = wfn.epsilon_b()
         if Nb == 0:
@@ -733,7 +733,7 @@ def ip_fitting(name: Union[str, Callable], omega_l: float = 0.05, omega_r: float
         core.set_global_option("DOCC", [Nb1])
         core.set_global_option("SOCC", [Na1 - Nb1])
         E1 = driver.energy('scf', dft_functional=name, molecule=molecule,
-                           banner='IP Fitting SCF: Cation, Omega = {:11.3E}'.format(omega), **kwargs)
+                           banner='IP Fitting SCF: Cation, Omega = {:11.3E}'.format(omega), quiet=True, **kwargs)
         core.IO.change_file_namespace(180, "ot", "cation")
 
         IP = E1 - E0

--- a/psi4/driver/qcdb/molecule.py
+++ b/psi4/driver/qcdb/molecule.py
@@ -1549,7 +1549,7 @@ class Molecule(LibmintsMolecule):
         schmol = qcel.molparse.to_schema(molrec, dtype=dtype, units=units)
         return schmol
 
-    def to_dict(self, force_c1=False, force_units=False, np_out=True):
+    def to_dict(self, force_c1=False, force_units=False, np_out=True, quiet=False):
         """Serializes instance into Molecule dictionary."""
 
         self.update_geometry()
@@ -1643,13 +1643,15 @@ class Molecule(LibmintsMolecule):
         #   to_dict, but is included as a check. in practice, only fills in mass
         #   numbers and heals user chgmult.
         try:
-            validated_molrec = qcel.molparse.from_arrays(speclabel=False, verbose=0, domain='qm', **molrec)
+            _elemental_verbosity = -1 if quiet else 0
+            validated_molrec = qcel.molparse.from_arrays(speclabel=False, verbose=_elemental_verbosity, domain='qm', **molrec)
         except qcel.ValidationError as err:
             # * this can legitimately happen if total chg or mult has been set
             #   independently b/c fragment chg/mult not reset. so try again.
-            print(
+            if not quiet:
+                print(
                 """Following warning is harmless if you've altered chgmult through `set_molecular_change` or `set_multiplicity`. Such alterations are an expert feature. Specifying in the original molecule string is preferred. Nonphysical masses may also trigger the warning."""
-            )
+                )
             molrec['fragment_charges'] = [None] * len(fragments)
             molrec['fragment_multiplicities'] = [None] * len(fragments)
             validated_molrec = qcel.molparse.from_arrays(speclabel=False, nonphysical=True, verbose=0, domain='qm', **molrec)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Running ip_tunning clogs stdout by emitting non-silenced printouts, and red-herring warnings.
`ip_tune` does set charge/multiplicity via `set_molecular_charge` and `set_multiplicity`:
* https://github.com/psi4/psi4/blob/master/psi4/driver/frac.py#L609
* https://github.com/psi4/psi4/blob/master/psi4/driver/frac.py#L610C5-L610C37

so it should be safe to keep them out.

An example:
```log
...
c: [1.0, 0]
fc: [0.0]
m: [2]
fm: [3]
Following warning is harmless if you've altered chgmult through `set_molecular_change` or `set_multiplicity`. Such alterations are an expert feature. Specifying in the original molecule string is preferred. Nonphysical masses may also trigger the warning.


c: [1.0, 0]
fc: [0.0]
m: [2]
fm: [3]
Following warning is harmless if you've altered chgmult through `set_molecular_change` or `set_multiplicity`. Such alterations are an expert feature. Specifying in the original molecule string is preferred. Nonphysical masses may also trigger the warning.


c: [1.0, 0]
fc: [0.0]
m: [2]
fm: [3]
Following warning is harmless if you've altered chgmult through `set_molecular_change` or `set_multiplicity`. Such alterations are an expert feature. Specifying in the original molecule string is preferred. Nonphysical masses may also trigger the warning.


c: [1.0, 0]
fc: [0.0]
m: [2]
fm: [3]
Following warning is harmless if you've altered chgmult through `set_molecular_change` or `set_multiplicity`. Such alterations are an expert feature. Specifying in the original molecule string is preferred. Nonphysical masses may also trigger the warning.
...
```

```
c: [1.0, 0]
fc: [0.0]
m: [2]
fm: [3]
```
steems from https://github.com/psi4/psi4/blob/master/psi4/driver/qcdb/molecule.py#L1646

and can be silenced by setting `verbose=-1`,
the other is 4 lines below:

https://github.com/psi4/psi4/blob/master/psi4/driver/qcdb/molecule.py#L1650


This PR, adds `quiet` param to `to_dict` in Molecule and `energy` in Driver, and uses that in `ip_fitting` not to post both of them out.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] removed noise from stdout while running `ip_tunning`

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] silences plain `print` from `Molecule.to_dict()` - `qcel.molparse.from_arrays` and warning around setting charge/multiplicity when running `ip_fitting`. This shouldn't change other code paths.

## Questions
- [x] Do psi have any tests that test stdout with pytest?

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
