### PR TITLE
SAPT(DFT) External Potential

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1884,6 +1884,10 @@ def scf_helper(name, post_scf=True, **kwargs):
             basisset=scf_wfn.basisset()
         )
 
+    if (jk_obj := kwargs.get('jk')):
+        core.print_out("  Using user-supplied JK object.\n")
+        scf_wfn.set_jk(jk_obj)
+
     e_scf = scf_wfn.compute_energy()
     for obj in [core, scf_wfn]:
         # set_variable("SCF TOTAL ENERGY")  # P::e SCF

--- a/psi4/driver/procrouting/proc_util.py
+++ b/psi4/driver/procrouting/proc_util.py
@@ -208,13 +208,17 @@ def print_ci_results(ciwfn, rname, scf_e, ci_e, print_opdm_no=False):
     dvec.close_io_files(True)
 
 
-def prepare_sapt_molecule(sapt_dimer: core.Molecule, sapt_basis: str) -> Tuple[core.Molecule, core.Molecule, core.Molecule]:
+def prepare_sapt_molecule(sapt_dimer: core.Molecule, sapt_basis: str, clone_molecule=True) -> Tuple[core.Molecule, core.Molecule, core.Molecule]:
     """
     Prepares a dimer molecule for a SAPT computation. Returns the dimer, monomerA, and monomerB.
     """
 
     # Shifting to C1 so we need to copy the active molecule
-    sapt_dimer = sapt_dimer.clone()
+    # This clone statement is making molecule incompatible with external
+    # potential for scf_helper dimer and monomers... what is not being cloned
+    # correctly? Cloning is resetting _initial_cartesians, need to block
+    if clone_molecule:
+        sapt_dimer = sapt_dimer.clone()
     if sapt_dimer.schoenflies_symbol() != 'c1':
         core.print_out('  SAPT does not make use of molecular symmetry, further calculations in C1 point group.\n')
         sapt_dimer.reset_point_group('c1')

--- a/psi4/driver/procrouting/sapt/sapt_jk_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_jk_terms.py
@@ -35,9 +35,16 @@ from psi4 import core
 from ...p4util import solvers
 from ...p4util.exceptions import *
 from .sapt_util import print_sapt_var
+from pprint import pprint as pp
 
 
-def build_sapt_jk_cache(wfn_A, wfn_B, jk, do_print=True):
+def build_sapt_jk_cache(
+        wfn_dimer: core.Wavefunction,
+        wfn_A: core.Wavefunction,
+        wfn_B: core.Wavefunction,
+        jk: core.JK,
+        do_print=True,
+):
     """
     Constructs the DCBS cache data required to compute ELST/EXCH/IND
     """

--- a/psi4/driver/procrouting/sapt/sapt_proc.py
+++ b/psi4/driver/procrouting/sapt/sapt_proc.py
@@ -34,77 +34,138 @@ from ... import p4util
 from ...constants import constants
 from ...p4util.exceptions import *
 from .. import proc_util
-from ..proc import scf_helper
+from ..proc import scf_helper, run_scf
 from . import sapt_jk_terms, sapt_mp2_terms, sapt_sf_terms
 from .sapt_util import print_sapt_dft_summary, print_sapt_hf_summary, print_sapt_var
+import qcelemental as qcel
+from ...p4util.exceptions import ConvergenceError
 
 # Only export the run_ scripts
-__all__ = ['run_sapt_dft', 'sapt_dft', 'run_sf_sapt']
+__all__ = ["run_sapt_dft", "sapt_dft", "run_sf_sapt"]
 
 
 def run_sapt_dft(name, **kwargs):
-    optstash = p4util.OptionsState(['SCF_TYPE'], ['SCF', 'REFERENCE'], ['SCF', 'DFT_GRAC_SHIFT'], ['SCF', 'SAVE_JK'])
+    optstash = p4util.OptionsState(
+        ["SCF_TYPE"],
+        ["SCF", "REFERENCE"],
+        ["SCF", "DFT_GRAC_SHIFT"],
+        ["SCF", "SAVE_JK"],
+    )
 
     core.tstart()
     # Alter default algorithm
-    if not core.has_global_option_changed('SCF_TYPE'):
-        core.set_global_option('SCF_TYPE', 'DF')
-
+    if not core.has_global_option_changed("SCF_TYPE"):
+        core.set_global_option("SCF_TYPE", "DF")
     core.prepare_options_for_module("SAPT")
 
-    # Get the molecule of interest
-    ref_wfn = kwargs.get('ref_wfn', None)
-    if ref_wfn is None:
-        sapt_dimer = kwargs.pop('molecule', core.get_active_molecule())
-    else:
-        core.print_out('Warning! SAPT argument "ref_wfn" is only able to use molecule information.')
-        sapt_dimer = ref_wfn.molecule()
-
-    sapt_dimer, monomerA, monomerB = proc_util.prepare_sapt_molecule(sapt_dimer, "dimer")
-
     # Grab overall settings
+    do_mon_grac_shift_A = False
+    do_mon_grac_shift_B = False
     mon_a_shift = core.get_option("SAPT", "SAPT_DFT_GRAC_SHIFT_A")
     mon_b_shift = core.get_option("SAPT", "SAPT_DFT_GRAC_SHIFT_B")
+
+    if np.isclose(mon_a_shift, -99.0, atol=1e-6):
+        do_mon_grac_shift_A = True
+        print("Monomer A GRAC shift set to -99.0, will compute automatically.")
+    if np.isclose(mon_b_shift, -99.0, atol=1e-6):
+        do_mon_grac_shift_B = True
+        print("Monomer B GRAC shift set to -99.0, will compute automatically.")
+
     do_delta_hf = core.get_option("SAPT", "SAPT_DFT_DO_DHF")
     sapt_dft_functional = core.get_option("SAPT", "SAPT_DFT_FUNCTIONAL")
     do_dft = sapt_dft_functional != "HF"
 
+    # Get the molecule of interest
+    ref_wfn = kwargs.get("ref_wfn", None)
+    if ref_wfn is None:
+        sapt_dimer_initial = kwargs.pop("molecule", core.get_active_molecule())
+    else:
+        core.print_out(
+            'Warning! SAPT argument "ref_wfn" is only able to use molecule information.'
+        )
+        sapt_dimer_initial = ref_wfn.molecule()
+
+    if do_mon_grac_shift_A or do_mon_grac_shift_B:
+        monA = sapt_dimer_initial.extract_subsets(1)
+        monB = sapt_dimer_initial.extract_subsets(2)
+
+    sapt_dimer, monomerA, monomerB = proc_util.prepare_sapt_molecule(
+        sapt_dimer_initial, "dimer"
+    )
+
+    sapt_dimer._initial_cartesian = sapt_dimer_initial._initial_cartesian
+    monomerA._initial_cartesian = core.Matrix.from_array(sapt_dimer._initial_cartesian.np.copy())
+    monomerB._initial_cartesian = core.Matrix.from_array(sapt_dimer._initial_cartesian.np.copy())
+
     # Print out the title and some information
     core.print_out("\n")
-    core.print_out("         ---------------------------------------------------------\n")
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
     core.print_out("         " + "SAPT(DFT) Procedure".center(58) + "\n")
     core.print_out("\n")
     core.print_out("         " + "by Daniel G. A. Smith".center(58) + "\n")
-    core.print_out("         ---------------------------------------------------------\n")
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
     core.print_out("\n")
 
     # core.print_out("  !!!  WARNING:  SAPT(DFT) capability is in beta. Please use with caution. !!!\n\n")
-    core.print_out("Warning! The default value of SAPT_DFT_EXCH_DISP_SCALE_SCHEME has changed from DISP to FIXED. Please be careful comparing results with earlier versions. \n\n")
+    core.print_out(
+        "Warning! The default value of SAPT_DFT_EXCH_DISP_SCALE_SCHEME has changed from DISP to FIXED. Please be careful comparing results with earlier versions. \n\n"
+    )
 
     core.print_out("  ==> Algorithm <==\n\n")
-    core.print_out("   SAPT DFT Functional     %12s\n" % str(sapt_dft_functional))
+    core.print_out("   SAPT DFT Functional     %12s\n" %
+                   str(sapt_dft_functional))
     core.print_out("   Monomer A GRAC Shift    %12.6f\n" % mon_a_shift)
     core.print_out("   Monomer B GRAC Shift    %12.6f\n" % mon_b_shift)
-    core.print_out("   Delta HF                %12s\n" % ("True" if do_delta_hf else "False"))
-    core.print_out("   JK Algorithm            %12s\n" % core.get_global_option("SCF_TYPE"))
+    core.print_out(
+        "   Delta HF                %12s\n" % (
+            "True" if do_delta_hf else "False")
+    )
+    core.print_out(
+        "   JK Algorithm            %12s\n" % core.get_global_option(
+            "SCF_TYPE")
+    )
     core.print_out("\n")
     core.print_out("   Required computations:\n")
