### PR TITLE
convey libgcc windows

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -20,6 +20,7 @@ jobs:
         PYTEST_MARKER_EXPR: "quick"
         PYTEST_NAME_EXPR: 'not asdfqwer'
         ENABLE_EINSUMS: "ON"
+        CMARGS: ""
 
       gcc_latest:
         CXX_COMPILER: 'g++'
@@ -32,6 +33,7 @@ jobs:
         PYTEST_MARKER_EXPR: 'api and not stdsuite and not (smoke or quick or medlong or long)'
         PYTEST_NAME_EXPR: 'not asdfqwer'
         ENABLE_EINSUMS: "ON"
+        CMARGS: ""
 
       clang_latest:
         CXX_COMPILER: 'clang++-15'
@@ -45,6 +47,7 @@ jobs:
         PYTEST_MARKER_EXPR: 'cli and not (smoke or quick or medlong or long)'
         PYTEST_NAME_EXPR: 'not asdfqwer'
         ENABLE_EINSUMS: "OFF"
+        CMARGS: '-DOpenMP_C_FLAGS=-fopenmp=libomp -DOpenMP_CXX_FLAGS=-fopenmp=libomp -DOpenMP_C_LIB_NAMES=omp -DOpenMP_CXX_LIB_NAMES=omp -DOpenMP_omp_LIBRARY=$CONDA_PREFIX/lib/libomp.so'
 
   pool:
     vmImage: $(vmImage)
@@ -150,6 +153,7 @@ jobs:
         -D OpenMP_C_INCLUDE_DIR=$CONDA_PREFIX/include \
         -D OpenMP_LIBRARY_DIRS=$CONDA_PREFIX/lib/libomp.so \
         -D OpenMP_omp_LIBRARY=$CONDA_PREFIX/lib/libomp.so \
+        ${CMARGS} \
         -D CMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/Install
     displayName: 'Configure Build'
 

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -147,6 +147,7 @@ jobs:
         -D ENABLE_gauxc=ON \
         -D FORCE_PEDANTIC=ON \
         -D OpenMP_ROOT="$CONDA_PREFIX" \
+        -D OpenMP_C_INCLUDE_DIR="$CONDA_PREFIX/include" \
         -D CMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/Install
     displayName: 'Configure Build'
 

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -131,6 +131,8 @@ jobs:
         --insist
       echo "\n<<<  cache_p4env@build.cmake  >>>\n"
       cat cache_p4env@build.cmake
+      echo $CONDA
+      echo $CONDA_PREFIX
       cmake \
         -S. \
         -B build \
@@ -144,7 +146,7 @@ jobs:
         -D ENABLE_IntegratorXX=OFF \
         -D ENABLE_gauxc=ON \
         -D FORCE_PEDANTIC=ON \
-        -D OpenMP_LIBRARY_DIRS="$CONDA/lib" \
+        -D OpenMP_ROOT="$CONDA" \
         -D CMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/Install
     displayName: 'Configure Build'
 

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -30,7 +30,7 @@ jobs:
         APT_INSTALL: 'gfortran'
         vmImage: 'ubuntu-latest'
         PYTEST_MARKER_EXPR: 'api and not stdsuite and not (smoke or quick or medlong or long)'
-        PYTEST_NAME_EXPR: 'not ITERATIVE'
+        PYTEST_NAME_EXPR: 'not asdfqwer'
         ENABLE_EINSUMS: "ON"
 
       clang_latest:
@@ -40,6 +40,7 @@ jobs:
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'
         APT_INSTALL: 'gfortran clang-15 clang++-15'
+        # needed by gauxc 'libomp-15-dev' leads to needing `export KMP_DUPLICATE_LIB_OK=TRUE`
         vmImage: 'ubuntu-22.04'
         PYTEST_MARKER_EXPR: 'cli and not (smoke or quick or medlong or long)'
         PYTEST_NAME_EXPR: 'not asdfqwer'
@@ -141,8 +142,9 @@ jobs:
         -D ENABLE_PLUGIN_TESTING=ON \
         -D ENABLE_Einsums="${ENABLE_EINSUMS}" \
         -D ENABLE_IntegratorXX=OFF \
-        -D ENABLE_gauxc=OFF \
+        -D ENABLE_gauxc=ON \
         -D FORCE_PEDANTIC=ON \
+        -D OpenMP_LIBRARY_DIRS="$CONDA/lib" \
         -D CMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/Install
     displayName: 'Configure Build'
 
@@ -160,7 +162,6 @@ jobs:
       python -V
       python -c 'import numpy; print(numpy.version.version)'
       python -c 'import qcelemental as q; print(q.__version__, q.__file__)'
-      export KMP_DUPLICATE_LIB_OK=TRUE
       ./stage/bin/psi4 ../tests/tu1-h2o-energy/input.dat
     displayName: 'Spot Test'
 
@@ -170,7 +171,6 @@ jobs:
       python -V
       python -c 'import numpy; print(numpy.version.version)'
       python -c 'import qcelemental as q; print(q.__version__, q.__file__)'
-      export KMP_DUPLICATE_LIB_OK=TRUE
       PYTHONPATH=stage/lib/ ./stage/bin/psi4 ../tests/fd-freq-energy/input.dat
     displayName: 'Spot Test 2'
 
@@ -186,7 +186,6 @@ jobs:
   - bash: |
       cd build
       source activate p4env
-      # export KMP_DUPLICATE_LIB_OK=TRUE
       python ../devtools/scripts/ci_run_test.py
       python ../devtools/scripts/ci_print_failing.py
     displayName: 'CTest Tests'
@@ -194,7 +193,6 @@ jobs:
   - bash: |
       cd build
       source activate p4env
-      # export KMP_DUPLICATE_LIB_OK=TRUE
       PYTHONPATH=stage/lib/ pytest -v -rws --durations=15 --durations-min=40 --strict-markers --color yes -n 2 -m "$PYTEST_MARKER_EXPR" -k "$PYTEST_NAME_EXPR" stage/lib/psi4/tests/
     displayName: 'PyTest Tests'
 

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -47,7 +47,7 @@ jobs:
         PYTEST_MARKER_EXPR: 'cli and not (smoke or quick or medlong or long)'
         PYTEST_NAME_EXPR: 'not asdfqwer'
         ENABLE_EINSUMS: "OFF"
-        CMARGS: '-DOpenMP_C_FLAGS=-fopenmp=libomp -DOpenMP_CXX_FLAGS=-fopenmp=libomp -DOpenMP_C_LIB_NAMES=omp -DOpenMP_CXX_LIB_NAMES=omp -DOpenMP_omp_LIBRARY=$CONDA_PREFIX/lib/libomp.so'
+        CMARGS: '-DOpenMP_C_FLAGS=-fopenmp=libomp -DOpenMP_CXX_FLAGS=-fopenmp=libomp -DOpenMP_C_LIB_NAMES=omp -DOpenMP_CXX_LIB_NAMES=omp -DOpenMP_omp_LIBRARY=/usr/share/miniconda/envs/p4env/lib/libomp.so'
 
   pool:
     vmImage: $(vmImage)
@@ -134,8 +134,6 @@ jobs:
         --insist
       echo "\n<<<  cache_p4env@build.cmake  >>>\n"
       cat cache_p4env@build.cmake
-      echo CONDA $CONDA
-      echo CONDA_PREFIX $CONDA_PREFIX
       cmake \
         -S. \
         -B build \

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -131,8 +131,8 @@ jobs:
         --insist
       echo "\n<<<  cache_p4env@build.cmake  >>>\n"
       cat cache_p4env@build.cmake
-      echo $CONDA
-      echo $CONDA_PREFIX
+      echo CONDA $CONDA
+      echo CONDA_PREFIX $CONDA_PREFIX
       cmake \
         -S. \
         -B build \
@@ -146,7 +146,7 @@ jobs:
         -D ENABLE_IntegratorXX=OFF \
         -D ENABLE_gauxc=ON \
         -D FORCE_PEDANTIC=ON \
-        -D OpenMP_ROOT="$CONDA" \
+        -D OpenMP_ROOT="$CONDA_PREFIX" \
         -D CMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/Install
     displayName: 'Configure Build'
 

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -18,6 +18,7 @@ jobs:
         APT_INSTALL: 'gfortran gcc-11 g++-11'
         vmImage: 'ubuntu-22.04'
         PYTEST_MARKER_EXPR: "quick"
+        PYTEST_NAME_EXPR: 'not asdfqwer'
         ENABLE_EINSUMS: "ON"
 
       gcc_latest:
@@ -29,6 +30,7 @@ jobs:
         APT_INSTALL: 'gfortran'
         vmImage: 'ubuntu-latest'
         PYTEST_MARKER_EXPR: 'api and not stdsuite and not (smoke or quick or medlong or long)'
+        PYTEST_NAME_EXPR: 'not ITERATIVE'
         ENABLE_EINSUMS: "ON"
 
       clang_latest:
