### PR TITLE
chore(cmake): Deprecate `BUILD_SHARED_LIBS` as a cache variable

### DIFF
--- a/cmake/psi4OptionsTools.cmake
+++ b/cmake/psi4OptionsTools.cmake
@@ -23,6 +23,36 @@ endfunction()
 #Syntax: option_with_print(<option name pointer> <default value>)
 #
 macro(psi4_deprecated_variable variable_var default)
+    # Handle `BUILD_SHARED_LIBS`. This should be replaced with `FOO_SHARED_LIBS`
+    # in order to be able to control how each component is a shared/static library
+    #
+    # FIXME: for backwards compatibility, the default value is OFF, but maybe it should
+    #  be changed with this introduction, or when the subproject fixes this deprecation message
+    if(${variable_var} STREQUAL "BUILD_SHARED_LIBS")
+        string(TOUPPER "${PROJECT_NAME}" project_name_upper)
+        string(CONCAT
+            "Defining BUILD_SHARED_LIBS as a cache variable is deprecated.\n"
+            "This variable is ignored, instead use ${project_name_upper}_SHARED_LIBS.\n"
+            "${project_name_upper}_SHARED_LIBS is defined by Psi4, please report to ${PROJECT_NAME} to define it instead."
+        )
+        message(WARNING "${msg}")
+
+        set(_msg_shared_libs "${PROJECT_NAME}: Build the project's libraries as shared libraries")
+
+        # Try to set a compatible default value for `FOO_SHARED_LIBS`
+        set(_default_shared_libs ${default})
+        # The `BUILD_SHARED_LIBS` might have been passed by the user, try to use that as
+        # default insted
+        if(DEFINED CACHE{BUILD_SHARED_LIBS})
+            set(_default_shared_libs $CACHE{BUILD_SHARED_LIBS})
+        endif()
+        option(${project_name_upper}_SHARED_LIBS "${_msg_shared_libs}" "${_default_shared_libs}")
+
+        # Set BUILD_SHARED_LIBS as a local variable thus scoped to the current project
+        # and return to avoid the rest of the logic
+        set(BUILD_SHARED_LIBS "${${project_name_upper}_SHARED_LIBS}" PARENT_SCOPE)
+        return()
+    endif()
 endmacro()
 
 # Wraps an option with default ON/OFF. Adds nice messaging to option()


### PR DESCRIPTION
## Description

In order to support the fine-grained control of how we want to build each components, we should deprecate the usage of `BUILD_SHARED_LIBS` as the cache variable used to control how the project `Foo`'s libraries are being built. I've tried to keep as much backwards compatibility as I could.

@loriab do you think you can propagate this PR to the similar projects that use the psi4 options syntax? Also maybe we should make it a cmake module with `include_guard` so that the version here would have priority in the upstream/downstream consumers.

I would add a commit to fix the value for the consumer in psi4 here, but maybe it should be its separate PR that fixes/prepares the other projects as well?