### PR TITLE
Alternate way to add an arbitrary potential to an SCF calculation

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1493,6 +1493,15 @@ def scf_wavefunction_factory(name, ref_wfn, reference, **kwargs):
         sapgau = core.BasisSet.build(wfn.molecule(), "SAPGAU_BASIS", core.get_global_option("SAPGAU_BASIS"))
         wfn.set_basisset("SAPGAU", sapgau)
 
+    if 'permanent_potential' in kwargs:
+        potential_matrix = kwargs["permanent_potential"]
+        if isinstance(potential_matrix, np.ndarray):
+            potential_matrix = core.Matrix.from_array(potential_matrix)
+        elif not isinstance(potential_matrix, core.Matrix):
+            raise ValidationError("Argument of 'permanent_potential' keyword has unrecognized type '%s', " %
+                                  type(potential_matrix) + "please provide a 'psi4.core.Matrix' or 'numpy.ndarray' object.")
+        wfn.set_permanent_potential(potential_matrix)
+
     if hasattr(core, "EXTERN") and 'external_potentials' in kwargs:
         core.print_out("\n  Warning! Both an external potential EXTERN object and the external_potential" +
                        " keyword argument are specified. The external_potentials keyword argument will be ignored.\n")

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -344,6 +344,8 @@ void export_wavefunction(py::module& m) {
                       "Do reset the occupation after the guess to the inital occupation.")
         .def_property("sad_", &scf::HF::sad, &scf::HF::set_sad,
                       "Do assume a non-idempotent density matrix and no orbitals after the guess.")