@@ -37,9 +39,10 @@ jobs:
         C_COMPILER: 'clang-15'
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'
-        APT_INSTALL: 'gfortran clang-15 clang++-15 libomp-15-dev'
+        APT_INSTALL: 'gfortran clang-15 clang++-15'
         vmImage: 'ubuntu-22.04'
         PYTEST_MARKER_EXPR: 'cli and not (smoke or quick or medlong or long)'
+        PYTEST_NAME_EXPR: 'not asdfqwer'
         ENABLE_EINSUMS: "OFF"
 
   pool:
@@ -109,7 +112,6 @@ jobs:
       echo "  - einsums>=1.0.6" >> env_p4env.yaml
       echo "  - range-v3" >> env_p4env.yaml
       echo "  - zlib" >> env_p4env.yaml
-      echo "  - setuptools=80.8.0" >> env_p4env.yaml
       echo "\n<<<  env_p4env.yaml  >>>\n"
       cat env_p4env.yaml
       conda env create -n p4env -f env_p4env.yaml
@@ -175,7 +177,16 @@ jobs:
   - bash: |
       cd build
       source activate p4env
-      export KMP_DUPLICATE_LIB_OK=TRUE
+      python -V
+      python -c 'import numpy; print(numpy.version.version)'
+      python -c 'import qcelemental as q; print(q.__version__, q.__file__)'
+      PATH=stage/bin:$PATH PYTHONPATH=stage/lib/ pytest -k ITERATIVE ../tests/pytests
+    displayName: 'Spot Test 3'
+
+  - bash: |
+      cd build
+      source activate p4env
+      # export KMP_DUPLICATE_LIB_OK=TRUE
       python ../devtools/scripts/ci_run_test.py
       python ../devtools/scripts/ci_print_failing.py
     displayName: 'CTest Tests'
@@ -183,8 +194,8 @@ jobs:
   - bash: |
       cd build
       source activate p4env
-      export KMP_DUPLICATE_LIB_OK=TRUE
-      PYTHONPATH=stage/lib/ pytest -v -rws --durations=15 --durations-min=40 --strict-markers --color yes -n 2 -m "$PYTEST_MARKER_EXPR" stage/lib/psi4/tests/
+      # export KMP_DUPLICATE_LIB_OK=TRUE
+      PYTHONPATH=stage/lib/ pytest -v -rws --durations=15 --durations-min=40 --strict-markers --color yes -n 2 -m "$PYTEST_MARKER_EXPR" -k "$PYTEST_NAME_EXPR" stage/lib/psi4/tests/
     displayName: 'PyTest Tests'
 
 # setuptools v66 (vendors packaging v23) incompatible with arb. tarballs. thinks the branch names are versions

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -141,7 +141,7 @@ jobs:
         -D ENABLE_PLUGIN_TESTING=ON \
         -D ENABLE_Einsums="${ENABLE_EINSUMS}" \
         -D ENABLE_IntegratorXX=OFF \
-        -D ENABLE_gauxc=ON \
+        -D ENABLE_gauxc=OFF \
         -D FORCE_PEDANTIC=ON \
         -D CMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/Install
     displayName: 'Configure Build'

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -106,9 +106,10 @@ jobs:
       fi
       sed -i "s;- libint;#- libint;g" env_p4env.yaml
       sed -i "s;#- psi4::libint;- psi4::libint=2.8.1;g" env_p4env.yaml
-      echo "  - einsums>=1.0.3" >> env_p4env.yaml
+      echo "  - einsums>=1.0.6" >> env_p4env.yaml
       echo "  - range-v3" >> env_p4env.yaml
       echo "  - zlib" >> env_p4env.yaml
+      echo "  - setuptools=80.8.0" >> env_p4env.yaml
       echo "\n<<<  env_p4env.yaml  >>>\n"
       cat env_p4env.yaml
       conda env create -n p4env -f env_p4env.yaml

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -149,6 +149,7 @@ jobs:
         -D OpenMP_ROOT="$CONDA_PREFIX" \
         -D OpenMP_C_INCLUDE_DIR=$CONDA_PREFIX/include \
         -D OpenMP_LIBRARY_DIRS=$CONDA_PREFIX/lib/libomp.so \
+        -D OpenMP_omp_LIBRARY=$CONDA_PREFIX/lib/libomp.so \
         -D CMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/Install
     displayName: 'Configure Build'
 

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -149,10 +149,6 @@ jobs:
         -D ENABLE_IntegratorXX=OFF \
         -D ENABLE_gauxc=ON \
         -D FORCE_PEDANTIC=ON \
-        -D OpenMP_ROOT="$CONDA_PREFIX" \
-        -D OpenMP_C_INCLUDE_DIR=$CONDA_PREFIX/include \
-        -D OpenMP_LIBRARY_DIRS=$CONDA_PREFIX/lib/libomp.so \
-        -D OpenMP_omp_LIBRARY=$CONDA_PREFIX/lib/libomp.so \
         ${CMARGS} \
         -D CMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/Install
     displayName: 'Configure Build'

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -147,7 +147,8 @@ jobs:
         -D ENABLE_gauxc=ON \
         -D FORCE_PEDANTIC=ON \
         -D OpenMP_ROOT="$CONDA_PREFIX" \
-        -D OpenMP_C_INCLUDE_DIR="$CONDA_PREFIX/include" \
+        -D OpenMP_C_INCLUDE_DIR=$CONDA_PREFIX/include \
+        -D OpenMP_LIBRARY_DIRS=$CONDA_PREFIX/lib/libomp.so \
         -D CMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/Install
     displayName: 'Configure Build'
 

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -18,7 +18,7 @@ jobs:
         APT_INSTALL: 'gfortran gcc-11 g++-11'
         vmImage: 'ubuntu-22.04'
         PYTEST_MARKER_EXPR: "quick"
-        PYTEST_NAME_EXPR: 'not asdfqwer'
+        PYTEST_NAME_EXPR: 'not nonsense1'
         ENABLE_EINSUMS: "ON"
         CMARGS: ""
 
@@ -31,7 +31,7 @@ jobs:
         APT_INSTALL: 'gfortran'
         vmImage: 'ubuntu-latest'
         PYTEST_MARKER_EXPR: 'api and not stdsuite and not (smoke or quick or medlong or long)'
-        PYTEST_NAME_EXPR: 'not asdfqwer'
+        PYTEST_NAME_EXPR: 'not nonsense1'
         ENABLE_EINSUMS: "ON"
         CMARGS: ""
 
@@ -45,9 +45,9 @@ jobs:
         # needed by gauxc 'libomp-15-dev' leads to needing `export KMP_DUPLICATE_LIB_OK=TRUE`
         vmImage: 'ubuntu-22.04'
         PYTEST_MARKER_EXPR: 'cli and not (smoke or quick or medlong or long)'
-        PYTEST_NAME_EXPR: 'not asdfqwer'
+        PYTEST_NAME_EXPR: 'not nonsense1'
         ENABLE_EINSUMS: "OFF"
-        CMARGS: '-DOpenMP_C_FLAGS=-fopenmp=libomp -DOpenMP_CXX_FLAGS=-fopenmp=libomp -DOpenMP_C_LIB_NAMES=omp -DOpenMP_CXX_LIB_NAMES=omp -DOpenMP_omp_LIBRARY=/usr/share/miniconda/envs/p4env/lib/libomp.so'
+        CMARGS: '-DOpenMP_C_FLAGS=-fopenmp=libomp -DOpenMP_CXX_FLAGS=-fopenmp=libomp -DOpenMP_omp_LIBRARY=/usr/share/miniconda/envs/p4env/lib/libomp.so'
 
   pool:
     vmImage: $(vmImage)
@@ -171,20 +171,8 @@ jobs:
   - bash: |
       cd build
       source activate p4env
-      python -V
-      python -c 'import numpy; print(numpy.version.version)'
-      python -c 'import qcelemental as q; print(q.__version__, q.__file__)'
-      PYTHONPATH=stage/lib/ ./stage/bin/psi4 ../tests/fd-freq-energy/input.dat
-    displayName: 'Spot Test 2'
-
-  - bash: |
-      cd build
-      source activate p4env
-      python -V
-      python -c 'import numpy; print(numpy.version.version)'
-      python -c 'import qcelemental as q; print(q.__version__, q.__file__)'
       PATH=stage/bin:$PATH PYTHONPATH=stage/lib/ pytest -k ITERATIVE ../tests/pytests
-    displayName: 'Spot Test 3'
+    displayName: 'Spot Test 2'
 
   - bash: |
       cd build

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -47,7 +47,7 @@ jobs:
         PYTEST_MARKER_EXPR: 'cli and not (smoke or quick or medlong or long)'
         PYTEST_NAME_EXPR: 'not nonsense1'
         ENABLE_EINSUMS: "OFF"
-        CMARGS: '-DOpenMP_C_FLAGS=-fopenmp=libomp -DOpenMP_CXX_FLAGS=-fopenmp=libomp -DOpenMP_omp_LIBRARY=/usr/share/miniconda/envs/p4env/lib/libomp.so'
+        CMARGS: '-DOpenMP_C_FLAGS=-fopenmp=libomp -DOpenMP_CXX_FLAGS=-fopenmp=libomp -DOpenMP_C_LIB_NAMES=omp -DOpenMP_CXX_LIB_NAMES=omp -DOpenMP_omp_LIBRARY=/usr/share/miniconda/envs/p4env/lib/libomp.so'
 
   pool:
     vmImage: $(vmImage)

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -188,8 +188,7 @@ jobs:
         fi
         if [[ "${{ runner.os }}" == "Windows" ]]; then
           :