-    if (do_delta_hf):
-        core.print_out("     HF  (Dimer)\n")
-        core.print_out("     HF  (Monomer A)\n")
-        core.print_out("     HF  (Monomer B)\n")
-    if (do_dft):
-        core.print_out("     DFT (Monomer A)\n")
-        core.print_out("     DFT (Monomer B)\n")
+    if do_delta_hf:
+        core.print_out("     HF   (Dimer)\n")
+        core.print_out("     HF   (Monomer A)\n")
+        core.print_out("     HF   (Monomer B)\n")
+    if do_dft:
+        core.print_out("     DFT  (Monomer A)\n")
+        core.print_out("     DFT  (Monomer B)\n")
+    if do_mon_grac_shift_A:
+        core.print_out("     GRAC (Monomer A)\n")
+        compute_GRAC_shift(
+            monA,
+            core.get_option("SAPT", "SAPT_DFT_GRAC_CONVERGENCE_TIER"),
+            "Monomer A",
+        )
+        mon_a_shift = core.get_option("SAPT", "SAPT_DFT_GRAC_SHIFT_A")
+    if do_mon_grac_shift_B:
+        core.print_out("     GRAC (Monomer B)\n")
+        compute_GRAC_shift(
+            monB,
+            core.get_option("SAPT", "SAPT_DFT_GRAC_CONVERGENCE_TIER"),
+            "Monomer B",
+        )
+        mon_b_shift = core.get_option("SAPT", "SAPT_DFT_GRAC_SHIFT_B")
     core.print_out("\n")
 
     if do_dft and ((mon_a_shift == 0.0) or (mon_b_shift == 0.0)):
-        raise ValidationError('SAPT(DFT): must set both "SAPT_DFT_GRAC_SHIFT_A" and "B".')
+        raise ValidationError(
+            'SAPT(DFT): must set both "SAPT_DFT_GRAC_SHIFT_A" and "B". To automatically compute the GRAC shift, set to -99.0.'
+        )
 
-    if (core.get_option('SCF', 'REFERENCE') != 'RHF'):
-        raise ValidationError('SAPT(DFT) currently only supports restricted references.')
+    if core.get_option("SCF", "REFERENCE") != "RHF":
+        raise ValidationError(
+            "SAPT(DFT) currently only supports restricted references."
+        )
 
-    core.IO.set_default_namespace('dimer')
+    core.IO.set_default_namespace("dimer")
     data = {}
 
     if (core.get_global_option('SCF_TYPE') in ['DF', 'DISK_DF']):
@@ -117,6 +178,7 @@ def run_sapt_dft(name, **kwargs):
 
     # Compute dimer wavefunction
     hf_wfn_dimer = None
+    from pprint import pprint as pp
     if do_delta_hf:
         if (core.get_global_option('SCF_TYPE') in ['DF', 'DISK_DF']):
             core.set_global_option('DF_INTS_IO', 'SAVE')
@@ -146,7 +208,7 @@ def run_sapt_dft(name, **kwargs):
         core.set_global_option("SAVE_JK", False)
         core.timer_off("SAPT(DFT):Monomer B SCF")
 
-        if do_dft: # For SAPT(HF) do the JK terms in sapt_dft()
+        if do_dft:  # For SAPT(HF) do the JK terms in sapt_dft()
             # Grab JK object and set to A (so we do not save many JK objects)
             sapt_jk = hf_wfn_B.jk()
             hf_wfn_A.set_jk(sapt_jk)
@@ -157,19 +219,31 @@ def run_sapt_dft(name, **kwargs):
                 core.IO.change_file_namespace(97, 'monomerB', 'dimer')
 
             core.print_out("\n")
-            core.print_out("         ---------------------------------------------------------\n")
-            core.print_out("         " + "SAPT(DFT): delta HF Segment".center(58) + "\n")
+            core.print_out(
+                "         ---------------------------------------------------------\n"
+            )
+            core.print_out(
+                "         " + "SAPT(DFT): delta HF Segment".center(58) + "\n"
+            )
             core.print_out("\n")
-            core.print_out("         " + "by Daniel G. A. Smith and Rob Parrish".center(58) + "\n")
-            core.print_out("         ---------------------------------------------------------\n")
+            core.print_out(
+                "         " +
+                "by Daniel G. A. Smith and Rob Parrish".center(58) + "\n"
+            )
+            core.print_out(
+                "         ---------------------------------------------------------\n"
+            )
             core.print_out("\n")
 
             # Build cache
-            hf_cache = sapt_jk_terms.build_sapt_jk_cache(hf_wfn_A, hf_wfn_B, sapt_jk, True)
+            hf_cache = sapt_jk_terms.build_sapt_jk_cache(
+               hf_wfn_dimer, hf_wfn_A, hf_wfn_B, sapt_jk, True
+            )
 
             # Electrostatics
             core.timer_on("SAPT(HF):elst")
-            elst = sapt_jk_terms.electrostatics(hf_cache, True)
+            elst, extern_extern_ie = sapt_jk_terms.electrostatics(hf_cache, True)
+            hf_data['extern_extern_ie'] = extern_extern_ie
             hf_data.update(elst)
             core.timer_off("SAPT(HF):elst")
 
@@ -181,19 +255,26 @@ def run_sapt_dft(name, **kwargs):
 
             # Induction
             core.timer_on("SAPT(HF):ind")
-            ind = sapt_jk_terms.induction(hf_cache,
-                                          sapt_jk,
-                                          True,
-                                          maxiter=core.get_option("SAPT", "MAXITER"),
-                                          conv=core.get_option("SAPT", "CPHF_R_CONVERGENCE"),
-                                          Sinf=core.get_option("SAPT", "DO_IND_EXCH_SINF"))
+            ind = sapt_jk_terms.induction(
+                hf_cache,
+                sapt_jk,
+                True,
+                maxiter=core.get_option("SAPT", "MAXITER"),
+                conv=core.get_option("SAPT", "CPHF_R_CONVERGENCE"),
+                Sinf=core.get_option("SAPT", "DO_IND_EXCH_SINF"),
+            )
             hf_data.update(ind)
             core.timer_off("SAPT(HF):ind")
 
-            dhf_value = hf_data["HF DIMER"] - hf_data["HF MONOMER A"] - hf_data["HF MONOMER B"]
+            dhf_value = (
+                hf_data["HF DIMER"] - hf_data["HF MONOMER A"] -
+                hf_data["HF MONOMER B"]
+            )
 
             core.print_out("\n")
-            core.print_out(print_sapt_hf_summary(hf_data, "SAPT(HF)", delta_hf=dhf_value))
+            core.print_out(
+                print_sapt_hf_summary(hf_data, "SAPT(HF)", delta_hf=dhf_value)
+            )
 
             data["Delta HF Correction"] = core.variable("SAPT(DFT) Delta HF")
             sapt_jk.finalize()
@@ -201,22 +282,26 @@ def run_sapt_dft(name, **kwargs):
             del hf_wfn_A, hf_wfn_B, sapt_jk
 
         else:
-            wfn_A = hf_wfn_A 
+            wfn_A = hf_wfn_A
             wfn_B = hf_wfn_B
-            data["DFT MONOMER A"] = hf_data["HF MONOMER A"] 
-            data["DFT MONOMER B"] = hf_data["HF MONOMER B"] 
-            dhf_value = hf_data["HF DIMER"] - hf_data["HF MONOMER A"] - hf_data["HF MONOMER B"]
+            data["DFT MONOMER A"] = hf_data["HF MONOMER A"]
+            data["DFT MONOMER B"] = hf_data["HF MONOMER B"]
+            dhf_value = (
+                hf_data["HF DIMER"] - hf_data["HF MONOMER A"] -
+                hf_data["HF MONOMER B"]
+            )
             data["DHF VALUE"] = dhf_value
 
     if hf_wfn_dimer is None:
-        dimer_wfn = core.Wavefunction.build(sapt_dimer, core.get_global_option("BASIS"))
+        dimer_wfn = core.Wavefunction.build(
+            sapt_dimer, core.get_global_option("BASIS"))
     else:
         dimer_wfn = hf_wfn_dimer
 
     if do_dft or not do_delta_hf:
 
         # Set the primary functional
-        core.set_local_option('SCF', 'REFERENCE', 'RKS')
+        core.set_local_option("SCF", "REFERENCE", "RKS")
 
         # Compute Monomer A wavefunction
         core.timer_on("SAPT(DFT): Monomer A DFT")
@@ -266,14 +351,27 @@ def run_sapt_dft(name, **kwargs):
 
     # Write out header
     scf_alg = core.get_global_option("SCF_TYPE")
