### PR TITLE
Add access to lowdin spins

### DIFF
--- a/psi4/driver/schema_wrapper.py
+++ b/psi4/driver/schema_wrapper.py
@@ -93,6 +93,7 @@ _qcschema_translation = {
     "properties": {
         "mulliken_charges": {"variables": "MULLIKEN CHARGES", "skip_null": True},
         "lowdin_charges": {"variables": "LOWDIN CHARGES", "skip_null": True},
+        "lowdin_spins": {"variables": "LOWDIN SPINS", "skip_null": True},
         "wiberg_lowdin_indices": {"variables": "WIBERG LOWDIN INDICES", "skip_null": True},
         "mayer_indices": {"variables": "MAYER INDICES", "skip_null": True},
     },

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -822,6 +822,7 @@ void OEProp::compute() {
     if (tasks_.count("MO_EXTENTS")) compute_mo_extents();
     if (tasks_.count("MULLIKEN_CHARGES")) compute_mulliken_charges();
     if (tasks_.count("LOWDIN_CHARGES")) compute_lowdin_charges();
+    if (tasks_.count("LOWDIN_SPINS")) compute_lowdin_charges();
     if (tasks_.count("MBIS_VOLUME_RATIOS")) compute_mbis_multipoles(true);
     else if (tasks_.count("MBIS_CHARGES")) compute_mbis_multipoles(false);
     if (tasks_.count("MAYER_INDICES")) compute_mayer_indices();
@@ -1508,8 +1509,8 @@ PopulationAnalysisCalc::compute_mulliken_charges(bool print_output) {
     return std::make_tuple(Qa, Qb, apcs);
 }
 void OEProp::compute_lowdin_charges() {
-    PAC::SharedStdVector Qa, Qb, apcs;
-    std::tie(Qa, Qb, apcs) = pac_.compute_lowdin_charges(true);
+    PAC::SharedStdVector Qa, Qb, apcs, asps;
+    std::tie(Qa, Qb, apcs, asps) = pac_.compute_lowdin_charges(true);
     wfn_->set_atomic_point_charges(apcs);
 
     auto vec_apcs = std::make_shared<Matrix>("Lowdin Charges: (a.u.)", 1, apcs->size());
@@ -1517,9 +1518,15 @@ void OEProp::compute_lowdin_charges() {
         vec_apcs->set(0, i, (*apcs)[i]);
     }
     wfn_->set_array_variable("LOWDIN CHARGES", vec_apcs);
+
+    auto vec_asps = std::make_shared<Matrix>("Lowdin Spins: (a.u.)", 1, apcs->size());
+    for (size_t i = 0; i < asps->size(); i++) {
+        vec_asps->set(0, i, (*asps)[i]);
+    }
+    wfn_->set_array_variable("LOWDIN SPINS", vec_asps);
 }
 
-std::tuple<PAC::SharedStdVector, PAC::SharedStdVector, PAC::SharedStdVector>
+std::tuple<PAC::SharedStdVector, PAC::SharedStdVector, PAC::SharedStdVector, PAC::SharedStdVector>
 PopulationAnalysisCalc::compute_lowdin_charges(bool print_output) {
     if (print_output) {
         outfile->Printf("  Lowdin Charges: (a.u.)\n");
@@ -1530,6 +1537,7 @@ PopulationAnalysisCalc::compute_lowdin_charges(bool print_output) {
     auto Qb = std::make_shared<std::vector<double>>(mol->natom());
 
     auto apcs = std::make_shared<std::vector<double>>(mol->natom());
+    auto asps = std::make_shared<std::vector<double>>(mol->natom());
 
     double suma = 0.0;
 
@@ -1592,6 +1600,7 @@ PopulationAnalysisCalc::compute_lowdin_charges(bool print_output) {
         double Qs = (*Qa)[A] - (*Qb)[A];
         double Qt = mol->Z(A) - ((*Qa)[A] + (*Qb)[A]);
         (*apcs)[A] = Qt;
+        (*asps)[A] = Qs;
         if (print_output) {
             outfile->Printf("   %5d    %2s    %8.5f %8.5f %8.5f %8.5f\n", A + 1, mol->label(A).c_str(), (*Qa)[A],
                             (*Qb)[A], Qs, Qt);
@@ -1603,7 +1612,7 @@ PopulationAnalysisCalc::compute_lowdin_charges(bool print_output) {
                         nuc - suma - sumb);
     }
 
-    return std::make_tuple(Qa, Qb, apcs);
+    return std::make_tuple(Qa, Qb, apcs, asps);
 }
 
 // See PopulationAnalysisCalc::compute_mbis_multipoles

--- a/psi4/src/psi4/libmints/oeprop.h
+++ b/psi4/src/psi4/libmints/oeprop.h
@@ -256,7 +256,7 @@ class PopulationAnalysisCalc : public Prop {
     /// Compute Mulliken Charges
     std::tuple<SharedStdVector, SharedStdVector, SharedStdVector> compute_mulliken_charges(bool print_output = false);
     /// Compute Lowdin Charges
-    std::tuple<SharedStdVector, SharedStdVector, SharedStdVector> compute_lowdin_charges(bool print_output = false);
+    std::tuple<SharedStdVector, SharedStdVector, SharedStdVector, SharedStdVector> compute_lowdin_charges(bool print_output = false);
     /// Compute MBIS Multipoles (doi:10.1021/acs.jctc.6b00456)
     std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> compute_mbis_multipoles(bool free_atom_volumes = false, bool print_output = false);
     /// Compute Mayer Bond Indices (non-orthogoal basis)

--- a/samples/json/schema-1-properties/input.py
+++ b/samples/json/schema-1-properties/input.py
@@ -37,6 +37,7 @@ json_data = {
       "quadrupole",
       "mulliken_charges",
       "lowdin_charges",
+      "lowdin_spin",
       "wiberg_lowdin_indices",
       "mayer_indices",
     ]
@@ -72,6 +73,11 @@ expected_return_result = {
     0.3983637847998822
   ],
   "lowdin_charges": [
+    -0.5945105406840803,
+    0.29725527034203636,
+    0.29725527034203636
+  ],
+  "lowdin_spin": [
     -0.5945105406840803,
     0.29725527034203636,
     0.29725527034203636


### PR DESCRIPTION
## Description
The per atom spin is calculated and printed to the psi4 output file, but not accessible as a property. This PR provides a property to retrieve that value.
Written with @bennybp 


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- Provide "lowdin_spins" property to users.

## Questions
- [ ] Is there a was to have both properties returns when only the "lowdin_charges" keyword is provided?

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