-          sed -i "s;#- dpcpp_linux-64;- clangdev ${{ matrix.cfg.llvm-version }};g" env_p4build.yaml
-          #echo "  - libgcc <14.3" >> env_p4build.yaml
+          # sed -i "s;#- dpcpp_linux-64;- clangdev ${{ matrix.cfg.llvm-version }};g" env_p4build.yaml
         fi
         echo "  - pygments" >> env_p4build.yaml
         echo "::group::View Env Spec File for Conda (Edited)"

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -173,7 +173,7 @@ jobs:
         if [[ "${{ runner.os }}" == "macOS" && "${{ matrix.cfg.label }}" == "Conda Clang (M-Intel)" ]]; then
           :
           # sed -E -i.bak "s;;;g" env_p4build.yaml
-          sed -E -i.bak "s;#- psi4::libint;libcxx=20.1.8=*_0;g" env_p4build.yaml
+          sed -E -i.bak "s;#- psi4::libint;- libcxx=20.1.8=*_0;g" env_p4build.yaml
         fi
         if [[ "${{ runner.os }}" == "macOS" && "${{ matrix.cfg.label }}" == "Conda Clang (M-Silicon)" ]]; then
           :

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -44,8 +44,6 @@ jobs:
             target-sdk: "10.10"
             cmargs: >
               -D CMAKE_VERBOSE_MAKEFILE=OFF
-              -D ENABLE_v2rdm_casscf=ON
-              -D CMAKE_DISABLE_FIND_PACKAGE_v2rdm_casscf=ON
               -D Python_NumPy_INCLUDE_DIR="/Users/runner/miniconda3/envs/p4build/lib/python3.11/site-packages/numpy/_core/include"
             # Notes:
             # * libiomp5 is picking up naturally but left here as guide
@@ -173,7 +171,6 @@ jobs:
         if [[ "${{ runner.os }}" == "macOS" && "${{ matrix.cfg.label }}" == "Conda Clang (M-Intel)" ]]; then
           :
           # sed -E -i.bak "s;;;g" env_p4build.yaml
-          sed -E -i.bak "s;#- psi4::libint;- libcxx=20.1.8=*_0;g" env_p4build.yaml
         fi
         if [[ "${{ runner.os }}" == "macOS" && "${{ matrix.cfg.label }}" == "Conda Clang (M-Silicon)" ]]; then
           :

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -189,7 +189,7 @@ jobs:
         if [[ "${{ runner.os }}" == "Windows" ]]; then
           :
           sed -i "s;#- dpcpp_linux-64;- clangdev ${{ matrix.cfg.llvm-version }};g" env_p4build.yaml
-          echo "  - libgcc <14.3" >> env_p4build.yaml
+          #echo "  - libgcc <14.3" >> env_p4build.yaml
         fi
         echo "  - pygments" >> env_p4build.yaml
         echo "::group::View Env Spec File for Conda (Edited)"

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -169,19 +169,13 @@ jobs:
         #
         if [[ "${{ runner.os }}" == "Linux" ]]; then
           :
-          sed -i "s;- openfermion;#- openfermion;g" env_p4build.yaml
-          # openfermion not yet ready for np v2
         fi
         if [[ "${{ runner.os }}" == "macOS" && "${{ matrix.cfg.label }}" == "Conda Clang (M-Intel)" ]]; then
           :
           # sed -E -i.bak "s;;;g" env_p4build.yaml
-          sed -E -i.bak "s;- openfermion;#- openfermion;g" env_p4build.yaml
-          # openfermion not yet ready for np v2
         fi
         if [[ "${{ runner.os }}" == "macOS" && "${{ matrix.cfg.label }}" == "Conda Clang (M-Silicon)" ]]; then
           :
-          sed -E -i.bak "s;- openfermion;#- openfermion;g" env_p4build.yaml
-          # openfermion not yet ready for np v2
           sed -E -i.bak "s;accelerate;openblas;g" env_p4build.yaml
           sed -E -i.bak "s;- memory_profiler;#- memory_profiler;g" env_p4build.yaml
           # memory leaks. accelerate is fine but openblas matches the scf-cholesky stored values

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -173,6 +173,7 @@ jobs:
         if [[ "${{ runner.os }}" == "macOS" && "${{ matrix.cfg.label }}" == "Conda Clang (M-Intel)" ]]; then
           :
           # sed -E -i.bak "s;;;g" env_p4build.yaml