-    sapt_dft_header(sapt_dft_functional, mon_a_shift, mon_b_shift, bool(do_delta_hf), scf_alg)
+    sapt_dft_header(
+        sapt_dft_functional, mon_a_shift, mon_b_shift, bool(
+            do_delta_hf), scf_alg
+    )
 
     # Compute Delta HF for SAPT(HF)?
     delta_hf = do_delta_hf and not do_dft
 
     # Call SAPT(DFT)
     sapt_jk = wfn_B.jk()
-    sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=do_dft, sapt_jk=sapt_jk, data=data, print_header=False, delta_hf=delta_hf)
+    sapt_dft(
+        dimer_wfn,
+        wfn_A,
+        wfn_B,
+        do_dft=do_dft,
+        sapt_jk=sapt_jk,
+        data=data,
+        print_header=False,
+        delta_hf=delta_hf,
+        external_potentials = kwargs.get("external_potentials", None),
+    )
 
     # Copy data back into globals
     for k, v in data.items():
@@ -286,22 +384,144 @@ def run_sapt_dft(name, **kwargs):
     return dimer_wfn
 
 
-def sapt_dft_header(sapt_dft_functional="unknown",
-                    mon_a_shift=None,
-                    mon_b_shift=None,
-                    do_delta_hf="N/A",
-                    jk_alg="N/A"):
+def sapt_dft_grac_convergence_tier_options():
+    return {
+        "SINGLE": [
+            {
+                "SCF_INITIAL_ACCELERATOR": "ADIIS",
+            }
+        ],
+        "ITERATIVE": [
+            {
+                "SCF_INITIAL_ACCELERATOR": "ADIIS",
+            },
+            {
+                "LEVEL_SHIFT": 0.01,
+                "LEVEL_SHIFT_CUTOFF": 0.01,
+                "SCF_INITIAL_ACCELERATOR": "ADIIS",
+                "MAXITER": 200,
+            },
+            {
+                "LEVEL_SHIFT": 0.02,
+                "LEVEL_SHIFT_CUTOFF": 0.02,
+                "SCF_INITIAL_ACCELERATOR": "ADIIS",
+                "MAXITER": 200,
+            },
+        ],
+    }
+
+
+def compute_GRAC_shift(
+    molecule, sapt_dft_grac_convergence_tier="SINGLE", label="Monomer A"
+):
+    optstash = p4util.OptionsState(
+        ["SCF_TYPE"],
+        ["SCF", "REFERENCE"],
+        ["SCF", "DFT_GRAC_SHIFT"],
+        ["SCF", "SAVE_JK"],
+    )
+
+    dft_functional = core.get_option("SAPT", "SAPT_DFT_FUNCTIONAL")
+    scf_reference = core.get_option("SCF", "REFERENCE")
+
+    print(f"Computing GRAC shift for {label} using {sapt_dft_grac_convergence_tier}...")
+    grac_options = sapt_dft_grac_convergence_tier_options()[
+        sapt_dft_grac_convergence_tier.upper()
+    ]
+    print(f"{grac_options = }")
+    for options in grac_options:
+        for key, val in options.items():
+            core.set_local_option("SCF", key, val)
+        core.set_local_option("SCF", "REFERENCE", "UHF")
+        # Need to get the neutral and cation to estimate ionization energy for
+        # GRAC shift
+        mol_qcel_dict = molecule.to_schema(dtype=2)
+        del mol_qcel_dict["fragment_charges"]
+        del mol_qcel_dict["fragment_multiplicities"]
+        del mol_qcel_dict["molecular_multiplicity"]
+        mol_qcel_dict["molecular_charge"] = 0
+
+        mol_qcel = qcel.models.Molecule(**mol_qcel_dict)
+        mol_neutral = core.Molecule.from_schema(mol_qcel.dict())
+
+        mol_qcel_dict["molecular_charge"] = 1
+        mol_qcel = qcel.models.Molecule(**mol_qcel_dict)
+        mol_cation = core.Molecule.from_schema(mol_qcel.dict())
+
+        core.print_out(f"\n\n  ==> GRAC {label}: Neutral <==\n\n")
+        try:
+            wfn_neutral = run_scf(
+                dft_functional.lower(),
+                molecule=mol_neutral,
+            )
+            core.print_out(f"\n\n  ==> GRAC {label}: Cation <==\n\n")
+            wfn_cation = run_scf(
+                dft_functional.lower(),
+                molecule=mol_cation,
+            )
+        except ConvergenceError:
+            if len(options) == 1:
+                raise Exception(
+                    "Convergence error in GRAC shift calculation, please try a different convergence tier."
+                )
+            else:
+                print("Convergence error, trying next GRAC iteration...")
+                print(f"{options = }")
+            continue
+        occ_neutral = wfn_neutral.epsilon_a_subset(basis="SO", subset="OCC").to_array(
+            dense=True
+        )
+        HOMO = np.amax(occ_neutral)
+
+        E_neutral = wfn_neutral.energy()
+        E_cation = wfn_cation.energy()
+        grac = E_cation - E_neutral + HOMO
+        if grac >= 1 or grac <= -1:
+            print(f"{grac = }")
+            raise Exception("Invalid GRAC")
+        if label == "Monomer A":
+            core.set_global_option("SAPT_DFT_GRAC_SHIFT_A", grac)
+            core.set_variable("SAPT_DFT_GRAC_SHIFT_A", grac)
+        elif label == "Monomer B":
+            core.set_global_option("SAPT_DFT_GRAC_SHIFT_B", grac)
+            core.set_variable("SAPT_DFT_GRAC_SHIFT_B", grac)
+        else:
+            raise ValueError(
+                "Only Monomer A and Monomer B are valid GRAC shift options"
+            )
+    core.set_local_option("SCF", "REFERENCE", scf_reference)
+    optstash.restore()
+    return
+
+
+def sapt_dft_header(
+    sapt_dft_functional="unknown",
+    mon_a_shift=None,
+    mon_b_shift=None,
+    do_delta_hf="N/A",
+    jk_alg="N/A",
+):
     # Print out the title and some information
     core.print_out("\n")
-    core.print_out("         ---------------------------------------------------------\n")
-    core.print_out("         " + "SAPT(DFT): Intermolecular Interaction Segment".center(58) + "\n")
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
+    core.print_out(
+        "         " +
+        "SAPT(DFT): Intermolecular Interaction Segment".center(58) + "\n"
+    )
     core.print_out("\n")
-    core.print_out("         " + "by Daniel G. A. Smith and Rob Parrish".center(58) + "\n")
-    core.print_out("         ---------------------------------------------------------\n")
+    core.print_out(
+        "         " + "by Daniel G. A. Smith and Rob Parrish".center(58) + "\n"
+    )
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
     core.print_out("\n")
 
     core.print_out("  ==> Algorithm <==\n\n")
-    core.print_out("   SAPT DFT Functional     %12s\n" % str(sapt_dft_functional))
+    core.print_out("   SAPT DFT Functional     %12s\n" %
+                   str(sapt_dft_functional))
     if mon_a_shift:
         core.print_out("   Monomer A GRAC Shift    %12.6f\n" % mon_a_shift)
     if mon_b_shift:
@@ -310,7 +530,19 @@ def sapt_dft_header(sapt_dft_functional="unknown",
     core.print_out("   JK Algorithm            %12s\n" % jk_alg)
 
 
-def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None, data=None, print_header=True, cleanup_jk=True, delta_hf=False):
+def sapt_dft(
+    dimer_wfn,
+    wfn_A,
+    wfn_B,
+    do_dft=True,
+    sapt_jk=None,
+    sapt_jk_B=None,
+    data=None,
+    print_header=True,
+    cleanup_jk=True,
+    delta_hf=False,
+    external_potentials=None,
+):
     """
     The primary SAPT(DFT) algorithm to compute the interaction energy once the wavefunctions have been built.
 
@@ -361,9 +593,12 @@ def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None,
         sapt_jk.initialize()
         sapt_jk.print_header()
 
-        if wfn_B.functional().is_x_lrc() and (wfn_A.functional().x_omega() != wfn_B.functional().x_omega()):
+        if wfn_B.functional().is_x_lrc() and (
+            wfn_A.functional().x_omega() != wfn_B.functional().x_omega()
+        ):
             core.print_out("   => Monomer B: Building SAPT JK object <= \n\n")
-            core.print_out("      Reason: MonomerA Omega != MonomerB Omega\n\n")
+            core.print_out(
+                "      Reason: MonomerA Omega != MonomerB Omega\n\n")
             sapt_jk_B = core.JK.build(dimer_wfn.basisset())
             sapt_jk_B.set_do_J(True)
             sapt_jk_B.set_do_K(True)
@@ -378,12 +613,14 @@ def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None,
         data = {}
 
     # Build SAPT cache
-    cache = sapt_jk_terms.build_sapt_jk_cache(wfn_A, wfn_B, sapt_jk, True)
+    cache = sapt_jk_terms.build_sapt_jk_cache(dimer_wfn, wfn_A, wfn_B, sapt_jk, True)
     core.timer_off("SAPT(DFT):Build JK")
+
+    print(f"{external_potentials = }")
 
     # Electrostatics
     core.timer_on("SAPT(DFT):elst")
-    elst = sapt_jk_terms.electrostatics(cache, True)
+    elst, extern_extern_ie = sapt_jk_terms.electrostatics(cache, True)
     data.update(elst)
     core.timer_off("SAPT(DFT):elst")
 
@@ -395,18 +632,23 @@ def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None,
 
     # Induction
     core.timer_on("SAPT(DFT):ind")
-    ind = sapt_jk_terms.induction(cache,
-                                  sapt_jk,
-                                  True,
-                                  sapt_jk_B=sapt_jk_B,
-                                  maxiter=core.get_option("SAPT", "MAXITER"),
-                                  conv=core.get_option("SAPT", "CPHF_R_CONVERGENCE"),
-                                  Sinf=core.get_option("SAPT", "DO_IND_EXCH_SINF"))
+    ind = sapt_jk_terms.induction(
+        cache,
+        sapt_jk,
+        True,
+        sapt_jk_B=sapt_jk_B,
+        maxiter=core.get_option("SAPT", "MAXITER"),
+        conv=core.get_option("SAPT", "CPHF_R_CONVERGENCE"),
+        Sinf=core.get_option("SAPT", "DO_IND_EXCH_SINF"),
+    )
     data.update(ind)
 
     # Set Delta HF for SAPT(HF)
     if delta_hf:
-        total_sapt = (data["Elst10,r"] + data["Exch10"] + data["Ind20,r"] + data["Exch-Ind20,r"])
+        total_sapt = (
+            data["Elst10,r"] + data["Exch10"] +
+            data["Ind20,r"] + data["Exch-Ind20,r"]
+        )
         sapt_hf_delta = data["DHF VALUE"] - total_sapt
         core.set_variable("SAPT(DFT) Delta HF", sapt_hf_delta)
         data["Delta HF Correction"] = core.variable("SAPT(DFT) Delta HF")
@@ -426,7 +668,8 @@ def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None,
         if do_hybrid:
             if hybrid_specified:
                 raise ValidationError(
-                    "SAPT(DFT): Hybrid xc kernel not yet implemented for range-separated funtionals.")
+                    "SAPT(DFT): Hybrid xc kernel not yet implemented for range-separated funtionals."
+                )
             else:
                 core.print_out(
                     "Warning: Hybrid xc kernel not yet implemented for range-separated funtionals; hybrid kernel capability is turned off.\n"
@@ -440,62 +683,77 @@ def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None,
 
     # Dispersion
     core.timer_on("SAPT(DFT):disp")
-    
+
     primary_basis = wfn_A.basisset()
-    aux_basis = core.BasisSet.build(dimer_wfn.molecule(), "DF_BASIS_MP2", core.get_option("DFMP2", "DF_BASIS_MP2"),
-                                        "RIFIT", core.get_global_option('BASIS'))
-    
+    aux_basis = core.BasisSet.build(
+        dimer_wfn.molecule(),
+        "DF_BASIS_MP2",
+        core.get_option("DFMP2", "DF_BASIS_MP2"),
+        "RIFIT",
+        core.get_global_option("BASIS"),
+    )
+
     if do_dft:
         core.timer_on("FDDS disp")
         core.print_out("\n")
         x_alpha = wfn_B.functional().x_alpha()
         if not is_hybrid:
             x_alpha = 0.0
-        fdds_disp = sapt_mp2_terms.df_fdds_dispersion(primary_basis, aux_basis, cache, is_hybrid, x_alpha)
+        fdds_disp = sapt_mp2_terms.df_fdds_dispersion(
+            primary_basis, aux_basis, cache, is_hybrid, x_alpha
+        )
         data.update(fdds_disp)
         nfrozen_A = 0
         nfrozen_B = 0
         core.timer_off("FDDS disp")
     else:
-# this is where we actually need to figure out the number of frozen-core orbitals
-# if SAPT_DFT_MP2_DISP_ALG == FISAPT, the code will not figure it out on its own
-        nfrozen_A = wfn_A.basisset().n_frozen_core(core.get_global_option("FREEZE_CORE"),wfn_A.molecule())
-        nfrozen_B = wfn_B.basisset().n_frozen_core(core.get_global_option("FREEZE_CORE"),wfn_B.molecule())
-        
-    
+        # this is where we actually need to figure out the number of frozen-core orbitals
+        # if SAPT_DFT_MP2_DISP_ALG == FISAPT, the code will not figure it out on its own
+        nfrozen_A = wfn_A.basisset().n_frozen_core(
+            core.get_global_option("FREEZE_CORE"), wfn_A.molecule()
+        )
+        nfrozen_B = wfn_B.basisset().n_frozen_core(
+            core.get_global_option("FREEZE_CORE"), wfn_B.molecule()
+        )
+
     core.timer_on("MP2 disp")
     if core.get_option("SAPT", "SAPT_DFT_MP2_DISP_ALG") == "FISAPT":
-        mp2_disp = sapt_mp2_terms.df_mp2_fisapt_dispersion(wfn_A, primary_basis, aux_basis, 
-                                                           cache, nfrozen_A, nfrozen_B, do_print=True)
+        mp2_disp = sapt_mp2_terms.df_mp2_fisapt_dispersion(
+            wfn_A, primary_basis, aux_basis, cache, nfrozen_A, nfrozen_B, do_print=True
+        )
     else:
-        mp2_disp = sapt_mp2_terms.df_mp2_sapt_dispersion(dimer_wfn,
-                                                         wfn_A,
-                                                         wfn_B,
-                                                         primary_basis,
-                                                         aux_basis,
-                                                         cache,
-                                                         do_print=True)
+        mp2_disp = sapt_mp2_terms.df_mp2_sapt_dispersion(
+            dimer_wfn, wfn_A, wfn_B, primary_basis, aux_basis, cache, do_print=True
+        )
     data.update(mp2_disp)
 
     # Exchange-dispersion scaling
     if do_dft:
-        exch_disp_scheme = core.get_option("SAPT", "SAPT_DFT_EXCH_DISP_SCALE_SCHEME")
-        core.print_out("    %-33s % s\n" % ("Scaling Scheme", exch_disp_scheme))
+        exch_disp_scheme = core.get_option(
+            "SAPT", "SAPT_DFT_EXCH_DISP_SCALE_SCHEME")
+        core.print_out("    %-33s % s\n" %
+                       ("Scaling Scheme", exch_disp_scheme))
         if exch_disp_scheme == "NONE":
             data["Exch-Disp20,r"] = data["Exch-Disp20,u"]
         elif exch_disp_scheme == "FIXED":
-            exch_disp_scale = core.get_option("SAPT", "SAPT_DFT_EXCH_DISP_FIXED_SCALE")
-            core.print_out("    %-28s % 10.3f\n" % ("Scaling Factor", exch_disp_scale))
+            exch_disp_scale = core.get_option(
+                "SAPT", "SAPT_DFT_EXCH_DISP_FIXED_SCALE")
+            core.print_out("    %-28s % 10.3f\n" %
+                           ("Scaling Factor", exch_disp_scale))
             data["Exch-Disp20,r"] = exch_disp_scale * data["Exch-Disp20,u"]
         elif exch_disp_scheme == "DISP":
             exch_disp_scale = data["Disp20"] / data["Disp20,u"]
             data["Exch-Disp20,r"] = exch_disp_scale * data["Exch-Disp20,u"]
         if exch_disp_scheme != "NONE":
-            core.print_out(print_sapt_var("Est. Exch-Disp20,r", data["Exch-Disp20,r"], short=True) + "\n")
+            core.print_out(
+                print_sapt_var("Est. Exch-Disp20,r",
+                               data["Exch-Disp20,r"], short=True)
+                + "\n"
+            )
 
     core.timer_off("MP2 disp")
     core.timer_off("SAPT(DFT):disp")
-    
+
     # Print out final data
     core.print_out("\n")
     core.print_out(print_sapt_dft_summary(data, "SAPT(DFT)", do_dft=do_dft))
@@ -504,66 +762,101 @@ def sapt_dft(dimer_wfn, wfn_A, wfn_B, do_dft=True, sapt_jk=None, sapt_jk_B=None,
 
 
 def run_sf_sapt(name, **kwargs):
-    optstash = p4util.OptionsState(['SCF_TYPE'], ['SCF', 'REFERENCE'], ['SCF', 'DFT_GRAC_SHIFT'], ['SCF', 'SAVE_JK'])
+    optstash = p4util.OptionsState(
+        ["SCF_TYPE"],
+        ["SCF", "REFERENCE"],
+        ["SCF", "DFT_GRAC_SHIFT"],
+        ["SCF", "SAVE_JK"],
+    )
 
     core.tstart()
 
     # Alter default algorithm
-    if not core.has_global_option_changed('SCF_TYPE'):
-        core.set_global_option('SCF_TYPE', 'DF')
+    if not core.has_global_option_changed("SCF_TYPE"):
+        core.set_global_option("SCF_TYPE", "DF")
 
     core.prepare_options_for_module("SAPT")
 
     # Get the molecule of interest
-    ref_wfn = kwargs.get('ref_wfn', None)
+    ref_wfn = kwargs.get("ref_wfn", None)
     if ref_wfn is None:
-        sapt_dimer = kwargs.pop('molecule', core.get_active_molecule())
+        sapt_dimer = kwargs.pop("molecule", core.get_active_molecule())
     else:
-        core.print_out('Warning! SAPT argument "ref_wfn" is only able to use molecule information.')
+        core.print_out(
+            'Warning! SAPT argument "ref_wfn" is only able to use molecule information.'
+        )
         sapt_dimer = ref_wfn.molecule()
 
-    sapt_dimer, monomerA, monomerB = proc_util.prepare_sapt_molecule(sapt_dimer, "dimer")
+    sapt_dimer, monomerA, monomerB = proc_util.prepare_sapt_molecule(
+        sapt_dimer, "dimer"
+    )
 
     # Print out the title and some information
     core.print_out("\n")
-    core.print_out("         ---------------------------------------------------------\n")
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
     core.print_out("         " + "Spin-Flip SAPT Procedure".center(58) + "\n")
     core.print_out("\n")
-    core.print_out("         " + "by Daniel G. A. Smith and Konrad Patkowski".center(58) + "\n")
-    core.print_out("         ---------------------------------------------------------\n")
+    core.print_out(
+        "         " +
+        "by Daniel G. A. Smith and Konrad Patkowski".center(58) + "\n"
+    )
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
     core.print_out("\n")
 
     core.print_out("  ==> Algorithm <==\n\n")
-    core.print_out("   JK Algorithm            %12s\n" % core.get_option("SCF", "SCF_TYPE"))
+    core.print_out(
+        "   JK Algorithm            %12s\n" % core.get_option(
+            "SCF", "SCF_TYPE")
+    )
     core.print_out("\n")
     core.print_out("   Required computations:\n")
     core.print_out("     HF  (Monomer A)\n")
     core.print_out("     HF  (Monomer B)\n")
     core.print_out("\n")
 
-    if (core.get_option('SCF', 'REFERENCE') != 'ROHF'):
-        raise ValidationError('Spin-Flip SAPT currently only supports restricted open-shell references.')
+    if core.get_option("SCF", "REFERENCE") != "ROHF":
+        raise ValidationError(
+            "Spin-Flip SAPT currently only supports restricted open-shell references."
+        )
 
     # Run the two monomer computations
-    core.IO.set_default_namespace('dimer')
+    core.IO.set_default_namespace("dimer")
     data = {}
 
     if (core.get_global_option('SCF_TYPE') in ['DF', 'DISK_DF']):
         core.set_global_option('DF_INTS_IO', 'SAVE')
 
     # Compute dimer wavefunction
-    wfn_A = scf_helper("SCF", molecule=monomerA, banner="SF-SAPT: HF Monomer A", **kwargs)
+    wfn_A = scf_helper(
+        "SCF", molecule=monomerA, banner="SF-SAPT: HF Monomer A", **kwargs
+    )
 
     core.set_global_option("SAVE_JK", True)
-    wfn_B = scf_helper("SCF", molecule=monomerB, banner="SF-SAPT: HF Monomer B", **kwargs)
+    wfn_B = scf_helper(
+        "SCF", molecule=monomerB, banner="SF-SAPT: HF Monomer B", **kwargs
+    )
     sapt_jk = wfn_B.jk()
     core.set_global_option("SAVE_JK", False)
     core.print_out("\n")
-    core.print_out("         ---------------------------------------------------------\n")
-    core.print_out("         " + "Spin-Flip SAPT Exchange and Electrostatics".center(58) + "\n")
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
+    core.print_out(
+        "         " +
+        "Spin-Flip SAPT Exchange and Electrostatics".center(58) + "\n"
+    )
     core.print_out("\n")
-    core.print_out("         " + "by Daniel G. A. Smith and Konrad Patkowski".center(58) + "\n")
-    core.print_out("         ---------------------------------------------------------\n")
+    core.print_out(
+        "         " +
+        "by Daniel G. A. Smith and Konrad Patkowski".center(58) + "\n"
+    )
+    core.print_out(
+        "         ---------------------------------------------------------\n"
+    )
     core.print_out("\n")
 
     sf_data = sapt_sf_terms.compute_sapt_sf(sapt_dimer, sapt_jk, wfn_A, wfn_B)
@@ -574,8 +867,15 @@ def run_sf_sapt(name, **kwargs):
 
     for key, value in sf_data.items():
         value = sf_data[key]
-        print_vals = (key, value * 1000, value * constants.hartree2kcalmol, value * constants.hartree2kJmol)
-        string = "    %-26s % 15.8f [mEh] % 15.8f [kcal/mol] % 15.8f [kJ/mol]\n" % print_vals
+        print_vals = (
+            key,
+            value * 1000,
+            value * constants.hartree2kcalmol,
+            value * constants.hartree2kJmol,
+        )
+        string = (
+            "    %-26s % 15.8f [mEh] % 15.8f [kcal/mol] % 15.8f [kJ/mol]\n" % print_vals
+        )
         core.print_out(string)
     core.print_out("  " + "-" * 103 + "\n\n")
 

--- a/psi4/driver/procrouting/sapt/sapt_proc.py
+++ b/psi4/driver/procrouting/sapt/sapt_proc.py
@@ -107,36 +107,41 @@ def run_sapt_dft(name, **kwargs):
     core.IO.set_default_namespace('dimer')
     data = {}
 
-    if (core.get_global_option('SCF_TYPE') == 'DF'):
-        # core.set_global_option('DF_INTS_IO', 'LOAD')
+    if (core.get_global_option('SCF_TYPE') in ['DF', 'DISK_DF']):
+        # Save integrals
+        # We want to try to re-use itegrals for the dimer and monomer SCF's.
+        # If we are using Disk based DF (DISK_DF) then we can use the
+        # DF_INTS_IO option.  MemDF does not know about this option but setting
+        # it will be harmless there.
         core.set_global_option('DF_INTS_IO', 'SAVE')
 
     # Compute dimer wavefunction
     hf_wfn_dimer = None
     if do_delta_hf:
-        if (core.get_global_option('SCF_TYPE') == 'DF'):
+        if (core.get_global_option('SCF_TYPE') in ['DF', 'DISK_DF']):
             core.set_global_option('DF_INTS_IO', 'SAVE')
-
         core.timer_on("SAPT(DFT):Dimer SCF")
         hf_data = {}
+
+        core.set_local_option("SCF", "SAVE_JK", True)
         hf_wfn_dimer = scf_helper("SCF", molecule=sapt_dimer, banner="SAPT(DFT): delta HF Dimer", **kwargs)
         hf_data["HF DIMER"] = core.variable("CURRENT ENERGY")
         core.timer_off("SAPT(DFT):Dimer SCF")
 
         core.timer_on("SAPT(DFT):Monomer A SCF")
-        if (core.get_global_option('SCF_TYPE') == 'DF'):
+        if (core.get_global_option('SCF_TYPE') in ['DF', 'DISK_DF']):
             core.IO.change_file_namespace(97, 'dimer', 'monomerA')
 
-        hf_wfn_A = scf_helper("SCF", molecule=monomerA, banner="SAPT(DFT): delta HF Monomer A", **kwargs)
+        jk_obj = hf_wfn_dimer.jk()
+        hf_wfn_A = scf_helper("SCF", molecule=monomerA, banner="SAPT(DFT): delta HF Monomer A", jk=jk_obj, **kwargs)
         hf_data["HF MONOMER A"] = core.variable("CURRENT ENERGY")
         core.timer_off("SAPT(DFT):Monomer A SCF")
 
         core.timer_on("SAPT(DFT):Monomer B SCF")
-        core.set_global_option("SAVE_JK", True)
-        if (core.get_global_option('SCF_TYPE') == 'DF'):
+        if (core.get_global_option('SCF_TYPE') in ['DF', 'DISK_DF']):
             core.IO.change_file_namespace(97, 'monomerA', 'monomerB')
 
-        hf_wfn_B = scf_helper("SCF", molecule=monomerB, banner="SAPT(DFT): delta HF Monomer B", **kwargs)
+        hf_wfn_B = scf_helper("SCF", molecule=monomerB, banner="SAPT(DFT): delta HF Monomer B", jk=jk_obj, **kwargs)
         hf_data["HF MONOMER B"] = core.variable("CURRENT ENERGY")
         core.set_global_option("SAVE_JK", False)
         core.timer_off("SAPT(DFT):Monomer B SCF")
@@ -148,7 +153,7 @@ def run_sapt_dft(name, **kwargs):
             core.set_global_option("SAVE_JK", False)
 
             # Move it back to monomer A
-            if (core.get_global_option('SCF_TYPE') == 'DF'):
+            if (core.get_global_option('SCF_TYPE') in ['DF', 'DISK_DF']):
                 core.IO.change_file_namespace(97, 'monomerB', 'dimer')
 
             core.print_out("\n")
@@ -215,13 +220,14 @@ def run_sapt_dft(name, **kwargs):
 
         # Compute Monomer A wavefunction
         core.timer_on("SAPT(DFT): Monomer A DFT")
-        if (core.get_global_option('SCF_TYPE') == 'DF'):
+        if (core.get_global_option('SCF_TYPE') in ['DF', 'DISK_DF']):
             core.IO.change_file_namespace(97, 'dimer', 'monomerA')
 
         if mon_a_shift:
             core.set_global_option("DFT_GRAC_SHIFT", mon_a_shift)
 
         core.IO.set_default_namespace('monomerA')
+        core.set_global_option("SAVE_JK", True)
         wfn_A = scf_helper(sapt_dft_functional,
                            post_scf=False,
                            molecule=monomerA,
@@ -234,7 +240,7 @@ def run_sapt_dft(name, **kwargs):
 
         # Compute Monomer B wavefunction
         core.timer_on("SAPT(DFT): Monomer B DFT")
-        if (core.get_global_option('SCF_TYPE') == 'DF'):
+        if (core.get_global_option('SCF_TYPE') in ['DF', 'DISK_DF']):
             core.IO.change_file_namespace(97, 'monomerA', 'monomerB')
 
         if mon_b_shift:
@@ -246,6 +252,7 @@ def run_sapt_dft(name, **kwargs):
                            post_scf=False,
                            molecule=monomerB,
                            banner="SAPT(DFT): DFT Monomer B",
+                           jk=wfn_A.jk(),
                            **kwargs)
         data["DFT MONOMERB"] = core.variable("CURRENT ENERGY")
         core.timer_off("SAPT(DFT): Monomer B DFT")
@@ -541,7 +548,7 @@ def run_sf_sapt(name, **kwargs):
     core.IO.set_default_namespace('dimer')
     data = {}
 
-    if (core.get_global_option('SCF_TYPE') == 'DF'):
+    if (core.get_global_option('SCF_TYPE') in ['DF', 'DISK_DF']):
         core.set_global_option('DF_INTS_IO', 'SAVE')
 
     # Compute dimer wavefunction

--- a/psi4/driver/procrouting/sapt/sapt_proc.py
+++ b/psi4/driver/procrouting/sapt/sapt_proc.py
@@ -242,8 +242,7 @@ def run_sapt_dft(name, **kwargs):
 
             # Electrostatics
             core.timer_on("SAPT(HF):elst")
-            elst, extern_extern_ie = sapt_jk_terms.electrostatics(hf_cache, True)
-            hf_data['extern_extern_ie'] = extern_extern_ie
+            elst = sapt_jk_terms.electrostatics(hf_cache, True)
             hf_data.update(elst)
             core.timer_off("SAPT(HF):elst")
 
@@ -616,11 +615,9 @@ def sapt_dft(
     cache = sapt_jk_terms.build_sapt_jk_cache(dimer_wfn, wfn_A, wfn_B, sapt_jk, True)
     core.timer_off("SAPT(DFT):Build JK")
 
-    print(f"{external_potentials = }")
-
     # Electrostatics
     core.timer_on("SAPT(DFT):elst")
-    elst, extern_extern_ie = sapt_jk_terms.electrostatics(cache, True)
+    elst = sapt_jk_terms.electrostatics(cache, True)
     data.update(elst)
     core.timer_off("SAPT(DFT):elst")
 

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -149,7 +149,13 @@ def scf_initialize(self):
         collocation_size = 0
 
     # Change allocation for collocation matrices based on DFT type
-    jk = _build_jk(self, total_memory)
+    initialize_jk_obj = False
+    if isinstance(self.jk(), core.JK):
+        core.print_out("\nRe-using passed JK object instead of rebuilding\n")
+        jk = self.jk()
+    else:
+        initialize_jk_obj = True
+        jk = _build_jk(self, total_memory)
     jk_size = jk.memory_estimate()
 
     # Give remaining to collocation
@@ -190,7 +196,8 @@ def scf_initialize(self):
     if self.attempt_number_ == 1:
         mints = core.MintsHelper(self.basisset())
 
-        self.initialize_jk(self.memory_jk_, jk=jk)
+        if initialize_jk_obj:
+            self.initialize_jk(self.memory_jk_, jk=jk)
         if self.V_potential():
             self.V_potential().build_collocation_cache(self.memory_collocation_)
         core.timer_on("HF: Form core H")

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1139,14 +1139,18 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
 
         /*- SUBSECTION SAPT(DFT) -*/
 
-        /*- Monomer A GRAC shift in Hartree -*/
+        /*- Monomer A GRAC shift in Hartree. Set to -99 to automatically
+           compute prior to SAPT(DFT)  -*/
         options.add_double("SAPT_DFT_GRAC_SHIFT_A", 0.0);
-        /*- Monomer B GRAC shift in Hartree -*/
+        /*- Monomer B GRAC shift in Hartree. Set to -99 to automatically
+           compute prior to SAPT(DFT) -*/
         options.add_double("SAPT_DFT_GRAC_SHIFT_B", 0.0);
+        /*- SAPT_DFT_GRAC_CONVERGENCE_TIER will specify how hard psi4 should
+          try to converge the cation for a GRAC shift before failing the
+          calculation completely -*/
+        options.add_str("SAPT_DFT_GRAC_CONVERGENCE_TIER", "SINGLE", "SINGLE ITERATIVE");
         /*- Compute the Delta-HF correction? -*/
         options.add_bool("SAPT_DFT_DO_DHF", true);
-        /*- How is the GRAC correction determined? !expert -*/
-        options.add_str("SAPT_DFT_GRAC_DETERMINATION", "INPUT", "INPUT");
         /*- Enables the hybrid xc kernel in dispersion? !expert -*/
         options.add_bool("SAPT_DFT_DO_HYBRID", true);
         /*- Scheme for approximating exchange-dispersion for SAPT-DFT.

--- a/pytest.ini
+++ b/pytest.ini
@@ -108,6 +108,7 @@ markers =
     restricted_triplet
     RPA
     sapt
+    saptdft
     scf
     soscf
     solver

--- a/tests/pytests/test_saptdft.py
+++ b/tests/pytests/test_saptdft.py
@@ -1,0 +1,437 @@
+import pytest
+import psi4
+from qcelemental import constants
+from psi4 import compare_values
+import numpy as np
+import qcelemental as qcel
+from pprint import pprint as pp
+
+hartree_to_kcalmol = constants.conversion_factor("hartree", "kcal/mol")
+pytestmark = [pytest.mark.psi, pytest.mark.api]
+
+
+psi4.set_memory("60 GB")
+
+
+@pytest.mark.saptdft
+def test_saptdft_auto_grac():
+    mol_dimer = psi4.geometry(
+        """
+0 1
+8   -0.702196054   -0.056060256   0.009942262
+1   -1.022193224   0.846775782   -0.011488714
+1   0.257521062   0.042121496   0.005218999
+--
+0 1
+8   2.268880784   0.026340101   0.000508029
+1   2.645502399   -0.412039965   0.766632411
+1   2.641145101   -0.449872874   -0.744894473
+units angstrom
+"""
+    )
+    psi4.set_options(
+        {
+            "basis": "STO-3G",
+            "sapt_dft_grac_shift_a": -99,
+            "sapt_dft_grac_shift_b": -99,
+            "SAPT_DFT_FUNCTIONAL": "pbe0",
+        }
+    )
+    psi4.energy("SAPT(DFT)", molecule=mol_dimer)
+    compare_values(
+        #  STO-3G target
+        0.19807358,
+        # aug-cc-pvdz target, 0.1307 (using experimental IP from CCCBDB)
+        # 0.13053068183319516,
+        psi4.core.variable("SAPT_DFT_GRAC_SHIFT_A"),
+        8,
+        "SAPT_DFT_GRAC_SHIFT_A",
+    )
+    compare_values(
+        #  STO-3G target
+        0.19830016,
+        # aug-cc-pvdz target, 0.1307 (using experimental IP from CCCBDB)
+        # 0.13063798506967816,
+        psi4.core.variable("SAPT_DFT_GRAC_SHIFT_B"),
+        8,
+        "SAPT_DFT_GRAC_SHIFT_B",
+    )
+    return
+
+
+@pytest.mark.saptdft
+def test_saptdft_auto_grac_iterative():
+    mol_dimer = psi4.geometry(
+        """
+-1 1
+8   -0.702196054   -0.056060256   0.009942262
+1   -1.022193224   0.846775782   -0.011488714
+--
+0 1
+8   2.268880784   0.026340101   0.000508029
+1   2.645502399   -0.412039965   0.766632411
+1   2.641145101   -0.449872874   -0.744894473
+units angstrom
+"""
+    )
+    psi4.set_options(
+        {
+            "SAPT_DFT_GRAC_CONVERGENCE_TIER": "ITERATIVE",
+            "basis": "STO-3G",
+            "sapt_dft_grac_shift_a": -99,
+            "sapt_dft_grac_shift_b": -99,
+            "SAPT_DFT_FUNCTIONAL": "pbe0",
+        }
+    )
+    psi4.energy("SAPT(DFT)", molecule=mol_dimer)
+    compare_values(
+        #  STO-3G target
+        0.3258340368,
+        psi4.core.variable("SAPT_DFT_GRAC_SHIFT_A"),
+        8,
+        "SAPT_DFT_GRAC_SHIFT_A",
+    )
+    compare_values(
+        #  STO-3G target
+        0.19830016,
+        psi4.core.variable("SAPT_DFT_GRAC_SHIFT_B"),
+        8,
+        "SAPT_DFT_GRAC_SHIFT_B",
+    )
+    return
+
+
+@pytest.mark.saptdft
+def test_saptdft_external_potential():
+    mol = psi4.geometry(
+        """
+0 1
+O   0.017225   0.031664   0.004802
+H  -0.046691  -0.052504   0.962436
+H   0.972017   0.055307  -0.185622
+--
+0 1
+O   2.516175   0.894012  -1.014512
+H   1.942080   1.572902  -1.410984
+H   3.056412   0.561271  -1.739079
+symmetry c1
+no_reorient
+no_com
+    """
+    )
+    fisapt0_external_potential_energies = {
+        "SAPT ELST ENERGY": -0.01581004514947182,
+        "SAPT ELST10,R ENERGY": -0.01581004514947182,
+        "SAPT EXCH ENERGY": 0.012282520736587468,
+        "SAPT IND ENERGY": -0.0035613061462424402,
+        "SAPT DISP ENERGY": -0.002185724589094623,
+        "SAPT TOTAL ENERGY": -0.009274555148221415,
+    }
+
+    saptdft_no_external_potential = {
+        "SAPT ELST ENERGY": -0.014201712642446296,
+        "ELST10,R": -0.014201712642446296,
+        "SAPT EXCH ENERGY": 0.014021550175337915,
+        "SAPT IND ENERGY": -0.0033383768785273885,
+        "SAPT DISP ENERGY": -0.002394920793165888,
+        "SAPT TOTAL ENERGY": -0.005913460138801657,
+    }
+    # External potential containing the third water from the trimer with TIP3P
+    # charges
+    Chargefield_C = np.array(
+        [
+            -0.834,
+            0.179217,
+            2.438389,
+            -1.484606,
+            0.417,
+            -0.194107,
+            1.702697,
+            -0.966751,
+            0.417,
+            -0.426657,
+            2.563754,
+            -2.222683,
+        ]
+    ).reshape((-1, 4))
+    Chargefield_C[:, [1, 2, 3]] /= qcel.constants.bohr2angstroms
+    psi4.set_options(
+        {
+            "basis": "jun-cc-pvdz",
+            "scf_type": "df",
+            "guess": "sad",
+            "freeze_core": "true",
+            "sapt_dft_grac_shift_a": 0.1307,
+            "sapt_dft_grac_shift_b": 0.1307,
+        }
+    )
+    # psi4.energy("fisapt0", external_potentials={"C": Chargefield_C})
+    psi4.energy(
+        "sapt(dft)",
+        external_potentials={"C": Chargefield_C},
+    )
+    pp(psi4.core.variables())
+    for key, value in fisapt0_external_potential_energies.items():
+        compare_values(
+            value,
+            psi4.core.variable(key),
+            8,
+            key,
+        )
+    return
+
+
+@pytest.mark.saptdft
+def test_sapthf_external_potential():
+    mol = psi4.geometry(
+        """
+0 1
+O   0.017225   0.031664   0.004802
+H  -0.046691  -0.052504   0.962436
+H   0.972017   0.055307  -0.185622
+--
+0 1
+O   2.516175   0.894012  -1.014512
+H   1.942080   1.572902  -1.410984
+H   3.056412   0.561271  -1.739079
+symmetry c1
+no_reorient
+no_com
+    """
+    )
+    fisapt0_external_potential_energies = {
+        "SAPT ELST ENERGY": -0.01581004514947182,
+        "SAPT ELST10,R ENERGY": -0.01581004514947182,
+        "SAPT EXCH ENERGY": 0.012282520736587468,
+        "SAPT IND ENERGY": -0.0035613061462424402,
+        "SAPT DISP ENERGY": -0.002185724589094623,
+        "SAPT TOTAL ENERGY": -0.009274555148221415,
+    }
+
+    saptdft_no_external_potential = {
+        "SAPT ELST ENERGY": -0.014201712642446296,
+        "ELST10,R": -0.014201712642446296,
+        "SAPT EXCH ENERGY": 0.014021550175337915,
+        "SAPT IND ENERGY": -0.0033383768785273885,
+        "SAPT DISP ENERGY": -0.002394920793165888,
+        "SAPT TOTAL ENERGY": -0.005913460138801657,
+    }
+    # External potential containing the third water from the trimer with TIP3P
+    # charges
+    Chargefield_C = np.array(
+        [
+            -0.834,
+            0.179217,
+            2.438389,
+            -1.484606,
+            0.417,
+            -0.194107,
+            1.702697,
+            -0.966751,
+            0.417,
+            -0.426657,
+            2.563754,
+            -2.222683,
+        ]
+    ).reshape((-1, 4))
+    Chargefield_C[:, [1, 2, 3]] /= qcel.constants.bohr2angstroms
+    psi4.set_options(
+        {
+            "basis": "jun-cc-pvdz",
+            "scf_type": "df",
+            "guess": "sad",
+            "freeze_core": "true",
+            "SAPT_DFT_FUNCTIONAL": "hf",
+            "SAPT_DFT_MP2_DISP_ALG": "FISAPT",
+        }
+    )
+    # psi4.energy("fisapt0", external_potentials={"C": Chargefield_C})
+    psi4.energy(
+        "sapt(dft)",
+        external_potentials={"C": Chargefield_C},
+    )
+    pp(psi4.core.variables())
+    pp(fisapt0_external_potential_energies)
+    key_labels = [
+        ["SAPT ELST10,R ENERGY", "ELST10,R"],
+        ["SAPT ELST ENERGY", "SAPT ELST ENERGY"],
+        ["SAPT EXCH ENERGY", "SAPT EXCH ENERGY"],
+        ["SAPT IND ENERGY", "SAPT IND ENERGY"],
+        ["SAPT DISP ENERGY", "SAPT DISP ENERGY"],
+        ["SAPT TOTAL ENERGY", "SAPT TOTAL ENERGY"],
+    ]
+    for k1, k2 in key_labels:
+        compare_values(
+            fisapt0_external_potential_energies[k1],
+            psi4.core.variable(k2),
+            8,
+            k1,
+        )
+    return
+
+
+@pytest.mark.saptdft
+def test_sapthf_external_potential2():
+    """ """
+    mol = psi4.geometry(
+        """
+0 1
+O   0.017225   0.031664   0.004802
+H  -0.046691  -0.052504   0.962436
+H   0.972017   0.055307  -0.185622
+--
+0 1
+O   2.516175   0.894012  -1.014512
+H   1.942080   1.572902  -1.410984
+H   3.056412   0.561271  -1.739079
+symmetry c1
+no_reorient
+no_com
+    """
+    )
+    fisapt0_external_potential_energies = {
+        "Enuc": 36.965201909136653,
+        "SAPT ELST ENERGY": -0.01581004515,
+        "SAPT EXCH ENERGY": 0.01228252074,
+        "SAPT IND ENERGY": -0.00356130615,
+        "SAPT DISP ENERGY": -0.00218572459,
+        "SAPT TOTAL ENERGY": -0.00927455515,
+        "SAPT ELST10,R ENERGY": -0.01581004514947182,
+    }
+    Chargefield_C = np.array(
+        [
+            -0.834,
+            0.179217,
+            2.438389,
+            -1.484606,
+            0.417,
+            -0.194107,
+            1.702697,
+            -0.966751,
+            0.417,
+            -0.426657,
+            2.563754,
+            -2.222683,
+        ]
+    ).reshape((-1, 4))
+    Chargefield_C[:, [1, 2, 3]] /= qcel.constants.bohr2angstroms
+    psi4.set_options(
+        {
+            "basis": "jun-cc-pvdz",
+            "scf_type": "df",
+            "guess": "sad",
+            "freeze_core": "true",
+            "SAPT_DFT_FUNCTIONAL": "hf",
+            "SAPT_DFT_MP2_DISP_ALG": "FISAPT",
+        }
+    )
+    psi4.energy(
+        "sapt(dft)",
+        external_potentials={"C": Chargefield_C},
+    )
+    pp(psi4.core.variables())
+    pp(fisapt0_external_potential_energies)
+    key_labels = [
+        ["SAPT ELST10,R ENERGY", "ELST10,R"],
+        ["SAPT ELST ENERGY", "SAPT ELST ENERGY"],
+        ["SAPT EXCH ENERGY", "SAPT EXCH ENERGY"],
+        ["SAPT IND ENERGY", "SAPT IND ENERGY"],
+        ["SAPT DISP ENERGY", "SAPT DISP ENERGY"],
+        ["SAPT TOTAL ENERGY", "SAPT TOTAL ENERGY"],
+    ]
+    for k1, k2 in key_labels:
+        compare_values(
+            fisapt0_external_potential_energies[k1],
+            psi4.core.variable(k2),
+            8,
+            k1,
+        )
+    compare_values(
+        fisapt0_external_potential_energies['Enuc'],
+        mol.nuclear_repulsion_energy(),
+        8,
+        'Enuc'
+    )
+    return
+
+
+def test_fisapt_external_potential():
+    mol = psi4.geometry(
+        """
+0 1
+O   0.017225   0.031664   0.004802
+H  -0.046691  -0.052504   0.962436
+H   0.972017   0.055307  -0.185622
+--
+0 1
+O   2.516175   0.894012  -1.014512
+H   1.942080   1.572902  -1.410984
+H   3.056412   0.561271  -1.739079
+symmetry c1
+no_reorient
+no_com
+    """
+    )
+    fisapt0_external_potential_energies = {
+        "SAPT ELST ENERGY": -0.01581004514947182,
+        "SAPT ELST10,R ENERGY": -0.01581004514947182,
+        "SAPT EXCH ENERGY": 0.012282520736587468,
+        "SAPT IND ENERGY": -0.0035613061462424402,
+        "SAPT DISP ENERGY": -0.002185724589094623,
+        "SAPT TOTAL ENERGY": -0.009274555148221415,
+    }
+
+    saptdft_no_external_potential = {
+        "SAPT ELST ENERGY": -0.014201712642446296,
+        "ELST10,R": -0.014201712642446296,
+        "SAPT EXCH ENERGY": 0.014021550175337915,
+        "SAPT IND ENERGY": -0.0033383768785273885,
+        "SAPT DISP ENERGY": -0.002394920793165888,
+        "SAPT TOTAL ENERGY": -0.005913460138801657,
+    }
+    # External potential containing the third water from the trimer with TIP3P
+    # charges
+    Chargefield_C = np.array(
+        [
+            -0.834,
+            0.179217,
+            2.438389,
+            -1.484606,
+            0.417,
+            -0.194107,
+            1.702697,
+            -0.966751,
+            0.417,
+            -0.426657,
+            2.563754,
+            -2.222683,
+        ]
+    ).reshape((-1, 4))
+    Chargefield_C[:, [1, 2, 3]] /= qcel.constants.bohr2angstroms
+    psi4.set_options(
+        {
+            "basis": "jun-cc-pvdz",
+            "scf_type": "df",
+            "guess": "sad",
+            "freeze_core": "true",
+        }
+    )
+    psi4.energy(
+        "fisapt0",
+        external_potentials={"C": Chargefield_C},
+    )
+    pp(psi4.core.variables())
+    for key, value in fisapt0_external_potential_energies.items():
+        compare_values(
+            value,
+            psi4.core.variable(key),
+            8,
+            key,
+        )
+    return
+
+
+if __name__ == "__main__":
+    test_sapthf_external_potential2()
+    # test_saptdft_external_potential()
+    # test_fisapt_external_potential()

--- a/tests/pytests/test_saptdft.py
+++ b/tests/pytests/test_saptdft.py
@@ -119,22 +119,13 @@ no_reorient
 no_com
     """
     )
