### PR TITLE
Nit: do not use double underscores at the beginning of incude guard names

### DIFF
--- a/psi4/src/psi4/libplugin/plugin.h
+++ b/psi4/src/psi4/libplugin/plugin.h
@@ -26,8 +26,8 @@
  * @END LICENSE
  */
 
-#ifndef __psi4_src_lib_libplugin_plugin_h
-#define __psi4_src_lib_libplugin_plugin_h
+#ifndef PSI4_LIBPLUGIN_PLUGIN_H
+#define PSI4_LIBPLUGIN_PLUGIN_H
 
 #include "psi4/libmints/typedefs.h"
 #include "psi4/liboptions/liboptions.h"

--- a/psi4/src/psi4/libscf_solver/cuhf.h
+++ b/psi4/src/psi4/libscf_solver/cuhf.h
@@ -26,8 +26,8 @@
  * @END LICENSE
  */
 
-#ifndef __math_test_cuhf_h__
-#define __math_test_cuhf_h__
+#ifndef PSI4_LIBSCF_SOLVER_CUHF_H
+#define PSI4_LIBSCF_SOLVER_CUHF_H
 
 #include "hf.h"
 #include "psi4/libpsio/psio.hpp"

--- a/psi4/src/psi4/libscf_solver/rohf.h
+++ b/psi4/src/psi4/libscf_solver/rohf.h
@@ -26,8 +26,8 @@
  * @END LICENSE
  */
 
-#ifndef __rohf_psi_h__
-#define __rohf_psi_h__
+#ifndef PSI4_LIBSCF_SOLVER_ROHF_H
+#define PSI4_LIBSCF_SOLVER_ROHF_H
 
 #include <vector>
 #include "psi4/libpsio/psio.hpp"

--- a/psi4/src/psi4/libscf_solver/uhf.h
+++ b/psi4/src/psi4/libscf_solver/uhf.h
@@ -26,8 +26,8 @@
  * @END LICENSE
  */
 
-#ifndef __math_test_uhf_h__
-#define __math_test_uhf_h__
+#ifndef PSI4_LIBSCF_SOLVER_UHF_H
+#define PSI4_LIBSCF_SOLVER_UHF_H
 
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libfock/v.h"


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Symbols beginning with 2 underscores are reserved for the C++ implementation.
While this is unlikely to cause any issues, they should not be used as include guards.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Plugin API: plugin.h now defines `PSI4_LIBPLUGIN_PLUGIN_H` as its include guard, instead of `__psi4_src_lib_libplugin_plugin_h`

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Change all include guards that start with double underscores

## Checklist
- [x] No new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [X] Ready for review
- [x] Ready for merge
