### PR TITLE
Fix potential nullptr dereference in DSYEV_descending

### DIFF
--- a/psi4/src/psi4/libciomr/dsyev_descending.cc
+++ b/psi4/src/psi4/libciomr/dsyev_descending.cc
@@ -56,7 +56,7 @@ namespace psi {
         std::swap(e_vals[i], e_vals[N - i - 1]);
     }
     // Reverse the order of columns of the row-major 2D eigenvector array
-    if (e_vecs != nullptr){
+    if (e_vecs != nullptr) {
         for (int64_t i = 0; i < N; i++) {
             for (int64_t j = 0; j < N / 2; j++) {
                 std::swap(e_vecs[i][j], e_vecs[i][N - j - 1]);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
DSYEV returns the eigenvalues and optionally eigenvectors sorted in the order of ascending eigenvalues.
DSYEV_descending swaps the order to descending without checking if the eigenvectors have been requested, resulting in a nullptr dereference if not. This PR fixes that corner case.

Thankfully, nothing in the current Psi4 codebase seems to be using this particular combination of "only eigenvalues, descending order", so the impact should be only on out-of-tree codes using Matrix::diagonalize with that particular setting.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] PSI_API: fixed corner case in `Matrix::diagonalize`, no longer dereferences a nullptr if `nMatz == evals_only_descending`

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Make sure the eigenvector pointer is not nullptr before trying to swap its elements in DSYEV_descending

## Checklist
- [x] No new features
- [x] Tests run by CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