+          sed -E -i.bak "s;#- psi4::libint;libcxx=20.1.8=*_0;g" env_p4build.yaml
         fi
         if [[ "${{ runner.os }}" == "macOS" && "${{ matrix.cfg.label }}" == "Conda Clang (M-Silicon)" ]]; then
           :

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,7 @@ ExternalProject_Add(psi4-core
               -DLIBC_INTERJECT=${LIBC_INTERJECT}
               -DRESTRICT_KEYWORD=${RESTRICT_KEYWORD}
               -DFC_SYMBOL=${FC_SYMBOL}
+              -DOpenMP_LIBRARY_DIRS=${OpenMP_LIBRARY_DIRS}
               -DOpenMP_C_FLAGS=${OpenMP_C_FLAGS}
               -DOpenMP_CXX_FLAGS=${OpenMP_CXX_FLAGS}
               -DOpenMP_omp_LIBRARY=${OpenMP_omp_LIBRARY}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,7 @@ ExternalProject_Add(psi4-core
               -DOpenMP_CXX_FLAGS=${OpenMP_CXX_FLAGS}
               -DOpenMP_omp_LIBRARY=${OpenMP_omp_LIBRARY}
               -DOpenMP_gomp_LIBRARY=${OpenMP_gomp_LIBRARY}
+              -DOpenMP_pthread_LIBRARY=${OpenMP_pthread_LIBRARY}
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
               -DENABLE_CYTHONIZE=${ENABLE_CYTHONIZE}
               -Dpsi4_SHGSHELL_ORDERING=${psi4_SHGSHELL_ORDERING}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,7 @@ ExternalProject_Add(psi4-core
               -DOpenMP_LIBRARY_DIRS=${OpenMP_LIBRARY_DIRS}
               -DOpenMP_C_FLAGS=${OpenMP_C_FLAGS}
               -DOpenMP_CXX_FLAGS=${OpenMP_CXX_FLAGS}
+              -DOpenMP_omp_LIBRARY=${OpenMP_omp_LIBRARY}
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
               -DENABLE_CYTHONIZE=${ENABLE_CYTHONIZE}
               -Dpsi4_SHGSHELL_ORDERING=${psi4_SHGSHELL_ORDERING}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,8 @@ ExternalProject_Add(psi4-core
               -DRESTRICT_KEYWORD=${RESTRICT_KEYWORD}
               -DFC_SYMBOL=${FC_SYMBOL}
               -DOpenMP_LIBRARY_DIRS=${OpenMP_LIBRARY_DIRS}
+              -DOpenMP_C_FLAGS=${OpenMP_C_FLAGS}
+              -DOpenMP_CXX_FLAGS=${OpenMP_CXX_FLAGS}
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
               -DENABLE_CYTHONIZE=${ENABLE_CYTHONIZE}
               -Dpsi4_SHGSHELL_ORDERING=${psi4_SHGSHELL_ORDERING}
@@ -342,6 +344,8 @@ ExternalProject_Add(psi4-core
               -DCMAKE_CXX_COMPILER_ARG1:STRING=${CMAKE_CXX_COMPILER_ARG1}
               -DCMAKE_Fortran_COMPILER_ARG1:STRING=${CMAKE_Fortran_COMPILER_ARG1}
                # CMAKE_<lang>_COMPILER_ARG1 vars pass args thru when CMAKE_<lang>_COMPILER set as "compiler --vital-args"
+              -DOpenMP_C_LIB_NAMES:STRING=${OpenMP_C_LIB_NAMES}
+              -DOpenMP_CXX_LIB_NAMES:STRING=${OpenMP_CXX_LIB_NAMES}
    USES_TERMINAL_BUILD 1
    BUILD_ALWAYS 1)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,7 @@ ExternalProject_Add(psi4-core
               -DOpenMP_C_FLAGS=${OpenMP_C_FLAGS}
               -DOpenMP_CXX_FLAGS=${OpenMP_CXX_FLAGS}
               -DOpenMP_omp_LIBRARY=${OpenMP_omp_LIBRARY}
+              -DOpenMP_gomp_LIBRARY=${OpenMP_gomp_LIBRARY}
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
               -DENABLE_CYTHONIZE=${ENABLE_CYTHONIZE}
               -Dpsi4_SHGSHELL_ORDERING=${psi4_SHGSHELL_ORDERING}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,7 +333,6 @@ ExternalProject_Add(psi4-core
               -DLIBC_INTERJECT=${LIBC_INTERJECT}
               -DRESTRICT_KEYWORD=${RESTRICT_KEYWORD}
               -DFC_SYMBOL=${FC_SYMBOL}
-              -DOpenMP_LIBRARY_DIRS=${OpenMP_LIBRARY_DIRS}
               -DOpenMP_C_FLAGS=${OpenMP_C_FLAGS}
               -DOpenMP_CXX_FLAGS=${OpenMP_CXX_FLAGS}
               -DOpenMP_omp_LIBRARY=${OpenMP_omp_LIBRARY}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,5 +14,4 @@ trigger:
   - 1.0.x
 
 jobs:
-  - template: ./.azure-pipelines/azure-pipelines-windows.yml
   - template: ./.azure-pipelines/azure-pipelines-linux.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,4 +14,5 @@ trigger:
   - 1.0.x
 
 jobs:
+  - template: ./.azure-pipelines/azure-pipelines-windows.yml
   - template: ./.azure-pipelines/azure-pipelines-linux.yml

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -950,18 +950,18 @@ data:
       name: OpenFermion-Psi4
       commit: v0.5
     cmake: null
-    conda:
-      channel: conda-forge
-      name: openfermionpsi4
-      constraint: null
-      skip_win: true
-      # TODO cirq-core still np v1. commenting so envs don't solve v1 for niche addon
+    # TODO cirq-core still np v1. commenting so envs don't solve v1 for niche addon
+    conda: null
+      # channel: conda-forge
+      # name: openfermionpsi4
+      # constraint: null
+      # skip_win: true
       # aux_run_names:
       #   - "openfermion>=1.7.1"
       # aux_run_names_note:
       #   "openfermion>1.7.1": "v1.7.1 compatible with numpy v2."
-      cmake: null
-      cmake_note: "Primarily OTF runtime detected."
+      # cmake: null
+      # cmake_note: "Primarily OTF runtime detected."
 
   - project: qcelemental
     use:

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -99,6 +99,7 @@ data:
           - "//dpcpp_linux-64"
         win-64:
           - "libgcc<14.3"
+          - "clangdev=17.0.6"
       aux_build_names_note:
         "libgcc<14.3": "Avoid 'specified procedure could not be found' DLL error."
       cmake:

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -95,7 +95,12 @@ data:
       name: cxx-compiler
       constraint: null
       aux_build_names:
-        - //dpcpp_linux-64
+        linux-64:
+          - "//dpcpp_linux-64"
+        win-64:
+          - "libgcc<14.3"
+      aux_build_names_note:
+        "libgcc<14.3": "Avoid 'specified procedure could not be found' DLL error."
       cmake:
         # {CMAKE_CXX_COMPILER_ID}_{Conda_platform}
         GNU_linux-64:
@@ -943,18 +948,19 @@ data:
       name: OpenFermion-Psi4
       commit: v0.5
     cmake: null
-    conda:
-      channel: conda-forge
-      name: openfermionpsi4
-      constraint: null
-      skip_win: true
-      aux_run_names:
-        - openfermion #=1
-#        - pydantic=1
-      aux_run_names_note:
-        "openfermion=1": "Shouldn't need to specify but do for the pydantic transition."
-      cmake: null
-      cmake_note: "Primarily OTF runtime detected."
+    conda: null
+      # temporary until np v2 compatible v1.7.1
+      #channel: conda-forge
+      #name: openfermionpsi4
+      #constraint: null
+      #skip_win: true
+      #aux_run_names:
+      #  - openfermion #=1
+#     #   - pydantic=1
+      #aux_run_names_note:
+      #  "openfermion=1": "Shouldn't need to specify but do for the pydantic transition."
+      #cmake: null
+      #cmake_note: "Primarily OTF runtime detected."
 
   - project: qcelemental
     use:

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -102,6 +102,7 @@ data:
           - "clangdev=17.0.6"
       aux_build_names_note:
         "libgcc<14.3": "Avoid 'specified procedure could not be found' DLL error."
+        "clangdev=17.0.6": "Avoid omp problem with v19, v20."
       cmake:
         # {CMAKE_CXX_COMPILER_ID}_{Conda_platform}
         GNU_linux-64:
@@ -949,19 +950,18 @@ data:
       name: OpenFermion-Psi4
       commit: v0.5
     cmake: null
-    conda: null
-      # temporary until np v2 compatible v1.7.1
-      #channel: conda-forge
-      #name: openfermionpsi4
-      #constraint: null
-      #skip_win: true
-      #aux_run_names:
-      #  - openfermion #=1
-#     #   - pydantic=1
-      #aux_run_names_note:
-      #  "openfermion=1": "Shouldn't need to specify but do for the pydantic transition."
-      #cmake: null
-      #cmake_note: "Primarily OTF runtime detected."
+    conda:
+      channel: conda-forge
+      name: openfermionpsi4
+      constraint: null
+      skip_win: true
+      # TODO cirq-core still np v1. commenting so envs don't solve v1 for niche addon
+      # aux_run_names:
+      #   - "openfermion>=1.7.1"
+      # aux_run_names_note:
+      #   "openfermion>1.7.1": "v1.7.1 compatible with numpy v2."
+      cmake: null
+      cmake_note: "Primarily OTF runtime detected."
 
   - project: qcelemental
     use:

--- a/conda/psi4-path-advisor.py
+++ b/conda/psi4-path-advisor.py
@@ -838,6 +838,10 @@ elif args.subparser_name in ["cmake", "cache"]:
             primary = conda["name"]
         aux_run = conda.get("aux_run_names", [])
         aux_bld = conda.get("aux_build_names", [])
+        if isinstance(aux_run, dict):
+            aux_run = aux_run .get(conda_platform, [])
+        if isinstance(aux_bld, dict):
+            aux_bld = aux_bld.get(conda_platform, [])
 
         constraint_delimiter = "=|!|<|>"
         package_set = [primary, *aux_bld, *aux_run]

--- a/conda/psi4-path-advisor.py
+++ b/conda/psi4-path-advisor.py
@@ -645,6 +645,10 @@ if args.subparser_name in ["conda", "env"]:
         # start collecting
         aux_run = conda.get("aux_run_names", [])
         aux_bld = conda.get("aux_build_names", [])
+        if isinstance(aux_run, dict):
+            aux_run = aux_run .get(conda_platform, [])
+        if isinstance(aux_bld, dict):
+            aux_bld = aux_bld.get(conda_platform, [])
 
         if isinstance(conda["name"], dict):
             primary = conda["name"][conda_platform]

--- a/conda/psi4-path-advisor.py
+++ b/conda/psi4-path-advisor.py
@@ -1075,30 +1075,52 @@ elif args.subparser_name in ["deploy"]:
     if not pm_available:
         raise RuntimeError("usage: this script requires either the conda or mamba command to be in envvar PATH.")
 
+    # sugg from docs CONDA_OVERRIDE_LINUX=1 and CONDA_OVERRIDE_GLIBC=2.17
+
     full_cmake_S = codedeps_yaml.parent
+    full_conda_envs = f"{full_cmake_S}/devtools/conda-envs/"
     script = f"""#!/usr/bin/env bash
 
 PNAME=p4dev8  # some env that doesn't exist
 
+# Core
 {full_cmake_S}/conda/psi4-path-advisor.py env --platform linux-64 --lapack mkl --disable addons docs
 CONDA_SUBDIR=linux-64 conda env create -n $PNAME -f env_p4dev.yaml --dry-run
-mv env_p4dev.yaml {full_cmake_S}/devtools/conda-envs/linux-64-buildrun.yaml
+mv env_p4dev.yaml {full_conda_envs}/linux-64-buildrun.yaml
 
 {full_cmake_S}/conda/psi4-path-advisor.py env --platform osx-64 --lapack mkl --disable addons docs
 CONDA_SUBDIR=osx-64 conda env create -n $PNAME -f env_p4dev.yaml --dry-run
-mv env_p4dev.yaml {full_cmake_S}/devtools/conda-envs/osx-64-buildrun.yaml
+mv env_p4dev.yaml {full_conda_envs}/osx-64-buildrun.yaml
 
 {full_cmake_S}/conda/psi4-path-advisor.py env --platform osx-arm64 --lapack accelerate --disable addons docs
 CONDA_SUBDIR=osx-arm64 conda env create -n $PNAME -f env_p4dev.yaml --dry-run
-mv env_p4dev.yaml {full_cmake_S}/devtools/conda-envs/osx-arm64-buildrun.yaml
+mv env_p4dev.yaml {full_conda_envs}/osx-arm64-buildrun.yaml
 
 {full_cmake_S}/conda/psi4-path-advisor.py env --platform win-64 --lapack mkl --disable addons docs
 CONDA_SUBDIR=win-64 conda env create -n $PNAME -f env_p4dev.yaml --dry-run
-mv env_p4dev.yaml {full_cmake_S}/devtools/conda-envs/win-64-buildrun.yaml
+mv env_p4dev.yaml {full_conda_envs}/win-64-buildrun.yaml
 
+# Docs
 {full_cmake_S}/conda/psi4-path-advisor.py env --name p4docs --platform linux-64 --disable addons
 CONDA_SUBDIR=linux-64 conda env create -n $PNAME -f env_p4docs.yaml --dry-run
-mv env_p4docs.yaml {full_cmake_S}/devtools/conda-envs/linux-64-docs.yaml
+mv env_p4docs.yaml {full_conda_envs}/linux-64-docs.yaml
+
+# Eco
+{full_cmake_S}/conda/psi4-path-advisor.py env --platform linux-64 --lapack mkl --disable docs
+CONDA_SUBDIR=linux-64 conda env create -n $PNAME -f env_p4dev.yaml --dry-run
+mv env_p4dev.yaml {full_conda_envs}/linux-64-buildrun-addons.yaml
+
+{full_cmake_S}/conda/psi4-path-advisor.py env --platform osx-64 --lapack mkl --disable docs
+CONDA_OVERRIDE_OSX=13 CONDA_SUBDIR=osx-64 conda env create -n $PNAME -f env_p4dev.yaml --dry-run
+mv env_p4dev.yaml {full_conda_envs}/osx-64-buildrun-addons.yaml
+
+{full_cmake_S}/conda/psi4-path-advisor.py env --platform osx-arm64 --lapack accelerate --disable docs
+CONDA_OVERRIDE_OSX=13 CONDA_SUBDIR=osx-arm64 conda env create -n $PNAME -f env_p4dev.yaml --dry-run
+mv env_p4dev.yaml {full_conda_envs}/osx-arm64-buildrun-addons.yaml
+
+{full_cmake_S}/conda/psi4-path-advisor.py env --platform win-64 --lapack mkl --disable docs
+CONDA_SUBDIR=win-64 conda env create -n $PNAME -f env_p4dev.yaml --dry-run
+mv env_p4dev.yaml {full_conda_envs}/win-64-buildrun-addons.yaml
 
 """
 

--- a/devtools/conda-envs/linux-64-buildrun-addons.yaml
+++ b/devtools/conda-envs/linux-64-buildrun-addons.yaml
@@ -5,17 +5,16 @@ channels:
 dependencies:
     # build
   - c-compiler
-  - clangdev=17.0.6           # req'd with cxx-compiler; Avoid omp problem with v19, v20.
   - cmake
   - cxx-compiler
-  - libgcc<14.3               # req'd with cxx-compiler; Avoid 'specified procedure could not be found' DLL error.
+  #- dpcpp_linux-64            # opt'l with cxx-compiler
   - ninja
     # non-qc buildtime required
   - blas-devel                # req'd with libblas
   - eigen                     # req'd with libint
-  - intel-openmp
   - libblas=*=*mkl
   - libboost-headers          # req'd with libint
+  - llvm-openmp
   - numpy
   - pip                       # req'd with python; Package installer not strictly needed but needs to be tied to this python if used.
   - pybind11
@@ -28,11 +27,42 @@ dependencies:
   - optking
   - qcelemental
   - qcengine
+    # buildtime optional
+  - ambit
+  - dkh
+  - einsums>=1.0.3
+  - fortran-compiler
+  - hdf5                      # req'd with einsums; Use 1.14.3 or 1.14.6 (so far) as .4 and .5 not setting HDF5_VERSION.
+  - integratorxx
+  - libecpint
+  - pcmsolver
+  - range-v3                  # req'd with einsums
+  - zlib                      # req'd with einsums
+  - zlib                      # req'd with einsums
     # runtime required
   - msgpack-python            # req'd with qcelemental
   - networkx                  # req'd with qcelemental
   - scipy
   - setuptools                # req'd with qcelemental; Needed for qcelemental cmake detection.
+    # runtime optional
+  - adcc
+  - basis_set_exchange
+  - cppe
+  - dftd3-python>=1.0
+  - dftd4-python
+  - gcp-correction
+  - geometric
+  - i-pi==3.1.0
+  - openfermionpsi4
+  - postgresql                # req'd with qcfractal; Easy way to use QCFractal, but you can instead supply your own database.
+  - pyddx
+  - pygdma
+  - pylibefp
+  - pymdi
+  - qcfractal>=0.60
+  - toml                      # req'd with dftd4-python
     # test
+  - h5py
+  - memory_profiler
   - pytest
   - pytest-xdist              # req'd with pytest; Parallel runner not strictly needed but very handy.

--- a/devtools/conda-envs/linux-64-buildrun-addons.yaml
+++ b/devtools/conda-envs/linux-64-buildrun-addons.yaml
@@ -30,7 +30,7 @@ dependencies:
     # buildtime optional
   - ambit
   - dkh
-  - einsums>=1.0.3
+  - einsums>=1.0.6
   - fortran-compiler
   - hdf5                      # req'd with einsums; Use 1.14.3 or 1.14.6 (so far) as .4 and .5 not setting HDF5_VERSION.
   - integratorxx
@@ -58,7 +58,7 @@ dependencies:
   - pygdma
   - pylibefp
   - pymdi
-  - qcfractal>=0.60
+  - qcfractal>=0.60,!=0.62
   - toml                      # req'd with dftd4-python
     # test
   - h5py

--- a/devtools/conda-envs/linux-64-buildrun-addons.yaml
+++ b/devtools/conda-envs/linux-64-buildrun-addons.yaml
@@ -53,7 +53,6 @@ dependencies:
   - gcp-correction
   - geometric
   - i-pi==3.1.0
-  - openfermionpsi4
   - postgresql                # req'd with qcfractal; Easy way to use QCFractal, but you can instead supply your own database.
   - pyddx
   - pygdma

--- a/devtools/conda-envs/linux-64-docs.yaml
+++ b/devtools/conda-envs/linux-64-docs.yaml
@@ -1,21 +1,20 @@
-name: p4dev
+name: p4docs
 channels:
   - conda-forge
   - nodefaults
 dependencies:
     # build
   - c-compiler
-  - clangdev=17.0.6           # req'd with cxx-compiler; Avoid omp problem with v19, v20.
   - cmake
   - cxx-compiler
-  - libgcc<14.3               # req'd with cxx-compiler; Avoid 'specified procedure could not be found' DLL error.
+  #- dpcpp_linux-64            # opt'l with cxx-compiler
   - ninja
     # non-qc buildtime required
   - blas-devel                # req'd with libblas
   - eigen                     # req'd with libint
-  - intel-openmp
   - libblas=*=*mkl
   - libboost-headers          # req'd with libint
+  - llvm-openmp
   - numpy
   - pip                       # req'd with python; Package installer not strictly needed but needs to be tied to this python if used.
   - pybind11
@@ -34,5 +33,19 @@ dependencies:
   - scipy
   - setuptools                # req'd with qcelemental; Needed for qcelemental cmake detection.
     # test
+  - h5py
+  - memory_profiler
   - pytest
   - pytest-xdist              # req'd with pytest; Parallel runner not strictly needed but very handy.
+    # docs
+  - autodoc-pydantic=1        # req'd with sphinx
+  - doxygen
+  - ipykernel                 # req'd with nbsphinx
+  - nbsphinx
+  - python-graphviz
+  - qcportal                  # req'd with sphinx; Required for docs to resolve objects in pydantic classes.
+  - sphinx<8
+  - sphinx-autodoc-typehints  # req'd with sphinx
+  - sphinx-automodapi         # req'd with sphinx
+  - psi4::sphinx-psi-theme
+  - sphinx-tabs               # req'd with sphinx

--- a/devtools/conda-envs/osx-64-buildrun-addons.yaml
+++ b/devtools/conda-envs/osx-64-buildrun-addons.yaml
@@ -5,17 +5,15 @@ channels:
 dependencies:
     # build
   - c-compiler
-  - clangdev=17.0.6           # req'd with cxx-compiler; Avoid omp problem with v19, v20.
   - cmake
   - cxx-compiler
-  - libgcc<14.3               # req'd with cxx-compiler; Avoid 'specified procedure could not be found' DLL error.
   - ninja
     # non-qc buildtime required
   - blas-devel                # req'd with libblas
   - eigen                     # req'd with libint
-  - intel-openmp
   - libblas=*=*mkl
   - libboost-headers          # req'd with libint
+  - llvm-openmp
   - numpy
   - pip                       # req'd with python; Package installer not strictly needed but needs to be tied to this python if used.
   - pybind11
@@ -28,11 +26,42 @@ dependencies:
   - optking
   - qcelemental
   - qcengine
+    # buildtime optional
+  - ambit
+  - dkh
+  - einsums>=1.0.3
+  - fortran-compiler
+  - hdf5                      # req'd with einsums; Use 1.14.3 or 1.14.6 (so far) as .4 and .5 not setting HDF5_VERSION.
+  - integratorxx
+  - libecpint
+  - pcmsolver
+  - range-v3                  # req'd with einsums
+  - zlib                      # req'd with einsums
+  - zlib                      # req'd with einsums
     # runtime required
   - msgpack-python            # req'd with qcelemental
   - networkx                  # req'd with qcelemental
   - scipy
   - setuptools                # req'd with qcelemental; Needed for qcelemental cmake detection.
+    # runtime optional
+  - adcc
+  - basis_set_exchange
+  - cppe
+  - dftd3-python>=1.0
+  - dftd4-python
+  - gcp-correction
+  - geometric
+  - i-pi==3.1.0
+  - openfermionpsi4
+  - postgresql                # req'd with qcfractal; Easy way to use QCFractal, but you can instead supply your own database.
+  - pyddx
+  - pygdma
+  - pylibefp
+  - pymdi
+  - qcfractal>=0.60
+  - toml                      # req'd with dftd4-python
     # test
+  - h5py
+  - memory_profiler
   - pytest
   - pytest-xdist              # req'd with pytest; Parallel runner not strictly needed but very handy.

--- a/devtools/conda-envs/osx-64-buildrun-addons.yaml
+++ b/devtools/conda-envs/osx-64-buildrun-addons.yaml
@@ -52,7 +52,6 @@ dependencies:
   - gcp-correction
   - geometric
   - i-pi==3.1.0
-  - openfermionpsi4
   - postgresql                # req'd with qcfractal; Easy way to use QCFractal, but you can instead supply your own database.
   - pyddx
   - pygdma

--- a/devtools/conda-envs/osx-64-buildrun-addons.yaml
+++ b/devtools/conda-envs/osx-64-buildrun-addons.yaml
@@ -29,7 +29,7 @@ dependencies:
     # buildtime optional
   - ambit
   - dkh
-  - einsums>=1.0.3
+  - einsums>=1.0.6
   - fortran-compiler
   - hdf5                      # req'd with einsums; Use 1.14.3 or 1.14.6 (so far) as .4 and .5 not setting HDF5_VERSION.
   - integratorxx
@@ -57,7 +57,7 @@ dependencies:
   - pygdma
   - pylibefp
   - pymdi
-  - qcfractal>=0.60
+  - qcfractal>=0.60,!=0.62
   - toml                      # req'd with dftd4-python
     # test
   - h5py

--- a/devtools/conda-envs/osx-64-buildrun.yaml
+++ b/devtools/conda-envs/osx-64-buildrun.yaml
@@ -7,7 +7,6 @@ dependencies:
   - c-compiler
   - cmake
   - cxx-compiler
-  #- dpcpp_linux-64            # opt'l with cxx-compiler
   - ninja
     # non-qc buildtime required
   - blas-devel                # req'd with libblas

--- a/devtools/conda-envs/osx-arm64-buildrun-addons.yaml
+++ b/devtools/conda-envs/osx-arm64-buildrun-addons.yaml
@@ -5,17 +5,15 @@ channels:
 dependencies:
     # build
   - c-compiler
-  - clangdev=17.0.6           # req'd with cxx-compiler; Avoid omp problem with v19, v20.
   - cmake
   - cxx-compiler
-  - libgcc<14.3               # req'd with cxx-compiler; Avoid 'specified procedure could not be found' DLL error.
   - ninja
     # non-qc buildtime required
   - blas-devel                # req'd with libblas
   - eigen                     # req'd with libint
-  - intel-openmp
-  - libblas=*=*mkl
+  - libblas=*=*accelerate
   - libboost-headers          # req'd with libint
+  - llvm-openmp
   - numpy
   - pip                       # req'd with python; Package installer not strictly needed but needs to be tied to this python if used.
   - pybind11
@@ -28,11 +26,42 @@ dependencies:
   - optking
   - qcelemental
   - qcengine
+    # buildtime optional
+  - ambit
+  - dkh
+  - einsums>=1.0.3
+  - fortran-compiler
+  - hdf5                      # req'd with einsums; Use 1.14.3 or 1.14.6 (so far) as .4 and .5 not setting HDF5_VERSION.
+  - integratorxx
+  - libecpint
+  - pcmsolver
+  - range-v3                  # req'd with einsums
+  - zlib                      # req'd with einsums
+  - zlib                      # req'd with einsums
     # runtime required
   - msgpack-python            # req'd with qcelemental
   - networkx                  # req'd with qcelemental
   - scipy
   - setuptools                # req'd with qcelemental; Needed for qcelemental cmake detection.
+    # runtime optional
+  - adcc
+  - basis_set_exchange
+  - cppe
+  - dftd3-python>=1.0
+  - dftd4-python
+  - gcp-correction
+  - geometric
+  - i-pi==3.1.0
+  - openfermionpsi4
+  - postgresql                # req'd with qcfractal; Easy way to use QCFractal, but you can instead supply your own database.
+  - pyddx
+  - pygdma
+  - pylibefp
+  - pymdi
+  - qcfractal>=0.60
+  - toml                      # req'd with dftd4-python
     # test
+  - h5py
+  - memory_profiler
   - pytest
   - pytest-xdist              # req'd with pytest; Parallel runner not strictly needed but very handy.

--- a/devtools/conda-envs/osx-arm64-buildrun-addons.yaml
+++ b/devtools/conda-envs/osx-arm64-buildrun-addons.yaml
@@ -52,7 +52,6 @@ dependencies:
   - gcp-correction
   - geometric
   - i-pi==3.1.0
-  - openfermionpsi4
   - postgresql                # req'd with qcfractal; Easy way to use QCFractal, but you can instead supply your own database.
   - pyddx
   - pygdma

--- a/devtools/conda-envs/osx-arm64-buildrun-addons.yaml
+++ b/devtools/conda-envs/osx-arm64-buildrun-addons.yaml
@@ -29,7 +29,7 @@ dependencies:
     # buildtime optional
   - ambit
   - dkh
-  - einsums>=1.0.3
+  - einsums>=1.0.6
   - fortran-compiler
   - hdf5                      # req'd with einsums; Use 1.14.3 or 1.14.6 (so far) as .4 and .5 not setting HDF5_VERSION.
   - integratorxx
@@ -57,7 +57,7 @@ dependencies:
   - pygdma
   - pylibefp
   - pymdi
-  - qcfractal>=0.60
+  - qcfractal>=0.60,!=0.62
   - toml                      # req'd with dftd4-python
     # test
   - h5py

--- a/devtools/conda-envs/osx-arm64-buildrun.yaml
+++ b/devtools/conda-envs/osx-arm64-buildrun.yaml
@@ -7,7 +7,6 @@ dependencies:
   - c-compiler
   - cmake
   - cxx-compiler
-  #- dpcpp_linux-64            # opt'l with cxx-compiler
   - ninja
     # non-qc buildtime required
   - blas-devel                # req'd with libblas

--- a/devtools/conda-envs/win-64-buildrun-addons.yaml
+++ b/devtools/conda-envs/win-64-buildrun-addons.yaml
@@ -28,11 +28,28 @@ dependencies:
   - optking
   - qcelemental
   - qcengine
+    # buildtime optional
+  - dkh
+  - integratorxx
+  - libecpint
+  - pcmsolver
+  - zlib                      # req'd with pcmsolver
     # runtime required
   - msgpack-python            # req'd with qcelemental
   - networkx                  # req'd with qcelemental
   - scipy
   - setuptools                # req'd with qcelemental; Needed for qcelemental cmake detection.
+    # runtime optional
+  - basis_set_exchange
+  - dftd3-python>=1.0
+  - dftd4-python
+  - gcp-correction
+  - geometric
+  - i-pi==3.1.0
+  - pygdma
+  - pylibefp
+  - pymdi
+  - toml                      # req'd with dftd4-python
     # test
   - pytest
   - pytest-xdist              # req'd with pytest; Parallel runner not strictly needed but very handy.

--- a/devtools/conda-envs/win-64-buildrun.yaml
+++ b/devtools/conda-envs/win-64-buildrun.yaml
@@ -7,7 +7,7 @@ dependencies:
   - c-compiler
   - cmake
   - cxx-compiler
-  #- dpcpp_linux-64            # opt'l with cxx-compiler
+  - libgcc<14.3               # req'd with cxx-compiler; Avoid 'specified procedure could not be found' DLL error.
   - ninja
     # non-qc buildtime required
   - blas-devel                # req'd with libblas

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -79,6 +79,7 @@ if(${ENABLE_gauxc})
                    -DOpenMP_CXX_FLAGS:STRING=${OpenMP_CXX_FLAGS}
                    -DOpenMP_omp_LIBRARY=${OpenMP_omp_LIBRARY}
                    -DOpenMP_gomp_LIBRARY=${OpenMP_gomp_LIBRARY}
+                   -DOpenMP_pthread_LIBRARY=${OpenMP_pthread_LIBRARY}
                    -DGAUXC_ENABLE_MPI=OFF
                    -DGAUXC_ENABLE_TESTS=OFF
                    -DGAUXC_ENABLE_HDF5=OFF

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -76,6 +76,8 @@ if(${ENABLE_gauxc})
                    -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_FPIC}
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                    -DOpenMP_ROOT=${OpenMP_ROOT}
+                   -DOpenMP_C_FLAGS:STRING=${OpenMP_C_FLAGS}
+                   -DOpenMP_CXX_FLAGS:STRING=${OpenMP_CXX_FLAGS}
                    -DOpenMP_omp_LIBRARY=${OpenMP_omp_LIBRARY}
                    -DGAUXC_ENABLE_MPI=OFF
                    -DGAUXC_ENABLE_TESTS=OFF
@@ -86,10 +88,8 @@ if(${ENABLE_gauxc})
                          -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
                          -DCMAKE_C_COMPILER_ARG1:STRING=${CMAKE_C_COMPILER_ARG1}
                          -DCMAKE_CXX_COMPILER_ARG1:STRING=${CMAKE_CXX_COMPILER_ARG1}
-                         -DOpenMP_C_FLAGS:STRING=-fopenmp=libomp
-                         -DOpenMP_CXX_FLAGS:STRING=-fopenmp=libomp
-                         -DOpenMP_C_LIB_NAMES:STRING=omp
-                         -DOpenMP_CXX_LIB_NAMES:STRING=omp
+                         -DOpenMP_C_LIB_NAMES:STRING=${OpenMP_C_LIB_NAMES}
+                         -DOpenMP_CXX_LIB_NAMES:STRING=${OpenMP_CXX_LIB_NAMES}
                          -DOpenMP_LIBRARY_DIRS:STRING=${OpenMP_LIBRARY_DIRS}
                          -DBLAS_LIBRARIES:STRING=${BLAS_LIBRARIES})
         set(gauxc_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/gauxc CACHE PATH "path to internally built gauxcConfig.cmake" FORCE)

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -86,10 +86,10 @@ if(${ENABLE_gauxc})
                          -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
                          -DCMAKE_C_COMPILER_ARG1:STRING=${CMAKE_C_COMPILER_ARG1}
                          -DCMAKE_CXX_COMPILER_ARG1:STRING=${CMAKE_CXX_COMPILER_ARG1}
-                         -DOpenMP_CXX_FLAGS:STRING=-fopenmp=libomp
-                         -DOpenMP_CXX_LIB_NAMES:STRING=omp
                          -DOpenMP_C_FLAGS:STRING=-fopenmp=libomp
+                         -DOpenMP_CXX_FLAGS:STRING=-fopenmp=libomp
                          -DOpenMP_C_LIB_NAMES:STRING=omp
+                         -DOpenMP_CXX_LIB_NAMES:STRING=omp
                          -DOpenMP_LIBRARY_DIRS:STRING=${OpenMP_LIBRARY_DIRS}
                          -DBLAS_LIBRARIES:STRING=${BLAS_LIBRARIES})
         set(gauxc_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/gauxc CACHE PATH "path to internally built gauxcConfig.cmake" FORCE)

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -75,6 +75,7 @@ if(${ENABLE_gauxc})
                    -Dgau2grid_DIR=${gau2grid_DIR}
                    -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_FPIC}
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                   -DOpenMP_LIBRARY_DIRS=${OpenMP_LIBRARY_DIRS}
                    -DGAUXC_ENABLE_MPI=OFF
                    -DGAUXC_ENABLE_TESTS=OFF
                    -DGAUXC_ENABLE_HDF5=OFF

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -87,6 +87,7 @@ if(${ENABLE_gauxc})
                          -DCMAKE_CXX_COMPILER_ARG1:STRING=${CMAKE_CXX_COMPILER_ARG1}
                          -DOpenMP_CXX_FLAGS:STRING=-fopenmp=libomp
                          -DOpenMP_C_FLAGS:STRING=-fopenmp=libomp
+                         -DOpenMP_LIBRARY_DIRS:STRING=${OpenMP_LIBRARY_DIRS}
                          -DBLAS_LIBRARIES:STRING=${BLAS_LIBRARIES})
         set(gauxc_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/gauxc CACHE PATH "path to internally built gauxcConfig.cmake" FORCE)
     endif()

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -75,7 +75,6 @@ if(${ENABLE_gauxc})
                    -Dgau2grid_DIR=${gau2grid_DIR}
                    -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_FPIC}
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-                   -DOpenMP_ROOT=${OpenMP_ROOT}
                    -DOpenMP_C_FLAGS:STRING=${OpenMP_C_FLAGS}
                    -DOpenMP_CXX_FLAGS:STRING=${OpenMP_CXX_FLAGS}
                    -DOpenMP_omp_LIBRARY=${OpenMP_omp_LIBRARY}
