### PR TITLE
Remove Several Pseudo-Ints from `libdpd`

### DIFF
--- a/psi4/src/psi4/libdpd/buf4_axpy.cc
+++ b/psi4/src/psi4/libdpd/buf4_axpy.cc
@@ -48,20 +48,20 @@ namespace psi {
 */
 
 int DPD::buf4_axpy(dpdbuf4 *BufX, dpdbuf4 *BufY, double alpha) {
-    int h, nirreps, my_irrep;
-    int row, col, incore, n, nbuckets;
+    int row, col, n, nbuckets;
     long int length;
     long int memoryd, rows_per_bucket, rows_left;
     double *X, *Y;
+    bool incore;
 
-    nirreps = BufX->params->nirreps;
-    my_irrep = BufX->file.my_irrep;
+    auto nirreps = BufX->params->nirreps;
+    auto my_irrep = BufX->file.my_irrep;
 
 #ifdef DPD_TIMER
     timer_on("buf4_axpy");
 #endif
 
-    for (h = 0; h < nirreps; h++) {
+    for (int h = 0; h < nirreps; h++) {
         memoryd = (dpd_memfree() - BufX->file.params->coltot[h ^ my_irrep]) / 2; /* use half the memory for each buf4 */
         if (BufX->params->rowtot[h] && BufX->params->coltot[h ^ my_irrep]) {
             rows_per_bucket = memoryd / BufX->params->coltot[h ^ my_irrep];
@@ -75,9 +75,9 @@ int DPD::buf4_axpy(dpdbuf4 *BufX, dpdbuf4 *BufY, double alpha) {
 
             rows_left = BufX->params->rowtot[h] % rows_per_bucket;
 
-            incore = 1;
+            incore = true;
             if (nbuckets > 1) {
-                incore = 0;
+                incore = false;
 #if DPD_DEBUG
                 outfile->Printf("buf4_axpy: memory information.\n");
                 outfile->Printf("buf4_axpy: rowtot[%d] = %d\n", h, BufX->params->rowtot[h]);
@@ -88,7 +88,7 @@ int DPD::buf4_axpy(dpdbuf4 *BufX, dpdbuf4 *BufY, double alpha) {
 #endif
             }
         } else
-            incore = 1;
+            incore = true;
 
         if (incore) {
             buf4_mat_irrep_init(BufX, h);

--- a/psi4/src/psi4/libdpd/buf4_copy.cc
+++ b/psi4/src/psi4/libdpd/buf4_copy.cc
@@ -55,9 +55,10 @@ int DPD::buf4_copy(dpdbuf4 *InBuf, int outfilenum, const std::string& label) {
     auto label_ptr = label.c_str();
     int h, row, col, my_irrep;
     long int rowtot, coltot;
-    int nbuckets, incore, n;
+    int nbuckets, n;
     long int memoryd, rows_per_bucket, rows_left, size;
     dpdbuf4 OutBuf;
+    bool incore;
 
     my_irrep = InBuf->file.my_irrep;
 
@@ -81,9 +82,9 @@ int DPD::buf4_copy(dpdbuf4 *InBuf, int outfilenum, const std::string& label) {
 
             rows_left = rowtot % rows_per_bucket;
 
-            incore = 1;
+            incore = true;
             if (nbuckets > 1) {
-                incore = 0;
+                incore = false;
 #if DPD_DEBUG
                 outfile->Printf("buf4_copy: memory information.\n");
                 outfile->Printf("buf4_copy: rowtot[%d] = %d.\n", h, InBuf->params->rowtot[h]);

--- a/psi4/src/psi4/libdpd/buf4_dot.cc
+++ b/psi4/src/psi4/libdpd/buf4_dot.cc
@@ -40,8 +40,9 @@ namespace psi {
 double DPD::buf4_dot(dpdbuf4 *BufA, dpdbuf4 *BufB) {
     int h, nirreps, n, my_irrep;
     double dot;
-    int incore, nbuckets;
+    int nbuckets;
     long int memoryd, rows_per_bucket, rows_left;
+    bool incore;
 
     nirreps = BufA->params->nirreps;
     my_irrep = BufA->file.my_irrep;
@@ -66,11 +67,11 @@ double DPD::buf4_dot(dpdbuf4 *BufA, dpdbuf4 *BufB) {
 
             rows_left = BufA->params->rowtot[h] % rows_per_bucket;
 
-            incore = 1;
-            if (nbuckets > 1) incore = 0;
+            incore = true;
+            if (nbuckets > 1) incore = false;
 
         } else
-            incore = 1;
+            incore = true;
 
         if (incore) {
             buf4_mat_irrep_init(BufA, h);

--- a/psi4/src/psi4/libdpd/buf4_mat_irrep_rd_block.cc
+++ b/psi4/src/psi4/libdpd/buf4_mat_irrep_rd_block.cc
@@ -49,8 +49,6 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
     int p, q, r, s;             /* orbital indices */
     int filepq, filers, filesr; /* Input dpdfile row and column indices */
     int rowtot, coltot;         /* dpdbuf row and column dimensions */
-    int b_perm_pq, b_perm_rs, b_peq, b_res;
-    int f_perm_pq, f_perm_rs, f_peq, f_res;
     int pq_permute, permute;
     double value;
 
@@ -62,14 +60,16 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
     rowtot = Buf->params->rowtot[irrep];
     coltot = Buf->params->coltot[irrep ^ all_buf_irrep];
 
-    b_perm_pq = Buf->params->perm_pq;
-    b_perm_rs = Buf->params->perm_rs;
-    f_perm_pq = Buf->file.params->perm_pq;
-    f_perm_rs = Buf->file.params->perm_rs;
-    b_peq = Buf->params->peq;
-    b_res = Buf->params->res;
-    f_peq = Buf->file.params->peq;
-    f_res = Buf->file.params->res;
+    const auto& b_perm_pq = Buf->params->perm_pq;
+    const auto& b_perm_rs = Buf->params->perm_rs;
+    const auto& f_perm_pq = Buf->file.params->perm_pq;
+    const auto& f_perm_rs = Buf->file.params->perm_rs;
+    const auto& b_peq = Buf->params->peq;
+    const auto& b_res = Buf->params->res;
+    const auto& f_peq = Buf->file.params->peq;
+    const auto& f_res = Buf->file.params->res;
+
+    const auto& AllPolicy = dpdparams4::DiagPolicy::All;
 
     if ((b_perm_pq == f_perm_pq) && (b_perm_rs == f_perm_rs) && (b_peq == f_peq) && (b_res == f_res)) {
         if (Buf->anti)
@@ -77,13 +77,13 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
         else
             method = 12;
     } else if ((b_perm_pq != f_perm_pq) && (b_perm_rs == f_perm_rs) && (b_res == f_res)) {
-        if (f_perm_pq && !b_perm_pq) {
+        if (b_perm_pq == AllPolicy) {
             if (Buf->anti) {
                 outfile->Printf("\n\tUnpack pq and antisymmetrize?\n");
                 throw PSIEXCEPTION("Unpack pq and antisymmetrize?");
             }
             method = 21;
-        } else if (!f_perm_pq && b_perm_pq) {
+        } else if (f_perm_pq == AllPolicy) {
             if (Buf->anti)
                 method = 22;
             else
@@ -93,13 +93,13 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
             throw PSIEXCEPTION("Invalid second-level method!");
         }
     } else if ((b_perm_pq == f_perm_pq) && (b_perm_rs != f_perm_rs) && (b_peq == f_peq)) {
-        if (f_perm_rs && !b_perm_rs) {
+        if (b_perm_rs == AllPolicy) {
             if (Buf->anti) {
                 outfile->Printf("\n\tUnpack rs and antisymmetrize?\n");
                 throw PSIEXCEPTION("Unpack rs and antisymmetrize?");
             }
             method = 31;
-        } else if (!f_perm_rs && b_perm_rs) {
+        } else if (f_perm_rs == AllPolicy) {
             if (Buf->anti)
                 method = 32;
             else
@@ -109,28 +109,28 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
             throw PSIEXCEPTION("Invalid third-level method!");
         }
     } else if ((b_perm_pq != f_perm_pq) && (b_perm_rs != f_perm_rs)) {
-        if (f_perm_pq && !b_perm_pq) {
-            if (f_perm_rs && !b_perm_rs) {
+        if (b_perm_pq == AllPolicy) {
+            if (b_perm_rs == AllPolicy) {
                 if (Buf->anti) {
                     outfile->Printf("\n\tUnpack pq and rs and antisymmetrize?\n");
                     throw PSIEXCEPTION("Unpack pq and rs and antisymmetrize?");
                 } else
                     method = 41;
-            } else if (!f_perm_rs && b_perm_rs) {
+            } else if (f_perm_rs == AllPolicy) {
                 if (Buf->anti) {
                     outfile->Printf("\n\tUnpack pq and antisymmetrize?\n");
                     throw PSIEXCEPTION("Unpack pq and antisymmetrize?");
                 } else
                     method = 42;
             }
-        } else if (!f_perm_pq && b_perm_pq) {
-            if (f_perm_rs && !b_perm_rs) {
+        } else if (f_perm_pq == AllPolicy) {
+            if (b_perm_rs == AllPolicy) {
                 if (Buf->anti) {
                     outfile->Printf("\n\tUnpack rs and antisymmetrize?\n");
                     throw PSIEXCEPTION("Unpack rs and antisymmetrize?");
                 } else
                     method = 43;
-            } else if (!f_perm_rs && b_perm_rs) {
+            } else if (f_perm_rs == AllPolicy) {
                 if (Buf->anti)
                     method = 44;
                 else
@@ -206,7 +206,7 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
                 filerow = Buf->file.incore ? filepq : 0;
 
                 /* set the permutation operator's value */
-                permute = ((p < q) && (f_perm_pq < 0) ? -1 : 1);
+                permute = ((p < q) && (f_perm_pq == dpdparams4::DiagPolicy::AntiSymm) ? -1 : 1);
 
                 /* fill the buffer */
                 if (filepq >= 0)
@@ -315,7 +315,7 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
                     filers = Buf->file.params->colidx[r][s];
 
                     /* rs permutation operator */
-                    permute = ((r < s) && (f_perm_rs < 0) ? -1 : 1);
+                    permute = ((r < s) && (f_perm_rs == dpdparams4::DiagPolicy::AntiSymm) ? -1 : 1);
 
                     /* is this fast enough? */
                     value = ((filers < 0) ? 0 : Buf->file.matrix[irrep][filerow][filers]);
@@ -406,7 +406,7 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
                 filerow = Buf->file.incore ? filepq : 0;
 
                 /* Set the value of the pq permutation operator */
-                pq_permute = ((p < q) && (f_perm_pq < 0) ? -1 : 1);
+                pq_permute = ((p < q) && (f_perm_pq == dpdparams4::DiagPolicy::AntiSymm) ? -1 : 1);
 
                 /* Fill the buffer */
                 if (filepq >= 0)
@@ -421,7 +421,7 @@ int DPD::buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_
                     filers = Buf->file.params->colidx[r][s];
 
                     /* Set the value of the pqrs permutation operator */
-                    permute = ((r < s) && (f_perm_rs < 0) ? -1 : 1) * pq_permute;
+                    permute = ((r < s) && (f_perm_rs == dpdparams4::DiagPolicy::AntiSymm) ? -1 : 1) * pq_permute;
 
                     value = 0;
 

--- a/psi4/src/psi4/libdpd/buf4_mat_irrep_row_rd.cc
+++ b/psi4/src/psi4/libdpd/buf4_mat_irrep_row_rd.cc
@@ -49,8 +49,6 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
     int p, q, r, s;             /* orbital indices */
     int filepq, filers, filesr; /* Input dpdfile row and column indices */
     int rowtot, coltot;         /* dpdbuf row and column dimensions */
-    int b_perm_pq, b_perm_rs, b_peq, b_res;
-    int f_perm_pq, f_perm_rs, f_peq, f_res;
     int pq_permute, permute;
     double value;
 
@@ -58,14 +56,16 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
     rowtot = Buf->params->rowtot[irrep];
     coltot = Buf->params->coltot[irrep ^ all_buf_irrep];
 
-    b_perm_pq = Buf->params->perm_pq;
-    b_perm_rs = Buf->params->perm_rs;
-    f_perm_pq = Buf->file.params->perm_pq;
-    f_perm_rs = Buf->file.params->perm_rs;
-    b_peq = Buf->params->peq;
-    b_res = Buf->params->res;
-    f_peq = Buf->file.params->peq;
-    f_res = Buf->file.params->res;
+    const auto& b_perm_pq = Buf->params->perm_pq;
+    const auto& b_perm_rs = Buf->params->perm_rs;
+    const auto& f_perm_pq = Buf->file.params->perm_pq;
+    const auto& f_perm_rs = Buf->file.params->perm_rs;
+    const auto& b_peq = Buf->params->peq;
+    const auto& b_res = Buf->params->res;
+    const auto& f_peq = Buf->file.params->peq;
+    const auto& f_res = Buf->file.params->res;
+
+    const auto& AllPolicy = dpdparams4::DiagPolicy::All;
 
     if ((b_perm_pq == f_perm_pq) && (b_perm_rs == f_perm_rs) && (b_peq == f_peq) && (b_res == f_res)) {
         if (Buf->anti)
@@ -73,13 +73,13 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
         else
             method = 12;
     } else if ((b_perm_pq != f_perm_pq) && (b_perm_rs == f_perm_rs) && (b_res == f_res)) {
-        if (f_perm_pq && !b_perm_pq) {
+        if (b_perm_pq == AllPolicy) {
             if (Buf->anti) {
                 outfile->Printf("\n\tUnpack pq and antisymmetrize?\n");
                 throw PSIEXCEPTION("Unpack pq and antisymmetrize?");
             }
             method = 21;
-        } else if (!f_perm_pq && b_perm_pq) {
+        } else if (f_perm_pq == AllPolicy) {
             if (Buf->anti)
                 method = 22;
             else
@@ -89,13 +89,13 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
             throw PSIEXCEPTION("Invalid second-level method!");
         }
     } else if ((b_perm_pq == f_perm_pq) && (b_perm_rs != f_perm_rs) && (b_peq == f_peq)) {
-        if (f_perm_rs && !b_perm_rs) {
+        if (b_perm_rs == AllPolicy) {
             if (Buf->anti) {
                 outfile->Printf("\n\tUnpack rs and antisymmetrize?\n");
                 throw PSIEXCEPTION("Unpack rs and antisymmetrize?");
             }
             method = 31;
-        } else if (!f_perm_rs && b_perm_rs) {
+        } else if (f_perm_rs == AllPolicy) {
             if (Buf->anti)
                 method = 32;
             else
@@ -105,28 +105,28 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
             throw PSIEXCEPTION("Invalid third-level method!");
         }
     } else if ((b_perm_pq != f_perm_pq) && (b_perm_rs != f_perm_rs)) {
-        if (f_perm_pq && !b_perm_pq) {
-            if (f_perm_rs && !b_perm_rs) {
+        if (b_perm_pq == AllPolicy) {
+            if (b_perm_rs == AllPolicy) {
                 if (Buf->anti) {
                     outfile->Printf("\n\tUnpack pq and rs and antisymmetrize?\n");
                     throw PSIEXCEPTION("Unpack pq and rs and antisymmetrize?");
                 } else
                     method = 41;
-            } else if (!f_perm_rs && b_perm_rs) {
+            } else if (f_perm_rs == AllPolicy) {
                 if (Buf->anti) {
                     outfile->Printf("\n\tUnpack pq and antisymmetrize?\n");
                     throw PSIEXCEPTION("Unpack pq and antisymmetrize?");
                 } else
                     method = 42;
             }
-        } else if (!f_perm_pq && b_perm_pq) {
-            if (f_perm_rs && !b_perm_rs) {
+        } else if (f_perm_pq == AllPolicy) {
+            if (b_perm_rs == AllPolicy) {
                 if (Buf->anti) {
                     outfile->Printf("\n\tUnpack rs and antisymmetrize?\n");
                     throw PSIEXCEPTION("Unpack rs and antisymmetrize?");
                 } else
                     method = 43;
-            } else if (!f_perm_rs && b_perm_rs) {
+            } else if (f_perm_rs == AllPolicy) {
                 if (Buf->anti)
                     method = 44;
                 else
@@ -194,7 +194,7 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
             filerow = Buf->file.incore ? filepq : 0;
 
             /* Set the permutation operator's value */
-            permute = ((p < q) && (f_perm_pq < 0) ? -1 : 1);
+            permute = ((p < q) && (f_perm_pq == dpdparams4::DiagPolicy::AntiSymm) ? -1 : 1);
 
             /* Fill the buffer */
             if (filepq >= 0)
@@ -294,7 +294,7 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
                 filers = Buf->file.params->colidx[r][s];
 
                 /* rs permutation operator */
-                permute = ((r < s) && (f_perm_rs < 0) ? -1 : 1);
+                permute = ((r < s) && (f_perm_rs == dpdparams4::DiagPolicy::AntiSymm) ? -1 : 1);
 
                 /* Is this fast enough? */
                 value = ((filers < 0) ? 0 : Buf->file.matrix[irrep][filerow][filers]);
@@ -375,7 +375,7 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
             filerow = Buf->file.incore ? filepq : 0;
 
             /* Set the value of the pq permutation operator */
-            pq_permute = ((p < q) && (f_perm_pq < 0) ? -1 : 1);
+            pq_permute = ((p < q) && (f_perm_pq == dpdparams4::DiagPolicy::AntiSymm) ? -1 : 1);
 
             /* Fill the buffer */
             if (filepq >= 0)
@@ -390,7 +390,7 @@ int DPD::buf4_mat_irrep_row_rd(dpdbuf4 *Buf, int irrep, int pq) {
                 filers = Buf->file.params->colidx[r][s];
 
                 /* Set the value of the pqrs permutation operator */
-                permute = ((r < s) && (f_perm_rs < 0) ? -1 : 1) * pq_permute;
+                permute = ((r < s) && (f_perm_rs == dpdparams4::DiagPolicy::AntiSymm) ? -1 : 1) * pq_permute;
 
                 value = 0;
 

--- a/psi4/src/psi4/libdpd/buf4_mat_irrep_row_wrt.cc
+++ b/psi4/src/psi4/libdpd/buf4_mat_irrep_row_wrt.cc
@@ -49,8 +49,6 @@ int DPD::buf4_mat_irrep_row_wrt(dpdbuf4 *Buf, int irrep, int pq) {
     int bufpq, bufrs; /* Input dpdbuf row and column indices */
     int filepq;
     int rowtot, coltot; /* dpdfile row and column dimensions */
-    int b_perm_pq, b_perm_rs, b_peq, b_res;
-    int f_perm_pq, f_perm_rs, f_peq, f_res;
     int permute;
     double value;
 
@@ -60,14 +58,16 @@ int DPD::buf4_mat_irrep_row_wrt(dpdbuf4 *Buf, int irrep, int pq) {
     coltot = Buf->file.params->coltot[irrep ^ all_buf_irrep];
 
     /* Index packing information */
-    b_perm_pq = Buf->params->perm_pq;
-    b_perm_rs = Buf->params->perm_rs;
-    f_perm_pq = Buf->file.params->perm_pq;
-    f_perm_rs = Buf->file.params->perm_rs;
-    b_peq = Buf->params->peq;
-    b_res = Buf->params->res;
-    f_peq = Buf->file.params->peq;
-    f_res = Buf->file.params->res;
+    const auto& b_perm_pq = Buf->params->perm_pq;
+    const auto& b_perm_rs = Buf->params->perm_rs;
+    const auto& f_perm_pq = Buf->file.params->perm_pq;
+    const auto& f_perm_rs = Buf->file.params->perm_rs;
+    const auto& b_peq = Buf->params->peq;
+    const auto& b_res = Buf->params->res;
+    const auto& f_peq = Buf->file.params->peq;
+    const auto& f_res = Buf->file.params->res;
+
+    const auto& AllPolicy = dpdparams4::DiagPolicy::All;
 
     /* Exit if buffer is antisymmetrized */
     if (Buf->anti) {
@@ -79,33 +79,33 @@ int DPD::buf4_mat_irrep_row_wrt(dpdbuf4 *Buf, int irrep, int pq) {
     if ((b_perm_pq == f_perm_pq) && (b_perm_rs == f_perm_rs) && (b_peq == f_peq) && (b_res == f_res))
         method = 12;
     else if ((b_perm_pq != f_perm_pq) && (b_perm_rs == f_perm_rs) && (b_res == f_res)) {
-        if (f_perm_pq && !b_perm_pq)
+        if (b_perm_pq == AllPolicy)
             method = 21;
-        else if (!f_perm_pq && b_perm_pq)
+        else if (f_perm_pq == AllPolicy)
             method = 23;
         else {
             outfile->Printf("\n\tInvalid second-level method!\n");
             throw PSIEXCEPTION("Invalid second-level method!");
         }
     } else if ((b_perm_pq == f_perm_pq) && (b_perm_rs != f_perm_rs) && (b_peq == f_peq)) {
-        if (f_perm_rs && !b_perm_rs)
+        if (b_perm_rs == AllPolicy)
             method = 31;
-        else if (!f_perm_rs && b_perm_rs)
+        else if (f_perm_rs == AllPolicy)
             method = 33;
         else {
             outfile->Printf("\n\tInvalid third-level method!\n");
             throw PSIEXCEPTION("Invalid third-level method!");
         }
     } else if ((b_perm_pq != f_perm_pq) && (b_perm_rs != f_perm_rs)) {
-        if (f_perm_pq && !b_perm_pq) {
-            if (f_perm_rs && !b_perm_rs)
+        if (b_perm_pq == AllPolicy) {
+            if (b_perm_rs == AllPolicy)
                 method = 41;
-            else if (!f_perm_rs && b_perm_rs)
+            else if (f_perm_rs == AllPolicy)
                 method = 42;
-        } else if (!f_perm_pq && b_perm_pq) {
-            if (f_perm_rs && !b_perm_rs)
+        } else if (f_perm_pq == AllPolicy) {
+            if (b_perm_rs == AllPolicy)
                 method = 43;
-            else if (!f_perm_rs && b_perm_rs)
+            else if (f_perm_rs == AllPolicy)
                 method = 45;
         } else {
             outfile->Printf("\n\tInvalid fourth-level method!\n");

--- a/psi4/src/psi4/libdpd/buf4_mat_irrep_wrt_block.cc
+++ b/psi4/src/psi4/libdpd/buf4_mat_irrep_wrt_block.cc
@@ -49,8 +49,6 @@ int DPD::buf4_mat_irrep_wrt_block(dpdbuf4 *Buf, int irrep, int start_pq, int num
     int p, q, r, s;           /* orbital indices */
     int filepq, bufpq, bufrs; /* Input dpdbuf row and column indices */
     int rowtot, coltot;       /* dpdfile row and column dimensions */
-    int b_perm_pq, b_perm_rs, b_peq, b_res;
-    int f_perm_pq, f_perm_rs, f_peq, f_res;
     int permute;
     double value;
 
@@ -60,14 +58,14 @@ int DPD::buf4_mat_irrep_wrt_block(dpdbuf4 *Buf, int irrep, int start_pq, int num
     coltot = Buf->file.params->coltot[irrep ^ all_buf_irrep];
 
     /* Index packing information */
-    b_perm_pq = Buf->params->perm_pq;
-    b_perm_rs = Buf->params->perm_rs;
-    f_perm_pq = Buf->file.params->perm_pq;
-    f_perm_rs = Buf->file.params->perm_rs;
-    b_peq = Buf->params->peq;
-    b_res = Buf->params->res;
-    f_peq = Buf->file.params->peq;
-    f_res = Buf->file.params->res;
+    const auto& b_perm_pq = Buf->params->perm_pq;
+    const auto& b_perm_rs = Buf->params->perm_rs;
+    const auto& f_perm_pq = Buf->file.params->perm_pq;
+    const auto& f_perm_rs = Buf->file.params->perm_rs;
+    const auto& b_peq = Buf->params->peq;
+    const auto& b_res = Buf->params->res;
+    const auto& f_peq = Buf->file.params->peq;
+    const auto& f_res = Buf->file.params->res;
 
     /* Exit if buffer is antisymmetrized */
     if (Buf->anti) {
@@ -76,36 +74,37 @@ int DPD::buf4_mat_irrep_wrt_block(dpdbuf4 *Buf, int irrep, int start_pq, int num
         throw PSIEXCEPTION("Cannot write antisymmetrized buffer back to original DPD file!");
     }
 
+    const auto& AllPolicy = dpdparams4::DiagPolicy::All;
     if ((b_perm_pq == f_perm_pq) && (b_perm_rs == f_perm_rs) && (b_peq == f_peq) && (b_res == f_res))
         method = 12;
     else if ((b_perm_pq != f_perm_pq) && (b_perm_rs == f_perm_rs) && (b_res == f_res)) {
-        if (f_perm_pq && !b_perm_pq)
+        if (f_perm_pq != AllPolicy && b_perm_pq == AllPolicy)
             method = 21;
-        else if (!f_perm_pq && b_perm_pq)
+        else if (f_perm_pq == AllPolicy && b_perm_pq != AllPolicy)
             method = 23;
         else {
             outfile->Printf("\n\tInvalid second-level method!\n");
             throw PSIEXCEPTION("Invalid second-level method!");
         }
     } else if ((b_perm_pq == f_perm_pq) && (b_perm_rs != f_perm_rs) && (b_peq == f_peq)) {
-        if (f_perm_rs && !b_perm_rs)
+        if (f_perm_rs != AllPolicy && b_perm_rs == AllPolicy)
             method = 31;
-        else if (!f_perm_rs && b_perm_rs)
+        else if (f_perm_rs == AllPolicy && b_perm_rs != AllPolicy)
             method = 33;
         else {
             outfile->Printf("\n\tInvalid third-level method!\n");
             throw PSIEXCEPTION("Invalid third-level method!");
         }
     } else if ((b_perm_pq != f_perm_pq) && (b_perm_rs != f_perm_rs)) {
-        if (f_perm_pq && !b_perm_pq) {
-            if (f_perm_rs && !b_perm_rs)
+        if (f_perm_pq != AllPolicy && b_perm_pq == AllPolicy) {
+            if (f_perm_rs != AllPolicy && b_perm_rs == AllPolicy)
                 method = 41;
-            else if (!f_perm_rs && b_perm_rs)
+            else if (f_perm_rs == AllPolicy && b_perm_rs != AllPolicy)
                 method = 42;
-        } else if (!f_perm_pq && b_perm_pq) {
-            if (f_perm_rs && !b_perm_rs)
+        } else if (f_perm_pq == AllPolicy && b_perm_pq != AllPolicy) {
+            if (f_perm_rs != AllPolicy && b_perm_rs == AllPolicy)
                 method = 43;
-            else if (!f_perm_rs && b_perm_rs)
+            else if (f_perm_rs == AllPolicy && b_perm_rs != AllPolicy)
                 method = 45;
         } else {
             outfile->Printf("\n\tInvalid fourth-level method!\n");

--- a/psi4/src/psi4/libdpd/buf4_scm.cc
+++ b/psi4/src/psi4/libdpd/buf4_scm.cc
@@ -67,8 +67,8 @@ int DPD::buf4_scm(dpdbuf4 *InBuf, double alpha) {
     long int length, core, memoryd, core_total, rowtot, coltot, maxrows;
     int h, nirreps, new_buf4, all_buf_irrep;
     int row, col;
-    int incore;
     double *X;
+    bool incore;
 
     nirreps = InBuf->params->nirreps;
     all_buf_irrep = InBuf->file.my_irrep;
@@ -85,7 +85,7 @@ int DPD::buf4_scm(dpdbuf4 *InBuf, double alpha) {
 
     for (h = 0; h < nirreps; h++) {
         memoryd = dpd_main.memory;
-        incore = 1; /* default */
+       incore = true; /* default */
 
         /* Compute the core requirements for the straight contraction */
         core_total = 0;
@@ -102,14 +102,14 @@ int DPD::buf4_scm(dpdbuf4 *InBuf, double alpha) {
         rowtot = InBuf->params->rowtot[h];
         for (; rowtot > maxrows; rowtot -= maxrows) {
             if (core_total > (core_total + maxrows * coltot))
-                incore = 0;
+                incore = false;
             else
                 core_total += maxrows * coltot;
         }
-        if (core_total > (core_total + rowtot * coltot)) incore = 0;
+        if (core_total > (core_total + rowtot * coltot)) incore = false;
         core_total += rowtot * coltot;
 
-        if (core_total > memoryd) incore = 0;
+        if (core_total > memoryd) incore = false;
 
         if (incore) {
             buf4_mat_irrep_init(InBuf, h);

--- a/psi4/src/psi4/libdpd/buf4_scmcopy.cc
+++ b/psi4/src/psi4/libdpd/buf4_scmcopy.cc
@@ -54,9 +54,10 @@ namespace psi {
 
 int DPD::buf4_scmcopy(dpdbuf4 *InBuf, int outfilenum, const char *label, double alpha) {
     int h, row, col, rowtot, coltot, all_buf_irrep;
-    int nbuckets, incore, n;
+    int nbuckets, n;
     long int size, memoryd, rows_per_bucket, rows_left;
     dpdbuf4 OutBuf;
+    bool incore;
 
     all_buf_irrep = InBuf->file.my_irrep;
 
@@ -78,9 +79,9 @@ int DPD::buf4_scmcopy(dpdbuf4 *InBuf, int outfilenum, const char *label, double 
 
             rows_left = InBuf->params->rowtot[h] % rows_per_bucket;
 
-            incore = 1;
+            incore = true;
             if (nbuckets > 1) {
-                incore = 0;
+                incore = false;
 #if DPD_DEBUG
                 outfile->Printf("buf4_scmcopy: memory information.\n");
                 outfile->Printf("buf4_scmcopy: rowtot[%d] = %d.\n", h, InBuf->params->rowtot[h]);
@@ -92,7 +93,7 @@ int DPD::buf4_scmcopy(dpdbuf4 *InBuf, int outfilenum, const char *label, double 
             }
 
         } else
-            incore = 1;
+            incore = true;
 
         if (incore) {
             buf4_mat_irrep_init(InBuf, h);

--- a/psi4/src/psi4/libdpd/buf4_sort.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort.cc
@@ -121,7 +121,6 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
     int PQ, RS;
     int Gp, Gq, Gr, Gs, Gpq, Grs, Gpr, Gqs, Grq, Gqr, Gps, Gsp, Grp, Gsq;
     dpdbuf4 OutBuf;
-    int incore;
     long int rowtot, coltot, core_total, maxrows;
     int Grow, Gcol;
     int out_rows_per_bucket, out_nbuckets, out_rows_left, out_row_start, n;
@@ -138,7 +137,7 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
     buf4_init(&OutBuf, outfilenum, my_irrep, pqnum, rsnum, pqnum, rsnum, 0, label);
 
     /* select in-core vs. out-of-core algorithms */
-    incore = 1;
+    bool incore = true;
     core_total = 0;
     for (h = 0; h < nirreps; h++) {
         coltot = InBuf->params->coltot[h ^ my_irrep];
@@ -153,17 +152,17 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
         rowtot = InBuf->params->rowtot[h];
         for (; rowtot > maxrows; rowtot -= maxrows) {
             if (core_total > (core_total + 2 * maxrows * coltot))
-                incore = 0;
+                incore = false;
             else
                 core_total += 2 * maxrows * coltot;
         }
-        if (core_total > (core_total + 2 * rowtot * coltot)) incore = 0;
+        if (core_total > (core_total + 2 * rowtot * coltot)) incore = false;
         core_total += 2 * rowtot * coltot;
     }
-    if (core_total > dpd_memfree()) incore = 0;
+    if (core_total > dpd_memfree()) incore = false;
 
 #ifdef DPD_DEBUG
-    if (incore == 0) {
+    if (incore == false) {
         switch (index) {
             case (pqsr):
                 printf("Doing out-of-core pqsr sort.\n");
@@ -193,25 +192,25 @@ int DPD::buf4_sort(dpdbuf4 *InBuf, int outfilenum, enum indices index, int pqnum
 #ifdef ALL_BUF4_SORT_OOC
     switch (index) {
         case (pqsr):
-            incore = 0;
+            incore = false;
             break;
         case (prqs):
-            incore = 0;
+            incore = false;
             break;
         case (prsq):
-            incore = 0;
+            incore = false;
             break;
         case (qprs):
-            incore = 0;
+            incore = false;
             break;
         case (qpsr):
-            incore = 0;
+            incore = false;
             break;
         case (sqpr):
-            incore = 0;
+            incore = false;
             break;
         case (rspq):
-            incore = 0;
+            incore = false;
             break;
     }
 #endif

--- a/psi4/src/psi4/libdpd/buf4_sort_axpy.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort_axpy.cc
@@ -101,7 +101,7 @@ int DPD::buf4_sort_axpy(dpdbuf4 *InBuf, int outfilenum, enum indices index, int 
     int Gp, Gq, Gr, Gs, Gpq, Grs, Gsr, Gpr, Gqs, Grq, Gqr, Gps, Gsp, Grp, Gsq;
     dpdbuf4 OutBuf;
     long int rowtot, coltot, core_total, maxrows;
-    int incore;
+    bool incore;
     int Grow, Gcol;
     int out_rows_per_bucket, out_nbuckets, out_rows_left, out_row_start, n;
     int in_rows_per_bucket, in_nbuckets, in_rows_left, in_row_start, m;
@@ -117,7 +117,7 @@ int DPD::buf4_sort_axpy(dpdbuf4 *InBuf, int outfilenum, enum indices index, int 
     buf4_init(&OutBuf, outfilenum, my_irrep, pqnum, rsnum, pqnum, rsnum, 0, label);
 
     /* select in-core vs. out-of-core algorithms */
-    incore = 1;
+    incore = true;
     core_total = 0;
     for (h = 0; h < nirreps; h++) {
         coltot = InBuf->params->coltot[h ^ my_irrep];
@@ -132,14 +132,14 @@ int DPD::buf4_sort_axpy(dpdbuf4 *InBuf, int outfilenum, enum indices index, int 
         rowtot = InBuf->params->rowtot[h];
         for (; rowtot > maxrows; rowtot -= maxrows) {
             if (core_total > (core_total + 2 * maxrows * coltot))
-                incore = 0;
+                incore = false;
             else
                 core_total += 2 * maxrows * coltot;
         }
-        if (core_total > (core_total + 2 * rowtot * coltot)) incore = 0;
+        if (core_total > (core_total + 2 * rowtot * coltot)) incore = false;
         core_total += 2 * rowtot * coltot;
     }
-    if (core_total > dpd_memfree()) incore = 0;
+    if (core_total > dpd_memfree()) incore = false;
 
 /* Init input and output buffers and read in all blocks of both */
 #ifdef DPD_TIMER

--- a/psi4/src/psi4/libdpd/buf4_sort_ooc.cc
+++ b/psi4/src/psi4/libdpd/buf4_sort_ooc.cc
@@ -54,8 +54,9 @@ int DPD::buf4_sort_ooc(dpdbuf4 *InBuf, int outfilenum, enum indices index, int p
     int h, nirreps, row, col, all_buf_irrep, r_irrep;
     int p, q, r, s, P, Q, R, S, pq, rs, sr, pr, qs, qp, rq, qr, ps, sp, rp, sq;
     int Gp, Gq, Gr, Gs, Gpq, Grs, Gpr, Gqs, Grq, Gqr, Gps, Gsp, Grp, Gsq;
-    int memoryd, rows_per_bucket, nbuckets, rows_left, incore, n;
+    int memoryd, rows_per_bucket, nbuckets, rows_left, n;
     dpdbuf4 OutBuf;
+    bool incore;
 
     nirreps = InBuf->params->nirreps;
     all_buf_irrep = InBuf->file.my_irrep;
@@ -97,9 +98,9 @@ int DPD::buf4_sort_ooc(dpdbuf4 *InBuf, int outfilenum, enum indices index, int p
 
                     rows_left = InBuf->params->rowtot[h] % rows_per_bucket;
 
-                    incore = 1;
+                    incore = true;
                     if (nbuckets > 1) {
-                        incore = 0;
+                        incore = false;
 #if DPD_DEBUG
                         outfile->Printf("buf4_sort_pqsr: memory information.\n");
                         outfile->Printf("buf4_sort_pqsr: rowtot[%d] = %d\n", h, InBuf->params->rowtot[h]);
@@ -111,7 +112,7 @@ int DPD::buf4_sort_ooc(dpdbuf4 *InBuf, int outfilenum, enum indices index, int p
                     }
 
                 } else
-                    incore = 1;
+                    incore = true;
 
                 if (incore) {
                     buf4_mat_irrep_init(&OutBuf, h);

--- a/psi4/src/psi4/libdpd/contract244.cc
+++ b/psi4/src/psi4/libdpd/contract244.cc
@@ -65,7 +65,6 @@ int DPD::contract244(dpdfile2 *X, dpdbuf4 *Y, dpdbuf4 *Z, int sum_X, int sum_Y, 
     int h, h0, Hx, hybuf, hzbuf, Hy, Hz, nirreps, GX, GY, GZ, bra_y;
     int rking = 0, *yrow, *ycol, symlink;
     int Xtrans, Ytrans = 0;
-    int incore;
     int rowx, rowz, colx, colz;
     int pq, Gr, GsY, GsZ, Gs, GrZ, GrY;
     int ncols, nrows, nlinks;
@@ -83,7 +82,7 @@ int DPD::contract244(dpdfile2 *X, dpdbuf4 *Y, dpdbuf4 *Z, int sum_X, int sum_Y, 
     GZ = Z->file.my_irrep;
 
     memoryd = dpd_main.memory;
-    incore = 1; /* default */
+    bool incore = true; /* default */
 
     file2_mat_init(X);
     file2_mat_rd(X);
@@ -119,7 +118,7 @@ int DPD::contract244(dpdfile2 *X, dpdbuf4 *Y, dpdbuf4 *Z, int sum_X, int sum_Y, 
 #endif
 
     for (hzbuf = 0; hzbuf < nirreps; hzbuf++) {
-        incore = 1; /* default */
+        incore = true; /* default */
 
         if (sum_Y < 2) {
             if (Ztrans)
@@ -148,11 +147,11 @@ int DPD::contract244(dpdfile2 *X, dpdbuf4 *Y, dpdbuf4 *Z, int sum_X, int sum_Y, 
         rowtot = Y->params->rowtot[hybuf];
         for (; rowtot > maxrows; rowtot -= maxrows) {
             if (core_total > (core_total + maxrows * coltot))
-                incore = 0;
+                incore = false;
             else
                 core_total += maxrows * coltot;
         }
-        if (core_total > (core_total + rowtot * coltot)) incore = 0;
+        if (core_total > (core_total + rowtot * coltot)) incore = false;
         core_total += rowtot * coltot;
 
         if (sum_Y == 1 || sum_Y == 2) core_total *= 2; /* we need room to transpose the Y buffer */
@@ -172,19 +171,19 @@ int DPD::contract244(dpdfile2 *X, dpdbuf4 *Y, dpdbuf4 *Z, int sum_X, int sum_Y, 
         if (Ztrans) Z_core *= 2;
         for (; rowtot > maxrows; rowtot -= maxrows) {
             if (core_total > (core_total + Z_core))
-                incore = 0;
+                incore = false;
             else
                 core_total += Z_core;
         }
         Z_core = rowtot * coltot;
         if (Ztrans) Z_core *= 2;
-        if (core_total > (core_total + Z_core)) incore = 0;
+        if (core_total > (core_total + Z_core)) incore = false;
         core_total += Z_core;
 
-        if (core_total > memoryd) incore = 0;
+        if (core_total > memoryd) incore = false;
 
         /* Force incore for all but a "normal" 244 contraction for now */
-        if (!Ztrans || sum_Y == 0 || sum_Y == 1 || sum_Y == 3) incore = 1;
+        if (!Ztrans || sum_Y == 0 || sum_Y == 1 || sum_Y == 3) incore = true;
 
         if (incore) {
             /*       dpd_buf4_scm(Z, beta); */

--- a/psi4/src/psi4/libdpd/contract424.cc
+++ b/psi4/src/psi4/libdpd/contract424.cc
@@ -64,7 +64,6 @@ int DPD::contract424(dpdbuf4 *X, dpdfile2 *Y, dpdbuf4 *Z, int sum_X, int sum_Y, 
     int rking = 0, symlink;
     int Xtrans, Ytrans;
     int *numlinks, *numrows, *numcols;
-    int incore;
     long int core, memoryd, core_total, rowtot, coltot, maxrows;
     int xcount, zcount, scount, Ysym;
     int rowx, rowz, colx, colz;
@@ -81,7 +80,7 @@ int DPD::contract424(dpdbuf4 *X, dpdfile2 *Y, dpdbuf4 *Z, int sum_X, int sum_Y, 
     GZ = Z->file.my_irrep;
 
     memoryd = dpd_main.memory;
-    incore = 1; /* default */
+    bool incore = true; /* default */
 
     file2_mat_init(Y);
     file2_mat_rd(Y);
@@ -117,7 +116,7 @@ int DPD::contract424(dpdbuf4 *X, dpdfile2 *Y, dpdbuf4 *Z, int sum_X, int sum_Y, 
 #endif
 
     for (hxbuf = 0; hxbuf < nirreps; hxbuf++) {
-        incore = 1; /* default */
+        incore = true; /* default */
 
         if (sum_X < 2) {
             if (!Ztrans)
@@ -146,11 +145,11 @@ int DPD::contract424(dpdbuf4 *X, dpdfile2 *Y, dpdbuf4 *Z, int sum_X, int sum_Y, 
         rowtot = X->params->rowtot[hxbuf];
         for (; rowtot > maxrows; rowtot -= maxrows) {
             if (core_total > (core_total + maxrows * coltot))
-                incore = 0;
+                incore = false;
             else
                 core_total += maxrows * coltot;
         }
-        if (core_total > (core_total + rowtot * coltot)) incore = 0;
+        if (core_total > (core_total + rowtot * coltot)) incore = false;
         core_total += rowtot * coltot;
 
         if (sum_X == 1 || sum_X == 2) core_total *= 2; /* we need room to transpose the X buffer */
@@ -168,17 +167,17 @@ int DPD::contract424(dpdbuf4 *X, dpdfile2 *Y, dpdbuf4 *Z, int sum_X, int sum_Y, 
         rowtot = Z->params->rowtot[hzbuf];
         for (; rowtot > maxrows; rowtot -= maxrows) {
             if (core_total > (core_total + maxrows * coltot))
-                incore = 0;
+                incore = false;
             else
                 core_total += maxrows * coltot;
         }
-        if (core_total > (core_total + rowtot * coltot)) incore = 0;
+        if (core_total > (core_total + rowtot * coltot)) incore = false;
         core_total += rowtot * coltot;
 
-        if (core_total > memoryd) incore = 0;
+        if (core_total > memoryd) incore = false;
 
         /* Force incore for all but a "normal" 424 contraction for now */
-        if (Ztrans || sum_X == 0 || sum_X == 1 || sum_X == 2) incore = 1;
+        if (Ztrans || sum_X == 0 || sum_X == 1 || sum_X == 2) incore = true;
 
         if (incore) {
             /*       dpd_buf4_scm(Z, beta); */

--- a/psi4/src/psi4/libdpd/contract444.cc
+++ b/psi4/src/psi4/libdpd/contract444.cc
@@ -61,7 +61,8 @@ namespace psi {
 int DPD::contract444(dpdbuf4 *X, dpdbuf4 *Y, dpdbuf4 *Z, int target_X, int target_Y, double alpha, double beta) {
     int n, Hx, Hy, Hz, GX, GY, GZ, nirreps, Xtrans, Ytrans, *numlinks, symlink;
     long int size_Y, size_Z, size_file_X_row;
-    int incore, nbuckets;
+    int nbuckets;
+    bool incore;
     long int memoryd, core, rows_per_bucket, rows_left, memtotal;
     int nrows, ncols, nlinks;
 #if DPD_DEBUG
@@ -150,10 +151,10 @@ int DPD::contract444(dpdbuf4 *X, dpdbuf4 *Y, dpdbuf4 *Z, int target_X, int targe
 
             rows_left = X->params->rowtot[Hx] % rows_per_bucket;
 
-            incore = 1;
-            if (nbuckets > 1) incore = 0;
+            incore = true;
+            if (nbuckets > 1) incore = false;
         } else
-            incore = 1;
+            incore = true;
 
 #if DPD_DEBUG
         if (!incore) {

--- a/psi4/src/psi4/libdpd/dpd.h
+++ b/psi4/src/psi4/libdpd/dpd.h
@@ -55,6 +55,13 @@ class Matrix;
 /* #define ALL_BUF4_SORT_OOC */
 
 struct dpdparams4 {
+    /*
+      How are p < q handled? If All, they're stored explicitly. This is the default.
+      If p and q are the same space, you can only store p < q. Symm / AntiSymm relates
+      element (p, q) to the implicit element (q, p).
+    */
+    enum class DiagPolicy { All, Symm, AntiSymm};
+
     int nirreps;   /* No. of irreps */
     int pqnum;     /* Pair number for the row indices */
     int rsnum;     /* Pair number for the column indices */
@@ -76,10 +83,10 @@ struct dpdparams4 {
     int *qsym;     /* Orbital symmetry for index q */
     int *rsym;     /* Orbital symmetry for index r */
     int *ssym;     /* Orbital symmetry for index s */
-    int perm_pq;   /* Can p and q be permuted? */
-    int perm_rs;   /* Can r and s be permuted? */
-    int peq;       /* Can p and q be equal? */
-    int res;       /* Can r and s be equal? */
+    DiagPolicy perm_pq;   /* Can p and q be permuted? */
+    DiagPolicy perm_rs;   /* Can r and s be permuted? */
+    bool peq;       /* Can p and q be equal? */
+    bool res;       /* Can r and s be equal? */
     int **start13; /* returns the starting row of irrep matrix h for orbital index p */
 };
 
@@ -90,7 +97,7 @@ struct dpdfile4 {
     int my_irrep;         /* Total irrep of this quantity */
     psio_address *lfiles; /* File address for each submatrix by ROW irrep */
     dpdparams4 *params;
-    int incore;
+    bool incore;
     double ***matrix;
 };
 
@@ -103,7 +110,7 @@ struct dpdshift4 {
 
 struct dpdbuf4 {
     int dpdnum; /* dpd structure reference */
-    int anti;   /* Is this buffer antisymmetric? */
+    bool anti;   /* Is this buffer antisymmetric? */
     dpdparams4 *params;
     dpdfile4 file;
     dpdshift4 shift;
@@ -146,7 +153,7 @@ struct dpdfile2 {
     int my_irrep;
     psio_address *lfiles;
     dpdparams2 *params;
-    int incore;
+    bool incore;
     double ***matrix;
 
     int axpy_matrix(const Matrix& MatX, double alpha);
@@ -166,8 +173,8 @@ struct dpd_file4_cache_entry {
     size_t access;               /* access time */
     size_t usage;                /* number of accesses */
     size_t priority;             /* priority level */
-    int lock;                    /* auto-deletion allowed? */
-    int clean;                   /* has this file4 changed? */
+    bool lock;                    /* auto-deletion allowed? */
+    bool clean;                   /* has this file4 changed? */
     dpd_file4_cache_entry *next; /* pointer to next cache entry */
     dpd_file4_cache_entry *last; /* pointer to previous cache entry */
 };
@@ -183,7 +190,7 @@ struct dpd_file2_cache_entry {
     char label[PSIO_KEYLEN];     /* libpsio TOC keyword */
     double ***matrix;            /* pointer to irrep blocks */
     int size;                    /* size of entry in double words */
-    int clean;                   /* has this file2 changed? */
+    bool clean;                   /* has this file2 changed? */
     dpd_file2_cache_entry *next; /* pointer to next cache entry */
     dpd_file2_cache_entry *last; /* pointer to previous cache entry */
 };

--- a/psi4/src/psi4/libdpd/file2_cache.cc
+++ b/psi4/src/psi4/libdpd/file2_cache.cc
@@ -133,11 +133,11 @@ int DPD::file2_cache_add(dpdfile2 *File) {
         file2_mat_init(File);
         file2_mat_rd(File);
 
-        this_entry->clean = 1;
+        this_entry->clean = true;
 
         this_entry->matrix = File->matrix;
 
-        File->incore = 1;
+        File->incore = true;
 
         dpd_set_default(dpdnum);
 
@@ -163,7 +163,7 @@ int DPD::file2_cache_del(dpdfile2 *File) {
     if (this_entry == nullptr)
         dpd_error("File2 cache delete error!", "outfile");
     else {
-        File->incore = 0;
+        File->incore = false;
 
         dpdnum = dpd_default;
         dpd_set_default(File->dpdnum);
@@ -221,7 +221,7 @@ void DPD::file2_cache_dirty(dpdfile2 *File) {
         (this_entry == nullptr && !File->incore))
         dpd_error("Error setting file4_cache dirty flag!", "outfile");
     else {
-        this_entry->clean = 0;
+        this_entry->clean = false;
     }
 }
 

--- a/psi4/src/psi4/libdpd/file2_init.cc
+++ b/psi4/src/psi4/libdpd/file2_init.cc
@@ -73,10 +73,10 @@ int DPD::file2_init(dpdfile2 *File, int filenum, int irrep, int pnum, int qnum, 
 
     this_entry = file2_cache_scan(filenum, irrep, pnum, qnum, label_ptr, dpd_default);
     if (this_entry != nullptr) {
-        File->incore = 1;
+        File->incore = true;
         File->matrix = this_entry->matrix;
     } else {
-        File->incore = 0;
+        File->incore = false;
         File->matrix = (double ***)malloc(File->params->nirreps * sizeof(double **));
     }
 

--- a/psi4/src/psi4/libdpd/file4_cache.cc
+++ b/psi4/src/psi4/libdpd/file4_cache.cc
@@ -162,7 +162,7 @@ void DPD::file4_cache_add(dpdfile4 *File, size_t priority) {
         this_entry->next = nullptr;
         this_entry->last = file4_cache_last();
 
-        this_entry->lock = 0;
+        this_entry->lock = false;
 
         if (this_entry->last != nullptr)
             this_entry->last->next = this_entry;
@@ -177,14 +177,14 @@ void DPD::file4_cache_add(dpdfile4 *File, size_t priority) {
         this_entry->usage = 1;
 
         /* Set the clean flag */
-        this_entry->clean = 1;
+        this_entry->clean = true;
 
         /* Set the priority level */
         this_entry->priority = priority;
 
         this_entry->matrix = File->matrix;
 
-        File->incore = 1;
+        File->incore = true;
 
         /* Adjust the global cache size value */
         dpd_main.memcache += this_entry->size;
@@ -198,7 +198,7 @@ dpd_file4_cache_entry* DPD::file4_cache_del_raw(dpd_file4_cache_entry *entry, dp
     /* Unlock the entry first */
     file4_cache_unlock(&File);
 
-    File.incore = 0;
+    File.incore = false;
 
     /* Write all the data to disk and free the memory */
     for (int h = 0; h < File.params->nirreps; h++) {
@@ -378,7 +378,7 @@ void DPD::file4_cache_dirty(dpdfile4 *File) {
     if (this_entry == nullptr || !(File->incore))
         dpd_error("Error setting file4_cache dirty flag!", "outfile");
     else {
-        this_entry->clean = 0;
+        this_entry->clean = false;
     }
 }
 
@@ -486,7 +486,7 @@ void DPD::file4_cache_lock(dpdfile4 *File) {
             dpd_main.memlocked += static_cast<size_t>(File->params->rowtot[h]) * File->params->coltot[h ^ (File->my_irrep)];
         }
 
-        this_entry->lock = 1;
+        this_entry->lock = true;
     }
 }
 
@@ -498,7 +498,7 @@ void DPD::file4_cache_unlock(dpdfile4 *File) {
                                   File->dpdnum);
 
     if (this_entry != nullptr && this_entry->lock) {
-        this_entry->lock = 0;
+        this_entry->lock = false;
 
         /* Decrement the locked cache memory counter */
         for (h = 0; h < File->params->nirreps; h++) {

--- a/psi4/src/psi4/libdpd/file4_init.cc
+++ b/psi4/src/psi4/libdpd/file4_init.cc
@@ -69,10 +69,10 @@ int DPD::file4_init(dpdfile4 *File, int filenum, int irrep, int pqnum, int rsnum
 
     this_entry = file4_cache_scan(filenum, irrep, pqnum, rsnum, label, dpd_default);
     if (this_entry != nullptr) {
-        File->incore = 1;
+        File->incore = true;
         File->matrix = this_entry->matrix;
     } else {
-        File->incore = 0;
+        File->incore = false;
         File->matrix = (double ***)malloc(File->params->nirreps * sizeof(double **));
     }
 

--- a/psi4/src/psi4/libdpd/file4_init_nocache.cc
+++ b/psi4/src/psi4/libdpd/file4_init_nocache.cc
@@ -70,10 +70,10 @@ int DPD::file4_init_nocache(dpdfile4 *File, int filenum, int irrep, int pqnum, i
 
     this_entry = file4_cache_scan(filenum, irrep, pqnum, rsnum, label, dpd_default);
     if (this_entry != nullptr) {
-        File->incore = 1;
+        File->incore = true;
         File->matrix = this_entry->matrix;
     } else {
-        File->incore = 0;
+        File->incore = false;
         File->matrix = (double ***)malloc(File->params->nirreps * sizeof(double **));
     }
 

--- a/psi4/src/psi4/libdpd/init.cc
+++ b/psi4/src/psi4/libdpd/init.cc
@@ -52,8 +52,8 @@ struct dpdpair {
     int *right_orbsym;
     int *left_orboff;
     int *right_orboff;
-    int permlr;
-    int ler;
+    dpdparams4::DiagPolicy permlr;
+    bool ler;
 };
 
 int dpd_set_default(int dpd_num) {
@@ -211,8 +211,8 @@ int DPD::init(int dpd_num_in, int nirreps_in, long int memory_in, int cachetype_
         pairs[5 * i].right_orbspi = orbspi[i];
         pairs[5 * i].right_orbsym = orbsym[i];
         pairs[5 * i].right_orboff = orboff[i];
-        pairs[5 * i].permlr = 0;
-        pairs[5 * i].ler = 0;
+        pairs[5 * i].permlr = dpdparams4::DiagPolicy::All;
+        pairs[5 * i].ler = false;
 
         pairs[5 * i + 1].left_orbspi = orbspi[i];
         pairs[5 * i + 1].left_orbsym = orbsym[i];
@@ -220,8 +220,8 @@ int DPD::init(int dpd_num_in, int nirreps_in, long int memory_in, int cachetype_
         pairs[5 * i + 1].right_orbspi = orbspi[i];
         pairs[5 * i + 1].right_orbsym = orbsym[i];
         pairs[5 * i + 1].right_orboff = orboff[i];
-        pairs[5 * i + 1].permlr = 1;
-        pairs[5 * i + 1].ler = 0;
+        pairs[5 * i + 1].permlr = dpdparams4::DiagPolicy::Symm;
+        pairs[5 * i + 1].ler = false;
 
         pairs[5 * i + 2].left_orbspi = orbspi[i];
         pairs[5 * i + 2].left_orbsym = orbsym[i];
@@ -229,8 +229,8 @@ int DPD::init(int dpd_num_in, int nirreps_in, long int memory_in, int cachetype_
         pairs[5 * i + 2].right_orbspi = orbspi[i];
         pairs[5 * i + 2].right_orbsym = orbsym[i];
         pairs[5 * i + 2].right_orboff = orboff[i];
-        pairs[5 * i + 2].permlr = -1;
-        pairs[5 * i + 2].ler = 0;
+        pairs[5 * i + 2].permlr = dpdparams4::DiagPolicy::AntiSymm;
+        pairs[5 * i + 2].ler = false;
 
         pairs[5 * i + 3].left_orbspi = orbspi[i];
         pairs[5 * i + 3].left_orbsym = orbsym[i];
@@ -238,8 +238,8 @@ int DPD::init(int dpd_num_in, int nirreps_in, long int memory_in, int cachetype_
         pairs[5 * i + 3].right_orbspi = orbspi[i];
         pairs[5 * i + 3].right_orbsym = orbsym[i];
         pairs[5 * i + 3].right_orboff = orboff[i];
-        pairs[5 * i + 3].permlr = 1;
-        pairs[5 * i + 3].ler = 1;
+        pairs[5 * i + 3].permlr = dpdparams4::DiagPolicy::Symm;
+        pairs[5 * i + 3].ler = true;
 
         pairs[5 * i + 4].left_orbspi = orbspi[i];
         pairs[5 * i + 4].left_orbsym = orbsym[i];
@@ -247,8 +247,8 @@ int DPD::init(int dpd_num_in, int nirreps_in, long int memory_in, int cachetype_
         pairs[5 * i + 4].right_orbspi = orbspi[i];
         pairs[5 * i + 4].right_orbsym = orbsym[i];
         pairs[5 * i + 4].right_orboff = orboff[i];
-        pairs[5 * i + 4].permlr = -1;
-        pairs[5 * i + 4].ler = 1;
+        pairs[5 * i + 4].permlr = dpdparams4::DiagPolicy::AntiSymm;
+        pairs[5 * i + 4].ler = true;
 
         for (j = 0; j < nirreps; j++)
             for (k = 0; k < nirreps; k++) {
@@ -289,8 +289,8 @@ int DPD::init(int dpd_num_in, int nirreps_in, long int memory_in, int cachetype_
             pairs[cnt].right_orbspi = orbspi[j];
             pairs[cnt].right_orbsym = orbsym[j];
             pairs[cnt].right_orboff = orboff[j];
-            pairs[cnt].permlr = 0;
-            pairs[cnt].ler = 0;
+            pairs[cnt].permlr = dpdparams4::DiagPolicy::All;
+            pairs[cnt].ler = false;
 
             pairs[cnt + 1].left_orbspi = orbspi[j];
             pairs[cnt + 1].left_orbsym = orbsym[j];
@@ -298,8 +298,8 @@ int DPD::init(int dpd_num_in, int nirreps_in, long int memory_in, int cachetype_
             pairs[cnt + 1].right_orbspi = orbspi[i];
             pairs[cnt + 1].right_orbsym = orbsym[i];
             pairs[cnt + 1].right_orboff = orboff[i];
-            pairs[cnt + 1].permlr = 0;
-            pairs[cnt + 1].ler = 0;
+            pairs[cnt + 1].permlr = dpdparams4::DiagPolicy::All;
+            pairs[cnt + 1].ler = false;
 
             for (k = 0; k < nirreps; k++)
                 for (l = 0; l < nirreps; l++) {


### PR DESCRIPTION
## Description
This PR reclassifies several variables in DPD from being integers to being something else - usually bools, although one case needs an enum. This is a small shard of a giant in-progress `libdpd` cleanup. This part, I can separate out without breaking API... Unfortunately, most of the rest of the PR doesn't separate out cleanly from the rest of the PR due to either API breaking or needed type conversions.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Reclassifies several variables in DPD from being integers to being something else - usually bools
- [x] dpdbuf4::DiagPolicy enum created to describe `p < q` symmetry symmetry/antisymmetry.

## Checklist
- [x] `cc` tests pass

## Status
- [x] Ready for review
- [x] Ready for merge