-    fisapt0_external_potential_energies = {
-        "SAPT ELST ENERGY": -0.01581004514947182,
-        "SAPT ELST10,R ENERGY": -0.01581004514947182,
-        "SAPT EXCH ENERGY": 0.012282520736587468,
-        "SAPT IND ENERGY": -0.0035613061462424402,
-        "SAPT DISP ENERGY": -0.002185724589094623,
-        "SAPT TOTAL ENERGY": -0.009274555148221415,
-    }
-
-    saptdft_no_external_potential = {
-        "SAPT ELST ENERGY": -0.014201712642446296,
-        "ELST10,R": -0.014201712642446296,
-        "SAPT EXCH ENERGY": 0.014021550175337915,
-        "SAPT IND ENERGY": -0.0033383768785273885,
-        "SAPT DISP ENERGY": -0.002394920793165888,
-        "SAPT TOTAL ENERGY": -0.005913460138801657,
+    saptdft_external_potential = {
+        "SAPT ELST ENERGY": -0.015497974872921816,
+        "ELST10,R": -0.015497974872921816,
+        "SAPT EXCH ENERGY": 0.014086924748375487,
+        "SAPT IND ENERGY": -0.0036106959685717815,
+        "SAPT DISP ENERGY": -0.002398227386784957,
+        "SAPT TOTAL ENERGY": -0.007419973479903067,
     }
     # External potential containing the third water from the trimer with TIP3P
     # charges
@@ -163,15 +154,16 @@ no_com
             "freeze_core": "true",
             "sapt_dft_grac_shift_a": 0.1307,
             "sapt_dft_grac_shift_b": 0.1307,
+            "SAPT_DFT_FUNCTIONAL": "pbe0",
         }
     )
