### PR TITLE
Need to include cstdint in qt.h to have uint64_t defined

### DIFF
--- a/psi4/src/psi4/libqt/qt.h
+++ b/psi4/src/psi4/libqt/qt.h
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "psi4/pragma.h"


### PR DESCRIPTION
Need to include cstdint in qt.h to fix "error: ‘uint64_t’ does not name a type" with GCC 15.0.1.

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Trivial compile fix

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
