### PR TITLE
DePointerDPD Warmup: `Dimension` for `cc`

### DIFF
--- a/psi4/src/psi4/cc/ccdensity/Iab.cc
+++ b/psi4/src/psi4/cc/ccdensity/Iab.cc
@@ -53,12 +53,12 @@ namespace ccdensity {
 
 void Iab(const struct RHO_Params& rho_params) {
     int a, b, c, A, B, C, Ga, Gb, Gc, Gac, Gbc;
-    int *vir_off, *virtpi, nirreps, length, col;
+    int length, col;
     dpdfile2 F, D, I;
     dpdbuf4 G, Bints, Cints, Dints, Eints, Fints;
-    vir_off = moinfo.vir_off;
-    virtpi = moinfo.virtpi;
-    nirreps = moinfo.nirreps;
+    const auto& vir_off = moinfo.vir_off;
+    const auto& virtpi = moinfo.virtpi;
+    const auto& nirreps = moinfo.nirreps;
 
     if (params.ref == 0) { /** RHF **/
         /* I'AB <-- sum_I fAI (DBI + DIB) + sum_C fAC (DBC + DCB) */

--- a/psi4/src/psi4/cc/ccdensity/MOInfo.h
+++ b/psi4/src/psi4/cc/ccdensity/MOInfo.h
@@ -71,12 +71,12 @@ struct MOInfo {
     Dimension virtpi;                /* no. of active virt. orbs. (incl. open) per irrep */
     Dimension avirtpi;               /* no. of alpha active virt. orbs. (incl. open) per irrep */
     Dimension bvirtpi;               /* no. of beta active virt. orbs. (incl. open) per irrep */
-    Dimension occ_off;               /* occupied orbital offsets within each irrep */
-    Dimension aocc_off;              /* alpha occupied orbital offsets within each irrep */
-    Dimension bocc_off;              /* beta occupied orbital offsets within each irrep */
-    Dimension vir_off;               /* virtual orbital offsets within each irrep */
-    Dimension avir_off;              /* alpha virtual orbital offsets within each irrep */
-    Dimension bvir_off;              /* beta virtual orbital offsets within each irrep */
+    std::vector<int> occ_off;        /* occupied orbital offsets within each irrep */
+    std::vector<int> aocc_off;       /* alpha occupied orbital offsets within each irrep */
+    std::vector<int> bocc_off;       /* beta occupied orbital offsets within each irrep */
+    std::vector<int> vir_off;        /* virtual orbital offsets within each irrep */
+    std::vector<int> avir_off;       /* alpha virtual orbital offsets within each irrep */
+    std::vector<int> bvir_off;       /* beta virtual orbital offsets within each irrep */
     std::vector<int> cc_occ;         /* QT->CC active occupied reordering array */
     std::vector<int> cc_aocc;        /* QT->CC alpha active occupied reordering array */
     std::vector<int> cc_bocc;        /* QT->CC beta active occupied reordering array */

--- a/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
@@ -73,8 +73,11 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
         moinfo.escf = wfn->energy();
 
     moinfo.orbspi = wfn->nmopi();
-    moinfo.clsdpi = wfn->doccpi();
+    moinfo.frdocc = wfn->frzcpi();
+    moinfo.fruocc = wfn->frzvpi();
+    moinfo.clsdpi = wfn->doccpi() - moinfo.frdocc;
     moinfo.openpi = wfn->soccpi();
+    moinfo.uoccpi = moinfo.orbspi - moinfo.clsdpi - moinfo.openpi - moinfo.fruocc - moinfo.frdocc;
 
     moinfo.Ca = wfn->Ca();
 
@@ -82,72 +85,52 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     for (i = 0; i < moinfo.nirreps; ++i)
         for (j = 0; j < moinfo.openpi[i]; ++j) moinfo.sym = moinfo.sym ^ i;
 
-    auto temp = std::vector<int>(moinfo.nirreps);
-
-    /* Get frozen and active orbital lookups from CC_INFO */
-    psio_read_entry(PSIF_CC_INFO, "Frozen Core Orbs Per Irrep", (char *)temp.data(), sizeof(int) * moinfo.nirreps);
-    moinfo.frdocc = Dimension(temp);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Virt Orbs Per Irrep", (char *)temp.data(), sizeof(int) * moinfo.nirreps);
-    moinfo.fruocc = Dimension(temp);
 
     psio_read_entry(PSIF_CC_INFO, "No. of Active Orbitals", (char *)&(nactive), sizeof(int));
     moinfo.nactive = nactive;
 
+    auto temp = std::vector<int>(moinfo.nirreps);
     if (params.ref == 0 || params.ref == 1) { /** RHF or ROHF **/
-
-        psio_read_entry(PSIF_CC_INFO, "Active Occ Orbs Per Irrep", (char *)temp.data(), sizeof(int) * moinfo.nirreps);
-        moinfo.occpi = Dimension(temp);
-        psio_read_entry(PSIF_CC_INFO, "Active Virt Orbs Per Irrep", (char *)temp.data(),
-                        sizeof(int) * moinfo.nirreps);
-        moinfo.virtpi = Dimension(temp);
+        moinfo.occpi = moinfo.clsdpi + wfn->soccpi();
+        moinfo.virtpi = moinfo.uoccpi + wfn->soccpi();
 
         moinfo.occ_sym = std::vector<int>(nactive);
         psio_read_entry(PSIF_CC_INFO, "Active Occ Orb Symmetry", (char *)moinfo.occ_sym.data(), sizeof(int) * nactive);
         moinfo.vir_sym = std::vector<int>(nactive);
         psio_read_entry(PSIF_CC_INFO, "Active Virt Orb Symmetry", (char *)moinfo.vir_sym.data(), sizeof(int) * nactive);
 
-        psio_read_entry(PSIF_CC_INFO, "Active Occ Orb Offsets", (char *)temp.data(), sizeof(int) * moinfo.nirreps);
-        moinfo.occ_off = Dimension(temp);
-        psio_read_entry(PSIF_CC_INFO, "Active Virt Orb Offsets", (char *)temp.data(), sizeof(int) * moinfo.nirreps);
-        moinfo.vir_off = Dimension(temp);
-
+        moinfo.occ_off = std::vector<int>(moinfo.nirreps);
+        psio_read_entry(PSIF_CC_INFO, "Active Occ Orb Offsets", (char *)moinfo.occ_off.data(), sizeof(int) * moinfo.nirreps);
+        moinfo.vir_off = std::vector<int>(moinfo.nirreps);
+        psio_read_entry(PSIF_CC_INFO, "Active Virt Orb Offsets", (char *)moinfo.vir_off.data(), sizeof(int) * moinfo.nirreps);
     } else if (params.ref == 2) { /** UHF **/
+        moinfo.aoccpi = moinfo.clsdpi + wfn->soccpi();
+        moinfo.boccpi = moinfo.clsdpi;
+        moinfo.avirtpi = moinfo.uoccpi;
+        moinfo.bvirtpi = moinfo.uoccpi + wfn->soccpi();
 
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orbs Per Irrep", (char *)temp.data(),
-                        sizeof(int) * moinfo.nirreps);
-        moinfo.aoccpi = Dimension(temp);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orbs Per Irrep", (char *)temp.data(),
-                        sizeof(int) * moinfo.nirreps);
-        moinfo.boccpi = Dimension(temp);
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orbs Per Irrep", (char *)temp.data(),
-                        sizeof(int) * moinfo.nirreps);
-        moinfo.avirtpi = Dimension(temp);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orbs Per Irrep", (char *)temp.data(),
-                        sizeof(int) * moinfo.nirreps);
-        moinfo.bvirtpi = Dimension(temp);
-
-        moinfo.aocc_sym = std::vector<int>(nactive);;
-        moinfo.bocc_sym = std::vector<int>(nactive);;
-        moinfo.avir_sym = std::vector<int>(nactive);;
-        moinfo.bvir_sym = std::vector<int>(nactive);;
-
+        moinfo.aocc_sym = std::vector<int>(nactive);
         psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orb Symmetry", (char *)moinfo.aocc_sym.data(), sizeof(int) * nactive);
+        moinfo.bocc_sym = std::vector<int>(nactive);
         psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orb Symmetry", (char *)moinfo.bocc_sym.data(), sizeof(int) * nactive);
+        moinfo.avir_sym = std::vector<int>(nactive);
         psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orb Symmetry", (char *)moinfo.avir_sym.data(), sizeof(int) * nactive);
+        moinfo.bvir_sym = std::vector<int>(nactive);
         psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orb Symmetry", (char *)moinfo.bvir_sym.data(), sizeof(int) * nactive);
 
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orb Offsets", (char *)temp.data(),
+
+        moinfo.aocc_off = std::vector<int>(moinfo.nirreps);
+        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orb Offsets", (char *)moinfo.aocc_off.data(),
                         sizeof(int) * moinfo.nirreps);
