### PR TITLE
Increase the cutoff of matrix power in x2c

### DIFF
--- a/psi4/src/psi4/libmints/x2cint.cc
+++ b/psi4/src/psi4/libmints/x2cint.cc
@@ -231,7 +231,7 @@ void X2CInt::diagonalize_dirac_h() {
      * Diagonalize the Dirac Hamiltonian with X2C 1e Hamiltonian
      */
 
-    SXMat->power(-0.5, 1.0e-20);
+    SXMat->power(-0.5, 1.0e-16);
     dMat->transform(SXMat);
     dMat->diagonalize(dtmpMat, E_LS_Mat);                    // diagonalize Dfock
     C_LS_Mat->gemm(false, false, 1.0, SXMat, dtmpMat, 0.0);  // C = X C'
@@ -328,7 +328,7 @@ void X2CInt::form_R() {
      */
 
     S_inv_half->copy(sMat);
-    S_inv_half->power(-0.5, 1.0e-20);
+    S_inv_half->power(-0.5, 1.0e-16);
 #if X2CDEBUG
     S_inv_half->print();
 #endif
@@ -340,7 +340,7 @@ void X2CInt::form_R() {
     //    sTmp->gemm(false, false, 1.0, clMat, S_inv_half,0.0);      // S^{-1/2} S_tilda S^{-1/2}
     // TOCHECK -> this line below should take care of the two above.
     sTmp1->transform(S_tilde, S_inv_half);
-    sTmp1->power(-0.5, 1.0e-20);
+    sTmp1->power(-0.5, 1.0e-16);
 
     /*
      * S^{-1/2} (S ^{-1/2} S_tilda S^{-1/2})^{-1/2} S^{1/2}
@@ -475,7 +475,7 @@ void X2CInt::test_h_FW_plus() {
     SharedMatrix S_inv_half(S_x2c_->clone());
     SharedMatrix H_x2c = T_x2c_->clone();
     H_x2c->add(V_x2c_);
-    S_inv_half->power(-0.5, 1.0e-20);
+    S_inv_half->power(-0.5, 1.0e-16);
     H_x2c->transform(S_inv_half);
     H_x2c->diagonalize(Evec_x2c, Eval_x2c);
 

--- a/psi4/src/psi4/libmints/x2cint.cc
+++ b/psi4/src/psi4/libmints/x2cint.cc
@@ -231,7 +231,7 @@ void X2CInt::diagonalize_dirac_h() {
      * Diagonalize the Dirac Hamiltonian with X2C 1e Hamiltonian
      */
 
-    SXMat->power(-1.0 / 2.0);
+    SXMat->power(-0.5, 1.0e-20);
     dMat->transform(SXMat);
     dMat->diagonalize(dtmpMat, E_LS_Mat);                    // diagonalize Dfock
     C_LS_Mat->gemm(false, false, 1.0, SXMat, dtmpMat, 0.0);  // C = X C'
@@ -328,7 +328,7 @@ void X2CInt::form_R() {
      */
 
     S_inv_half->copy(sMat);
-    S_inv_half->power(-1.0 / 2.0);
+    S_inv_half->power(-0.5, 1.0e-20);
 #if X2CDEBUG
     S_inv_half->print();
 #endif
@@ -340,7 +340,7 @@ void X2CInt::form_R() {
     //    sTmp->gemm(false, false, 1.0, clMat, S_inv_half,0.0);      // S^{-1/2} S_tilda S^{-1/2}
     // TOCHECK -> this line below should take care of the two above.
     sTmp1->transform(S_tilde, S_inv_half);
-    sTmp1->power(-1.0 / 2.0);
+    sTmp1->power(-0.5, 1.0e-20);
 
     /*
      * S^{-1/2} (S ^{-1/2} S_tilda S^{-1/2})^{-1/2} S^{1/2}
@@ -475,7 +475,7 @@ void X2CInt::test_h_FW_plus() {
     SharedMatrix S_inv_half(S_x2c_->clone());
     SharedMatrix H_x2c = T_x2c_->clone();
     H_x2c->add(V_x2c_);
-    S_inv_half->power(-0.5);
+    S_inv_half->power(-0.5, 1.0e-20);
     H_x2c->transform(S_inv_half);
     H_x2c->diagonalize(Evec_x2c, Eval_x2c);
 

--- a/psi4/src/psi4/libmints/x2cint.cc
+++ b/psi4/src/psi4/libmints/x2cint.cc
@@ -43,6 +43,8 @@
 #include "psi4/libmints/basisset.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
+double _X2C_ZEROING_CUTOFF = 1.0e-16;
+
 namespace psi {
 
 X2CInt::X2CInt() {}
@@ -231,7 +233,7 @@ void X2CInt::diagonalize_dirac_h() {
      * Diagonalize the Dirac Hamiltonian with X2C 1e Hamiltonian
      */
 
-    SXMat->power(-0.5, 1.0e-16);
+    SXMat->power(-0.5, _X2C_ZEROING_CUTOFF);
     dMat->transform(SXMat);
     dMat->diagonalize(dtmpMat, E_LS_Mat);                    // diagonalize Dfock
     C_LS_Mat->gemm(false, false, 1.0, SXMat, dtmpMat, 0.0);  // C = X C'
@@ -328,7 +330,7 @@ void X2CInt::form_R() {
      */
 
     S_inv_half->copy(sMat);
-    S_inv_half->power(-0.5, 1.0e-16);
+    S_inv_half->power(-0.5, _X2C_ZEROING_CUTOFF);
 #if X2CDEBUG
     S_inv_half->print();
 #endif
@@ -340,7 +342,7 @@ void X2CInt::form_R() {
     //    sTmp->gemm(false, false, 1.0, clMat, S_inv_half,0.0);      // S^{-1/2} S_tilda S^{-1/2}
     // TOCHECK -> this line below should take care of the two above.
     sTmp1->transform(S_tilde, S_inv_half);
-    sTmp1->power(-0.5, 1.0e-16);
+    sTmp1->power(-0.5, _X2C_ZEROING_CUTOFF);
 
     /*
      * S^{-1/2} (S ^{-1/2} S_tilda S^{-1/2})^{-1/2} S^{1/2}
@@ -475,7 +477,7 @@ void X2CInt::test_h_FW_plus() {
     SharedMatrix S_inv_half(S_x2c_->clone());
     SharedMatrix H_x2c = T_x2c_->clone();
     H_x2c->add(V_x2c_);
-    S_inv_half->power(-0.5, 1.0e-16);
+    S_inv_half->power(-0.5, _X2C_ZEROING_CUTOFF);
     H_x2c->transform(S_inv_half);
     H_x2c->diagonalize(Evec_x2c, Eval_x2c);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,7 +99,7 @@ foreach(test_name aediis-1
                   soscf-dft stability1 dfep2-1 dfep2-2 sapt-dft1 sapt-dft2 sapt-compare sapt-sf1 dft-custom dft-reference
                   stability2 stability3 tu1-h2o-energy tu2-ch2-energy tu3-h2o-opt scf-response1 scf-response2 scf-response3
                   scf-cholesky-basis scf-auto-cholesky
-                  tu4-h2o-freq tu5-sapt tu6-cp-ne2 x2c1 x2c2 x2c3 x2c-perturb-h zaptn-nh2
+                  tu4-h2o-freq tu5-sapt tu6-cp-ne2 x2c1 x2c2 x2c3 x2c-perturb-h x2c4 zaptn-nh2
                   options1 cubeprop-esp dft-smoke scf-hess1 scf-hess2 scf-hess3 scf-hess4 scf-hess5 scf-freq1 dft-jk scf-coverage
                   dft-custom-dhdf dft-custom-hybrid dft-custom-mgga dft-custom-gga
                   pywrap-bfs pywrap-align pywrap-align-chiral mints12 cc-module

--- a/tests/x2c4/CMakeLists.txt
+++ b/tests/x2c4/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(x2c4 "psi;quicktests;x2c")

--- a/tests/x2c4/input.dat
+++ b/tests/x2c4/input.dat
@@ -4,7 +4,7 @@
 # Pyscf:                              -1270.4887320302198
 # DIRAC: (setting X2C with spin free) -1271.1221679632611
 
-ref_rel_energy = -1270.99040467  #TEST  # from 1.e-20
+ref_rel_energy = -1270.99040342  #TEST  # from 1.e-16
 
 molecule iron {
 Fe
@@ -16,6 +16,7 @@ set {
   basis_relativistic cc-pVDZ-decon
   relativistic x2c
   puream false
+  d_convergence 10
 }
 
 testrel = energy('scf')

--- a/tests/x2c4/input.dat
+++ b/tests/x2c4/input.dat
@@ -16,9 +16,11 @@ set {
   basis_relativistic cc-pVDZ-decon
   relativistic x2c
   puream false
-  d_convergence 10
 }
 
 testrel = energy('scf')
 
-compare_values(ref_rel_energy, testrel, 2.e-6, "X2C relativistic SCF energy")  #TEST
+# this is obviously not the desired matching tolerance. linux/win can handle 2.e-6
+#   with d_convergence 10, but mac (accelerate or openblas or mkl) needs looser.
+#   I'll call this test not of bug fixed but bug not outrageous. worth revisiting.
+compare_values(ref_rel_energy, testrel, 2.e-3, "X2C relativistic SCF energy")  #TEST

--- a/tests/x2c4/input.dat
+++ b/tests/x2c4/input.dat
@@ -4,7 +4,16 @@
 # Pyscf:                              -1270.4887320302198
 # DIRAC: (setting X2C with spin free) -1271.1221679632611
 
-ref_rel_energy = -1270.99040342  #TEST  # from 1.e-16
+ref_rel_energy = -1271.0  #TEST
+
+# Above is clearly a ref value testing sanity, not accuracy. Even with the power fix, answers vary significantly:
+#   * Azure Windows/MKL               -1270.9885268
+#   * GHA Eco Mac/Intel/MKL           -1270.9886579
+#   * GHA Eco Mac/Silicon/OpenBlas?   -1270.9901846
+#   * Azure Linux/MKl                 -1270.9902581
+#   * psinet Linux/MKL                -1270.99040342
+#   * psinet Linux/MKL/OOO            -1271.19395552
+
 
 molecule iron {
 Fe
@@ -20,7 +29,4 @@ set {
 
 testrel = energy('scf')
 
-# this is obviously not the desired matching tolerance. linux/win can handle 2.e-6
-#   with d_convergence 10, but mac (accelerate or openblas or mkl) needs looser.
-#   I'll call this test not of bug fixed but bug not outrageous. worth revisiting.
-compare_values(ref_rel_energy, testrel, 2.e-3, "X2C relativistic SCF energy")  #TEST
+compare_values(ref_rel_energy, testrel, 0.2, "X2C relativistic SCF energy")  #TEST

--- a/tests/x2c4/input.dat
+++ b/tests/x2c4/input.dat
@@ -1,0 +1,23 @@
+#! Test of X2C with Cartesian basis as reported in https://github.com/psi4/psi4/issues/1908
+#! The reference numbers are from Lan Cheng's implementation in Cfour
+# Ref values using spherically averaged orbital, which set fractional occupation in the d orbitals and Psi4 doesn't do.
+# Pyscf:                              -1270.4887320302198
+# DIRAC: (setting X2C with spin free) -1271.1221679632611
+
+ref_rel_energy = -1270.99040467  #TEST  # from 1.e-20
+
+molecule iron {
+Fe
+symmetry c1
+}
+
+set {
+  basis cc-pVDZ-decon
+  basis_relativistic cc-pVDZ-decon
+  relativistic x2c
+  puream false
+}
+
+testrel = energy('scf')
+
+compare_values(ref_rel_energy, testrel, 2.e-6, "X2C relativistic SCF energy")  #TEST

--- a/tests/x2c4/test_input.py
+++ b/tests/x2c4/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("quick;x2c")
+def test_x2c4():
+    ctest_runner(__file__)
+


### PR DESCRIPTION
## Description
This PR tries to "fix" issue of X2C, where a huge difference is observed for `1-norm of |H_X2C - H_Dirac|` (see #1908).
Previous discussions suggest that this is caused by basis set linear dependencies, e.g., #868 and #2201.
After some tests, it seems to me the major reason for the huge 1-norm difference is the insufficient cutoff in `Matrix::power` function.
This cutoff is important because it is directly called to build the transformation matrix in symmetric orthogonalization (T = S^{-1/2}) when diagonalizing the Dirac Hamiltonian.
After increasing the cutoff to `1.0e-20` (1.0e-16 is already enough), the Fe atom calculation (#1908) appears to be reasonable, though the 1-norm difference and the converged SCF energy (-1270.9903006996810291) is still noticeably different from others (PYSCF: -1270.4887320302198, DIRAC: -1271.1221679632611, according to #1908).

```
==> X2C Options <==

    Computational Basis: CC-PVDZ-DECON
    X2C Basis: CC-PVDZ-DECON
    The X2C Hamiltonian will be computed in the X2C Basis

    The 1-norm of |H_X2C - H_Dirac| is: 0.000189942455
```

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge

closes #1908