@@ -90,7 +89,6 @@ if(${ENABLE_gauxc})
                          -DCMAKE_CXX_COMPILER_ARG1:STRING=${CMAKE_CXX_COMPILER_ARG1}
                          -DOpenMP_C_LIB_NAMES:STRING=${OpenMP_C_LIB_NAMES}
                          -DOpenMP_CXX_LIB_NAMES:STRING=${OpenMP_CXX_LIB_NAMES}
-                         -DOpenMP_LIBRARY_DIRS:STRING=${OpenMP_LIBRARY_DIRS}
                          -DBLAS_LIBRARIES:STRING=${BLAS_LIBRARIES})
         set(gauxc_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/gauxc CACHE PATH "path to internally built gauxcConfig.cmake" FORCE)
     endif()

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -87,6 +87,7 @@ if(${ENABLE_gauxc})
                          -DCMAKE_C_COMPILER_ARG1:STRING=${CMAKE_C_COMPILER_ARG1}
                          -DCMAKE_CXX_COMPILER_ARG1:STRING=${CMAKE_CXX_COMPILER_ARG1}
                          -DOpenMP_CXX_FLAGS:STRING=-fopenmp=libomp
+                         -DOpenMP_CXX_LIB_NAMES:STRING=omp
                          -DOpenMP_C_FLAGS:STRING=-fopenmp=libomp
                          -DOpenMP_C_LIB_NAMES:STRING=omp
                          -DOpenMP_LIBRARY_DIRS:STRING=${OpenMP_LIBRARY_DIRS}

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -75,7 +75,7 @@ if(${ENABLE_gauxc})
                    -Dgau2grid_DIR=${gau2grid_DIR}
                    -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_FPIC}
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-                   -DOpenMP_LIBRARY_DIRS=${OpenMP_LIBRARY_DIRS}
+                   -DOpenMP_ROOT=${OpenMP_ROOT}
                    -DGAUXC_ENABLE_MPI=OFF
                    -DGAUXC_ENABLE_TESTS=OFF
                    -DGAUXC_ENABLE_HDF5=OFF

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -77,10 +77,6 @@ if(${ENABLE_gauxc})
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                    -DOpenMP_ROOT=${OpenMP_ROOT}
                    -DOpenMP_C_INCLUDE_DIR=${OpenMP_C_INCLUDE_DIR}
