### PR TITLE
expanding external_potential: diffuse charges

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -852,6 +852,9 @@ def validate_external_potential(external_potential) -> Dict:
             else:
                 raise ValidationError(f"external_potential: primary or sec keys should be among {mode_keys_list}, not {frag_ep.keys()}. Full input: {external_potential}")
         elif isinstance(frag_ep, list):
+            # list might be new-fangled structure holding one or many among points, diffuse, matrix (the `else` branch),
+            #   or it might be the outer list of an longstanding list-o-points (the `if` branch), in which case it'll pass
+            #   the `validate_charge_list` check and needs wrapping in an outer list to match the new-fangled structure.
             if (w := validate_charge_list(frag_ep)):
                 ep_building[frag] = dict(zip(mode_keys_list, [w]))
             else:

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1257,7 +1257,9 @@ void export_mints(py::module& m) {
             auto capsule = py::capsule(phi_ao, [](void *phi_ao) { delete reinterpret_cast<std::vector<double>*>(phi_ao); });
             basis.compute_phi(phi_ao->data(), x, y, z);
             return py::array(phi_ao->size(), phi_ao->data(), capsule);
-        }, "Calculate the value of all basis functions at a given point x, y, and z");
+        }, "Calculate the value of all basis functions at a given point x, y, and z")
+        .def("convert_sap_contraction", &BasisSet::convert_sap_contraction,
+            "Remove normalization from a s-function basis set. Not idempotent");
 
     typedef void (OneBodyAOInt::*vecmatrix_version)(std::vector<SharedMatrix>&);
     py::class_<OneBodyAOInt, std::shared_ptr<OneBodyAOInt>> pyOneBodyAOInt(

--- a/psi4/src/psi4/libmints/basisset.h
+++ b/psi4/src/psi4/libmints/basisset.h
@@ -405,6 +405,7 @@ class PSI_API BasisSet {
     // Returns the values of the basis functions at a point
     void compute_phi(double *phi_ao, double x, double y, double z);
     // Converts the contraction to match the SAP approach.
+    //   Note this is NOT idempotent and is only for s-function bases.
     void convert_sap_contraction();
     
    private:

--- a/tests/pytests/test_extern.py
+++ b/tests/pytests/test_extern.py
@@ -319,3 +319,79 @@ def test_extern_parsing(ep, ans):
 def test_extern_parsing_error(ep):
     with pytest.raises((psi4.ValidationError, TypeError)):
         psi4.p4util.validate_external_potential(ep)
+
+
+_one_far_point = [[0.001, 100.0, 0.0, 0.0]]
+_one_farther_point = [[1.0, 0.0, 10000.0, 0.0]]
+_one_far_diffuse = [[0.001, 100.0, 0.0, 0.0, 5.0]]
+_one_farther_diffuse = [[1.0, 0.0, 10000.0, 0.0, 5.0]]
+
+_three_near_points = np.array([
+    [-0.834, 3.11659683, 0.0, -4.45223936],
+    [ 0.417, 1.02944157, 0.0, -7.18088642],
+    [ 0.417, 1.02944157, 0.0, -1.72359229]])
+_three_near_sharp_diffuse = np.array([
+    [-0.834,  3.11659683, 0.0, -4.45223936, 1000.0],
+    [ 0.417,  1.02944157, 0.0, -7.18088642, 1000.0],
+    [ 0.417,  1.02944157, 0.0, -1.72359229, 1000.0]])
+_three_near_natural_diffuse = np.array([
+    [ 0.417,  1.02944157, 0.0, -7.18088642, 0.2],
+    [-0.834,  3.11659683, 0.0, -4.45223936, 0.5],
+    [ 0.417,  1.02944157, 0.0, -1.72359229, 0.2]])
+
+_two_very_near_points = np.array([
+    [ 1.0, -1.5,  0.1, 2.14],
+    [-1.0, -1.5,  0.2, 2.14]])
+_two_very_near_sharp_diffuse = np.array([
+    [ 1.0, -1.5,  0.1, 2.14, 1000000000.0],
+    [-1.0, -1.5,  0.2, 2.14, 1000000000.0]])
+
+@pytest.mark.quick
+@pytest.mark.parametrize("ep,anskey", [
+    # lone H2O equivalents
+    pytest.param(None, "h2o_plain_df", id="water"),
+    pytest.param(_one_far_point, "h2o_plain_df", id="water_farP"),
+    pytest.param(_one_farther_point, "h2o_plain_df", id="water_farP_2"),
+    pytest.param({"diffuse": _one_far_diffuse}, "h2o_plain_df", id="water_farD"),
+    pytest.param([None, _one_farther_diffuse], "h2o_plain_df", id="water_farD_2"),
+    # H2O + point charge H2O equivalents
+    pytest.param(_three_near_points, "h2o_ee_df", id="water_P"),
+    pytest.param([_one_far_point, _three_near_sharp_diffuse], "h2o_ee_df", id="water_farP_D"),
+    pytest.param([None, _three_near_sharp_diffuse], "h2o_ee_df", id="water_D"),
+    pytest.param([_three_near_points[:1], _three_near_sharp_diffuse[1:]], "h2o_ee_df", id="water_2P_D"),
+    pytest.param([_three_near_points[1:], _three_near_sharp_diffuse[:1]], "h2o_ee_df", id="water_P_2D"),
+    # H2O + diffuse charge H2O equivalents
+    pytest.param([None, _three_near_natural_diffuse], "h2o_dd_df", id="water_DD"),
+    # H2O + very near strong charges equivalents
+    pytest.param(_two_very_near_points, "h2o_de_df", id="water_near_PP"),
+    pytest.param([None, _two_very_near_sharp_diffuse], "h2o_de_df", id="water_near_DD"),
+    pytest.param([_two_very_near_points[:1], _two_very_near_sharp_diffuse[1:]], "h2o_de_df", id="water_near_DP"),
+    pytest.param([_two_very_near_points[1:], _two_very_near_sharp_diffuse[:1]], "h2o_de_df", id="water_near_PD"),
+])
+def test_extern_points_diffuse(ep, anskey):
+
+    h2o_bohr = [-1.47172438,  0.0,         2.14046066,
+                -1.25984639,  1.44393784,  3.22442268,
+                -1.25984639, -1.44393784,  3.22442079]
+    water = psi4.core.Molecule.from_arrays(units="Bohr", geom=h2o_bohr, elem=["O", "H", "H"])
+            #, fix_com=True, fix_orientation=True)
+
+    ans = {
+        "h2o_plain_df": {  # copied from psi4/extern1 test
+            "energy": -76.010274923509,
+        },
+        "h2o_ee_df": {  # copied from psi4/extern1 test
+            "energy": -76.0194112285529968,
+        },
+        "h2o_dd_df": {  # uncorroborated, merely to check calc stable
+            #"energy": -76.01481363, # all 0.2
+            "energy": -76.014805897408,
+        },
+        "h2o_de_df": {
+            "energy": -42.27378086,
+        },
+    }
+
+    ene = psi4.energy("hf/6-31G*", molecule=water, external_potentials=ep)
+    psi4.compare_values(ans[anskey]["energy"], ene, 6, anskey)
+


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
For a long time, this PR was parsing + diffuse charges. Now it's just diffuse charges. Update: now the diffuse charges implementation came in with 3222, so this is just testing.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- Background: These diffuse charges are correct in their sharp or far-away limits. Practical testing (thanks, @lukekurfman) finds them to not really solve anything, but at least they're ready for future exploration.
- [x] As discussed at the 7 Feb Patkowski/Pederson/CDSgroup meeting, we want to route more user permanent potentials through the `external_potential` keyword (`embedding charges` in MBE). This is step 2 to allow diffuse charges to be specified and computed.
- Future Todo needs threading
- Future Todo needs gradient (although that could be a later PR)


## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
