### PR TITLE
SAPT(DFT) auto compute GRAC

### DIFF
--- a/psi4/driver/procrouting/sapt/sapt_proc.py
+++ b/psi4/driver/procrouting/sapt/sapt_proc.py
@@ -93,7 +93,6 @@ def run_sapt_dft(name, **kwargs):
         sapt_dimer, "dimer"
     )
 
-
     # Print out the title and some information
     core.print_out("\n")
     core.print_out(
@@ -113,17 +112,14 @@ def run_sapt_dft(name, **kwargs):
     )
 
     core.print_out("  ==> Algorithm <==\n\n")
-    core.print_out("   SAPT DFT Functional     %12s\n" %
-                   str(sapt_dft_functional))
+    core.print_out("   SAPT DFT Functional     %12s\n" % str(sapt_dft_functional))
     core.print_out("   Monomer A GRAC Shift    %12.6f\n" % mon_a_shift)
     core.print_out("   Monomer B GRAC Shift    %12.6f\n" % mon_b_shift)
     core.print_out(
-        "   Delta HF                %12s\n" % (
-            "True" if do_delta_hf else "False")
+        "   Delta HF                %12s\n" % ("True" if do_delta_hf else "False")
     )
     core.print_out(
-        "   JK Algorithm            %12s\n" % core.get_global_option(
-            "SCF_TYPE")
+        "   JK Algorithm            %12s\n" % core.get_global_option("SCF_TYPE")
     )
     core.print_out("\n")
     core.print_out("   Required computations:\n")
@@ -141,6 +137,7 @@ def run_sapt_dft(name, **kwargs):
             core.get_option("SAPT", "SAPT_DFT_GRAC_CONVERGENCE_TIER"),
             "Monomer A",
         )
+        mon_a_shift = core.get_option("SAPT", "SAPT_DFT_GRAC_SHIFT_A")
     if do_mon_grac_shift_B:
         core.print_out("     GRAC(Monomer B)\n")
         compute_GRAC_shift(
@@ -148,6 +145,7 @@ def run_sapt_dft(name, **kwargs):
             core.get_option("SAPT", "SAPT_DFT_GRAC_CONVERGENCE_TIER"),
             "Monomer B",
         )
+        mon_b_shift = core.get_option("SAPT", "SAPT_DFT_GRAC_SHIFT_B")
     core.print_out("\n")
 
     if do_dft and ((mon_a_shift == 0.0) or (mon_b_shift == 0.0)):