-                   -DOpenMP_CXX_FLAGS="-fopenmp=libomp"
-                   -DOpenMP_CXX_LIB_NAMES="omp;pthread"
-                   -DOpenMP_C_FLAGS="-fopenmp=libomp"
-                   -DOpenMP_C_LIB_NAMES="omp;pthread"
                    -DGAUXC_ENABLE_MPI=OFF
                    -DGAUXC_ENABLE_TESTS=OFF
                    -DGAUXC_ENABLE_HDF5=OFF
@@ -90,6 +86,10 @@ if(${ENABLE_gauxc})
                          -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
                          -DCMAKE_C_COMPILER_ARG1:STRING=${CMAKE_C_COMPILER_ARG1}
                          -DCMAKE_CXX_COMPILER_ARG1:STRING=${CMAKE_CXX_COMPILER_ARG1}
+                         -DOpenMP_CXX_FLAGS:STRING=-fopenmp=libomp
+                         -DOpenMP_CXX_LIB_NAMES:STRING=omp;pthread
+                         -DOpenMP_C_FLAGS:STRING=-fopenmp=libomp
+                         -DOpenMP_C_LIB_NAMES:STRING=omp;pthread
                          -DBLAS_LIBRARIES:STRING=${BLAS_LIBRARIES})
         set(gauxc_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/gauxc CACHE PATH "path to internally built gauxcConfig.cmake" FORCE)
     endif()

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -76,7 +76,6 @@ if(${ENABLE_gauxc})
                    -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_FPIC}
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                    -DOpenMP_ROOT=${OpenMP_ROOT}
-                   -DOpenMP_C_INCLUDE_DIR=${OpenMP_C_INCLUDE_DIR}
                    -DGAUXC_ENABLE_MPI=OFF
                    -DGAUXC_ENABLE_TESTS=OFF
                    -DGAUXC_ENABLE_HDF5=OFF