-    # psi4.energy("fisapt0", external_potentials={"C": Chargefield_C})
     psi4.energy(
         "sapt(dft)",
         external_potentials={"C": Chargefield_C},
+        molecule=mol,
     )
     pp(psi4.core.variables())
-    for key, value in fisapt0_external_potential_energies.items():
+    for key, value in saptdft_external_potential.items():
         compare_values(
             value,
             psi4.core.variable(key),
@@ -249,6 +241,7 @@ no_com
     psi4.energy(
         "sapt(dft)",
         external_potentials={"C": Chargefield_C},
+        molecule=mol,
     )
     pp(psi4.core.variables())
     pp(fisapt0_external_potential_energies)
@@ -328,6 +321,7 @@ no_com
     psi4.energy(
         "sapt(dft)",
         external_potentials={"C": Chargefield_C},
+        molecule=mol,
     )
     pp(psi4.core.variables())
     pp(fisapt0_external_potential_energies)
@@ -419,6 +413,7 @@ no_com
     psi4.energy(
         "fisapt0",
         external_potentials={"C": Chargefield_C},
+        molecule=mol,
     )
     pp(psi4.core.variables())
     for key, value in fisapt0_external_potential_energies.items():


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
The objective of this PR is to enable external potentials to be used for both SAPT(DFT) and SAPT(HF).

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] Enables users to call `psi4.energy('sapt(dft)', external_potenial=<EXT_POTENTIAL>)` and acquire SAPT(HF) and SAPT(DFT) energies in the presence of an external potential.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] The present implementation leverages the `scf_helper()` external_potential logic to generate and re-use the jk-object to obtain the correct SAPT external potential energies; however, this does not re-use the logic of FISAPT's external potential code. Another ongoing implementation of external potentials in SAPT(DFT) can be found on [this branch](https://github.com/Awallace3/psi4/tree/ext_pot_saptdft) for long term goals of migrating FI-SAPT functionality into SAPT(DFT).
- [ ] This PR depends on [PR#3256](https://github.com/psi4/psi4/pull/3256) for re-using jk-objects and [PR#3232](https://github.com/psi4/psi4/pull/3232) for automatic GRAC shifts. 

## Questions
- [ ] Do we require any additional information about the external potential energies for SAPT(HF) and SAPT(DFT) that isn't provided from the `scf_helper()` route of re-using jk-objects? Most of the logic in FISAPT0 that is neglected is for handling FI-SAPT. 

## Checklist
- [X] Tests added for any new features (see `./tests/pytests/test_saptdft.py` with specifically `test_sapthf_external_potential()` corresponding to the FISAPT0 test located `psi4/tests/fsapt-ext/input.dat`.
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
