### PR TITLE
Fix CI, update QCEl 0.29, QCEn 0.31, and Einsums 0.6.1

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -23,7 +23,7 @@ jobs:
             python-version: "3.12"
             mkl-version: ""
             platform: linux-64
-            pytest-marker-expr: "addon and not (medlong or long) and not (snowflake and (multi or wrapper))"
+            pytest-marker-expr: "addon and not (medlong or long)"
             cmargs: >
               -D CMAKE_VERBOSE_MAKEFILE=OFF
               -D ENABLE_v2rdm_casscf=ON
@@ -38,7 +38,7 @@ jobs:
             python-version: "3.9"
             mkl-version: ""
             platform: osx-64
-            pytest-marker-expr: "addon and not (medlong or long) and not (snowflake and (multi or wrapper))"
+            pytest-marker-expr: "addon and not (medlong or long)"
             target-sdk: "10.10"
             cmargs: >
               -D CMAKE_VERBOSE_MAKEFILE=OFF
@@ -60,7 +60,7 @@ jobs:
             python-version: "3.10"
             mkl-version: ""
             platform: osx-64
-            pytest-marker-expr: "addon and not (medlong or long) and not (snowflake and (multi or wrapper))"
+            pytest-marker-expr: "addon and not (medlong or long)"
             target-sdk: "10.10"
             cmargs: >
               -D CMAKE_VERBOSE_MAKEFILE=OFF

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -23,7 +23,7 @@ jobs:
             python-version: "3.12"
             mkl-version: ""
             platform: linux-64
-            pytest-marker-expr: "addon and not (medlong or long)"
+            pytest-marker-expr: "addon and not (medlong or long) and not (snowflake and (multi or wrapper))"
             cmargs: >
               -D CMAKE_VERBOSE_MAKEFILE=OFF
               -D ENABLE_v2rdm_casscf=ON
@@ -38,7 +38,7 @@ jobs:
             python-version: "3.9"
             mkl-version: ""
             platform: osx-64
-            pytest-marker-expr: "addon and not (medlong or long)"
+            pytest-marker-expr: "addon and not (medlong or long) and not (snowflake and (multi or wrapper))"
             target-sdk: "10.10"
             cmargs: >
               -D CMAKE_VERBOSE_MAKEFILE=OFF
@@ -60,7 +60,7 @@ jobs:
             python-version: "3.10"
             mkl-version: ""
             platform: osx-64
-            pytest-marker-expr: "addon and not (medlong or long)"
+            pytest-marker-expr: "addon and not (medlong or long) and not (snowflake and (multi or wrapper))"
             target-sdk: "10.10"
             cmargs: >
               -D CMAKE_VERBOSE_MAKEFILE=OFF
@@ -165,6 +165,7 @@ jobs:
           :
           # not for py312
           sed -i "s;- cppe;#- cppe;g" env_p4build.yaml
+          sed -i "s;- qcfractal;- qcfractal>=0.59;g" env_p4build.yaml
         fi
         if [[ "${{ runner.os }}" == "macOS" && "${{ matrix.cfg.label }}" == "Conda Clang (M-Intel)" ]]; then
           :

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -1134,7 +1134,8 @@ data:
     conda:
       channel: conda-forge
       name: i-pi
-      constraint: null
+      constraint: "==3.1.0"
+      constraint_note: "Higher requires ASE be installed."
       cmake: null
       cmake_note: "Primarily OTF runtime detected."
 

--- a/external/upstream/einsums/CMakeLists.txt
+++ b/external/upstream/einsums/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(${ENABLE_Einsums})
-    find_package(Einsums 0.5 CONFIG)
+    find_package(Einsums 0.6 CONFIG)
 
     if(TARGET Einsums::einsums)
         get_property(_loc TARGET Einsums::einsums PROPERTY LOCATION)
