### PR TITLE
Fix DLPNO-CCSD(T) Segfault and Memory Estimate

### DIFF
--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -266,7 +266,7 @@ void DLPNOCCSD::estimate_memory() {
         } // end if
     } // end ij
 
-    size_t oo, ov, vv, vv_non_proj, vvv, qo, qv, qov, qvv;
+    size_t oo = 0, ov = 0, vv = 0, vv_non_proj = 0, vvv = 0, qo = 0, qv = 0, qov = 0, qvv = 0;
 
     // oo => n_lmo_pairs * (nlmo_{ij}, nlmo_{ij})-like quantities: \beta_{ij}^{kl} (1 case over strong pairs, restricted indexing)
 
@@ -1207,7 +1207,7 @@ template<bool crude> double DLPNOCCSD::filter_pairs(const std::vector<double>& e
         int ij_new = 0;
         for (int ij = 0; ij < n_lmo_pairs; ++ij) {
             auto &[i, j] = ij_to_i_j_[ij];
-            if (std::fabs(e_ijs[ij]) >= T_CUT_PAIRS_MP2_) { // If this pair survives, it continues in the computation
+            if (std::fabs(e_ijs[ij]) >= T_CUT_PAIRS_MP2_ || i == j) { // If this pair survives, it continues in the computation
                 i_j_to_ij_new[i][j] = ij_new;
                 ij_to_i_j_new.push_back(std::make_pair(i, j));
                 ++ij_new;
@@ -1241,7 +1241,7 @@ template<bool crude> double DLPNOCCSD::filter_pairs(const std::vector<double>& e
         int ij_strong = 0, ij_weak = 0;
         for (int ij = 0; ij < n_lmo_pairs; ++ij) {
             auto &[i, j] = ij_to_i_j_[ij];
-            if (std::fabs(e_ijs[ij]) >= T_CUT_PAIRS_) { // Pair is strong pair
+            if (std::fabs(e_ijs[ij]) >= T_CUT_PAIRS_ || i == j) { // Pair is strong pair, diagonal pairs are ALWAYS strong pairs
                 i_j_to_ij_strong_[i][j] = ij_strong;
                 ij_to_i_j_strong_.push_back(std::make_pair(i, j));
                 ++ij_strong;

--- a/psi4/src/psi4/dlpno/dlpno.cc
+++ b/psi4/src/psi4/dlpno/dlpno.cc
@@ -721,7 +721,7 @@ void DLPNO::prep_sparsity(bool initial, bool final) {
                 bool overlap_big = (DOI_ij_->get(i, j) > options_.get_double("T_CUT_DO_IJ"));
                 bool energy_big = (fabs(dipole_pair_e_bound_->get(i, j)) > T_CUT_PRE_);
 
-                if (overlap_big || energy_big) {
+                if (overlap_big || energy_big || i == j) {
                     i_j_to_ij_[i].push_back(ij);
                     ij_to_i_j_.push_back(std::make_pair(i, j));
                     ij++;

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2682,9 +2682,9 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- DOI threshold for including PAO (u) in domain of LMO (i) during pre-screening !expert -*/
         options.add_double("T_CUT_DO_PRE", 3e-2);
         /*- Basis set coefficient threshold for including basis function (m) in domain of LMO (i) !expert -*/
-        options.add_double("T_CUT_CLMO", 1e-3);
+        options.add_double("T_CUT_CLMO", 1e-4);
         /*- Basis set coefficient threshold for including basis function (n) in domain of PAO (u) !expert -*/
-        options.add_double("T_CUT_CPAO", 1e-3);
+        options.add_double("T_CUT_CPAO", 1e-4);
         /*- Overlap matrix threshold for removing linear dependencies !expert -*/
         options.add_double("S_CUT", 1e-8);
         /*- Fock matrix threshold for treating ampltudes as coupled during local MP2 iterations !expert -*/


### PR DESCRIPTION
## Description
Fixes the memory printout issues as well as `freeze_core false` segfault discussed in issue #3336 

## Dev notes & details
- [x] My code DLPNO-CCSD(T) has always operated under the assumption that diagonal pairs (i = j) are always a strong pair (treated at CC level). This is a reasonable assumption with frozen core on, but with some very low energy occupied core orbitals, this assumption may fail. My code now manually sets all diagonal pairs to be strong pairs no matter what!
- [x] For the memory printout issue, some of the memory counters, I did not initialize them to zero, leading to undefined behavior. This has also been fixed
- [x] We also set `T_CUT_CLMO` and `T_CUT_CPAO` to `1.0e-4` to match ORCA (see https://doi.org/10.1063/1.4939030). This will only affect the time it takes to compute the initial LMO and PAO integrals, and will not affect memory since integrals are built from an AO-direct algorithm!

## Questions
- [x] @loriab Should I set `freeze_core true` if the user doesn’t specify?

## Checklist
- [x] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