+        .def("set_permanent_potential", &scf::HF::set_permanent_potential,
+             "Sets an arbitrary permanent 1e potential matrix to add to the core Hamiltonian.")
         .def("set_sad_basissets", &scf::HF::set_sad_basissets, "Sets the Superposition of Atomic Densities basisset.")
         .def("set_sad_fitting_basissets", &scf::HF::set_sad_fitting_basissets,
              "Sets the Superposition of Atomic Densities density-fitted basisset.")

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -541,6 +541,16 @@ void HF::form_H() {
     if (debug_ > 2) T_->print("outfile");
     if (debug_ > 2) V_->print("outfile");
 
+    if (Vperm_) {
+        if (nirrep_ > 1)
+            throw PSIEXCEPTION("RHF_embed: arbitrary permanent 1e potentials require 'symmetry c1'.");
+        if (Vperm_->rowdim() != Vperm_->coldim())
+            throw PSIEXCEPTION("RHF_embed: arbitrary permanent 1e potential matrix must be a square matrix.");
+        if (V_->coldim() != Vperm_->coldim())
+            throw PSIEXCEPTION("RHF_embed: arbitrary permanent 1e potential matrix must be nbf x nbf.");
+        V_->add(Vperm_);
+    }
+
     if (perturb_h_) {
         if (dipole_field_type_ == embpot || dipole_field_type_ == sphere ||
             dipole_field_type_ == dx) {  // embedding potential read from file

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -66,6 +66,8 @@ class HF : public Wavefunction {
     /// List of external potentials to add to Fock matrix and updated at every iteration
     /// e.g. PCM potential
     std::vector<SharedMatrix> external_potentials_;
+    /// A permanent 1e potential matrix to add to the core Hamiltonian
+    SharedMatrix Vperm_;
 
     /// Map of external potentials/perturbations to add to the CPSCF two-electron contribution
     /// e.g. PCM or PE potential
@@ -436,6 +438,9 @@ class HF : public Wavefunction {
     }
     void clear_external_cpscf_perturbations() { external_cpscf_perturbations_.clear(); }
     void compute_fvpi();
+
+    // Permanent potential
+    void set_permanent_potential(SharedMatrix Vperm) { Vperm_ = Vperm; }
 };
 }  // namespace scf
 }  // namespace psi

--- a/pytest.ini
+++ b/pytest.ini
@@ -99,6 +99,7 @@ markers =
     omp
     opt
     pasture
+    perm: "tests that use an added permanent 1e potential"
     properties
     psimrcc
     pte

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,7 +80,7 @@ foreach(test_name aediis-1
                   opt11 opt12 opt13 opt14 opt15 opt16 opt-irc-1 opt-irc-2 opt-irc-3
                   opt-freeze-coords opt-full-hess-every
                   oremp-grad1 oremp-grad2
-                  phi-ao
+                  phi-ao perm
                   props1 props2 props3 props4 psimrcc-ccsd_t-1 psimrcc-ccsd_t-2
                   psimrcc-ccsd_t-3 psimrcc-ccsd_t-4 psimrcc-fd-freq1
                   psimrcc-fd-freq2 psimrcc-pt2 psimrcc-sp1 psithon1 psithon2

--- a/tests/perm/CMakeLists.txt
+++ b/tests/perm/CMakeLists.txt
@@ -1,0 +1,4 @@
+include(TestingMacros)
+
+add_regression_test(perm "psi;quicktests;perm;scf")
+

--- a/tests/perm/input.dat
+++ b/tests/perm/input.dat
@@ -1,0 +1,55 @@
+#! External potential calculation involving a TIP3P water and a QM water.
+#! Gradient on the external charges is compared to gradient on the QM atoms to validate the gradient on the charges.
+
+molecule water {
+  0 1
+  O  -0.778803000000  0.000000000000  1.132683000000
+  H  -0.666682000000  0.764099000000  1.706291000000
+  H  -0.666682000000  -0.764099000000  1.706290000000
+  symmetry c1
+  no_reorient
+  no_com
+}
+# Define a TIP3P water as the external potential
+import numpy as np
+external_potentials = np.array([
+-0.834,1.649232019048,0.0,-2.356023604706,
+0.417,0.544757019107,0.0,-3.799961446760,
+0.417,0.544757019107,0.0,-0.912085762652]).reshape((-1, 4))
+# convert coordinates columns to bohr
+external_potentials[:,[1,2,3]] /= psi_bohr2angstroms
+
+set {
+    scf_type df
+    d_convergence 12
+    basis 6-31G*
+}
+
+# Calculate the total gradient on the wavefunction in the presence of the external potential charges.
+e_analytic = energy('scf', molecule=water, external_potentials=external_potentials)
+
+extern = core.ExternalPotential()
+for point_charge in external_potentials:
+    extern.addCharge(*point_charge.tolist())
+basis = core.BasisSet.build(
+    water,
+    "ORBITAL",
+    "6-31G*",
+)
+potential = extern.computePotentialMatrix(basis)
+
+# Calculate the nuclear contributions to the energy and gradient on
+# the wavefunction in the presence of the external potential charges.
+e_nuc = 0
+for atom in range(water.natom()):
+    for charge in external_potentials:
+        r = np.array(
+            [water.x(atom) - charge[1],
+             water.y(atom) - charge[2],
+             water.z(atom) - charge[3]],
+        )
+        e_nuc += charge[0] * water.Z(atom) / np.linalg.norm(r)
+
+e_perm = energy('scf', molecule=water, permanent_potential=potential)
+
+compare_values(e_analytic, e_perm + e_nuc, 6, "Energy with 'external_potentials' vs. 'permanent_potential' keyword")  #TEST

--- a/tests/perm/output.ref
+++ b/tests/perm/output.ref
@@ -1,0 +1,557 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.10a1.dev60 
+
+                         Git: Rev {master} 36ddfd8 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 06 November 2024 10:24AM
+
+    Process ID: 227738
+    Host:       login-hive-2.pace.gatech.edu
+    PSIDATADIR: /storage/hive/project/chem-mcdaniel/jpederson6/programs/potential/build/psi4/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! External potential calculation involving a TIP3P water and a QM water.
+#! Gradient on the external charges is compared to gradient on the QM atoms to validate the gradient on the charges.
+
+molecule water {
+  0 1
+  O  -0.778803000000  0.000000000000  1.132683000000
+  H  -0.666682000000  0.764099000000  1.706291000000
+  H  -0.666682000000  -0.764099000000  1.706290000000
+  symmetry c1
+  no_reorient
+  no_com
+}
+# Define a TIP3P water as the external potential
+import numpy as np
+external_potentials = np.array([
+-0.834,1.649232019048,0.0,-2.356023604706,
+0.417,0.544757019107,0.0,-3.799961446760,
+0.417,0.544757019107,0.0,-0.912085762652]).reshape((-1, 4))
+# convert coordinates columns to bohr
+external_potentials[:,[1,2,3]] /= psi_bohr2angstroms
+
+set {
+    scf_type df
+    d_convergence 12
+    basis 6-31G*
+}
+
+# Calculate the total gradient on the wavefunction in the presence of the external potential charges.
+e_analytic = energy('scf', molecule=water, external_potentials=external_potentials)
+
+extern = core.ExternalPotential()
+for point_charge in external_potentials:
+    extern.addCharge(*point_charge.tolist())
+basis = core.BasisSet.build(
+    water,
+    "ORBITAL",
+    "6-31G*",
+)
+potential = extern.computePotentialMatrix(basis)
+
+# Calculate the nuclear contributions to the energy and gradient on
+# the wavefunction in the presence of the external potential charges.
+e_nuc = 0
+for atom in range(water.natom()):
+    for charge in external_potentials:
+        r = np.array(
+            [water.x(atom) - charge[1],
+             water.y(atom) - charge[2],
+             water.z(atom) - charge[3]],
+        )
+        e_nuc += charge[0] * water.Z(atom) / np.linalg.norm(r)
+
+e_perm = energy('scf', molecule=water, permanent_potential=potential)
+
+compare_values(e_analytic, e_perm + e_nuc, 6, "Energy with 'external_potentials' vs. 'permanent_potential' keyword")  #TEST
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+  PE does not make use of molecular symmetry: further calculations in C1 point group.
+  PE geometry must align with POTFILE keyword: resetting coordinates with fixed origin and orientation.
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 7, 4
+    Auxiliary basis highest AM E, G, H:  12, 7, 5
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on login-hive-2.pace.gatech.edu
+*** at Wed Nov  6 10:24:41 2024
+
+   => Loading Basis Set <=
+
+    Name: 6-31G*
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   145 file /storage/hive/project/chem-mcdaniel/jpederson6/programs/potential/build/psi4/share/psi4/basis/6-31gs.gbs 
+    atoms 2-3 entry H          line    44 file /storage/hive/project/chem-mcdaniel/jpederson6/programs/potential/build/psi4/share/psi4/basis/6-31gs.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -0.778803000000     0.000000000000     1.132683000000    15.994914619570
+         H           -0.666682000000     0.764099000000     1.706291000000     1.007825032230
+         H           -0.666682000000    -0.764099000000     1.706290000000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.49898  B =      0.45577  C =      0.44509 [cm^-1]
+  Rotational constants: A = 344730.75999  B =  13663.77650  C =  13343.54221 [MHz]
+  Nuclear repulsion =    9.147559631264109
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-12
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G*
+    Blend: 6-31G*
+    Number of shells: 10
+    Number of basis functions: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (6-31G* AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /storage/hive/project/chem-mcdaniel/jpederson6/programs/potential/build/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /storage/hive/project/chem-mcdaniel/jpederson6/programs/potential/build/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (6-31G* AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis functions: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+   => External Potential Field:  <= 
+
+    > Charges [e] [a0] < 
+
+              Z          x          y          z
+       -0.83400    3.11660    0.00000   -4.45224
+        0.41700    1.02944    0.00000   -7.18089
+        0.41700    1.02944    0.00000   -1.72359
+
+  Old nuclear repulsion        =    9.147559631264109
+  Additional nuclear repulsion =    0.278918444542759
+  Total nuclear repulsion      =    9.426478075806868
+
+  Minimum eigenvalue in the overlap matrix is 2.2468083698E-02.
+  Reciprocal condition number of the overlap matrix is 4.8187283774E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         19      19 
+   -------------------------
+    Total      19      19
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -76.53234571687094   -7.65323e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.91777381668138    6.14572e-01   2.46423e-02 DIIS/ADIIS
+   @DF-RHF iter   2:   -76.00232599329566   -8.45522e-02   1.17179e-02 DIIS/ADIIS
+   @DF-RHF iter   3:   -76.01856375092025   -1.62378e-02   2.42468e-03 DIIS/ADIIS
+   @DF-RHF iter   4:   -76.01939095723738   -8.27206e-04   2.78497e-04 DIIS/ADIIS
+   @DF-RHF iter   5:   -76.01941053080304   -1.95736e-05   5.48319e-05 DIIS
+   @DF-RHF iter   6:   -76.01941120659973   -6.75797e-07   7.14082e-06 DIIS
+   @DF-RHF iter   7:   -76.01941122837377   -2.17740e-08   1.12142e-06 DIIS
+   @DF-RHF iter   8:   -76.01941122881162   -4.37851e-10   1.40972e-07 DIIS
+   @DF-RHF iter   9:   -76.01941122881959   -7.97229e-12   3.45261e-08 DIIS
+   @DF-RHF iter  10:   -76.01941122882025   -6.53699e-13   5.18584e-09 DIIS
+   @DF-RHF iter  11:   -76.01941122882025    0.00000e+00   9.76573e-10 DIIS
+   @DF-RHF iter  12:   -76.01941122882025    0.00000e+00   1.86094e-10 DIIS
+   @DF-RHF iter  13:   -76.01941122882030   -5.68434e-14   3.66274e-11 DIIS
+   @DF-RHF iter  14:   -76.01941122882029    1.42109e-14   3.88539e-12 DIIS
+   @DF-RHF iter  15:   -76.01941122882032   -2.84217e-14   4.30729e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586638     2A     -1.364209     3A     -0.730374  
+       4A     -0.598176     5A     -0.524223  
+
+    Virtual:                                                              
+
+       6A      0.191881     7A      0.285573     8A      0.998607  
+       9A      1.098592    10A      1.135870    11A      1.142910  
+      12A      1.354188    13A      1.409183    14A      1.994997  
+      15A      2.007853    16A      2.040889    17A      2.591169  
+      18A      2.913219    19A      3.941789  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+    NA   [     5 ]
+    NB   [     5 ]
+
+  @DF-RHF Final Energy:   -76.01941122882032
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.4264780758068678
+    One-Electron Energy =                -123.2845377107279887
+    Two-Electron Energy =                  37.8386484061008090
+    Total Energy =                        -76.0194112288203030
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         14.4533281          -14.2934878            0.1598403
+ Dipole Y            :         -0.0000002            0.0000000           -0.0000002
+ Dipole Z            :        -22.6701899           23.5725287            0.9023388
+ Magnitude           :                                                    0.9163865
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on login-hive-2.pace.gatech.edu at Wed Nov  6 10:24:44 2024
+Module time:
+	user time   =       0.34 seconds =       0.01 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =       0.34 seconds =       0.01 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+   => Loading Basis Set <=
+
+    Name: 6-31G*
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   145 file /storage/hive/project/chem-mcdaniel/jpederson6/programs/potential/build/psi4/share/psi4/basis/6-31gs.gbs 
+    atoms 2-3 entry H          line    44 file /storage/hive/project/chem-mcdaniel/jpederson6/programs/potential/build/psi4/share/psi4/basis/6-31gs.gbs 
+
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 7, 4
+    Auxiliary basis highest AM E, G, H:  12, 7, 5
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on login-hive-2.pace.gatech.edu
+*** at Wed Nov  6 10:24:44 2024
+
+   => Loading Basis Set <=
+
+    Name: 6-31G*
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   145 file /storage/hive/project/chem-mcdaniel/jpederson6/programs/potential/build/psi4/share/psi4/basis/6-31gs.gbs 
+    atoms 2-3 entry H          line    44 file /storage/hive/project/chem-mcdaniel/jpederson6/programs/potential/build/psi4/share/psi4/basis/6-31gs.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O           -0.778803000000     0.000000000000     1.132683000000    15.994914619570
+         H           -0.666682000000     0.764099000000     1.706291000000     1.007825032230
+         H           -0.666682000000    -0.764099000000     1.706290000000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     11.49898  B =      0.45577  C =      0.44509 [cm^-1]
+  Rotational constants: A = 344730.75999  B =  13663.77650  C =  13343.54221 [MHz]
+  Nuclear repulsion =    9.147559631264109
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-06
+  Density threshold  = 1.00e-12
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G*
+    Blend: 6-31G*
+    Number of shells: 10
+    Number of basis functions: 19
+    Number of Cartesian functions: 19
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (6-31G* AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /storage/hive/project/chem-mcdaniel/jpederson6/programs/potential/build/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /storage/hive/project/chem-mcdaniel/jpederson6/programs/potential/build/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (6-31G* AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis functions: 131
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: false
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 2.2468083698E-02.
+  Reciprocal condition number of the overlap matrix is 4.8187283774E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         19      19 
+   -------------------------
+    Total      19      19
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -76.81126416141313   -7.68113e+01   0.00000e+00 
+   @DF-RHF iter   1:   -76.19669226122342    6.14572e-01   2.46423e-02 DIIS/ADIIS
+   @DF-RHF iter   2:   -76.28124443783804   -8.45522e-02   1.17179e-02 DIIS/ADIIS
+   @DF-RHF iter   3:   -76.29748219546254   -1.62378e-02   2.42468e-03 DIIS/ADIIS
+   @DF-RHF iter   4:   -76.29830940177982   -8.27206e-04   2.78497e-04 DIIS/ADIIS
+   @DF-RHF iter   5:   -76.29832897534540   -1.95736e-05   5.48319e-05 DIIS
+   @DF-RHF iter   6:   -76.29832965114217   -6.75797e-07   7.14082e-06 DIIS
+   @DF-RHF iter   7:   -76.29832967291613   -2.17740e-08   1.12142e-06 DIIS
+   @DF-RHF iter   8:   -76.29832967335402   -4.37893e-10   1.40972e-07 DIIS
+   @DF-RHF iter   9:   -76.29832967336192   -7.90124e-12   3.45261e-08 DIIS
+   @DF-RHF iter  10:   -76.29832967336266   -7.38964e-13   5.18584e-09 DIIS
+   @DF-RHF iter  11:   -76.29832967336263    2.84217e-14   9.76573e-10 DIIS
+   @DF-RHF iter  12:   -76.29832967336264   -1.42109e-14   1.86093e-10 DIIS
+   @DF-RHF iter  13:   -76.29832967336272   -7.10543e-14   3.66279e-11 DIIS
+   @DF-RHF iter  14:   -76.29832967336272    0.00000e+00   3.88542e-12 DIIS
+   @DF-RHF iter  15:   -76.29832967336269    2.84217e-14   4.30919e-13 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.586638     2A     -1.364209     3A     -0.730374  
+       4A     -0.598176     5A     -0.524223  
+
+    Virtual:                                                              
+
+       6A      0.191881     7A      0.285573     8A      0.998607  
+       9A      1.098592    10A      1.135870    11A      1.142910  
+      12A      1.354188    13A      1.409183    14A      1.994997  
+      15A      2.007853    16A      2.040889    17A      2.591169  
+      18A      2.913219    19A      3.941789  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+    NA   [     5 ]
+    NB   [     5 ]
+
+  @DF-RHF Final Energy:   -76.29832967336269
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1475596312641088
+    One-Electron Energy =                -123.2845377107234270
+    Two-Electron Energy =                  37.8386484060966168
+    Total Energy =                        -76.2983296733627014
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         14.4533281          -14.2934878            0.1598403
+ Dipole Y            :         -0.0000002            0.0000000           -0.0000002
+ Dipole Z            :        -22.6701899           23.5725287            0.9023388
+ Magnitude           :                                                    0.9163865
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on login-hive-2.pace.gatech.edu at Wed Nov  6 10:24:44 2024
+Module time:
+	user time   =       0.24 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.63 seconds =       0.01 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+    Energy with 'external_potentials' vs. 'permanent_potential' keyword...................PASSED
+
+    Psi4 stopped on: Wednesday, 06 November 2024 10:24AM
+    Psi4 wall time for execution: 0:00:03.77
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/perm/test_input.py
+++ b/tests/perm/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("quick;perm;scf")
+def test_perm():
+    ctest_runner(__file__)
+


### PR DESCRIPTION
## Description
This is an alternative to the fix proposed in #3228 for issue #3227, where an arbitrary one-electron potential provided by the user can be included in an SCF calculation.

I had a conversation about this functionality with @konpat, and it seems like this would be a generally useful feature. Following the suggestion made by @susilehtola on #3228, I have added a permanent potential data structure (shared matrix), `Vperm_`, to the `HF` class, which is set when the user provides a matrix to the `permanent_potential` keyword in the `energy()` call. The permanent potential is added to the core Hamiltonian in the `HF::form_H()` call in a similar manner to the `PERTURB_WITH` potentials (dipoles, EMBPOT, etc.), and so it persists during the SCF, along with the other parts of the core Hamiltonian. Seeing as the user is performing integrals outside of Psi4 to generate the 1e matrix, this should be considered an advanced usage feature.

## User API & Changelog headlines
- [x] Users may provide an arbitrary one-electron potential to be included in the core Hamiltonian during an SCF call as a `Matrix` or `numpy.ndarray` object with the `permanent_potential` keyword.

## Dev notes & details
- [x] Added a check to `scf_wavefunction_factory` in `proc.py` for the `permanent_potential` keyword. A validation error is thrown if the argument type is not `Matrix` or `numpy.ndarray`; otherwise, the permanent potential is sent to the wavefunction object.
- [x] Added the `Vperm_` shared matrix data structure to the `HF` class, which is added onto the core Hamiltonian in the `HF::form_H()` call if it is populated. The implementation is comparable to the `PERTURB_H` machinery, and checks are performed to ensure c1 symmetry and that the matrix is square and `nbf` by `nbf`.

## Questions
- [ ] Any gradients performed with this permanent potential will not include the Hellmann-Feynman contribution from the permanent potential, and I don't think there is any way to back this out from the potential matrix since the potential is arbitrary. We could require that the user provide the appropriate Hellmann-Feynman contribution to the gradient when they call `gradient()` with a `permanent_potential` through an additional keyword, or we could print a warning and leave it up to the user to add the Hellmann-Feynman contribution onto the gradient *post hoc*. How should we approach this?

## Checklist
- [x] Added test `perm` which compares energies computed by including embedded point charges through the `external_potentials` keyword and by providing the appropriate 1e matrix from this potential through the `permanent_potential` keyword (the 1e matrix is constructed by instantiating a separate `ExternalPotential` object, adding the point charges, and calling `ExternalPotential::computePotentialMatrix()` on the basis).
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
