### PR TITLE
Update read_options.cc

### DIFF
--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1754,7 +1754,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         due to compile-time issues and requiring very modern CUDA CCs (>=80) -*/
         options.add_str("SNLINK_LWD_KERNEL", "DEFAULT", "DEFAULT REFERENCE SCHEME1 SCHEME1-MAGMA"); 
         /*- Overwrite sn-LinK grid options with debug grid matching GauXC's Ultrafine grid spec !expert -*/
-        options.add_int("SNLINK_USE_DEBUG_GRID", false);
+        options.add_bool("SNLINK_USE_DEBUG_GRID", false);
 
         /*- SUBSECTION SAD Guess Algorithm -*/
 


### PR DESCRIPTION
## Description
An option that had been incorrectly labelled as an int is now marked as a bool.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] An option that had been incorrectly labelled as an int is now marked as a bool.

## Status
- [x] Ready for review
- [x] Ready for merge