@@ -87,9 +86,7 @@ if(${ENABLE_gauxc})
                          -DCMAKE_C_COMPILER_ARG1:STRING=${CMAKE_C_COMPILER_ARG1}
                          -DCMAKE_CXX_COMPILER_ARG1:STRING=${CMAKE_CXX_COMPILER_ARG1}
                          -DOpenMP_CXX_FLAGS:STRING=-fopenmp=libomp
-                         -DOpenMP_CXX_LIB_NAMES:STRING=omp;pthread
                          -DOpenMP_C_FLAGS:STRING=-fopenmp=libomp
-                         -DOpenMP_C_LIB_NAMES:STRING=omp;pthread
                          -DBLAS_LIBRARIES:STRING=${BLAS_LIBRARIES})
         set(gauxc_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/gauxc CACHE PATH "path to internally built gauxcConfig.cmake" FORCE)
     endif()

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -78,6 +78,7 @@ if(${ENABLE_gauxc})
                    -DOpenMP_C_FLAGS:STRING=${OpenMP_C_FLAGS}
                    -DOpenMP_CXX_FLAGS:STRING=${OpenMP_CXX_FLAGS}
                    -DOpenMP_omp_LIBRARY=${OpenMP_omp_LIBRARY}
+                   -DOpenMP_gomp_LIBRARY=${OpenMP_gomp_LIBRARY}
                    -DGAUXC_ENABLE_MPI=OFF
                    -DGAUXC_ENABLE_TESTS=OFF
                    -DGAUXC_ENABLE_HDF5=OFF

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -76,6 +76,7 @@ if(${ENABLE_gauxc})
                    -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_FPIC}
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                    -DOpenMP_ROOT=${OpenMP_ROOT}
+                   -DOpenMP_omp_LIBRARY=${OpenMP_omp_LIBRARY}
                    -DGAUXC_ENABLE_MPI=OFF
                    -DGAUXC_ENABLE_TESTS=OFF
                    -DGAUXC_ENABLE_HDF5=OFF