@@ -32,7 +32,7 @@ if(${ENABLE_Einsums})
         ExternalProject_Add(einsums_external
             DEPENDS lapack_external
                     hdf5_external
-            URL https://github.com/Einsums/Einsums/archive/v0.5.tar.gz
+            URL https://github.com/Einsums/Einsums/archive/v0.6.1.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/qcelemental/CMakeLists.txt
+++ b/external/upstream/qcelemental/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 
     ExternalProject_Add(qcelemental_external
         BUILD_ALWAYS 1
-        URL https://github.com/MolSSI/QCElemental/archive/v0.28.0.tar.gz
+        URL https://github.com/MolSSI/QCElemental/archive/v0.29.0.tar.gz
         DOWNLOAD_NO_EXTRACT 1
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""

--- a/external/upstream/qcengine/CMakeLists.txt
+++ b/external/upstream/qcengine/CMakeLists.txt
@@ -38,7 +38,7 @@ else()
     ExternalProject_Add(qcengine_external
         DEPENDS qcelemental_external
         BUILD_ALWAYS 1
-        URL https://github.com/MolSSI/QCEngine/archive/v0.30.0.tar.gz
+        URL https://github.com/MolSSI/QCEngine/archive/v0.31.0.tar.gz
         DOWNLOAD_NO_EXTRACT 1
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -135,7 +135,7 @@ else()
 endif()
 
 if(${ENABLE_Einsums})
-    find_package(Einsums 0.5 CONFIG REQUIRED)
+    find_package(Einsums 0.6 CONFIG REQUIRED)
     get_property(_loc TARGET Einsums::einsums PROPERTY LOCATION)
     list(APPEND _addons ${_loc})
     message(STATUS "${Cyan}Using Einsums${ColourReset}: ${_loc} (version ${Einsums_VERSION})")

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -265,6 +265,7 @@ if(MSVC)
       _CRT_NONSTDC_NO_DEPRECATE
       _CRT_NONSTDC_NO_WARNINGS
       _CRT_SECURE_NO_WARNINGS
+      _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
       )
     # Set the exception handling model
     add_compile_options("/EHsc")

--- a/tests/cbs-xtpl-wrapper/test_input.py
+++ b/tests/cbs-xtpl-wrapper/test_input.py
@@ -4,7 +4,7 @@ from addons import *
 @ctest_labeler("cbs")
 @pytest.mark.parametrize("distributed", [
     pytest.param(False, id="internal"),
-    pytest.param(True,  id="snowflake", marks=using("qcfractal_next")),
+    pytest.param(True,  id="snowflake", marks=[*using("qcfractal_next"), pytest.mark.medlong]),
 ])
 def test_cbs_xtpl_wrapper(distributed):
     setenv = ["_PSI4_USE_QCF"] if distributed else None

--- a/tests/nbody-multi-level/test_input.py
+++ b/tests/nbody-multi-level/test_input.py
@@ -4,7 +4,7 @@ from addons import *
 @ctest_labeler("nbody;extern")
 @pytest.mark.parametrize("distributed", [
     pytest.param(False, id="internal"),
-    pytest.param(True,  id="snowflake", marks=using("qcfractal_next")),
+    pytest.param(True,  id="snowflake", marks=[*using("qcfractal_next"), pytest.mark.medlong]),
 ])
 def test_nbody_multi_level(distributed):
     setenv = ["_PSI4_USE_QCF"] if distributed else None


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] It's not required but check that QCElemental v0.29 (latest on c-f) works ok
- [x] Einsums v0.5 gives compile errors. v0.6.1 builds ok, though it's shortly going to be replaced by restucturing
- [x] It's not required but update to latest v0.31 QCEngine
- [x] work around a Windows GHA image bug
- [x] i-pi v3.1.1 seems to expect ASE installed, so let's not use it
- [x] the longest snowflake tests pass fine locally but take ~3m so tend to be flaky on CI. moving them to `medlong` label so won't run in ecosys

## Status
- [x] Ready for review
- [x] Ready for merge
