### PR TITLE
einsums new_structure changes

### DIFF
--- a/external/upstream/einsums/CMakeLists.txt
+++ b/external/upstream/einsums/CMakeLists.txt
@@ -32,7 +32,8 @@ if(${ENABLE_Einsums})
         ExternalProject_Add(einsums_external
             DEPENDS lapack_external
                     hdf5_external
-            URL https://github.com/Einsums/Einsums/archive/v0.5.tar.gz
+            URL https://github.com/jturney/Einsums/archive/new_structure.tar.gz
+            #URL https://github.com/Einsums/Einsums/archive/v0.5.tar.gz
             UPDATE_COMMAND ""
             CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -136,7 +136,7 @@ endif()
 
 if(${ENABLE_Einsums})
     find_package(Einsums 0.5 CONFIG REQUIRED)
-    get_property(_loc TARGET Einsums::einsums PROPERTY LOCATION)
+    get_property(_loc TARGET Einsums::Einsums PROPERTY LOCATION)
     list(APPEND _addons ${_loc})
     message(STATUS "${Cyan}Using Einsums${ColourReset}: ${_loc} (version ${Einsums_VERSION})")
 else()

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -116,7 +116,7 @@ if(TARGET ECPINT::ecpint)
     )
 endif()
 
-if(TARGET Einsums::einsums)
+if(TARGET Einsums::Einsums)
   target_compile_definitions(core
     PRIVATE
       USING_Einsums

--- a/psi4/src/psi4/dummy_einsums/CMakeLists.txt
+++ b/psi4/src/psi4/dummy_einsums/CMakeLists.txt
@@ -2,12 +2,12 @@ list(APPEND sources
   ein_test.cc
   )
 
-if(TARGET Einsums::einsums)
+if(TARGET Einsums::Einsums)
     psi4_add_module(bin dummy_einsums sources)
     target_link_libraries(
       dummy_einsums
       PRIVATE
-        Einsums::einsums
+        Einsums::Einsums
       )
 
     if(DEFINED ENV{CONDA_TOOLCHAIN_BUILD})

--- a/psi4/src/psi4/dummy_einsums/ein_test.cc
+++ b/psi4/src/psi4/dummy_einsums/ein_test.cc
@@ -29,9 +29,10 @@
 #include <cmath>
 #include <cstdlib>
 
-#include "einsums.hpp"
-#include "range/v3/algorithm/for_each.hpp"
-#include "range/v3/view/zip.hpp"
+#include <Einsums/Print.hpp>
+#include <Einsums/Runtime.hpp>
+#include <Einsums/Tensor.hpp>
+#include <Einsums/TensorAlgebra.hpp>
 
 #include "psi4/libmints/wavefunction.h"
 
@@ -42,37 +43,45 @@ SharedWavefunction dummy_einsums(SharedWavefunction ref_wfn, Options& options) {
 
     using namespace einsums;
     using namespace einsums::tensor_algebra;
-    using namespace einsums::tensor_algebra::index;
+    using namespace einsums::index;
 
-    einsums::initialize();
+    einsums::initialize(0, nullptr);
 
     // Create a file to hold the data from the DiskTensor tests.
     //einsums::state::data = h5::create("Data.h5", H5F_ACC_TRUNC);
 
-    auto [_t, _w] = polynomial::laguerre::gauss_laguerre(40);
-    println(_t);
-    println(_w);
-
-    auto weights = create_tensor_like(_w);
-    {
-        using namespace element_operations::new_tensor;
-        einsum(Indices{i}, &_w, Indices{i}, _w, Indices{i}, exp(_t));
-    }
-    println(_w);
-
-    ranges::for_each(ranges::views::zip(_t.vector_data(), _w.vector_data()), [](auto &&v) {
-        auto t = std::get<0>(v);
-        auto w = std::get<1>(v);
-
-        println("test : {:14.10f} {:14.10f}", t, w);
-    });
+//    auto [_t, _w] = polynomial::laguerre::gauss_laguerre(40);
+//    println(_t);
+//    println(_w);
+//
+//    auto weights = create_tensor_like(_w);
+//    {
+//        using namespace element_operations::new_tensor;
+//        einsum(Indices{i}, &_w, Indices{i}, _w, Indices{i}, exp(_t));
+//    }
+//    println(_w);
+//
+//    ranges::for_each(ranges::views::zip(_t.vector_data(), _w.vector_data()), [](auto &&v) {
+//        auto t = std::get<0>(v);
+//        auto w = std::get<1>(v);
+//
+//        println("test : {:14.10f} {:14.10f}", t, w);
+//    });
 
     // BEGIN: FFT tests
 
     // auto result = fft::fftfreq(8, 0.1);
     // println(result);
 
-    einsums::finalize(true);
+    println("Hello world!");
+
+    auto A = create_random_tensor("A", 3, 3);
+    auto B = create_random_tensor("B", 3, 3);
+    auto C = create_random_tensor("C", 3, 3);
+
+    einsum(Indices{i, j}, &C, Indices{i, k}, A, Indices{k, j}, B);
+
+    einsums::finalize();
 
     return ref_wfn;
 }

--- a/tests/extern5/input.dat
+++ b/tests/extern5/input.dat
@@ -1,0 +1,47 @@
+#! External potential sanity check with 0 charge far away
+#! Checks if all units behave the same and energy is same as no
+#! potential
+
+molecule water_ang {
+  0 1
+  O  -0.778803000000  0.000000000000  1.132683000000
+  H  -0.666682000000  0.764099000000  1.706291000000
+  H  -0.666682000000  -0.764099000000  1.706290000000
+  symmetry c1
+  no_reorient
+  no_com
+}
+
+molecule water_bohr {
+  0 1
+  O  -1.4717242691    0.000000000000  2.1404605019
+  H  -1.2598463015    1.4439377381  3.2244224468
+  H  -1.2598463015    -1.4439377381  3.2244224468
+  units bohr
+  symmetry c1
+  no_reorient
+  no_com
+}
+
+external_potentials = np.array([
+0.0,10.0,10.0,10.0]).reshape((-1, 4))
+# convert coordinates columns to bohr
+external_potentials[:,[1,2,3]] /= psi_bohr2angstroms
+
+
+set {
+    scf_type df
+    d_convergence 8
+    basis 6-31G*
+}
+
+# Reference energies without external potential
+energy_bohr = energy('scf', molecule=water_bohr)
+energy_ang = energy('scf', molecule=water_ang)
+compare_values(energy_bohr, energy_ang, 6, 'Bohr Angstrom energy equality')
+
+energy_bohr_charges = energy('scf', molecule=water_bohr, external_potentials=external_potentials)
+compare_values(energy_bohr, energy_bohr_charges, 6, 'Bohr - Bohr energy equality')
+
+energy_ang_charges = energy('scf', molecule=water_ang, external_potentials=external_potentials)
+compare_values(energy_ang, energy_ang_charges, 6, 'Ang - Ang energy equality')

--- a/tests/python/nopotential/input.py
+++ b/tests/python/nopotential/input.py
@@ -1,0 +1,37 @@
+#! Python equivalent of extern5 test:
+#! External potential sanity check with 0 charge far away
+#! Checks if all units behave the same and energy is same as no
+#! potential
+import numpy as np
+import psi4.core
+import psi4
+
+b2a=0.529177249
+# Coordinates added in angstrom
+coords = np.array([[ -0.778803000000 , 0.000000000000,  1.132683000000],
+ [ -0.666682000000,  0.764099000000,  1.706291000000],
+ [ -0.666682000000,  -0.764099000000 , 1.706290000000]])
+elements = ["O","H","H"]
+molecule_ang  = psi4.core.Molecule.from_arrays(geom=coords,     elem=elements, fix_symmetry="c1", fix_com=True, fix_orientation=True)
+molecule_bohr = psi4.core.Molecule.from_arrays(geom=coords/b2a, elem=elements, fix_symmetry="c1", fix_com=True, fix_orientation=True, units="Bohr")
+
+external_potentials = [[0.00, np.array([10.0,10.0,10.0]) / b2a]]
+
+psi4.set_options( {
+    "scf_type": "df",
+    "d_convergence": 12,
+    "basis": "STO-3G",
+    "print": 0,
+    "debug": 0,
+})
+
+
+ene_bohr_charges = psi4.energy('scf', molecule=molecule_bohr, external_potentials=external_potentials)
+ene_bohr_pure = psi4.energy('scf', molecule=molecule_bohr)
+psi4.compare_values(ene_bohr_charges, ene_bohr_pure, 6, "Bohr geometry, charges vs no charges energy equality")
+
+ene_ang_pure = psi4.energy('scf', molecule=molecule_ang)
+psi4.compare_values(ene_ang_pure, ene_bohr_pure, 6, "No charges, Bohr vs Angstrom geometry energy equality")
+
+ene_ang_charges = psi4.energy('scf', molecule=molecule_ang, external_potentials=external_potentials)
+psi4.compare_values(ene_ang_charges, ene_ang_pure, 6, "Angstrom geometry, charges vs no charges energy equality")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

* mostly for @jturney 
* adjust the `new_structure` in the CM to `main` or a commit/branch/tag
* ignore the `nopotential.py` that snuck in from another topic.
* will probably fail with below on linux. perhaps that embed that I don't think should be necessary for einsums is transitive?

```
/psi/toolchainconda/envs/py313/bin/../lib/gcc/x86_64-conda-linux-gnu/13.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: src/psi4/libscf_solver/libscf_solver.a(uhf.cc.o): in function `psi::scf::UHF::form_C(double)':
uhf.cc:(.text._ZN3psi3scf3UHF6form_CEd+0x223): undefined reference to `_Py_NoneStruct'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
FAILED: psi4-core-prefix/src/psi4-core-stamp/psi4-core-build /psi/gits/hrw-np2/objdir_py313/psi4-core-prefix/src/psi4-core-stamp/psi4-core-build 
cd /psi/gits/hrw-np2/objdir_py313/psi4-core-prefix/src/psi4-core-build && /psi/toolchainconda/envs/py313/bin/cmake --build .
ninja: build stopped: subcommand failed.
```

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
