### PR TITLE
Update read_options.cc

### DIFF
--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -424,7 +424,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("DAMPING_FACTOR_MULTIPOLE", 2.1304);
 
         /*- Summation scheme for field computations, can be direct or fmm -*/
-        options.add_str_i("SUMMATION_FIELDS", "DIRECT", "DIRECT FMM");
+        options.add_str("SUMMATION_FIELDS", "DIRECT", "DIRECT FMM");
         /*- Expansion order of the multipoles for FMM -*/
         options.add_int("TREE_EXPANSION_ORDER", 5);
         /*- Opening angle theta -*/


### PR DESCRIPTION
## Description
Unmarks an option as case-sensitive.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] The "summation_fields" option for polarizable embedding is no longer case-sensitive.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Marks an option as case-insensitive that was never supposed to be case sensitive.

## Status
- [x] Ready for review
- [x] Ready for merge
