### PR TITLE
Try bumping macos-x86 version to 15 in CI

### DIFF
--- a/tests/scf-cholesky-basis/CMakeLists.txt
+++ b/tests/scf-cholesky-basis/CMakeLists.txt
@@ -1,9 +1,3 @@
 include(TestingMacros)
 
 add_regression_test(scf-cholesky-basis "psi;quicktests;scf;noc1")
-
-# MKL_CBWR=AVX needed on macOS-Intel GHA runners (macos-14 upgrade changed FP results slightly)
-if(APPLE)
-    get_test_property(scf-cholesky-basis ENVIRONMENT _env)
-    set_tests_properties(scf-cholesky-basis PROPERTIES ENVIRONMENT "${_env};MKL_VERBOSE=1")
-endif()


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
MacOS 13 is gone from CI and 14 will be gone in a year or so.
Try 15.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
