### PR TITLE
Bump yapf version to v0.43.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: check-case-conflict
       - id: check-merge-conflict
   - repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.27.0
+    rev: v0.43.0
     hooks:
       - id: yapf
   - repo: https://github.com/doublify/pre-commit-clang-format.git


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
YAPF is currently pinned to a rather old version in the pre-commit-config.
It would probably be good practice to try and bump it up to the latest tag.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- None

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Updated YAPF version pin in the pre-commit hook to v0.43.0 from v0.27.0

## Checklist
- [x] No new features
- [x] Not sure how to test a pre-commit hook, but CI seems to be fine? (Azure timed out)

## Status
- [x] Ready for review
- [x] Ready for merge