@@ -222,8 +220,7 @@ def run_sapt_dft(name, **kwargs):
             )
             core.print_out("\n")
             core.print_out(
-                "         " +
-                "by Daniel G. A. Smith and Rob Parrish".center(58) + "\n"
+                "         " + "by Daniel G. A. Smith and Rob Parrish".center(58) + "\n"
             )
             core.print_out(
                 "         ---------------------------------------------------------\n"
@@ -261,8 +258,7 @@ def run_sapt_dft(name, **kwargs):
             core.timer_off("SAPT(HF):ind")
 
             dhf_value = (
-                hf_data["HF DIMER"] - hf_data["HF MONOMER A"] -
-                hf_data["HF MONOMER B"]
+                hf_data["HF DIMER"] - hf_data["HF MONOMER A"] - hf_data["HF MONOMER B"]
             )
 
             core.print_out("\n")
@@ -281,14 +277,12 @@ def run_sapt_dft(name, **kwargs):
             data["DFT MONOMER A"] = hf_data["HF MONOMER A"]
             data["DFT MONOMER B"] = hf_data["HF MONOMER B"]
             dhf_value = (
-                hf_data["HF DIMER"] - hf_data["HF MONOMER A"] -
-                hf_data["HF MONOMER B"]
+                hf_data["HF DIMER"] - hf_data["HF MONOMER A"] - hf_data["HF MONOMER B"]
             )
             data["DHF VALUE"] = dhf_value
 
     if hf_wfn_dimer is None:
-        dimer_wfn = core.Wavefunction.build(
-            sapt_dimer, core.get_global_option("BASIS"))
+        dimer_wfn = core.Wavefunction.build(sapt_dimer, core.get_global_option("BASIS"))
     else:
         dimer_wfn = hf_wfn_dimer
 
@@ -348,8 +342,7 @@ def run_sapt_dft(name, **kwargs):
     # Write out header
     scf_alg = core.get_global_option("SCF_TYPE")
     sapt_dft_header(
-        sapt_dft_functional, mon_a_shift, mon_b_shift, bool(
-            do_delta_hf), scf_alg
+        sapt_dft_functional, mon_a_shift, mon_b_shift, bool(do_delta_hf), scf_alg
     )
 
     # Compute Delta HF for SAPT(HF)?
@@ -381,12 +374,14 @@ def run_sapt_dft(name, **kwargs):
 
 def sapt_dft_grac_convergence_tier_options():
     return {
-        "SINGLE": [{
-            # "level_shift": 0.01,
-            # "level_shift_cutoff": 0.01,
-            "SCF_INITIAL_ACCELERATOR": "ADIIS",
-            # "MAXITER": 200,
-        }],
+        "SINGLE": [
+            {
+                # "level_shift": 0.01,
+                # "level_shift_cutoff": 0.01,
+                "SCF_INITIAL_ACCELERATOR": "ADIIS",
+                # "MAXITER": 200,
+            }
+        ],
         # "medium": {},
         # "high": {},
     }
@@ -405,17 +400,21 @@ def compute_GRAC_shift(
     dft_functional = core.get_option("SAPT", "SAPT_DFT_FUNCTIONAL")
     scf_reference = core.get_option("SCF", "REFERENCE")
 
-    for i in sapt_dft_grac_convergence_tier_options()[sap_dft_grac_convergence_tier.upper()]:
-        # for k, v in i.items():
-        #     core.set_global_option(k, v)
+    for i in sapt_dft_grac_convergence_tier_options()[
+        sap_dft_grac_convergence_tier.upper()
+    ]:
         core.set_local_option("SCF", "REFERENCE", "UHF")
         # Need to get the neutral and cation to estimate ionization energy for GRAC shift
         mol_qcel_dict = molecule.to_schema(dtype=2)
         print(f"{mol_qcel_dict = }")
+        # mol_qcel_dict["geometry"] = [
+        #     i / constants.bohr2angstroms for i in mol_qcel_dict["geometry"]
+        # ]
         del mol_qcel_dict["fragment_charges"]
         del mol_qcel_dict["fragment_multiplicities"]
         del mol_qcel_dict["molecular_multiplicity"]
         mol_qcel_dict["molecular_charge"] = 0
+
         mol_qcel = qcel.models.Molecule(**mol_qcel_dict)
         mol_neutral = core.Molecule.from_schema(mol_qcel.dict())
 
@@ -426,32 +425,42 @@ def compute_GRAC_shift(
         wfn_neutral = scf_helper(
             "SCF",
             molecule=mol_neutral,
+            functional=dft_functional,
             banner=f"GRAC Shift: Neutral {label}",
+        )
+        wfn_cation = scf_helper(
+            "SCF",
+            molecule=mol_cation,
+            functional=dft_functional,
+            banner=f"GRAC Shift: Cation {label}",
         )
         occ_neutral = wfn_neutral.epsilon_a_subset(basis="SO", subset="OCC").to_array(
             dense=True
         )
         HOMO = np.amax(occ_neutral)
-        wfn_cation = scf_helper(
-            "SCF",
-            molecule=mol_cation,
-            banner=f"GRAC Shift: Cation {label}",
-        )
 
-        e_neutral = wfn_neutral.energy()
-        e_cation = wfn_cation.energy()
-        print(f"{e_neutral = }, {e_cation = }, {HOMO = }")
-        grac = e_cation - e_neutral + HOMO
+        neut_geom = mol_neutral.to_arrays()[0]
+        cati_geom = mol_cation.to_arrays()[0]
+        print(neut_geom)
+        print(cati_geom)
+        E_neutral = wfn_neutral.energy()
+        E_cation = wfn_cation.energy()
+        print(f"{E_neutral = }, {E_cation = }, {HOMO = }")
+        grac = E_neutral - E_cation - HOMO
         print(f"{grac = }")
+        if grac >= 1 or grac <= -1:
+            print(f"{grac = }")
+            raise Exception("Grac appears wrong...")
         if label == "Monomer A":
-            core.set_global_option("SAPT", "SAPT_DFT_GRAC_SHIFT_A", grac)
             core.set_global_option("SAPT_DFT_GRAC_SHIFT_A", grac)
             core.set_variable("SAPT_DFT_GRAC_SHIFT_A", grac)
         elif label == "Monomer B":
             core.set_global_option("SAPT_DFT_GRAC_SHIFT_B", grac)
             core.set_variable("SAPT_DFT_GRAC_SHIFT_B", grac)
         else:
-            raise ValueError("Only Monomer A and Monomer B are valid GRAC shift options")
+            raise ValueError(
+                "Only Monomer A and Monomer B are valid GRAC shift options"
+            )
     core.set_local_option("SCF", "REFERENCE", scf_reference)
     optstash.restore()
     return
@@ -470,8 +479,7 @@ def sapt_dft_header(
         "         ---------------------------------------------------------\n"
     )
     core.print_out(
-        "         " +
-        "SAPT(DFT): Intermolecular Interaction Segment".center(58) + "\n"
+        "         " + "SAPT(DFT): Intermolecular Interaction Segment".center(58) + "\n"
     )
     core.print_out("\n")
     core.print_out(
@@ -483,8 +491,7 @@ def sapt_dft_header(
     core.print_out("\n")
 
     core.print_out("  ==> Algorithm <==\n\n")
-    core.print_out("   SAPT DFT Functional     %12s\n" %
-                   str(sapt_dft_functional))
+    core.print_out("   SAPT DFT Functional     %12s\n" % str(sapt_dft_functional))
     if mon_a_shift:
         core.print_out("   Monomer A GRAC Shift    %12.6f\n" % mon_a_shift)
     if mon_b_shift:
@@ -559,8 +566,7 @@ def sapt_dft(
             wfn_A.functional().x_omega() != wfn_B.functional().x_omega()
         ):
             core.print_out("   => Monomer B: Building SAPT JK object <= \n\n")
-            core.print_out(
-                "      Reason: MonomerA Omega != MonomerB Omega\n\n")
+            core.print_out("      Reason: MonomerA Omega != MonomerB Omega\n\n")
             sapt_jk_B = core.JK.build(dimer_wfn.basisset())
             sapt_jk_B.set_do_J(True)
             sapt_jk_B.set_do_K(True)
@@ -606,8 +612,7 @@ def sapt_dft(
     # Set Delta HF for SAPT(HF)
     if delta_hf:
         total_sapt = (
-            data["Elst10,r"] + data["Exch10"] +
-            data["Ind20,r"] + data["Exch-Ind20,r"]
+            data["Elst10,r"] + data["Exch10"] + data["Ind20,r"] + data["Exch-Ind20,r"]
         )
         sapt_hf_delta = data["DHF VALUE"] - total_sapt
         core.set_variable("SAPT(DFT) Delta HF", sapt_hf_delta)
@@ -689,25 +694,20 @@ def sapt_dft(
 
     # Exchange-dispersion scaling
     if do_dft:
-        exch_disp_scheme = core.get_option(
-            "SAPT", "SAPT_DFT_EXCH_DISP_SCALE_SCHEME")
-        core.print_out("    %-33s % s\n" %
-                       ("Scaling Scheme", exch_disp_scheme))
+        exch_disp_scheme = core.get_option("SAPT", "SAPT_DFT_EXCH_DISP_SCALE_SCHEME")
+        core.print_out("    %-33s % s\n" % ("Scaling Scheme", exch_disp_scheme))
         if exch_disp_scheme == "NONE":
             data["Exch-Disp20,r"] = data["Exch-Disp20,u"]
         elif exch_disp_scheme == "FIXED":
-            exch_disp_scale = core.get_option(
-                "SAPT", "SAPT_DFT_EXCH_DISP_FIXED_SCALE")
-            core.print_out("    %-28s % 10.3f\n" %
-                           ("Scaling Factor", exch_disp_scale))
+            exch_disp_scale = core.get_option("SAPT", "SAPT_DFT_EXCH_DISP_FIXED_SCALE")
+            core.print_out("    %-28s % 10.3f\n" % ("Scaling Factor", exch_disp_scale))
             data["Exch-Disp20,r"] = exch_disp_scale * data["Exch-Disp20,u"]
         elif exch_disp_scheme == "DISP":
             exch_disp_scale = data["Disp20"] / data["Disp20,u"]
             data["Exch-Disp20,r"] = exch_disp_scale * data["Exch-Disp20,u"]
         if exch_disp_scheme != "NONE":
             core.print_out(
-                print_sapt_var("Est. Exch-Disp20,r",
-                               data["Exch-Disp20,r"], short=True)
+                print_sapt_var("Est. Exch-Disp20,r", data["Exch-Disp20,r"], short=True)
                 + "\n"
             )
 
@@ -759,8 +759,7 @@ def run_sf_sapt(name, **kwargs):
     core.print_out("         " + "Spin-Flip SAPT Procedure".center(58) + "\n")
     core.print_out("\n")
     core.print_out(
-        "         " +
-        "by Daniel G. A. Smith and Konrad Patkowski".center(58) + "\n"
+        "         " + "by Daniel G. A. Smith and Konrad Patkowski".center(58) + "\n"
     )
     core.print_out(
         "         ---------------------------------------------------------\n"
@@ -769,8 +768,7 @@ def run_sf_sapt(name, **kwargs):
 
     core.print_out("  ==> Algorithm <==\n\n")
     core.print_out(
-        "   JK Algorithm            %12s\n" % core.get_option(
-            "SCF", "SCF_TYPE")
+        "   JK Algorithm            %12s\n" % core.get_option("SCF", "SCF_TYPE")
     )
     core.print_out("\n")
     core.print_out("   Required computations:\n")
@@ -806,13 +804,11 @@ def run_sf_sapt(name, **kwargs):
         "         ---------------------------------------------------------\n"
     )
     core.print_out(
-        "         " +
-        "Spin-Flip SAPT Exchange and Electrostatics".center(58) + "\n"
+        "         " + "Spin-Flip SAPT Exchange and Electrostatics".center(58) + "\n"
     )
     core.print_out("\n")
     core.print_out(
-        "         " +
-        "by Daniel G. A. Smith and Konrad Patkowski".center(58) + "\n"
+        "         " + "by Daniel G. A. Smith and Konrad Patkowski".center(58) + "\n"
     )
     core.print_out(
         "         ---------------------------------------------------------\n"

--- a/psi4/driver/procrouting/sapt/sapt_proc.py
+++ b/psi4/driver/procrouting/sapt/sapt_proc.py
@@ -37,130 +37,203 @@ from .. import proc_util
 from ..proc import scf_helper
 from . import sapt_jk_terms, sapt_mp2_terms, sapt_sf_terms
 from .sapt_util import print_sapt_dft_summary, print_sapt_hf_summary, print_sapt_var
+import qcelemental as qcel
 
 # Only export the run_ scripts
-__all__ = ['run_sapt_dft', 'sapt_dft', 'run_sf_sapt']
+__all__ = ["run_sapt_dft", "sapt_dft", "run_sf_sapt"]
 
 
 def run_sapt_dft(name, **kwargs):
-    optstash = p4util.OptionsState(['SCF_TYPE'], ['SCF', 'REFERENCE'], ['SCF', 'DFT_GRAC_SHIFT'], ['SCF', 'SAVE_JK'])
+    optstash = p4util.OptionsState(
+        ["SCF_TYPE"],
+        ["SCF", "REFERENCE"],
+        ["SCF", "DFT_GRAC_SHIFT"],
+        ["SCF", "SAVE_JK"],
+    )
 
     core.tstart()
     # Alter default algorithm
-    if not core.has_global_option_changed('SCF_TYPE'):
-        core.set_global_option('SCF_TYPE', 'DF')
+    if not core.has_global_option_changed("SCF_TYPE"):
+        core.set_global_option("SCF_TYPE", "DF")
 
     core.prepare_options_for_module("SAPT")
 
-    # Get the molecule of interest
-    ref_wfn = kwargs.get('ref_wfn', None)
-    if ref_wfn is None:
-        sapt_dimer = kwargs.pop('molecule', core.get_active_molecule())
-    else:
-        core.print_out('Warning! SAPT argument "ref_wfn" is only able to use molecule information.')
-        sapt_dimer = ref_wfn.molecule()
-
-    sapt_dimer, monomerA, monomerB = proc_util.prepare_sapt_molecule(sapt_dimer, "dimer")
-
     # Grab overall settings
+    do_mon_grac_shift_A = False
+    do_mon_grac_shift_B = False
     mon_a_shift = core.get_option("SAPT", "SAPT_DFT_GRAC_SHIFT_A")
     mon_b_shift = core.get_option("SAPT", "SAPT_DFT_GRAC_SHIFT_B")
+
+    if np.isclose(mon_a_shift, -99.0, atol=1e-6):
+        do_mon_grac_shift_A = True
+        print("Monomer A GRAC shift set to -99.0, will compute automatically.")
+    if np.isclose(mon_b_shift, -99.0, atol=1e-6):
+        do_mon_grac_shift_B = True
+        print("Monomer B GRAC shift set to -99.0, will compute automatically.")
+
     do_delta_hf = core.get_option("SAPT", "SAPT_DFT_DO_DHF")
     sapt_dft_functional = core.get_option("SAPT", "SAPT_DFT_FUNCTIONAL")
     do_dft = sapt_dft_functional != "HF"
 
+    # Get the molecule of interest
+    ref_wfn = kwargs.get("ref_wfn", None)
+    if ref_wfn is None:
+        sapt_dimer = kwargs.pop("molecule", core.get_active_molecule())
+    else:
+        core.print_out(
+            'Warning! SAPT argument "ref_wfn" is only able to use molecule information.'
+        )
+        sapt_dimer = ref_wfn.molecule()
+
+    if do_mon_grac_shift_A or do_mon_grac_shift_B:
+        monA = sapt_dimer.extract_subsets(1)
+        monB = sapt_dimer.extract_subsets(2)
+
+    sapt_dimer, monomerA, monomerB = proc_util.prepare_sapt_molecule(
+        sapt_dimer, "dimer"
+    )
+
+
     # Print out the title and some information
     core.print_out("\n")
-    core.print_out("         ---------------------------------------------------------\n")
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
     core.print_out("         " + "SAPT(DFT) Procedure".center(58) + "\n")
     core.print_out("\n")
     core.print_out("         " + "by Daniel G. A. Smith".center(58) + "\n")
-    core.print_out("         ---------------------------------------------------------\n")
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
     core.print_out("\n")
 
     # core.print_out("  !!!  WARNING:  SAPT(DFT) capability is in beta. Please use with caution. !!!\n\n")
-    core.print_out("Warning! The default value of SAPT_DFT_EXCH_DISP_SCALE_SCHEME has changed from DISP to FIXED. Please be careful comparing results with earlier versions. \n\n")
+    core.print_out(
+        "Warning! The default value of SAPT_DFT_EXCH_DISP_SCALE_SCHEME has changed from DISP to FIXED. Please be careful comparing results with earlier versions. \n\n"
+    )
 
     core.print_out("  ==> Algorithm <==\n\n")
-    core.print_out("   SAPT DFT Functional     %12s\n" % str(sapt_dft_functional))
+    core.print_out("   SAPT DFT Functional     %12s\n" %
+                   str(sapt_dft_functional))
     core.print_out("   Monomer A GRAC Shift    %12.6f\n" % mon_a_shift)
     core.print_out("   Monomer B GRAC Shift    %12.6f\n" % mon_b_shift)
-    core.print_out("   Delta HF                %12s\n" % ("True" if do_delta_hf else "False"))
-    core.print_out("   JK Algorithm            %12s\n" % core.get_global_option("SCF_TYPE"))
+    core.print_out(
+        "   Delta HF                %12s\n" % (
+            "True" if do_delta_hf else "False")
+    )
+    core.print_out(
+        "   JK Algorithm            %12s\n" % core.get_global_option(
+            "SCF_TYPE")
+    )
     core.print_out("\n")
     core.print_out("   Required computations:\n")
-    if (do_delta_hf):
+    if do_delta_hf:
         core.print_out("     HF  (Dimer)\n")
         core.print_out("     HF  (Monomer A)\n")
         core.print_out("     HF  (Monomer B)\n")
-    if (do_dft):
+    if do_dft:
         core.print_out("     DFT (Monomer A)\n")
         core.print_out("     DFT (Monomer B)\n")
+    if do_mon_grac_shift_A:
+        core.print_out("     GRAC(Monomer A)\n")
+        compute_GRAC_shift(
+            monA,
+            core.get_option("SAPT", "SAPT_DFT_GRAC_CONVERGENCE_TIER"),
+            "Monomer A",
+        )
+    if do_mon_grac_shift_B:
+        core.print_out("     GRAC(Monomer B)\n")
+        compute_GRAC_shift(
+            monB,
+            core.get_option("SAPT", "SAPT_DFT_GRAC_CONVERGENCE_TIER"),
+            "Monomer B",
+        )
     core.print_out("\n")
 
     if do_dft and ((mon_a_shift == 0.0) or (mon_b_shift == 0.0)):
-        raise ValidationError('SAPT(DFT): must set both "SAPT_DFT_GRAC_SHIFT_A" and "B".')
+        raise ValidationError(
+            'SAPT(DFT): must set both "SAPT_DFT_GRAC_SHIFT_A" and "B". To automatically compute the GRAC shift, set to -99.0.'
+        )
 
-    if (core.get_option('SCF', 'REFERENCE') != 'RHF'):
-        raise ValidationError('SAPT(DFT) currently only supports restricted references.')
+    if core.get_option("SCF", "REFERENCE") != "RHF":
+        raise ValidationError(
+            "SAPT(DFT) currently only supports restricted references."
+        )
 
-    core.IO.set_default_namespace('dimer')
+    core.IO.set_default_namespace("dimer")
     data = {}
 
-    if (core.get_global_option('SCF_TYPE') == 'DF'):
+    if core.get_global_option("SCF_TYPE") == "DF":
         # core.set_global_option('DF_INTS_IO', 'LOAD')
-        core.set_global_option('DF_INTS_IO', 'SAVE')
+        core.set_global_option("DF_INTS_IO", "SAVE")
 
     # Compute dimer wavefunction
     hf_wfn_dimer = None
     if do_delta_hf:
-        if (core.get_global_option('SCF_TYPE') == 'DF'):
-            core.set_global_option('DF_INTS_IO', 'SAVE')
+        if core.get_global_option("SCF_TYPE") == "DF":
+            core.set_global_option("DF_INTS_IO", "SAVE")
 
         core.timer_on("SAPT(DFT):Dimer SCF")
         hf_data = {}
-        hf_wfn_dimer = scf_helper("SCF", molecule=sapt_dimer, banner="SAPT(DFT): delta HF Dimer", **kwargs)
+        hf_wfn_dimer = scf_helper(
+            "SCF", molecule=sapt_dimer, banner="SAPT(DFT): delta HF Dimer", **kwargs
+        )
         hf_data["HF DIMER"] = core.variable("CURRENT ENERGY")
         core.timer_off("SAPT(DFT):Dimer SCF")
 
         core.timer_on("SAPT(DFT):Monomer A SCF")
-        if (core.get_global_option('SCF_TYPE') == 'DF'):
-            core.IO.change_file_namespace(97, 'dimer', 'monomerA')
+        if core.get_global_option("SCF_TYPE") == "DF":
+            core.IO.change_file_namespace(97, "dimer", "monomerA")
 
-        hf_wfn_A = scf_helper("SCF", molecule=monomerA, banner="SAPT(DFT): delta HF Monomer A", **kwargs)
+        hf_wfn_A = scf_helper(
+            "SCF", molecule=monomerA, banner="SAPT(DFT): delta HF Monomer A", **kwargs
+        )
         hf_data["HF MONOMER A"] = core.variable("CURRENT ENERGY")
         core.timer_off("SAPT(DFT):Monomer A SCF")
 
         core.timer_on("SAPT(DFT):Monomer B SCF")
         core.set_global_option("SAVE_JK", True)
-        if (core.get_global_option('SCF_TYPE') == 'DF'):
-            core.IO.change_file_namespace(97, 'monomerA', 'monomerB')
+        if core.get_global_option("SCF_TYPE") == "DF":
+            core.IO.change_file_namespace(97, "monomerA", "monomerB")
 
-        hf_wfn_B = scf_helper("SCF", molecule=monomerB, banner="SAPT(DFT): delta HF Monomer B", **kwargs)
+        hf_wfn_B = scf_helper(
+            "SCF", molecule=monomerB, banner="SAPT(DFT): delta HF Monomer B", **kwargs
+        )
         hf_data["HF MONOMER B"] = core.variable("CURRENT ENERGY")
         core.set_global_option("SAVE_JK", False)
         core.timer_off("SAPT(DFT):Monomer B SCF")
 
-        if do_dft: # For SAPT(HF) do the JK terms in sapt_dft()
+        if do_dft:  # For SAPT(HF) do the JK terms in sapt_dft()
             # Grab JK object and set to A (so we do not save many JK objects)
             sapt_jk = hf_wfn_B.jk()
             hf_wfn_A.set_jk(sapt_jk)
             core.set_global_option("SAVE_JK", False)
 
             # Move it back to monomer A
-            if (core.get_global_option('SCF_TYPE') == 'DF'):
-                core.IO.change_file_namespace(97, 'monomerB', 'dimer')
+            if core.get_global_option("SCF_TYPE") == "DF":
+                core.IO.change_file_namespace(97, "monomerB", "dimer")
 
             core.print_out("\n")
-            core.print_out("         ---------------------------------------------------------\n")
-            core.print_out("         " + "SAPT(DFT): delta HF Segment".center(58) + "\n")
+            core.print_out(
+                "         ---------------------------------------------------------\n"
+            )
+            core.print_out(
+                "         " + "SAPT(DFT): delta HF Segment".center(58) + "\n"
+            )
             core.print_out("\n")
-            core.print_out("         " + "by Daniel G. A. Smith and Rob Parrish".center(58) + "\n")
-            core.print_out("         ---------------------------------------------------------\n")
+            core.print_out(
+                "         " +
+                "by Daniel G. A. Smith and Rob Parrish".center(58) + "\n"
+            )
+            core.print_out(
+                "         ---------------------------------------------------------\n"
+            )
             core.print_out("\n")
 
             # Build cache
-            hf_cache = sapt_jk_terms.build_sapt_jk_cache(hf_wfn_A, hf_wfn_B, sapt_jk, True)
+            hf_cache = sapt_jk_terms.build_sapt_jk_cache(
+                hf_wfn_A, hf_wfn_B, sapt_jk, True
+            )
 
             # Electrostatics
             core.timer_on("SAPT(HF):elst")
@@ -176,19 +249,26 @@ def run_sapt_dft(name, **kwargs):
 
             # Induction
             core.timer_on("SAPT(HF):ind")
-            ind = sapt_jk_terms.induction(hf_cache,
-                                          sapt_jk,
-                                          True,
-                                          maxiter=core.get_option("SAPT", "MAXITER"),
-                                          conv=core.get_option("SAPT", "CPHF_R_CONVERGENCE"),
-                                          Sinf=core.get_option("SAPT", "DO_IND_EXCH_SINF"))
+            ind = sapt_jk_terms.induction(
+                hf_cache,
+                sapt_jk,
+                True,
+                maxiter=core.get_option("SAPT", "MAXITER"),
+                conv=core.get_option("SAPT", "CPHF_R_CONVERGENCE"),
+                Sinf=core.get_option("SAPT", "DO_IND_EXCH_SINF"),
+            )
             hf_data.update(ind)
             core.timer_off("SAPT(HF):ind")
 
-            dhf_value = hf_data["HF DIMER"] - hf_data["HF MONOMER A"] - hf_data["HF MONOMER B"]
+            dhf_value = (
+                hf_data["HF DIMER"] - hf_data["HF MONOMER A"] -
+                hf_data["HF MONOMER B"]
+            )
 
             core.print_out("\n")
-            core.print_out(print_sapt_hf_summary(hf_data, "SAPT(HF)", delta_hf=dhf_value))
+            core.print_out(
+                print_sapt_hf_summary(hf_data, "SAPT(HF)", delta_hf=dhf_value)
+            )
 
             data["Delta HF Correction"] = core.variable("SAPT(DFT) Delta HF")
             sapt_jk.finalize()
@@ -196,37 +276,43 @@ def run_sapt_dft(name, **kwargs):
             del hf_wfn_A, hf_wfn_B, sapt_jk
 
         else:
-            wfn_A = hf_wfn_A 
+            wfn_A = hf_wfn_A
             wfn_B = hf_wfn_B
-            data["DFT MONOMER A"] = hf_data["HF MONOMER A"] 
-            data["DFT MONOMER B"] = hf_data["HF MONOMER B"] 
-            dhf_value = hf_data["HF DIMER"] - hf_data["HF MONOMER A"] - hf_data["HF MONOMER B"]
+            data["DFT MONOMER A"] = hf_data["HF MONOMER A"]
+            data["DFT MONOMER B"] = hf_data["HF MONOMER B"]
+            dhf_value = (
+                hf_data["HF DIMER"] - hf_data["HF MONOMER A"] -
+                hf_data["HF MONOMER B"]
+            )
             data["DHF VALUE"] = dhf_value
 
     if hf_wfn_dimer is None:
-        dimer_wfn = core.Wavefunction.build(sapt_dimer, core.get_global_option("BASIS"))
+        dimer_wfn = core.Wavefunction.build(
+            sapt_dimer, core.get_global_option("BASIS"))
     else:
         dimer_wfn = hf_wfn_dimer
 
     if do_dft or not do_delta_hf:
 
         # Set the primary functional
-        core.set_local_option('SCF', 'REFERENCE', 'RKS')
+        core.set_local_option("SCF", "REFERENCE", "RKS")
 
         # Compute Monomer A wavefunction
         core.timer_on("SAPT(DFT): Monomer A DFT")
-        if (core.get_global_option('SCF_TYPE') == 'DF'):
-            core.IO.change_file_namespace(97, 'dimer', 'monomerA')
+        if core.get_global_option("SCF_TYPE") == "DF":
+            core.IO.change_file_namespace(97, "dimer", "monomerA")
 
         if mon_a_shift:
             core.set_global_option("DFT_GRAC_SHIFT", mon_a_shift)
 
-        core.IO.set_default_namespace('monomerA')
-        wfn_A = scf_helper(sapt_dft_functional,
-                           post_scf=False,
-                           molecule=monomerA,
-                           banner="SAPT(DFT): DFT Monomer A",
-                           **kwargs)
+        core.IO.set_default_namespace("monomerA")
+        wfn_A = scf_helper(
+            sapt_dft_functional,
+            post_scf=False,
+            molecule=monomerA,
+            banner="SAPT(DFT): DFT Monomer A",
+            **kwargs,
+        )
         data["DFT MONOMERA"] = core.variable("CURRENT ENERGY")
 
         core.set_global_option("DFT_GRAC_SHIFT", 0.0)
@@ -234,19 +320,21 @@ def run_sapt_dft(name, **kwargs):
 
         # Compute Monomer B wavefunction
         core.timer_on("SAPT(DFT): Monomer B DFT")
-        if (core.get_global_option('SCF_TYPE') == 'DF'):
-            core.IO.change_file_namespace(97, 'monomerA', 'monomerB')
+        if core.get_global_option("SCF_TYPE") == "DF":
+            core.IO.change_file_namespace(97, "monomerA", "monomerB")
 
         if mon_b_shift:
             core.set_global_option("DFT_GRAC_SHIFT", mon_b_shift)
 
         core.set_global_option("SAVE_JK", True)
-        core.IO.set_default_namespace('monomerB')
-        wfn_B = scf_helper(sapt_dft_functional,
-                           post_scf=False,
-                           molecule=monomerB,
-                           banner="SAPT(DFT): DFT Monomer B",
-                           **kwargs)
+        core.IO.set_default_namespace("monomerB")
+        wfn_B = scf_helper(
+            sapt_dft_functional,
+            post_scf=False,
+            molecule=monomerB,
+            banner="SAPT(DFT): DFT Monomer B",
+            **kwargs,
+        )
         data["DFT MONOMERB"] = core.variable("CURRENT ENERGY")
         core.timer_off("SAPT(DFT): Monomer B DFT")
 
@@ -259,14 +347,26 @@ def run_sapt_dft(name, **kwargs):
 
     # Write out header
     scf_alg = core.get_global_option("SCF_TYPE")
-    sapt_dft_header(sapt_dft_functional, mon_a_shift, mon_b_shift, bool(do_delta_hf), scf_alg)
+    sapt_dft_header(
+        sapt_dft_functional, mon_a_shift, mon_b_shift, bool(
+            do_delta_hf), scf_alg
+    )
 
     # Compute Delta HF for SAPT(HF)?
     delta_hf = do_delta_hf and not do_dft
 
     # Call SAPT(DFT)
     sapt_jk = wfn_B.jk()
-    sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=do_dft, sapt_jk=sapt_jk, data=data, print_header=False, delta_hf=delta_hf)
+    sapt_dft(
+        dimer_wfn,
+        wfn_A,
+        wfn_B,
+        do_dft=do_dft,
+        sapt_jk=sapt_jk,
+        data=data,
+        print_header=False,
+        delta_hf=delta_hf,
+    )
 
     # Copy data back into globals
     for k, v in data.items():
@@ -279,22 +379,112 @@ def run_sapt_dft(name, **kwargs):
     return dimer_wfn
 
 
-def sapt_dft_header(sapt_dft_functional="unknown",
-                    mon_a_shift=None,
-                    mon_b_shift=None,
-                    do_delta_hf="N/A",
-                    jk_alg="N/A"):
+def sapt_dft_grac_convergence_tier_options():
+    return {
+        "SINGLE": [{
+            # "level_shift": 0.01,
+            # "level_shift_cutoff": 0.01,
+            "SCF_INITIAL_ACCELERATOR": "ADIIS",
+            # "MAXITER": 200,
+        }],
+        # "medium": {},
+        # "high": {},
+    }
+
+
+def compute_GRAC_shift(
+    molecule, sap_dft_grac_convergence_tier="SINGLE", label="Monomer A"
+):
+    optstash = p4util.OptionsState(
+        ["SCF_TYPE"],
+        ["SCF", "REFERENCE"],
+        ["SCF", "DFT_GRAC_SHIFT"],
+        ["SCF", "SAVE_JK"],
+    )
+
+    dft_functional = core.get_option("SAPT", "SAPT_DFT_FUNCTIONAL")
+    scf_reference = core.get_option("SCF", "REFERENCE")
+
+    for i in sapt_dft_grac_convergence_tier_options()[sap_dft_grac_convergence_tier.upper()]:
+        # for k, v in i.items():
+        #     core.set_global_option(k, v)
+        core.set_local_option("SCF", "REFERENCE", "UHF")
+        # Need to get the neutral and cation to estimate ionization energy for GRAC shift
+        mol_qcel_dict = molecule.to_schema(dtype=2)
+        print(f"{mol_qcel_dict = }")
+        del mol_qcel_dict["fragment_charges"]
+        del mol_qcel_dict["fragment_multiplicities"]
+        del mol_qcel_dict["molecular_multiplicity"]
+        mol_qcel_dict["molecular_charge"] = 0
+        mol_qcel = qcel.models.Molecule(**mol_qcel_dict)
+        mol_neutral = core.Molecule.from_schema(mol_qcel.dict())
+
+        mol_qcel_dict["molecular_charge"] = 1
+        mol_qcel = qcel.models.Molecule(**mol_qcel_dict)
+        mol_cation = core.Molecule.from_schema(mol_qcel.dict())
+
+        wfn_neutral = scf_helper(
+            "SCF",
+            molecule=mol_neutral,
+            banner=f"GRAC Shift: Neutral {label}",
+        )
+        occ_neutral = wfn_neutral.epsilon_a_subset(basis="SO", subset="OCC").to_array(
+            dense=True
+        )
+        HOMO = np.amax(occ_neutral)
+        wfn_cation = scf_helper(
+            "SCF",
+            molecule=mol_cation,
+            banner=f"GRAC Shift: Cation {label}",
+        )
+
+        e_neutral = wfn_neutral.energy()
+        e_cation = wfn_cation.energy()
+        print(f"{e_neutral = }, {e_cation = }, {HOMO = }")
+        grac = e_cation - e_neutral + HOMO
+        print(f"{grac = }")
+        if label == "Monomer A":
+            core.set_global_option("SAPT", "SAPT_DFT_GRAC_SHIFT_A", grac)
+            core.set_global_option("SAPT_DFT_GRAC_SHIFT_A", grac)
+            core.set_variable("SAPT_DFT_GRAC_SHIFT_A", grac)
+        elif label == "Monomer B":
+            core.set_global_option("SAPT_DFT_GRAC_SHIFT_B", grac)
+            core.set_variable("SAPT_DFT_GRAC_SHIFT_B", grac)
+        else:
+            raise ValueError("Only Monomer A and Monomer B are valid GRAC shift options")
+    core.set_local_option("SCF", "REFERENCE", scf_reference)
+    optstash.restore()
+    return
+
+
+def sapt_dft_header(
+    sapt_dft_functional="unknown",
+    mon_a_shift=None,
+    mon_b_shift=None,
+    do_delta_hf="N/A",
+    jk_alg="N/A",
+):
     # Print out the title and some information
     core.print_out("\n")
-    core.print_out("         ---------------------------------------------------------\n")
-    core.print_out("         " + "SAPT(DFT): Intermolecular Interaction Segment".center(58) + "\n")
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
+    core.print_out(
+        "         " +
+        "SAPT(DFT): Intermolecular Interaction Segment".center(58) + "\n"
+    )
     core.print_out("\n")
-    core.print_out("         " + "by Daniel G. A. Smith and Rob Parrish".center(58) + "\n")
-    core.print_out("         ---------------------------------------------------------\n")
+    core.print_out(
+        "         " + "by Daniel G. A. Smith and Rob Parrish".center(58) + "\n"
+    )
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
     core.print_out("\n")
 
     core.print_out("  ==> Algorithm <==\n\n")
-    core.print_out("   SAPT DFT Functional     %12s\n" % str(sapt_dft_functional))
+    core.print_out("   SAPT DFT Functional     %12s\n" %
+                   str(sapt_dft_functional))
     if mon_a_shift:
         core.print_out("   Monomer A GRAC Shift    %12.6f\n" % mon_a_shift)
     if mon_b_shift:
@@ -303,7 +493,18 @@ def sapt_dft_header(sapt_dft_functional="unknown",
     core.print_out("   JK Algorithm            %12s\n" % jk_alg)
 
 
-def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None, data=None, print_header=True, cleanup_jk=True, delta_hf=False):
+def sapt_dft(
+    dimer_wfn,
+    wfn_A,
+    wfn_B,
+    do_dft=True,
+    sapt_jk=None,
+    sapt_jk_B=None,
+    data=None,
+    print_header=True,
+    cleanup_jk=True,
+    delta_hf=False,
+):
     """
     The primary SAPT(DFT) algorithm to compute the interaction energy once the wavefunctions have been built.
 
@@ -354,9 +555,12 @@ def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None,
         sapt_jk.initialize()
         sapt_jk.print_header()
 
-        if wfn_B.functional().is_x_lrc() and (wfn_A.functional().x_omega() != wfn_B.functional().x_omega()):
+        if wfn_B.functional().is_x_lrc() and (
+            wfn_A.functional().x_omega() != wfn_B.functional().x_omega()
+        ):
             core.print_out("   => Monomer B: Building SAPT JK object <= \n\n")
-            core.print_out("      Reason: MonomerA Omega != MonomerB Omega\n\n")
+            core.print_out(
+                "      Reason: MonomerA Omega != MonomerB Omega\n\n")
             sapt_jk_B = core.JK.build(dimer_wfn.basisset())
             sapt_jk_B.set_do_J(True)
             sapt_jk_B.set_do_K(True)
@@ -388,18 +592,23 @@ def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None,
 
     # Induction
     core.timer_on("SAPT(DFT):ind")
-    ind = sapt_jk_terms.induction(cache,
-                                  sapt_jk,
-                                  True,
-                                  sapt_jk_B=sapt_jk_B,
-                                  maxiter=core.get_option("SAPT", "MAXITER"),
-                                  conv=core.get_option("SAPT", "CPHF_R_CONVERGENCE"),
-                                  Sinf=core.get_option("SAPT", "DO_IND_EXCH_SINF"))
+    ind = sapt_jk_terms.induction(
+        cache,
+        sapt_jk,
+        True,
+        sapt_jk_B=sapt_jk_B,
+        maxiter=core.get_option("SAPT", "MAXITER"),
+        conv=core.get_option("SAPT", "CPHF_R_CONVERGENCE"),
+        Sinf=core.get_option("SAPT", "DO_IND_EXCH_SINF"),
+    )
     data.update(ind)
 
     # Set Delta HF for SAPT(HF)
     if delta_hf:
-        total_sapt = (data["Elst10,r"] + data["Exch10"] + data["Ind20,r"] + data["Exch-Ind20,r"])
+        total_sapt = (
+            data["Elst10,r"] + data["Exch10"] +
+            data["Ind20,r"] + data["Exch-Ind20,r"]
+        )
         sapt_hf_delta = data["DHF VALUE"] - total_sapt
         core.set_variable("SAPT(DFT) Delta HF", sapt_hf_delta)
         data["Delta HF Correction"] = core.variable("SAPT(DFT) Delta HF")
@@ -419,7 +628,8 @@ def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None,
         if do_hybrid:
             if hybrid_specified:
                 raise ValidationError(
-                    "SAPT(DFT): Hybrid xc kernel not yet implemented for range-separated funtionals.")
+                    "SAPT(DFT): Hybrid xc kernel not yet implemented for range-separated funtionals."
+                )
             else:
                 core.print_out(
                     "Warning: Hybrid xc kernel not yet implemented for range-separated funtionals; hybrid kernel capability is turned off.\n"
@@ -433,62 +643,77 @@ def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None,
 
     # Dispersion
     core.timer_on("SAPT(DFT):disp")
-    
+
     primary_basis = wfn_A.basisset()
-    aux_basis = core.BasisSet.build(dimer_wfn.molecule(), "DF_BASIS_MP2", core.get_option("DFMP2", "DF_BASIS_MP2"),
-                                        "RIFIT", core.get_global_option('BASIS'))
-    
+    aux_basis = core.BasisSet.build(
+        dimer_wfn.molecule(),
+        "DF_BASIS_MP2",
+        core.get_option("DFMP2", "DF_BASIS_MP2"),
+        "RIFIT",
+        core.get_global_option("BASIS"),
+    )
+
     if do_dft:
         core.timer_on("FDDS disp")
         core.print_out("\n")
         x_alpha = wfn_B.functional().x_alpha()
         if not is_hybrid:
             x_alpha = 0.0
-        fdds_disp = sapt_mp2_terms.df_fdds_dispersion(primary_basis, aux_basis, cache, is_hybrid, x_alpha)
+        fdds_disp = sapt_mp2_terms.df_fdds_dispersion(
+            primary_basis, aux_basis, cache, is_hybrid, x_alpha
+        )
         data.update(fdds_disp)
         nfrozen_A = 0
         nfrozen_B = 0
         core.timer_off("FDDS disp")
     else:
-# this is where we actually need to figure out the number of frozen-core orbitals
-# if SAPT_DFT_MP2_DISP_ALG == FISAPT, the code will not figure it out on its own
-        nfrozen_A = wfn_A.basisset().n_frozen_core(core.get_global_option("FREEZE_CORE"),wfn_A.molecule())
-        nfrozen_B = wfn_B.basisset().n_frozen_core(core.get_global_option("FREEZE_CORE"),wfn_B.molecule())
-        
-    
+        # this is where we actually need to figure out the number of frozen-core orbitals
+        # if SAPT_DFT_MP2_DISP_ALG == FISAPT, the code will not figure it out on its own
+        nfrozen_A = wfn_A.basisset().n_frozen_core(
+            core.get_global_option("FREEZE_CORE"), wfn_A.molecule()
+        )
+        nfrozen_B = wfn_B.basisset().n_frozen_core(
+            core.get_global_option("FREEZE_CORE"), wfn_B.molecule()
+        )
+
     core.timer_on("MP2 disp")
     if core.get_option("SAPT", "SAPT_DFT_MP2_DISP_ALG") == "FISAPT":
-        mp2_disp = sapt_mp2_terms.df_mp2_fisapt_dispersion(wfn_A, primary_basis, aux_basis, 
-                                                           cache, nfrozen_A, nfrozen_B, do_print=True)
+        mp2_disp = sapt_mp2_terms.df_mp2_fisapt_dispersion(
+            wfn_A, primary_basis, aux_basis, cache, nfrozen_A, nfrozen_B, do_print=True
+        )
     else:
-        mp2_disp = sapt_mp2_terms.df_mp2_sapt_dispersion(dimer_wfn,
-                                                         wfn_A,
-                                                         wfn_B,
-                                                         primary_basis,
-                                                         aux_basis,
-                                                         cache,
-                                                         do_print=True)
+        mp2_disp = sapt_mp2_terms.df_mp2_sapt_dispersion(
+            dimer_wfn, wfn_A, wfn_B, primary_basis, aux_basis, cache, do_print=True
+        )
     data.update(mp2_disp)
 
     # Exchange-dispersion scaling
     if do_dft:
-        exch_disp_scheme = core.get_option("SAPT", "SAPT_DFT_EXCH_DISP_SCALE_SCHEME")
-        core.print_out("    %-33s % s\n" % ("Scaling Scheme", exch_disp_scheme))
+        exch_disp_scheme = core.get_option(
+            "SAPT", "SAPT_DFT_EXCH_DISP_SCALE_SCHEME")
+        core.print_out("    %-33s % s\n" %
+                       ("Scaling Scheme", exch_disp_scheme))
         if exch_disp_scheme == "NONE":
             data["Exch-Disp20,r"] = data["Exch-Disp20,u"]
         elif exch_disp_scheme == "FIXED":
-            exch_disp_scale = core.get_option("SAPT", "SAPT_DFT_EXCH_DISP_FIXED_SCALE")
-            core.print_out("    %-28s % 10.3f\n" % ("Scaling Factor", exch_disp_scale))
+            exch_disp_scale = core.get_option(
+                "SAPT", "SAPT_DFT_EXCH_DISP_FIXED_SCALE")
+            core.print_out("    %-28s % 10.3f\n" %
+                           ("Scaling Factor", exch_disp_scale))
             data["Exch-Disp20,r"] = exch_disp_scale * data["Exch-Disp20,u"]
         elif exch_disp_scheme == "DISP":
             exch_disp_scale = data["Disp20"] / data["Disp20,u"]
             data["Exch-Disp20,r"] = exch_disp_scale * data["Exch-Disp20,u"]
         if exch_disp_scheme != "NONE":
-            core.print_out(print_sapt_var("Est. Exch-Disp20,r", data["Exch-Disp20,r"], short=True) + "\n")
+            core.print_out(
+                print_sapt_var("Est. Exch-Disp20,r",
+                               data["Exch-Disp20,r"], short=True)
+                + "\n"
+            )
 
     core.timer_off("MP2 disp")
     core.timer_off("SAPT(DFT):disp")
-    
+
     # Print out final data
     core.print_out("\n")
     core.print_out(print_sapt_dft_summary(data, "SAPT(DFT)", do_dft=do_dft))
@@ -497,66 +722,101 @@ def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None,
 
 
 def run_sf_sapt(name, **kwargs):
-    optstash = p4util.OptionsState(['SCF_TYPE'], ['SCF', 'REFERENCE'], ['SCF', 'DFT_GRAC_SHIFT'], ['SCF', 'SAVE_JK'])
+    optstash = p4util.OptionsState(
+        ["SCF_TYPE"],
+        ["SCF", "REFERENCE"],
+        ["SCF", "DFT_GRAC_SHIFT"],
+        ["SCF", "SAVE_JK"],
+    )
 
     core.tstart()
 
     # Alter default algorithm
-    if not core.has_global_option_changed('SCF_TYPE'):
-        core.set_global_option('SCF_TYPE', 'DF')
+    if not core.has_global_option_changed("SCF_TYPE"):
+        core.set_global_option("SCF_TYPE", "DF")
 
     core.prepare_options_for_module("SAPT")
 
     # Get the molecule of interest
-    ref_wfn = kwargs.get('ref_wfn', None)
+    ref_wfn = kwargs.get("ref_wfn", None)
     if ref_wfn is None:
-        sapt_dimer = kwargs.pop('molecule', core.get_active_molecule())
+        sapt_dimer = kwargs.pop("molecule", core.get_active_molecule())
     else:
-        core.print_out('Warning! SAPT argument "ref_wfn" is only able to use molecule information.')
+        core.print_out(
+            'Warning! SAPT argument "ref_wfn" is only able to use molecule information.'
+        )
         sapt_dimer = ref_wfn.molecule()
 
-    sapt_dimer, monomerA, monomerB = proc_util.prepare_sapt_molecule(sapt_dimer, "dimer")
+    sapt_dimer, monomerA, monomerB = proc_util.prepare_sapt_molecule(
+        sapt_dimer, "dimer"
+    )
 
     # Print out the title and some information
     core.print_out("\n")
-    core.print_out("         ---------------------------------------------------------\n")
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
     core.print_out("         " + "Spin-Flip SAPT Procedure".center(58) + "\n")
     core.print_out("\n")
-    core.print_out("         " + "by Daniel G. A. Smith and Konrad Patkowski".center(58) + "\n")
-    core.print_out("         ---------------------------------------------------------\n")
+    core.print_out(
+        "         " +
+        "by Daniel G. A. Smith and Konrad Patkowski".center(58) + "\n"
+    )
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
     core.print_out("\n")
 
     core.print_out("  ==> Algorithm <==\n\n")
-    core.print_out("   JK Algorithm            %12s\n" % core.get_option("SCF", "SCF_TYPE"))
+    core.print_out(
+        "   JK Algorithm            %12s\n" % core.get_option(
+            "SCF", "SCF_TYPE")
+    )
     core.print_out("\n")
     core.print_out("   Required computations:\n")
     core.print_out("     HF  (Monomer A)\n")
     core.print_out("     HF  (Monomer B)\n")
     core.print_out("\n")
 
-    if (core.get_option('SCF', 'REFERENCE') != 'ROHF'):
-        raise ValidationError('Spin-Flip SAPT currently only supports restricted open-shell references.')
+    if core.get_option("SCF", "REFERENCE") != "ROHF":
+        raise ValidationError(
+            "Spin-Flip SAPT currently only supports restricted open-shell references."
+        )
 
     # Run the two monomer computations
-    core.IO.set_default_namespace('dimer')
+    core.IO.set_default_namespace("dimer")
     data = {}
 
-    if (core.get_global_option('SCF_TYPE') == 'DF'):
-        core.set_global_option('DF_INTS_IO', 'SAVE')
+    if core.get_global_option("SCF_TYPE") == "DF":
+        core.set_global_option("DF_INTS_IO", "SAVE")
 
     # Compute dimer wavefunction
-    wfn_A = scf_helper("SCF", molecule=monomerA, banner="SF-SAPT: HF Monomer A", **kwargs)
+    wfn_A = scf_helper(
+        "SCF", molecule=monomerA, banner="SF-SAPT: HF Monomer A", **kwargs
+    )
 
     core.set_global_option("SAVE_JK", True)
-    wfn_B = scf_helper("SCF", molecule=monomerB, banner="SF-SAPT: HF Monomer B", **kwargs)
+    wfn_B = scf_helper(
+        "SCF", molecule=monomerB, banner="SF-SAPT: HF Monomer B", **kwargs
+    )
     sapt_jk = wfn_B.jk()
     core.set_global_option("SAVE_JK", False)
     core.print_out("\n")
-    core.print_out("         ---------------------------------------------------------\n")
-    core.print_out("         " + "Spin-Flip SAPT Exchange and Electrostatics".center(58) + "\n")
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
+    core.print_out(
+        "         " +
+        "Spin-Flip SAPT Exchange and Electrostatics".center(58) + "\n"
+    )
     core.print_out("\n")
-    core.print_out("         " + "by Daniel G. A. Smith and Konrad Patkowski".center(58) + "\n")
-    core.print_out("         ---------------------------------------------------------\n")
+    core.print_out(
+        "         " +
+        "by Daniel G. A. Smith and Konrad Patkowski".center(58) + "\n"
+    )
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
     core.print_out("\n")
 
     sf_data = sapt_sf_terms.compute_sapt_sf(sapt_dimer, sapt_jk, wfn_A, wfn_B)
@@ -567,8 +827,15 @@ def run_sf_sapt(name, **kwargs):
 
     for key, value in sf_data.items():
         value = sf_data[key]
-        print_vals = (key, value * 1000, value * constants.hartree2kcalmol, value * constants.hartree2kJmol)
-        string = "    %-26s % 15.8f [mEh] % 15.8f [kcal/mol] % 15.8f [kJ/mol]\n" % print_vals
+        print_vals = (
+            key,
+            value * 1000,
+            value * constants.hartree2kcalmol,
+            value * constants.hartree2kJmol,
+        )
+        string = (
+            "    %-26s % 15.8f [mEh] % 15.8f [kcal/mol] % 15.8f [kJ/mol]\n" % print_vals
+        )
         core.print_out(string)
     core.print_out("  " + "-" * 103 + "\n\n")
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1148,7 +1148,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- SAPT_DFT_GRAC_CONVERGENCE_TIER will specify how hard psi4 should
           try to converge the cation for a GRAC shift before failing the
           calculation completely -*/
-        options.add_str("SAPT_DFT_GRAC_CONVERGENCE_TIER", "single", "single medium high");
+        options.add_str("SAPT_DFT_GRAC_CONVERGENCE_TIER", "SINGLE", "SINGLE ITERATIVE");
         /*- Compute the Delta-HF correction? -*/
         options.add_bool("SAPT_DFT_DO_DHF", true);
         /*- Enables the hybrid xc kernel in dispersion? !expert -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1139,14 +1139,18 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
 
         /*- SUBSECTION SAPT(DFT) -*/
 
-        /*- Monomer A GRAC shift in Hartree -*/
+        /*- Monomer A GRAC shift in Hartree. Set to -99 to automatically
+           compute prior to SAPT(DFT)  -*/
         options.add_double("SAPT_DFT_GRAC_SHIFT_A", 0.0);
-        /*- Monomer B GRAC shift in Hartree -*/
+        /*- Monomer B GRAC shift in Hartree. Set to -99 to automatically
+           compute prior to SAPT(DFT) -*/
         options.add_double("SAPT_DFT_GRAC_SHIFT_B", 0.0);
+        /*- SAPT_DFT_GRAC_CONVERGENCE_TIER will specify how hard psi4 should
+          try to converge the cation for a GRAC shift before failing the
+          calculation completely -*/
+        options.add_str("SAPT_DFT_GRAC_CONVERGENCE_TIER", "single", "single medium high");
         /*- Compute the Delta-HF correction? -*/
         options.add_bool("SAPT_DFT_DO_DHF", true);
-        /*- How is the GRAC correction determined? !expert -*/
-        options.add_str("SAPT_DFT_GRAC_DETERMINATION", "INPUT", "INPUT");
         /*- Enables the hybrid xc kernel in dispersion? !expert -*/
         options.add_bool("SAPT_DFT_DO_HYBRID", true);
         /*- Scheme for approximating exchange-dispersion for SAPT-DFT.

--- a/tests/pytests/test_saptdft.py
+++ b/tests/pytests/test_saptdft.py
@@ -25,16 +25,10 @@ units angstrom
     )
     psi4.set_options(
         {
-            # "basis": "sto-3g",
             "level_shift": 0.060000000000000005,
             "level_shift_cutoff": 0.001,
-            "E_CONVERGENCE": 5,
-            "D_CONVERGENCE": 5,
-            # "reference": "uhf",
             "MAXITER": 300,
             "SCF_INITIAL_ACCELERATOR": "ADIIS",
-            # "e_convergence": 1e-8,
-            # "d_convergence": 1e-8,
             "basis": "aug-cc-pvdz",
             "sapt_dft_grac_shift_a": -99,
             "sapt_dft_grac_shift_b": -99,
@@ -43,11 +37,18 @@ units angstrom
     )
     psi4.energy("SAPT(DFT)", molecule=mol_dimer)
     compare_values(
-        0.13053423593332453,
+        0.13053068183319516,
         psi4.core.variable("SAPT_DFT_GRAC_SHIFT_A"),
         6,
         "SAPT_DFT_GRAC_SHIFT_A",
     )
+    compare_values(
+        0.13063798506967816,
+        psi4.core.variable("SAPT_DFT_GRAC_SHIFT_B"),
+        6,
+        "SAPT_DFT_GRAC_SHIFT_B",
+    )
+    return
 
 
 @pytest.mark.saptdft
@@ -69,6 +70,7 @@ units angstrom
         }
     )
     psi4.energy("SAPT(DFT)", molecule=mol)
+    return
 
 
 if __name__ == "__main__":

--- a/tests/pytests/test_saptdft.py
+++ b/tests/pytests/test_saptdft.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest 
 import psi4
 from qcelemental import constants
 from psi4 import compare_values
@@ -25,11 +25,6 @@ units angstrom
     )
     psi4.set_options(
         {
-            # "level_shift": 0.060000000000000005,
-            # "level_shift_cutoff": 0.001,
-            # "MAXITER": 300,
-            # "SCF_INITIAL_ACCELERATOR": "ADIIS",
-            # "basis": "aug-cc-pvdz",
             "basis": "STO-3G",
             "sapt_dft_grac_shift_a": -99,
             "sapt_dft_grac_shift_b": -99,
@@ -62,10 +57,9 @@ units angstrom
 def test_saptdft_auto_grac_iterative():
     mol_dimer = psi4.geometry(
         """
-0 1
+-1 1
 8   -0.702196054   -0.056060256   0.009942262
 1   -1.022193224   0.846775782   -0.011488714
-1   0.257521062   0.042121496   0.005218999
 --
 0 1
 8   2.268880784   0.026340101   0.000508029
@@ -106,5 +100,4 @@ units angstrom
 
 
 if __name__ == "__main__":
-    # test_saptdft_auto_grac()
     test_saptdft_auto_grac_iterative()

--- a/tests/pytests/test_saptdft.py
+++ b/tests/pytests/test_saptdft.py
@@ -1,0 +1,63 @@
+import pytest
+import psi4
+from qcelemental import constants
+from psi4 import compare_values
+
+hartree_to_kcalmol = constants.conversion_factor("hartree", "kcal/mol")
+pytestmark = [pytest.mark.psi, pytest.mark.api]
+
+
+@pytest.mark.saptdft
+def test_saptdft_auto_grac():
+    mol_dimer = psi4.geometry(
+        """
+0 1
+O  -1.551007  -0.114520   0.000000
+H  -1.934259   0.762503   0.000000
+H  -0.599677   0.040712   0.000000
+--
+0 1
+O   1.350625   0.111469   0.000000
+H   1.680398  -0.373741  -0.758561
+H   1.680398  -0.373741   0.758561
+
+units angstrom
+"""
+    )
+    psi4.set_options(
+        {
+            # "basis": "sto-3g",
+            "basis": "aug-cc-pvtz",
+            # "e_convergence": 1e-8,
+            # "d_convergence": 1e-8,
+            "sapt_dft_grac_shift_a": -99,
+            "sapt_dft_grac_shift_b": -99,
+            "SAPT_DFT_FUNCTIONAL": "pbe0",
+        }
+    )
+    psi4.energy("SAPT(DFT)", molecule=mol_dimer)
+
+
+@pytest.mark.saptdft
+def test_saptdft_monomer_grac():
+    mol = psi4.geometry(
+        """
+0 1
+O  -1.551007  -0.114520   0.000000
+H  -1.934259   0.762503   0.000000
+H  -0.599677   0.040712   0.000000
+
+units angstrom
+"""
+    )
+    psi4.set_options(
+        {
+            "basis": "sto-3g",
+            "SAPT_DFT_FUNCTIONAL": "pbe0",
+        }
+    )
+    psi4.energy("SAPT(DFT)", molecule=mol)
+
+
+if __name__ == "__main__":
+    test_saptdft_auto_grac()

--- a/tests/pytests/test_saptdft.py
+++ b/tests/pytests/test_saptdft.py
@@ -12,30 +12,42 @@ def test_saptdft_auto_grac():
     mol_dimer = psi4.geometry(
         """
 0 1
-O  -1.551007  -0.114520   0.000000
-H  -1.934259   0.762503   0.000000
-H  -0.599677   0.040712   0.000000
+8   -0.702196054   -0.056060256   0.009942262
+1   -1.022193224   0.846775782   -0.011488714
+1   0.257521062   0.042121496   0.005218999
 --
 0 1
-O   1.350625   0.111469   0.000000
-H   1.680398  -0.373741  -0.758561
-H   1.680398  -0.373741   0.758561
-
+8   2.268880784   0.026340101   0.000508029
+1   2.645502399   -0.412039965   0.766632411
+1   2.641145101   -0.449872874   -0.744894473
 units angstrom
 """
     )
     psi4.set_options(
         {
             # "basis": "sto-3g",
-            "basis": "aug-cc-pvtz",
+            "level_shift": 0.060000000000000005,
+            "level_shift_cutoff": 0.001,
+            "E_CONVERGENCE": 5,
+            "D_CONVERGENCE": 5,
+            # "reference": "uhf",
+            "MAXITER": 300,
+            "SCF_INITIAL_ACCELERATOR": "ADIIS",
             # "e_convergence": 1e-8,
             # "d_convergence": 1e-8,
+            "basis": "aug-cc-pvdz",
             "sapt_dft_grac_shift_a": -99,
             "sapt_dft_grac_shift_b": -99,
             "SAPT_DFT_FUNCTIONAL": "pbe0",
         }
     )
     psi4.energy("SAPT(DFT)", molecule=mol_dimer)
+    compare_values(
+        0.13053423593332453,
+        psi4.core.variable("SAPT_DFT_GRAC_SHIFT_A"),
+        6,
+        "SAPT_DFT_GRAC_SHIFT_A",
+    )
 
 
 @pytest.mark.saptdft

--- a/tests/pytests/test_saptdft.py
+++ b/tests/pytests/test_saptdft.py
@@ -25,11 +25,12 @@ units angstrom
     )
     psi4.set_options(
         {
-            "level_shift": 0.060000000000000005,
-            "level_shift_cutoff": 0.001,
-            "MAXITER": 300,
-            "SCF_INITIAL_ACCELERATOR": "ADIIS",
-            "basis": "aug-cc-pvdz",
+            # "level_shift": 0.060000000000000005,
+            # "level_shift_cutoff": 0.001,
+            # "MAXITER": 300,
+            # "SCF_INITIAL_ACCELERATOR": "ADIIS",
+            # "basis": "aug-cc-pvdz",
+            "basis": "STO-3G",
             "sapt_dft_grac_shift_a": -99,
             "sapt_dft_grac_shift_b": -99,
             "SAPT_DFT_FUNCTIONAL": "pbe0",
@@ -37,41 +38,73 @@ units angstrom
     )
     psi4.energy("SAPT(DFT)", molecule=mol_dimer)
     compare_values(
-        0.13053068183319516,
+        #  STO-3G target
+        0.19807358,
+        # aug-cc-pvdz target, 0.1307 (using experimental IP from CCCBDB)
+        # 0.13053068183319516,
         psi4.core.variable("SAPT_DFT_GRAC_SHIFT_A"),
-        6,
+        8,
         "SAPT_DFT_GRAC_SHIFT_A",
     )
     compare_values(
-        0.13063798506967816,
+        #  STO-3G target
+        0.19830016,
+        # aug-cc-pvdz target, 0.1307 (using experimental IP from CCCBDB)
+        # 0.13063798506967816,
         psi4.core.variable("SAPT_DFT_GRAC_SHIFT_B"),
-        6,
+        8,
         "SAPT_DFT_GRAC_SHIFT_B",
     )
     return
 
 
 @pytest.mark.saptdft
-def test_saptdft_monomer_grac():
-    mol = psi4.geometry(
+def test_saptdft_auto_grac_iterative():
+    mol_dimer = psi4.geometry(
         """
 0 1
-O  -1.551007  -0.114520   0.000000
-H  -1.934259   0.762503   0.000000
-H  -0.599677   0.040712   0.000000
-
+8   -0.702196054   -0.056060256   0.009942262
+1   -1.022193224   0.846775782   -0.011488714
+1   0.257521062   0.042121496   0.005218999
+--
+0 1
+8   2.268880784   0.026340101   0.000508029
+1   2.645502399   -0.412039965   0.766632411
+1   2.641145101   -0.449872874   -0.744894473
 units angstrom
 """
     )
     psi4.set_options(
         {
-            "basis": "sto-3g",
+            "SAPT_DFT_GRAC_CONVERGENCE_TIER": "ITERATIVE",
+            "basis": "STO-3G",
+            "sapt_dft_grac_shift_a": -99,
+            "sapt_dft_grac_shift_b": -99,
             "SAPT_DFT_FUNCTIONAL": "pbe0",
         }
     )
-    psi4.energy("SAPT(DFT)", molecule=mol)
+    psi4.energy("SAPT(DFT)", molecule=mol_dimer)
+    compare_values(
+        #  STO-3G target
+        0.19807358,
+        # aug-cc-pvdz target, 0.1307 (using experimental IP from CCCBDB)
+        # 0.13053068183319516,
+        psi4.core.variable("SAPT_DFT_GRAC_SHIFT_A"),
+        8,
+        "SAPT_DFT_GRAC_SHIFT_A",
+    )
+    compare_values(
+        #  STO-3G target
+        0.19830016,
+        # aug-cc-pvdz target, 0.1307 (using experimental IP from CCCBDB)
+        # 0.13063798506967816,
+        psi4.core.variable("SAPT_DFT_GRAC_SHIFT_B"),
+        8,
+        "SAPT_DFT_GRAC_SHIFT_B",
+    )
     return
 
 
 if __name__ == "__main__":
-    test_saptdft_auto_grac()
+    # test_saptdft_auto_grac()
+    test_saptdft_auto_grac_iterative()


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
I have added an option to compute the necessary GRAC shifts for SAPT(DFT) automatically. I added a little extra logic to "try harder" at converging cations to hopefully fail less often if this option is specified. These changes will enable more users to call SAPT(DFT) more routinely in their workflows without having to consider acquiring GRAC shifts externally through their own logic or tabulated sources. 

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Automatically computes SAPT(DFT) GRAC shifts for monomer A and/or B
- [ ] Logic for trying extra options with level shifts to attempt to converge more cations in approximating the ionization potential

## Questions
- [ ] Perhaps I should add a more challenging pytest in which the first cation SCF convergence attempt fails but the iterative options approach succeeds

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