@@ -87,6 +88,7 @@ if(${ENABLE_gauxc})
                          -DCMAKE_CXX_COMPILER_ARG1:STRING=${CMAKE_CXX_COMPILER_ARG1}
                          -DOpenMP_CXX_FLAGS:STRING=-fopenmp=libomp
                          -DOpenMP_C_FLAGS:STRING=-fopenmp=libomp
+                         -DOpenMP_C_LIB_NAMES:STRING=omp
                          -DOpenMP_LIBRARY_DIRS:STRING=${OpenMP_LIBRARY_DIRS}
                          -DBLAS_LIBRARIES:STRING=${BLAS_LIBRARIES})
         set(gauxc_DIR ${STAGED_INSTALL_PREFIX}/share/cmake/gauxc CACHE PATH "path to internally built gauxcConfig.cmake" FORCE)

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -77,6 +77,10 @@ if(${ENABLE_gauxc})
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                    -DOpenMP_ROOT=${OpenMP_ROOT}
                    -DOpenMP_C_INCLUDE_DIR=${OpenMP_C_INCLUDE_DIR}
+                   -DOpenMP_CXX_FLAGS="-fopenmp=libomp"
+                   -DOpenMP_CXX_LIB_NAMES="omp;pthread"
+                   -DOpenMP_C_FLAGS="-fopenmp=libomp"
+                   -DOpenMP_C_LIB_NAMES="omp;pthread"
                    -DGAUXC_ENABLE_MPI=OFF
                    -DGAUXC_ENABLE_TESTS=OFF
                    -DGAUXC_ENABLE_HDF5=OFF

--- a/external/upstream/gauxc/CMakeLists.txt
+++ b/external/upstream/gauxc/CMakeLists.txt
@@ -76,6 +76,7 @@ if(${ENABLE_gauxc})
                    -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_FPIC}
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                    -DOpenMP_ROOT=${OpenMP_ROOT}
+                   -DOpenMP_C_INCLUDE_DIR=${OpenMP_C_INCLUDE_DIR}
                    -DGAUXC_ENABLE_MPI=OFF
                    -DGAUXC_ENABLE_TESTS=OFF
                    -DGAUXC_ENABLE_HDF5=OFF

--- a/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
@@ -157,11 +157,11 @@ def df_fdds_dispersion(primary, auxiliary, cache, is_hybrid, x_alpha, leg_points
             print("R_B RAW")
             print(R_B)
             print("R_A SANITIZED")
-            R_A[np.abs(R_A) < zero_tol] = 0
+            # R_A[np.abs(R_A) < zero_tol] = 0
             R_A = np.nan_to_num(R_A)
             print(R_A)
             print("R_B SANITIZED")
-            R_B[np.abs(R_B) < zero_tol] = 0
+            # R_B[np.abs(R_B) < zero_tol] = 0
             R_B = np.nan_to_num(R_B)
             print(R_B)
 

--- a/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
@@ -148,23 +148,16 @@ def df_fdds_dispersion(primary, auxiliary, cache, is_hybrid, x_alpha, leg_points
     # Read R
     if is_hybrid:
         R_A = fdds_obj.R_A().to_array()
-        zero_tol = 1e-20
-
         R_B = fdds_obj.R_B().to_array()
-        with np.printoptions(threshold=sys.maxsize):
-            print("R_A RAW")
-            print(R_A)
-            print("R_B RAW")
-            print(R_B)
-            print("R_A SANITIZED")
-            # R_A[np.abs(R_A) < zero_tol] = 0
-            R_A = np.nan_to_num(R_A)
-            print(R_A)
-            print("R_B SANITIZED")
-            # R_B[np.abs(R_B) < zero_tol] = 0
-            R_B = np.nan_to_num(R_B)
-            print(R_B)
-
+        # `pinv` below can throw `numpy.linalg.LinAlgError: "SVD did not converge"`, so sanitize arrays
+        # zero_tol = 1e-20
+        # R_A[np.abs(R_A) < zero_tol] = 0
+        # R_B[np.abs(R_B) < zero_tol] = 0
+        R_A = np.nan_to_num(R_A)
+        R_B = np.nan_to_num(R_B)
+        # with np.printoptions(threshold=sys.maxsize):
+        #     print("R_A SANITIZED", R_A)
+        #     print("R_B SANITIZED", R_B)
         Rtinv_A = np.linalg.pinv(R_A, rcond=1.e-13).transpose()
         Rtinv_B = np.linalg.pinv(R_B, rcond=1.e-13).transpose()
 

--- a/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
@@ -148,12 +148,23 @@ def df_fdds_dispersion(primary, auxiliary, cache, is_hybrid, x_alpha, leg_points
     # Read R
     if is_hybrid:
         R_A = fdds_obj.R_A().to_array()
+        zero_tol = 1e-20
+
         R_B = fdds_obj.R_B().to_array()
         with np.printoptions(threshold=sys.maxsize):
-            print("R_A")
+            print("R_A RAW")
             print(R_A)
-            print("R_B")
+            print("R_B RAW")
             print(R_B)
+            print("R_A SANITIZED")
+            R_A[np.abs(R_A) < zero_tol] = 0
+            R_A = np.nan_to_num(R_A)
+            print(R_A)
+            print("R_B SANITIZED")
+            R_B[np.abs(R_B) < zero_tol] = 0
+            R_B = np.nan_to_num(R_B)
+            print(R_B)
+
         Rtinv_A = np.linalg.pinv(R_A, rcond=1.e-13).transpose()
         Rtinv_B = np.linalg.pinv(R_B, rcond=1.e-13).transpose()
 

--- a/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
+++ b/psi4/driver/procrouting/sapt/sapt_mp2_terms.py
@@ -26,6 +26,7 @@
 # @END LICENSE
 #
 
+import sys
 import time
 
 import numpy as np
@@ -148,6 +149,11 @@ def df_fdds_dispersion(primary, auxiliary, cache, is_hybrid, x_alpha, leg_points
     if is_hybrid:
         R_A = fdds_obj.R_A().to_array()
         R_B = fdds_obj.R_B().to_array()
+        with np.printoptions(threshold=sys.maxsize):
+            print("R_A")
+            print(R_A)
+            print("R_B")
+            print(R_B)
         Rtinv_A = np.linalg.pinv(R_A, rcond=1.e-13).transpose()
         Rtinv_B = np.linalg.pinv(R_B, rcond=1.e-13).transpose()
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
~There's been a strange error message the past few weeks on Windows at runtime that's fixed by `libgcc<14.3`. Let's test the rebuild of g2g 2.0.8 and see if this might have fixed this issue, as g2g was the oldest dep on c-f.~


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] conda env spec yaml files including addons are now saved in the repo

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] new adcc version. averts pkg_resources/setuptools restriction
- [x] update reason openfermionpsi4 is blocked (it's fine but restricts the whole conda env to numpy v1)
- [x] now save full conda env with addons yaml files
- [x] convey some windows+conda peculiarities through codedeps rather than GHA sed's
Later
- [x] deployed v1.0.6 Einsums and new conda envs (probably in another PR too)
- [x] v2rdm stopped linking the with "no files found" for Intel Mac. no reason. I just disabled it since on its way out
- [x] the middle (3/4) Linux lane started reliably failing on two of the new GRAC tests with "SVD did not converge" even though it passed them fine three times last week. I added a nan_to_num call b/c there was at least one NaN and lots o e-308 . Austin didn't add that code, just triggered it in a new way. it should be investigated further
- [x] I got rid of the KMP stuff and added lots to detect and coney OpenMP. gauxc is using different (more modern) detection and needs help to see the conda files. If it sees the apt-get omp files, that's when multiple get linked in and triggers the runtime error

## Status
- [x] Ready for review
- [x] Ready for merge