-        moinfo.aocc_off = Dimension(temp);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orb Offsets", (char *)temp.data(),
+        moinfo.bocc_off = std::vector<int>(moinfo.nirreps);
+        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orb Offsets", (char *)moinfo.bocc_off.data(),
                         sizeof(int) * moinfo.nirreps);
-        moinfo.bocc_off = Dimension(temp);
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orb Offsets", (char *)temp.data(),
+        moinfo.avir_off = std::vector<int>(moinfo.nirreps);
+        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orb Offsets", (char *)moinfo.avir_off.data(),
                         sizeof(int) * moinfo.nirreps);
-        moinfo.avir_off = Dimension(temp);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orb Offsets", (char *)temp.data(),
+        moinfo.bvir_off = std::vector<int>(moinfo.nirreps);
+        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orb Offsets", (char *)moinfo.bvir_off.data(),
                         sizeof(int) * moinfo.nirreps);
-        moinfo.bvir_off = Dimension(temp);
     }
 
     /* Compute spatial-orbital reordering arrays */
@@ -160,10 +143,6 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
         moinfo.qt2pitzer[j] = i;
     }
 
-    /* Adjust clsdpi array for frozen orbitals */
-    moinfo.clsdpi -= moinfo.frdocc;
-
-    moinfo.uoccpi = moinfo.orbspi - moinfo.clsdpi - moinfo.openpi - moinfo.fruocc - moinfo.frdocc;
 
     moinfo.nfzc = moinfo.frdocc.sum();
     moinfo.nfzv = moinfo.fruocc.sum();

--- a/psi4/src/psi4/cc/ccenergy/MOInfo.h
+++ b/psi4/src/psi4/cc/ccenergy/MOInfo.h
@@ -46,22 +46,22 @@ struct MOInfo {
     int nmo;                         /* no. of molecular orbitals */
     int nso;                         /* no. of symmetry orbitals */
     int nao;                         /* no. of atomic orbitals */
-    int *sopi;                       /* no. of SOs per irrep (only used in AO-based algorithm) */
+    Dimension sopi;                  /* no. of SOs per irrep (only used in AO-based algorithm) */
     int *sosym;                      /* SO symmetry (Pitzer) */
-    int *orbspi;                     /* no. of MOs per irrep */
+    Dimension orbspi;                /* no. of MOs per irrep */
     Dimension clsdpi;                /* no. of closed-shells per irrep excl. frdocc */
     Dimension openpi;                /* no. of open-shells per irrep */
-    int *uoccpi;                     /* no. of unoccupied orbitals per irr. ex. fruocc */
-    int *frdocc;                     /* no. of frozen core orbitals per irrep */
-    int *fruocc;                     /* no. of frozen unoccupied orbitals per irrep */
+    Dimension uoccpi;                /* no. of unoccupied orbitals per irr. ex. fruocc */
+    Dimension frdocc;                /* no. of frozen core orbitals per irrep */
+    Dimension fruocc;                /* no. of frozen unoccupied orbitals per irrep */
     int nvirt;                       /* total no. of virtual orbitals */
     std::vector<std::string> labels; /* irrep labels */
-    int *occpi;                      /* no. of occupied orbs. (incl. open) per irrep */
-    int *aoccpi;                     /* no. of alpha occupied orbs. (incl. open) per irrep */
-    int *boccpi;                     /* no. of beta occupied orbs. (incl. open) per irrep */
-    int *virtpi;                     /* no. of virtual orbs. (incl. open) per irrep */
-    int *avirtpi;                    /* no. of alpha virtual orbs. (incl. open) per irrep */
-    int *bvirtpi;                    /* no. of beta virtual orbs. (incl. open) per irrep */
+    Dimension occpi;                 /* no. of occupied orbs. (incl. open) per irrep */
+    Dimension aoccpi;                /* no. of alpha occupied orbs. (incl. open) per irrep */
+    Dimension boccpi;                /* no. of beta occupied orbs. (incl. open) per irrep */
+    Dimension virtpi;                /* no. of virtual orbs. (incl. open) per irrep */
+    Dimension avirtpi;               /* no. of alpha virtual orbs. (incl. open) per irrep */
+    Dimension bvirtpi;               /* no. of beta virtual orbs. (incl. open) per irrep */
     int *occ_sym;                    /* relative occupied index symmetry */
     int *aocc_sym;                   /* relative alpha occupied index symmetry */
     int *bocc_sym;                   /* relative beta occupied index symmetry */

--- a/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_moinfo.cc
@@ -77,37 +77,24 @@ void CCEnergyWavefunction::get_moinfo() {
         moinfo_.escf = energy_;
     moinfo_.sopi = nsopi_;
     moinfo_.orbspi = nmopi_;
+    moinfo_.frdocc = frzcpi_;
+    moinfo_.fruocc = frzvpi_;
     moinfo_.openpi = soccpi();
-    // We'll remove the frzcpi later in this file.
-    moinfo_.clsdpi = doccpi();
+    moinfo_.clsdpi = doccpi() - frzcpi_;
+    moinfo_.uoccpi = moinfo_.orbspi - moinfo_.clsdpi - moinfo_.openpi - moinfo_.fruocc - moinfo_.frdocc;
 
     auto nirreps = moinfo_.nirreps;
 
     psio_read_entry(PSIF_CC_INFO, "Reference Wavefunction", (char *)&(params_.ref), sizeof(int));
 
-    /* Get frozen and active orbital lookups from CC_INFO */
-    moinfo_.frdocc = init_int_array(nirreps);
-    moinfo_.fruocc = init_int_array(nirreps);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Core Orbs Per Irrep", (char *)moinfo_.frdocc, sizeof(int) * nirreps);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Virt Orbs Per Irrep", (char *)moinfo_.fruocc, sizeof(int) * nirreps);
-
     psio_read_entry(PSIF_CC_INFO, "No. of Active Orbitals", (char *)&(nactive), sizeof(int));
 
     if (params_.ref == 2) { /** UHF **/
 
-        moinfo_.aoccpi = init_int_array(nirreps);
-        moinfo_.boccpi = init_int_array(nirreps);
-        moinfo_.avirtpi = init_int_array(nirreps);
-        moinfo_.bvirtpi = init_int_array(nirreps);
-
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orbs Per Irrep", (char *)moinfo_.aoccpi,
-                        sizeof(int) * moinfo_.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orbs Per Irrep", (char *)moinfo_.boccpi,
-                        sizeof(int) * moinfo_.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orbs Per Irrep", (char *)moinfo_.avirtpi,
-                        sizeof(int) * moinfo_.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orbs Per Irrep", (char *)moinfo_.bvirtpi,
-                        sizeof(int) * moinfo_.nirreps);
+        moinfo_.aoccpi = moinfo_.clsdpi + soccpi();
+        moinfo_.boccpi = moinfo_.clsdpi;
+        moinfo_.avirtpi = moinfo_.uoccpi;
+        moinfo_.bvirtpi = moinfo_.uoccpi + soccpi();
 
         moinfo_.aocc_sym = init_int_array(nactive);
         moinfo_.bocc_sym = init_int_array(nactive);
@@ -135,12 +122,10 @@ void CCEnergyWavefunction::get_moinfo() {
 
     } else { /** RHF or ROHF **/
 
-        moinfo_.occpi = init_int_array(nirreps);
-        moinfo_.virtpi = init_int_array(nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Occ Orbs Per Irrep", (char *)moinfo_.occpi, sizeof(int) * nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Virt Orbs Per Irrep", (char *)moinfo_.virtpi, sizeof(int) * nirreps);
-        act_occpi_ = Dimension(std::vector<int>(moinfo_.occpi, moinfo_.occpi + nirreps));
-        act_virpi_ = Dimension(std::vector<int>(moinfo_.virtpi, moinfo_.virtpi + nirreps));
+        moinfo_.occpi = moinfo_.clsdpi + soccpi();
+        moinfo_.virtpi = moinfo_.uoccpi + soccpi();
+        act_occpi_ = moinfo_.occpi;
+        act_virpi_ = moinfo_.virtpi;
         moinfo_.occ_sym = init_int_array(nactive);
         moinfo_.vir_sym = init_int_array(nactive);
         psio_read_entry(PSIF_CC_INFO, "Active Occ Orb Symmetry", (char *)moinfo_.occ_sym, sizeof(int) * nactive);
@@ -208,17 +193,9 @@ void CCEnergyWavefunction::get_moinfo() {
         moinfo_.Cbv = Cb;
     }
 
-    /* Adjust clsdpi array for frozen orbitals */
-    for (int i = 0; i < nirreps; i++) moinfo_.clsdpi[i] -= moinfo_.frdocc[i];
-
-    moinfo_.uoccpi = init_int_array(moinfo_.nirreps);
-    for (int i = 0; i < nirreps; i++)
-        moinfo_.uoccpi[i] =
-            moinfo_.orbspi[i] - moinfo_.clsdpi[i] - moinfo_.openpi[i] - moinfo_.fruocc[i] - moinfo_.frdocc[i];
 
     if (params_.ref == 0) {
-        moinfo_.nvirt = 0;
-        for (int h = 0; h < nirreps; h++) moinfo_.nvirt += moinfo_.virtpi[h];
+        moinfo_.nvirt = moinfo_.virtpi.sum();;
     }
 
     psio_read_entry(PSIF_CC_INFO, "Reference Energy", (char *)&(moinfo_.eref), sizeof(double));
@@ -253,19 +230,7 @@ void CCEnergyWavefunction::cleanup() {
         free(moinfo_.Cbv);
     }
 
-    // Wavefunction owns these arrays
-    //    free(moinfo.sopi);
-    //    free(moinfo.sosym);
-    //    free(moinfo.orbspi);
-    //    free(moinfo.openpi);
-    //    free(moinfo.uoccpi);
-    //  free(moinfo.fruocc);
-    //  free(moinfo.frdocc);
     if (params_.ref == 2) {
-        free(moinfo_.aoccpi);
-        free(moinfo_.boccpi);
-        free(moinfo_.avirtpi);
-        free(moinfo_.bvirtpi);
         free(moinfo_.aocc_sym);
         free(moinfo_.bocc_sym);
         free(moinfo_.avir_sym);
@@ -275,8 +240,6 @@ void CCEnergyWavefunction::cleanup() {
         free(moinfo_.avir_off);
         free(moinfo_.bvir_off);
     } else {
-        free(moinfo_.occpi);
-        free(moinfo_.virtpi);
         free(moinfo_.occ_sym);
         free(moinfo_.vir_sym);
         free(moinfo_.occ_off);

--- a/psi4/src/psi4/cc/cceom/MOInfo.h
+++ b/psi4/src/psi4/cc/cceom/MOInfo.h
@@ -36,8 +36,10 @@
 
 #include <string>
 #include <vector>
+#include "psi4/libmints/dimension.h"
 
 namespace psi {
+
 namespace cceom {
 
 struct MOInfo {
@@ -45,23 +47,23 @@ struct MOInfo {
     int nmo;                           /* no. of molecular orbitals */
     int nso;                           /* no. of symmetry orbitals */
     int iopen;                         /* 0=closed shell; >0=open shell */
-    int *sopi;                         /* no. of SOs per irrep */
+    Dimension sopi;                         /* no. of SOs per irrep */
     int *sosym;                        /* orbital symmetry (Pitzer/SO) */
-    int *orbspi;                       /* no. of MOs per irrep */
-    int *clsdpi;                       /* no. of closed-shells per irrep excl. frdocc */
-    int *openpi;                       /* no. of open-shells per irrep */
-    int *uoccpi;                       /* no. of unoccupied orbitals per irr. ex. fruocc */
-    int *frdocc;                       /* no. of frozen core orbitals per irrep */
-    int *fruocc;                       /* no. of frozen unoccupied orbitals per irrep */
+    Dimension orbspi;                       /* no. of MOs per irrep */
+    Dimension clsdpi;                       /* no. of closed-shells per irrep excl. frdocc */
+    Dimension openpi;                       /* no. of open-shells per irrep */
+    Dimension uoccpi;                       /* no. of unoccupied orbitals per irr. ex. fruocc */
+    Dimension frdocc;                       /* no. of frozen core orbitals per irrep */
+    Dimension fruocc;                       /* no. of frozen unoccupied orbitals per irrep */
     int nvirt;                         /* total no. of (active) virtual orbitals */
     std::vector<std::string> irr_labs; /* irrep labels */
     char **irr_labs_lowercase;         /* irrep labels */
-    int *occpi;                        /* no. of occupied orbs. (incl. open) per irrep */
-    int *aoccpi;                       /* no. of alpha occupied orbs. (incl. open) per irrep */
-    int *boccpi;                       /* no. of beta occupied orbs. (incl. open) per irrep */
-    int *virtpi;                       /* no. of virtual orbs. (incl. open) per irrep */
-    int *avirtpi;                      /* no. of alpha virtual orbs. (incl. open) per irrep */
-    int *bvirtpi;                      /* no. of beta virtual orbs. (incl. open) per irrep */
+    Dimension occpi;                        /* no. of occupied orbs. (incl. open) per irrep */
+    Dimension aoccpi;                       /* no. of alpha occupied orbs. (incl. open) per irrep */
+    Dimension boccpi;                       /* no. of beta occupied orbs. (incl. open) per irrep */
+    Dimension virtpi;                       /* no. of virtual orbs. (incl. open) per irrep */
+    Dimension avirtpi;                      /* no. of alpha virtual orbs. (incl. open) per irrep */
+    Dimension bvirtpi;                      /* no. of beta virtual orbs. (incl. open) per irrep */
     int *occ_sym;                      /* relative occupied index symmetry */
     int *aocc_sym;                     /* relative alpha occupied index symmetry */
     int *bocc_sym;                     /* relative beta occupied index symmetry */

--- a/psi4/src/psi4/cc/cceom/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cceom/get_moinfo.cc
@@ -65,8 +65,7 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     moinfo.nirreps = wfn->nirrep();
     moinfo.nmo = wfn->nmo();
     moinfo.nso = wfn->nso();
-    moinfo.iopen = 0;
-    for (int h = 0; h < moinfo.nirreps; h++) moinfo.iopen += wfn->nsopi()[h];
+    moinfo.iopen = wfn->nsopi().n();
     moinfo.irr_labs = wfn->molecule()->irrep_labels();
     moinfo.enuc = wfn->molecule()->nuclear_repulsion_energy(wfn->get_dipole_field_strength());
     if (wfn->reference_wavefunction())
@@ -74,16 +73,13 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     else
         moinfo.escf = wfn->energy();
 
-    moinfo.sopi = init_int_array(moinfo.nirreps);
-    moinfo.orbspi = init_int_array(moinfo.nirreps);
-    moinfo.clsdpi = init_int_array(moinfo.nirreps);
-    moinfo.openpi = init_int_array(moinfo.nirreps);
-    for (int h = 0; h < moinfo.nirreps; ++h) {
-        moinfo.sopi[h] = wfn->nsopi()[h];
-        moinfo.orbspi[h] = wfn->nmopi()[h];
-        moinfo.clsdpi[h] = wfn->doccpi()[h];
-        moinfo.openpi[h] = wfn->soccpi()[h];
-    }
+    moinfo.sopi = wfn->nsopi();
+    moinfo.orbspi = wfn->nmopi();
+    moinfo.clsdpi = wfn->doccpi() - wfn->frzcpi();
+    moinfo.openpi = wfn->soccpi();
+    moinfo.frdocc = wfn->frzcpi();
+    moinfo.fruocc = wfn->frzvpi();
+    moinfo.uoccpi = moinfo.orbspi - moinfo.clsdpi - moinfo.openpi - moinfo.fruocc - moinfo.frdocc;
 
     sym = 0;
     for (i = 0; i < moinfo.nirreps; ++i)
@@ -101,20 +97,12 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
 
     psio_read_entry(PSIF_CC_INFO, "Reference Wavefunction", (char *)&(params.ref), sizeof(int));
 
-    /* Get frozen and active orbital lookups from CC_INFO */
-    moinfo.frdocc = init_int_array(nirreps);
-    moinfo.fruocc = init_int_array(nirreps);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Core Orbs Per Irrep", (char *)moinfo.frdocc, sizeof(int) * nirreps);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Virt Orbs Per Irrep", (char *)moinfo.fruocc, sizeof(int) * nirreps);
-
     psio_read_entry(PSIF_CC_INFO, "No. of Active Orbitals", (char *)&(nactive), sizeof(int));
 
     if (params.ref == 0 || params.ref == 1) { /** RHF or ROHF **/
 
-        moinfo.occpi = init_int_array(nirreps);
-        moinfo.virtpi = init_int_array(nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Occ Orbs Per Irrep", (char *)moinfo.occpi, sizeof(int) * nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Virt Orbs Per Irrep", (char *)moinfo.virtpi, sizeof(int) * nirreps);
+        moinfo.occpi = moinfo.clsdpi + wfn->soccpi();
+        moinfo.virtpi = moinfo.uoccpi + wfn->soccpi();
 
         moinfo.occ_sym = init_int_array(nactive);
         moinfo.vir_sym = init_int_array(nactive);
@@ -129,19 +117,10 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
 
     else { /** UHF **/
 
-        moinfo.aoccpi = init_int_array(nirreps);
-        moinfo.boccpi = init_int_array(nirreps);
-        moinfo.avirtpi = init_int_array(nirreps);
-        moinfo.bvirtpi = init_int_array(nirreps);
-
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orbs Per Irrep", (char *)moinfo.aoccpi,
-                        sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orbs Per Irrep", (char *)moinfo.boccpi,
-                        sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orbs Per Irrep", (char *)moinfo.avirtpi,
-                        sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orbs Per Irrep", (char *)moinfo.bvirtpi,
-                        sizeof(int) * moinfo.nirreps);
+        moinfo.aoccpi = moinfo.clsdpi + wfn->soccpi();
+        moinfo.boccpi = moinfo.clsdpi;
+        moinfo.avirtpi = moinfo.uoccpi;
+        moinfo.bvirtpi = moinfo.uoccpi + wfn->soccpi();
 
         moinfo.aocc_sym = init_int_array(nactive);
         moinfo.bocc_sym = init_int_array(nactive);
@@ -211,16 +190,8 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
         moinfo.Cb = Cb;
     }
 
-    /* Adjust clsdpi array for frozen orbitals */
-    for (i = 0; i < nirreps; i++) moinfo.clsdpi[i] -= moinfo.frdocc[i];
-
-    moinfo.uoccpi = init_int_array(moinfo.nirreps);
-    for (i = 0; i < nirreps; i++)
-        moinfo.uoccpi[i] = moinfo.orbspi[i] - moinfo.clsdpi[i] - moinfo.openpi[i] - moinfo.fruocc[i] - moinfo.frdocc[i];
-
     if (params.ref == 0) {
-        moinfo.nvirt = 0;
-        for (h = 0; h < moinfo.nirreps; h++) moinfo.nvirt += moinfo.virtpi[h];
+        moinfo.nvirt = moinfo.virtpi.sum();
     }
 
     psio_read_entry(PSIF_CC_INFO, "Reference Energy", (char *)&(moinfo.eref), sizeof(double));
@@ -247,28 +218,14 @@ void cleanup() {
         free(moinfo.Cb);
     }
 
-    free(moinfo.sopi);
-    free(moinfo.orbspi);
-    //    free(moinfo.sosym);
-    free(moinfo.clsdpi);
-    free(moinfo.openpi);
-    //    free(moinfo.uoccpi);
-    //    free(moinfo.fruocc);
-    //    free(moinfo.frdocc);
     for (i = 0; i < moinfo.nirreps; i++) free(moinfo.irr_labs_lowercase[i]);
     free(moinfo.irr_labs_lowercase);
     if (params.ref == 2) {
-        free(moinfo.aoccpi);
-        free(moinfo.boccpi);
-        free(moinfo.avirtpi);
-        free(moinfo.bvirtpi);
         free(moinfo.aocc_sym);
         free(moinfo.bocc_sym);
         free(moinfo.avir_sym);
         free(moinfo.bvir_sym);
     } else {
-        free(moinfo.occpi);
-        free(moinfo.virtpi);
         free(moinfo.occ_sym);
         free(moinfo.vir_sym);
     }

--- a/psi4/src/psi4/cc/cchbar/MOInfo.h
+++ b/psi4/src/psi4/cc/cchbar/MOInfo.h
@@ -36,6 +36,7 @@
 
 #include <string>
 #include <vector>
+#include "psi4/libmints/dimension.h"
 
 namespace psi {
 namespace cchbar {
@@ -43,12 +44,12 @@ namespace cchbar {
 struct MOInfo {
     int nirreps;                     /* no. of irreducible representations */
     int nmo;                         /* no. of molecular orbitals */
-    int *orbspi;                     /* no. of MOs per irrep */
-    int *clsdpi;                     /* no. of closed-shells per irrep excl. frdocc */
-    int *openpi;                     /* no. of open-shells per irrep */
-    int *uoccpi;                     /* no. of unoccupied orbitals per irrep excl. fruocc */
-    int *frdocc;                     /* no. of frozen core orbitals per irrep */
-    int *fruocc;                     /* no. of frozen unoccupied orbitals per irrep */
+    Dimension orbspi;                     /* no. of MOs per irrep */
+    Dimension clsdpi;                     /* no. of closed-shells per irrep excl. frdocc */
+    Dimension openpi;                     /* no. of open-shells per irrep */
+    Dimension uoccpi;                     /* no. of unoccupied orbitals per irrep excl. fruocc */
+    Dimension frdocc;                     /* no. of frozen core orbitals per irrep */
+    Dimension fruocc;                     /* no. of frozen unoccupied orbitals per irrep */
     std::vector<std::string> labels; /* irrep labels */
     int *occ_sym;                    /* relative occupied index symmetry */
     int *aocc_sym;                   /* relative alpha occupied index symmetry */
@@ -56,12 +57,12 @@ struct MOInfo {
     int *vir_sym;                    /* relative virtual index symmetry */
     int *avir_sym;                   /* relative alpha virtual index symmetry */
     int *bvir_sym;                   /* relative beta virtual index symmetry */
-    int *occpi;                      /* no. of occupied orbs. (incl. open) per irrep */
-    int *aoccpi;                     /* no. of alpha occupied orbs. (incl. open) per irrep */
-    int *boccpi;                     /* no. of beta occupied orbs. (incl. open) per irrep */
-    int *virtpi;                     /* no. of virtual orbs. (incl. open) per irrep */
-    int *avirtpi;                    /* no. of alpha virtual orbs. (incl. open) per irrep */
-    int *bvirtpi;                    /* no. of beta virtual orbs. (incl. open) per irrep */
+    Dimension occpi;                      /* no. of occupied orbs. (incl. open) per irrep */
+    Dimension aoccpi;                     /* no. of alpha occupied orbs. (incl. open) per irrep */
+    Dimension boccpi;                     /* no. of beta occupied orbs. (incl. open) per irrep */
+    Dimension virtpi;                     /* no. of virtual orbs. (incl. open) per irrep */
+    Dimension avirtpi;                    /* no. of alpha virtual orbs. (incl. open) per irrep */
+    Dimension bvirtpi;                    /* no. of beta virtual orbs. (incl. open) per irrep */
     int *occ_off;                    /* occupied orbital offsets within each irrep */
     int *aocc_off;                   /* alpha occupied orbital offsets within each irrep */
     int *bocc_off;                   /* beta occupied orbital offsets within each irrep */

--- a/psi4/src/psi4/cc/cchbar/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cchbar/get_moinfo.cc
@@ -61,14 +61,12 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn, Options &options) {
     moinfo.nirreps = wfn->nirrep();
     moinfo.nmo = wfn->nmo();
     moinfo.labels = wfn->molecule()->irrep_labels();
-    moinfo.orbspi = init_int_array(moinfo.nirreps);
-    moinfo.clsdpi = init_int_array(moinfo.nirreps);
-    moinfo.openpi = init_int_array(moinfo.nirreps);
-    for (int h = 0; h < moinfo.nirreps; ++h) {
-        moinfo.orbspi[h] = wfn->nmopi()[h];
-        moinfo.clsdpi[h] = wfn->doccpi()[h];
-        moinfo.openpi[h] = wfn->soccpi()[h];
-    }
+    moinfo.orbspi = wfn->nmopi();
+    moinfo.clsdpi = wfn->doccpi() - wfn->frzcpi();
+    moinfo.openpi = wfn->soccpi();
+    moinfo.frdocc = wfn->frzcpi();
+    moinfo.fruocc = wfn->frzvpi();
+    moinfo.uoccpi = moinfo.orbspi - moinfo.clsdpi - moinfo.openpi - moinfo.fruocc - moinfo.frdocc;
 
     nirreps = moinfo.nirreps;
 
@@ -80,20 +78,12 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn, Options &options) {
     //  errcod = ip_string("EOM_REFERENCE", &(read_eom_ref),0);
     if (read_eom_ref == "ROHF") params.ref = 1;
 
-    /* Get frozen and active orbital lookups from CC_INFO */
-    moinfo.frdocc = init_int_array(moinfo.nirreps);
-    moinfo.fruocc = init_int_array(moinfo.nirreps);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Core Orbs Per Irrep", (char *)moinfo.frdocc, sizeof(int) * moinfo.nirreps);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Virt Orbs Per Irrep", (char *)moinfo.fruocc, sizeof(int) * moinfo.nirreps);
     psio_read_entry(PSIF_CC_INFO, "No. of Active Orbitals", (char *)&(nactive), sizeof(int));
 
     if (params.ref == 0 || params.ref == 1) { /** RHF or ROHF **/
 
-        moinfo.occpi = init_int_array(moinfo.nirreps);
-        moinfo.virtpi = init_int_array(moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Occ Orbs Per Irrep", (char *)moinfo.occpi, sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Virt Orbs Per Irrep", (char *)moinfo.virtpi,
-                        sizeof(int) * moinfo.nirreps);
+        moinfo.occpi = moinfo.clsdpi + wfn->soccpi();
+        moinfo.virtpi = moinfo.uoccpi + wfn->soccpi();
 
         moinfo.occ_sym = init_int_array(nactive);
         moinfo.vir_sym = init_int_array(nactive);
@@ -106,19 +96,10 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn, Options &options) {
         psio_read_entry(PSIF_CC_INFO, "Active Virt Orb Offsets", (char *)moinfo.vir_off, sizeof(int) * moinfo.nirreps);
     } else if (params.ref == 2) { /** UHF **/
 
-        moinfo.aoccpi = init_int_array(nirreps);
-        moinfo.boccpi = init_int_array(nirreps);
-        moinfo.avirtpi = init_int_array(nirreps);
-        moinfo.bvirtpi = init_int_array(nirreps);
-
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orbs Per Irrep", (char *)moinfo.aoccpi,
-                        sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orbs Per Irrep", (char *)moinfo.boccpi,
-                        sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orbs Per Irrep", (char *)moinfo.avirtpi,
-                        sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orbs Per Irrep", (char *)moinfo.bvirtpi,
-                        sizeof(int) * moinfo.nirreps);
+        moinfo.aoccpi = moinfo.clsdpi + wfn->soccpi();
+        moinfo.boccpi = moinfo.clsdpi;
+        moinfo.avirtpi = moinfo.uoccpi;
+        moinfo.bvirtpi = moinfo.uoccpi + wfn->soccpi();
 
         moinfo.aocc_sym = init_int_array(nactive);
         moinfo.bocc_sym = init_int_array(nactive);
@@ -146,29 +127,11 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn, Options &options) {
                         sizeof(int) * moinfo.nirreps);
     }
 
-    /* Adjust clsdpi array for frozen orbitals */
-    for (i = 0; i < moinfo.nirreps; i++) moinfo.clsdpi[i] -= moinfo.frdocc[i];
-
-    moinfo.uoccpi = init_int_array(moinfo.nirreps);
-    for (i = 0; i < moinfo.nirreps; i++)
-        moinfo.uoccpi[i] = moinfo.orbspi[i] - moinfo.clsdpi[i] - moinfo.openpi[i] - moinfo.fruocc[i] - moinfo.frdocc[i];
 }
 
 /* Frees memory allocated in get_moinfo() and dumps some info. */
 void cleanup() {
-    int i;
-
-    free(moinfo.orbspi);
-    free(moinfo.clsdpi);
-    free(moinfo.openpi);
-    //  free(moinfo.uoccpi);
-    //  free(moinfo.fruocc);
-    //  free(moinfo.frdocc);
     if (params.ref == 2) {
-        free(moinfo.aoccpi);
-        free(moinfo.boccpi);
-        free(moinfo.avirtpi);
-        free(moinfo.bvirtpi);
         free(moinfo.aocc_sym);
         free(moinfo.bocc_sym);
         free(moinfo.avir_sym);
@@ -178,8 +141,6 @@ void cleanup() {
         free(moinfo.vir_sym);
         free(moinfo.occ_off);
         free(moinfo.vir_off);
-        free(moinfo.occpi);
-        free(moinfo.virtpi);
     }
 }
 

--- a/psi4/src/psi4/cc/cclambda/MOInfo.h
+++ b/psi4/src/psi4/cc/cclambda/MOInfo.h
@@ -36,6 +36,7 @@
 
 #include <string>
 #include <vector>
+#include "psi4/libmints/dimension.h"
 
 namespace psi {
 namespace cclambda {
@@ -45,22 +46,22 @@ struct MOInfo {
     int nmo;     /* no. of molecular orbitals */
     int nso;
     int nao;
-    int *sopi;                       /* no. of SOs per irrep */
+    Dimension sopi;                  /* no. of SOs per irrep */
     int *sosym;                      /* SO symmetry (Pitzer) */
-    int *orbspi;                     /* no. of MOs per irrep */
-    int *clsdpi;                     /* no. of closed-shells per irrep excl. frdocc */
-    int *openpi;                     /* no. of open-shells per irrep */
-    int *uoccpi;                     /* no. of unoccupied orbitals per irrep excl. fruocc */
-    int *frdocc;                     /* no. of frozen core orbitals per irrep */
-    int *fruocc;                     /* no. of frozen unoccupied orbitals per irrep */
+    Dimension orbspi;                /* no. of MOs per irrep */
+    Dimension clsdpi;                /* no. of closed-shells per irrep excl. frdocc */
+    Dimension openpi;                /* no. of open-shells per irrep */
+    Dimension uoccpi;                /* no. of unoccupied orbitals per irrep excl. fruocc */
+    Dimension frdocc;                /* no. of frozen core orbitals per irrep */
+    Dimension fruocc;                /* no. of frozen unoccupied orbitals per irrep */
     int nvirt;                       /* total no. of (active) virtual orbitals */
     std::vector<std::string> labels; /* irrep labels */
-    int *occpi;                      /* no. of occupied orbs. (incl. open) per irrep */
-    int *aoccpi;                     /* no. of alpha occupied orbs. (incl. open) per irrep */
-    int *boccpi;                     /* no. of beta occupied orbs. (incl. open) per irrep */
-    int *virtpi;                     /* no. of virtual orbs. (incl. open) per irrep */
-    int *avirtpi;                    /* no. of alpha virtual orbs. (incl. open) per irrep */
-    int *bvirtpi;                    /* no. of beta virtual orbs. (incl. open) per irrep */
+    Dimension occpi;                 /* no. of occupied orbs. (incl. open) per irrep */
+    Dimension aoccpi;                /* no. of alpha occupied orbs. (incl. open) per irrep */
+    Dimension boccpi;                /* no. of beta occupied orbs. (incl. open) per irrep */
+    Dimension virtpi;                /* no. of virtual orbs. (incl. open) per irrep */
+    Dimension avirtpi;               /* no. of alpha virtual orbs. (incl. open) per irrep */
+    Dimension bvirtpi;               /* no. of beta virtual orbs. (incl. open) per irrep */
     int *occ_sym;                    /* relative occupied index symmetry */
     int *aocc_sym;                   /* relative alpha occupied index symmetry */
     int *bocc_sym;                   /* relative beta occupied index symmetry */

--- a/psi4/src/psi4/cc/cclambda/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cclambda/get_moinfo.cc
@@ -72,16 +72,13 @@ void CCLambdaWavefunction::get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     else
         moinfo.escf = wfn->energy();
 
-    moinfo.sopi = init_int_array(moinfo.nirreps);
-    moinfo.orbspi = init_int_array(moinfo.nirreps);
-    moinfo.clsdpi = init_int_array(moinfo.nirreps);
-    moinfo.openpi = init_int_array(moinfo.nirreps);
-    for (int h = 0; h < moinfo.nirreps; ++h) {
-        moinfo.sopi[h] = wfn->nsopi()[h];
-        moinfo.orbspi[h] = wfn->nmopi()[h];
-        moinfo.clsdpi[h] = wfn->doccpi()[h];
-        moinfo.openpi[h] = wfn->soccpi()[h];
-    }
+    moinfo.sopi = wfn->nsopi();
+    moinfo.orbspi = wfn->nmopi();
+    moinfo.clsdpi = wfn->doccpi() - wfn->frzcpi();
+    moinfo.openpi = wfn->soccpi();
+    moinfo.frdocc = wfn->frzcpi();
+    moinfo.fruocc = wfn->frzvpi();
+    moinfo.uoccpi = moinfo.orbspi - moinfo.clsdpi - moinfo.openpi - moinfo.fruocc - moinfo.frdocc;
 
     sym = 0;
     for (i = 0; i < moinfo.nirreps; ++i)
@@ -90,21 +87,11 @@ void CCLambdaWavefunction::get_moinfo(std::shared_ptr<Wavefunction> wfn) {
 
     psio_read_entry(PSIF_CC_INFO, "Reference Wavefunction", (char *)&(params.ref), sizeof(int));
 
-    /* Get frozen and active orbital lookups from CC_INFO */
-    moinfo.frdocc = init_int_array(moinfo.nirreps);
-    moinfo.fruocc = init_int_array(moinfo.nirreps);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Core Orbs Per Irrep", (char *)moinfo.frdocc, sizeof(int) * moinfo.nirreps);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Virt Orbs Per Irrep", (char *)moinfo.fruocc, sizeof(int) * moinfo.nirreps);
-
     psio_read_entry(PSIF_CC_INFO, "No. of Active Orbitals", (char *)&(nactive), sizeof(int));
 
     if (params.ref == 0 || params.ref == 1) { /** RHF or ROHF **/
-
-        moinfo.occpi = init_int_array(moinfo.nirreps);
-        moinfo.virtpi = init_int_array(moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Occ Orbs Per Irrep", (char *)moinfo.occpi, sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Virt Orbs Per Irrep", (char *)moinfo.virtpi,
-                        sizeof(int) * moinfo.nirreps);
+        moinfo.occpi = moinfo.clsdpi + soccpi();
+        moinfo.virtpi = moinfo.uoccpi + soccpi();
 
         moinfo.occ_sym = init_int_array(nactive);
         moinfo.vir_sym = init_int_array(nactive);
@@ -116,20 +103,10 @@ void CCLambdaWavefunction::get_moinfo(std::shared_ptr<Wavefunction> wfn) {
         psio_read_entry(PSIF_CC_INFO, "Active Occ Orb Offsets", (char *)moinfo.occ_off, sizeof(int) * moinfo.nirreps);
         psio_read_entry(PSIF_CC_INFO, "Active Virt Orb Offsets", (char *)moinfo.vir_off, sizeof(int) * moinfo.nirreps);
     } else if (params.ref == 2) { /** UHF **/
-
-        moinfo.aoccpi = init_int_array(moinfo.nirreps);
-        moinfo.boccpi = init_int_array(moinfo.nirreps);
-        moinfo.avirtpi = init_int_array(moinfo.nirreps);
-        moinfo.bvirtpi = init_int_array(moinfo.nirreps);
-
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orbs Per Irrep", (char *)moinfo.aoccpi,
-                        sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orbs Per Irrep", (char *)moinfo.boccpi,
-                        sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orbs Per Irrep", (char *)moinfo.avirtpi,
-                        sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orbs Per Irrep", (char *)moinfo.bvirtpi,
-                        sizeof(int) * moinfo.nirreps);
+        moinfo.aoccpi = moinfo.clsdpi + wfn->soccpi();
+        moinfo.boccpi = moinfo.clsdpi;
+        moinfo.avirtpi = moinfo.uoccpi;
+        moinfo.bvirtpi = moinfo.uoccpi + wfn->soccpi();
 
         moinfo.aocc_sym = init_int_array(nactive);
         moinfo.bocc_sym = init_int_array(nactive);
@@ -197,16 +174,9 @@ void CCLambdaWavefunction::get_moinfo(std::shared_ptr<Wavefunction> wfn) {
         moinfo.Cb = Cb;
     }
 
-    /* Adjust clsdpi array for frozen orbitals */
-    for (i = 0; i < moinfo.nirreps; i++) moinfo.clsdpi[i] -= moinfo.frdocc[i];
-
-    moinfo.uoccpi = init_int_array(moinfo.nirreps);
-    for (i = 0; i < moinfo.nirreps; i++)
-        moinfo.uoccpi[i] = moinfo.orbspi[i] - moinfo.clsdpi[i] - moinfo.openpi[i] - moinfo.fruocc[i] - moinfo.frdocc[i];
 
     if (params.ref == 0) {
-        moinfo.nvirt = 0;
-        for (h = 0; h < moinfo.nirreps; h++) moinfo.nvirt += moinfo.virtpi[h];
+        moinfo.nvirt = moinfo.virtpi.sum();
     }
 
     psio_read_entry(PSIF_CC_INFO, "Reference Energy", (char *)&(moinfo.eref), sizeof(double));
@@ -236,14 +206,6 @@ void CCLambdaWavefunction::cleanup() {
         free(moinfo.Cb);
     }
 
-    free(moinfo.sopi);
-    //    free(moinfo.sosym);
-    free(moinfo.orbspi);
-    free(moinfo.clsdpi);
-    free(moinfo.openpi);
-    //    free(moinfo.uoccpi);
-    //    free(moinfo.fruocc);
-    //    free(moinfo.frdocc);
     if (params.ref == 2) {
         free(moinfo.aocc_sym);
         free(moinfo.bocc_sym);
@@ -253,17 +215,11 @@ void CCLambdaWavefunction::cleanup() {
         free(moinfo.bocc_off);
         free(moinfo.avir_off);
         free(moinfo.bvir_off);
-        free(moinfo.aoccpi);
-        free(moinfo.boccpi);
-        free(moinfo.avirtpi);
-        free(moinfo.bvirtpi);
     } else {
         free(moinfo.occ_sym);
         free(moinfo.vir_sym);
         free(moinfo.occ_off);
         free(moinfo.vir_off);
-        free(moinfo.occpi);
-        free(moinfo.virtpi);
     }
 }
 

--- a/psi4/src/psi4/cc/ccresponse/MOInfo.h
+++ b/psi4/src/psi4/cc/ccresponse/MOInfo.h
@@ -51,24 +51,23 @@ struct MOInfo {
     int noei_ao;                     /* no. of elements in AOxAO lower triangle */
     int nactive;                     /* no. of active MO's */
     int nfzc;                        /* no. of frozen core orbitals */
-    int *sopi;                       /* no. of SOs per irrep */
-    int *orbspi;                     /* no. of MOs per irrep */
-    int *clsdpi;                     /* no. of closed-shells per irrep  */
-    int *openpi;                     /* no. of open-shells per irrep */
-    int *uoccpi;                     /* no. of unoccupied orbitals per irrep  */
-    int *frdocc;                     /* no. of frozen core orbitals per irrep */
-    int *fruocc;                     /* no. of frozen unoccupied orbitals per irrep */
+    Dimension sopi;                       /* no. of SOs per irrep */
+    Dimension orbspi;                     /* no. of MOs per irrep */
+    Dimension clsdpi;                     /* no. of closed-shells per irrep  */
+    Dimension openpi;                     /* no. of open-shells per irrep */
+    Dimension uoccpi;                     /* no. of unoccupied orbitals per irrep  */
+    Dimension frdocc;                     /* no. of frozen core orbitals per irrep */
+    Dimension fruocc;                     /* no. of frozen unoccupied orbitals per irrep */
     int nvirt;                       /* total no. of (active) virtual orbitals */
-    int *actpi;                      /* no. of active orbitals per irrep */
-    Dimension act_pi;                /* Dimension form of actpi */
+    Dimension actpi;                      /* no. of active orbitals per irrep */
     std::vector<std::string> labels; /* irrep labels */
-    int *occpi;                      /* no. of occupied orbs. (incl. open) per irrep */
+    Dimension occpi;                      /* no. of occupied orbs. (incl. open) per irrep */
     Dimension act_occpi;             /* Dimension form of occpi */
-    int *aoccpi;                     /* no. of alpha occupied orbs. (incl. open) per irrep */
-    int *boccpi;                     /* no. of beta occupied orbs. (incl. open) per irrep */
-    int *virtpi;                     /* no. of virtual orbs. (incl. open) per irrep */
-    int *avirtpi;                    /* no. of alpha virtual orbs. (incl. open) per irrep */
-    int *bvirtpi;                    /* no. of beta virtual orbs. (incl. open) per irrep */
+    Dimension aoccpi;                     /* no. of alpha occupied orbs. (incl. open) per irrep */
+    Dimension boccpi;                     /* no. of beta occupied orbs. (incl. open) per irrep */
+    Dimension virtpi;                     /* no. of virtual orbs. (incl. open) per irrep */
+    Dimension avirtpi;                    /* no. of alpha virtual orbs. (incl. open) per irrep */
+    Dimension bvirtpi;                    /* no. of beta virtual orbs. (incl. open) per irrep */
     int *occ_sym;                    /* relative occupied index symmetry */
     int *aocc_sym;                   /* relative alpha occupied index symmetry */
     int *bocc_sym;                   /* relative beta occupied index symmetry */

--- a/psi4/src/psi4/cc/ccresponse/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccresponse/get_moinfo.cc
@@ -71,16 +71,13 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     moinfo.nao = wfn->basisset()->nao();
     moinfo.labels = wfn->molecule()->irrep_labels();
 
-    moinfo.sopi = init_int_array(moinfo.nirreps);
-    moinfo.orbspi = init_int_array(moinfo.nirreps);
-    moinfo.clsdpi = init_int_array(moinfo.nirreps);
-    moinfo.openpi = init_int_array(moinfo.nirreps);
-    for (int h = 0; h < moinfo.nirreps; ++h) {
-        moinfo.sopi[h] = wfn->nsopi()[h];
-        moinfo.orbspi[h] = wfn->nmopi()[h];
-        moinfo.clsdpi[h] = wfn->doccpi()[h];
-        moinfo.openpi[h] = wfn->soccpi()[h];
-    }
+    moinfo.sopi = wfn->nsopi();
+    moinfo.orbspi = wfn->nmopi();
+    moinfo.clsdpi = wfn->doccpi() - wfn->frzcpi();
+    moinfo.openpi = wfn->soccpi();
+    moinfo.frdocc = wfn->frzcpi();
+    moinfo.fruocc = wfn->frzvpi();
+    moinfo.uoccpi = moinfo.orbspi - moinfo.clsdpi - moinfo.openpi - moinfo.fruocc - moinfo.frdocc;
 
     moinfo.natom = wfn->molecule()->natom();
 
@@ -90,33 +87,17 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
     moinfo.noei = moinfo.nso * (moinfo.nso + 1) / 2;
     moinfo.noei_ao = moinfo.nao * (moinfo.nao + 1) / 2;
 
-    /* Get frozen and active orbital lookups from CC_INFO */
-    moinfo.frdocc = init_int_array(nirreps);
-    moinfo.fruocc = init_int_array(nirreps);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Core Orbs Per Irrep", (char *)moinfo.frdocc, sizeof(int) * nirreps);
-    psio_read_entry(PSIF_CC_INFO, "Frozen Virt Orbs Per Irrep", (char *)moinfo.fruocc, sizeof(int) * nirreps);
-
     psio_read_entry(PSIF_CC_INFO, "No. of Active Orbitals", (char *)&(nactive), sizeof(int));
     moinfo.nactive = nactive;
 
-    moinfo.nfzc = 0;
-    for (h = 0; h < nirreps; h++) moinfo.nfzc += moinfo.frdocc[h];
+    moinfo.nfzc = moinfo.frdocc.sum();
 
     if (params.ref == 2) { /** UHF **/
 
-        moinfo.aoccpi = init_int_array(nirreps);
-        moinfo.boccpi = init_int_array(nirreps);
-        moinfo.avirtpi = init_int_array(nirreps);
-        moinfo.bvirtpi = init_int_array(nirreps);
-
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Occ Orbs Per Irrep", (char *)moinfo.aoccpi,
-                        sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Occ Orbs Per Irrep", (char *)moinfo.boccpi,
-                        sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Alpha Virt Orbs Per Irrep", (char *)moinfo.avirtpi,
-                        sizeof(int) * moinfo.nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Beta Virt Orbs Per Irrep", (char *)moinfo.bvirtpi,
-                        sizeof(int) * moinfo.nirreps);
+        moinfo.aoccpi = moinfo.clsdpi + wfn->soccpi();
+        moinfo.boccpi = moinfo.clsdpi;
+        moinfo.avirtpi = moinfo.uoccpi;
+        moinfo.bvirtpi = moinfo.uoccpi + wfn->soccpi();
 
         moinfo.aocc_sym = init_int_array(nactive);
         moinfo.bocc_sym = init_int_array(nactive);
@@ -143,11 +124,9 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
 
     } else { /** RHF or ROHF **/
 
-        moinfo.occpi = init_int_array(nirreps);
-        moinfo.virtpi = init_int_array(nirreps);
-        psio_read_entry(PSIF_CC_INFO, "Active Occ Orbs Per Irrep", (char *)moinfo.occpi, sizeof(int) * nirreps);
-        moinfo.act_occpi = Dimension(std::vector<int>(moinfo.occpi, moinfo.occpi + nirreps));
-        psio_read_entry(PSIF_CC_INFO, "Active Virt Orbs Per Irrep", (char *)moinfo.virtpi, sizeof(int) * nirreps);
+        moinfo.occpi = moinfo.clsdpi + wfn->soccpi();
+        moinfo.virtpi = moinfo.uoccpi + wfn->soccpi();
+        moinfo.act_occpi = moinfo.occpi;
 
         moinfo.occ_sym = init_int_array(nactive);
         moinfo.vir_sym = init_int_array(nactive);
@@ -160,21 +139,10 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
         psio_read_entry(PSIF_CC_INFO, "Active Virt Orb Offsets", (char *)moinfo.vir_off, sizeof(int) * moinfo.nirreps);
     }
 
-    /* Adjust clsdpi array for frozen orbitals */
-    for (i = 0; i < nirreps; i++) moinfo.clsdpi[i] -= moinfo.frdocc[i];
-
-    moinfo.uoccpi = init_int_array(moinfo.nirreps);
-    for (i = 0; i < nirreps; i++)
-        moinfo.uoccpi[i] = moinfo.orbspi[i] - moinfo.clsdpi[i] - moinfo.openpi[i] - moinfo.fruocc[i] - moinfo.frdocc[i];
-
-    moinfo.nvirt = 0;
-    for (i = 0; i < nirreps; i++) moinfo.nvirt += moinfo.virtpi[i];
+    moinfo.nvirt = moinfo.virtpi.sum();
 
     /*** arrange active SCF MO's ***/
-    actpi = init_int_array(nirreps);
-    for (h = 0; h < nirreps; h++) actpi[h] = moinfo.orbspi[h] - moinfo.frdocc[h] - moinfo.fruocc[h];
-    moinfo.actpi = actpi;
-    moinfo.act_pi = Dimension(std::vector<int>(moinfo.actpi, moinfo.actpi + nirreps));
+    moinfo.actpi = moinfo.orbspi - moinfo.frdocc - moinfo.fruocc;
     moinfo.Ca = wfn->Ca_subset("SO", "ACTIVE");
 
     /* Get the active virtual orbitals */
@@ -198,10 +166,6 @@ void cleanup() {
     int i;
 
     if (params.ref == 2) { /* UHF */
-        free(moinfo.aoccpi);
-        free(moinfo.boccpi);
-        free(moinfo.avirtpi);
-        free(moinfo.bvirtpi);
         free(moinfo.aocc_sym);
         free(moinfo.bocc_sym);
         free(moinfo.avir_sym);
@@ -214,22 +178,11 @@ void cleanup() {
         for (i = 0; i < moinfo.nirreps; i++)
             if (moinfo.sopi[i] && moinfo.virtpi[i]) free_block(moinfo.C[i]);
         free(moinfo.C);
-        free(moinfo.occpi);
-        free(moinfo.virtpi);
         free(moinfo.occ_sym);
         free(moinfo.vir_sym);
         free(moinfo.occ_off);
         free(moinfo.vir_off);
     }
-
-    free(moinfo.sopi);
-    free(moinfo.orbspi);
-    free(moinfo.clsdpi);
-    free(moinfo.openpi);
-    //    free(moinfo.uoccpi);
-    //    free(moinfo.fruocc);
-    //    free(moinfo.frdocc);
-    free(moinfo.actpi);
 
     free(moinfo.mu_irreps);
     free(moinfo.l_irreps);

--- a/psi4/src/psi4/cc/ccresponse/sort_pert.cc
+++ b/psi4/src/psi4/cc/ccresponse/sort_pert.cc
@@ -56,7 +56,7 @@ namespace ccresponse {
 
 void write_blocks(const Matrix& mat) {
     Slice occ_slice(Dimension(moinfo.nirreps), moinfo.act_occpi);
-    Slice vir_slice(moinfo.act_occpi, moinfo.act_pi);
+    Slice vir_slice(moinfo.act_occpi, moinfo.actpi);
 
     dpdfile2 f;
 

--- a/psi4/src/psi4/cc/cctriples/MOInfo.h
+++ b/psi4/src/psi4/cc/cctriples/MOInfo.h
@@ -36,6 +36,7 @@
 
 #include <string>
 #include <vector>
+#include "psi4/libmints/dimension.h"
 
 namespace psi {
 namespace cctriples {
@@ -43,19 +44,19 @@ namespace cctriples {
 struct MOInfo {
     int nirreps;                     /* no. of irreducible representations */
     int nmo;                         /* no. of molecular orbitals */
-    int *orbspi;                     /* no. of MOs per irrep */
-    int *clsdpi;                     /* no. of closed-shells per irrep excl. frdocc */
-    int *openpi;                     /* no. of open-shells per irrep */
-    int *uoccpi;                     /* no. of unoccupied orbitals per irrep excl. fruocc */
-    int *frdocc;                     /* no. of frozen core orbitals per irrep */
-    int *fruocc;                     /* no. of frozen unoccupied orbitals per irrep */
+    Dimension orbspi;                /* no. of MOs per irrep */
+    Dimension clsdpi;                /* no. of closed-shells per irrep excl. frdocc */
+    Dimension openpi;                /* no. of open-shells per irrep */
+    Dimension uoccpi;                /* no. of unoccupied orbitals per irrep excl. fruocc */
+    Dimension frdocc;                /* no. of frozen core orbitals per irrep */
+    Dimension fruocc;                /* no. of frozen unoccupied orbitals per irrep */
     std::vector<std::string> labels; /* irrep labels */
-    int *occpi;                      /* no. of occupied orbs. (incl. open) per irrep */
-    int *aoccpi;                     /* no. of alpha occupied orbs. (incl. open) per irrep */
-    int *boccpi;                     /* no. of beta occupied orbs. (incl. open) per irrep */
-    int *virtpi;                     /* no. of virtual orbs. (incl. open) per irrep */
-    int *avirtpi;                    /* no. of alpha virtual orbs. (incl. open) per irrep */
-    int *bvirtpi;                    /* no. of beta virtual orbs. (incl. open) per irrep */
+    Dimension occpi;                 /* no. of occupied orbs. (incl. open) per irrep */
+    Dimension aoccpi;                /* no. of alpha occupied orbs. (incl. open) per irrep */
+    Dimension boccpi;                /* no. of beta occupied orbs. (incl. open) per irrep */
+    Dimension virtpi;                /* no. of virtual orbs. (incl. open) per irrep */
+    Dimension avirtpi;               /* no. of alpha virtual orbs. (incl. open) per irrep */
+    Dimension bvirtpi;               /* no. of beta virtual orbs. (incl. open) per irrep */
     int *occ_sym;                    /* relative occupied index symmetry */
     int *aocc_sym;                   /* relative alpha occupied index symmetry */
     int *bocc_sym;                   /* relative beta occupied index symmetry */

--- a/psi4/src/psi4/cctransort/cctransort.cc
+++ b/psi4/src/psi4/cctransort/cctransort.cc
@@ -187,8 +187,6 @@ PsiReturnType cctransort(SharedWavefunction ref, Options &options) {
     psio->open(PSIF_CC_INFO, PSIO_OPEN_OLD);
 
     psio->write_entry(PSIF_CC_INFO, "Reference Wavefunction", (char *)&(reference), sizeof(int));
-    psio->write_entry(PSIF_CC_INFO, "Frozen Core Orbs Per Irrep", (char *)(int *)frzcpi, sizeof(int) * nirreps);
-    psio->write_entry(PSIF_CC_INFO, "Frozen Virt Orbs Per Irrep", (char *)(int *)frzvpi, sizeof(int) * nirreps);
     psio->write_entry(PSIF_CC_INFO, "No. of Active Orbitals", (char *)&(nactive), sizeof(int));
 
     // Build QT->CC and CC->QT reordering arrays
@@ -266,13 +264,6 @@ PsiReturnType cctransort(SharedWavefunction ref, Options &options) {
             }
         }
 
-        psio->write_entry(PSIF_CC_INFO, "Active Alpha Occ Orbs Per Irrep", (char *)(int *)aoccpi,
-                          sizeof(int) * nirreps);
-        psio->write_entry(PSIF_CC_INFO, "Active Beta Occ Orbs Per Irrep", (char *)(int *)boccpi, sizeof(int) * nirreps);
-        psio->write_entry(PSIF_CC_INFO, "Active Alpha Virt Orbs Per Irrep", (char *)(int *)avirpi,
-                          sizeof(int) * nirreps);
-        psio->write_entry(PSIF_CC_INFO, "Active Beta Virt Orbs Per Irrep", (char *)(int *)bvirpi,
-                          sizeof(int) * nirreps);
         psio->write_entry(PSIF_CC_INFO, "Active Alpha Occ Orb Offsets", (char *)aocc_off.data(), sizeof(int) * nirreps);
         psio->write_entry(PSIF_CC_INFO, "Active Beta Occ Orb Offsets", (char *)bocc_off.data(), sizeof(int) * nirreps);
         psio->write_entry(PSIF_CC_INFO, "Active Alpha Virt Orb Offsets", (char *)avir_off.data(),
@@ -342,8 +333,6 @@ PsiReturnType cctransort(SharedWavefunction ref, Options &options) {
             }
         }
 
-        psio->write_entry(PSIF_CC_INFO, "Active Occ Orbs Per Irrep", (char *)(int *)occpi, sizeof(int) * nirreps);
-        psio->write_entry(PSIF_CC_INFO, "Active Virt Orbs Per Irrep", (char *)(int *)virpi, sizeof(int) * nirreps);
         psio->write_entry(PSIF_CC_INFO, "Active Occ Orb Offsets", (char *)occ_off.data(), sizeof(int) * nirreps);
         psio->write_entry(PSIF_CC_INFO, "Active Virt Orb Offsets", (char *)vir_off.data(), sizeof(int) * nirreps);
         psio->write_entry(PSIF_CC_INFO, "Active Occ Orb Symmetry", (char *)occ_sym.data(), sizeof(int) * nactive);

--- a/psi4/src/psi4/libdpd/dpd.h
+++ b/psi4/src/psi4/libdpd/dpd.h
@@ -328,8 +328,6 @@ class PSI_API DPD {
     ~DPD();
 
     int init(int dpd_num, int nirreps, long int memory, int cachetype, int *cachefiles, int **cachelist,
-             dpd_file4_cache_entry *priority, int num_subspaces, ...);
-    int init(int dpd_num, int nirreps, long int memory, int cachetype, int *cachefiles, int **cachelist,
              dpd_file4_cache_entry *priority, int num_subspaces, std::vector<int *> &spaceArrays);
 
     void dpd_error(const char *caller, std::string out_fname);

--- a/psi4/src/psi4/libdpd/init.cc
+++ b/psi4/src/psi4/libdpd/init.cc
@@ -129,24 +129,6 @@ DPD::DPD(int dpd_num, int nirreps, long int memory, int cachetype, int *cachefil
     init(dpd_num, nirreps, memory, cachetype, cachefiles, cachelist, priority, num_subspaces, spaceArrays);
 }
 
-/* This is the original function call, but is now just a wrapper to the same function
- * that takes the spaces in a vector instead of using variable argument lists */
-int DPD::init(int dpd_num, int nirreps, long int memory, int cachetype, int *cachefiles, int **cachelist,
-              dpd_file4_cache_entry *priority, int num_subspaces, ...) {
-    std::vector<int *> spaceArrays;
-    va_list ap;
-    int *tmparray;
-
-    va_start(ap, num_subspaces);
-    for (int i = 0; i < num_subspaces; i++) {
-        tmparray = va_arg(ap, int *);
-        spaceArrays.push_back(tmparray);
-        tmparray = va_arg(ap, int *);
-        spaceArrays.push_back(tmparray);
-    }
-    va_end(ap);
-    return init(dpd_num, nirreps, memory, cachetype, cachefiles, cachelist, priority, num_subspaces, spaceArrays);
-}
 
 /* This is the original function code, but modified to take a vector of the orbital
  * space information arrays, rather than a variable argument list; the former is


### PR DESCRIPTION
## Description
This is a PR that goes into all the `cc` modules and changes the type of their orbital spaces from `int *` to `Dimension`. Data is now pulled from the wavefunction rather than  what `cctransort` wrote to disk. The unused `cctransort` write operations are removed. I also remove an unused `DPD::init` and converted some `Dimension` that didn't represent a dimension to `std::vector<int>`.

There is nothing remotely exciting about this PR, but the much more important DePointerDPD PR will have `DPD::DPD` demand `Dimension` objects (or rather `DPDMOSpace` objects which require a `Dimension`), so I might as well split this part out.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `cc` mega-module uses `Dimension` more appropriately
- [x] `cctransort` no longer writes Dimension to disk.

## Checklist
- [x] `cc` tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
