### PR TITLE
Try updated Windows constraints for MKL (2025) and OpenMP

### DIFF
--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -130,7 +130,6 @@ jobs:
                         eigen ^
                         libboost-headers ^
                         conda-verify ^
-                        intel-openmp=%MKL_VERSION% ^
                         mkl-devel=%MKL_VERSION% ^
                         mpmath ^
                         msgpack-python ^
@@ -167,17 +166,6 @@ jobs:
           echo '##vso[task.setvariable variable=PATH]%PATH%'
           clang-cl --version
         displayName: "Install LLVM"
-
-      # Install Intel OpenMP import library
-      # NOTE: libiomp5md.lib is located in conda/win/$(mkl.version)
-      #set LIB=$(Build.SourcesDirectory)\conda\win\$(mkl.version);%LIB%
-      #    set LIB=%cd%\iomp5md\conda\win\$(mkl.version);%LIB%
-      - script: |
-          cd
-          git clone https://github.com/psi4/iomp5md.git
-          set LIB=%cd%\iomp5md\conda\win\2019.1;%LIB%
-          echo '##vso[task.setvariable variable=LIB]%LIB%'
-        displayName: "Install Intel OpenMP import library"
 
       # Configure
       # call "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -7,8 +7,8 @@ jobs:
       vmImage: 'windows-2022'
     timeoutInMinutes: 360
     variables:
-      llvm.version: '17.0.6'
-      mkl.version: '2022.1.0'
+      llvm.version: '19.1.7'
+      mkl.version: '2025.3.0'
       cmake.build_type: 'Release'
       conda.build: false
       ctest.type: 'smoke'

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -141,7 +141,7 @@ jobs:
                         pytest=7 ^
                         pytest-xdist ^
                         python=%PYTHON_VERSION% ^
-                        dftd3-python=0.6.0 ^
+                        dftd3-python ^
                         gcp-correction ^
                         gau2grid ^
                         libxc-c ^

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -158,7 +158,7 @@ jobs:
           env \
           --name p4build \
           --python ${{ matrix.cfg.python-version }} \
-          --disable docs addons \
+          --disable docs \
           --offline-conda
         echo "::group::View Env Spec File for Conda (from advisor)"
         printf "\n<<<  env_p4build.yaml  >>>\n"

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -158,7 +158,7 @@ jobs:
           env \
           --name p4build \
           --python ${{ matrix.cfg.python-version }} \
-          --disable docs \
+          --disable docs addons \
           --offline-conda
         echo "::group::View Env Spec File for Conda (from advisor)"
         printf "\n<<<  env_p4build.yaml  >>>\n"

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -181,6 +181,7 @@ jobs:
         fi
         if [[ "${{ runner.os }}" == "Windows" ]]; then
           :
+          sed -i "s;- resp;#- resp;g" env_p4build.yaml
           # sed -i "s;#- dpcpp_linux-64;- clangdev ${{ matrix.cfg.llvm-version }};g" env_p4build.yaml
         fi
         echo "  - pygments" >> env_p4build.yaml

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -18,33 +18,33 @@ jobs:
       matrix:
         cfg:
 
-          - label: "Conda GNU (L)"
-            runs-on: ubuntu-latest
-            python-version: "3.13"
-            mkl-version: ""
-            platform: linux-64
-            pytest-marker-expr: "addon and not (medlong or long)"
-            pytest-name-expr: "not (pe_ecp or pvdz_adc2_any_6)"
-            cmargs: >
-              -D CMAKE_VERBOSE_MAKEFILE=OFF
-              -D ENABLE_v2rdm_casscf=ON
-              -D CMAKE_DISABLE_FIND_PACKAGE_v2rdm_casscf=ON
+          #- label: "Conda GNU (L)"
+          #  runs-on: ubuntu-latest
+          #  python-version: "3.13"
+          #  mkl-version: ""
+          #  platform: linux-64
+          #  pytest-marker-expr: "addon and not (medlong or long)"
+          #  pytest-name-expr: "not (pe_ecp or pvdz_adc2_any_6)"
+          #  cmargs: >
+          #    -D CMAKE_VERBOSE_MAKEFILE=OFF
+          #    -D ENABLE_v2rdm_casscf=ON
+          #    -D CMAKE_DISABLE_FIND_PACKAGE_v2rdm_casscf=ON
             # Notes:
             # * for all three lanes, can consider:
             #    -D BUILD_SHARED_LIBS=ON
             #    -D ENABLE_XHOST=OFF
 
-          - label: "Conda Clang (M-Intel)"
-            runs-on: macos-15-intel
-            python-version: "3.11"
-            mkl-version: ""
-            platform: osx-64
-            pytest-marker-expr: "addon and not (medlong or long)"
-            pytest-name-expr: "not (pe_ecp or pvdz_adc2_any_6 or v2rdm6 or v2rdm7)"
-            target-sdk: "10.10"
-            cmargs: >
-              -D CMAKE_VERBOSE_MAKEFILE=OFF
-              -D Python_NumPy_INCLUDE_DIR="/Users/runner/miniconda3/envs/p4build/lib/python3.11/site-packages/numpy/_core/include"
+          #- label: "Conda Clang (M-Intel)"
+          #  runs-on: macos-15-intel
+          #  python-version: "3.11"
+          #  mkl-version: ""
+          #  platform: osx-64
+          #  pytest-marker-expr: "addon and not (medlong or long)"
+          #  pytest-name-expr: "not (pe_ecp or pvdz_adc2_any_6 or v2rdm6 or v2rdm7)"
+          #  target-sdk: "10.10"
+          #  cmargs: >
+          #    -D CMAKE_VERBOSE_MAKEFILE=OFF
+          #    -D Python_NumPy_INCLUDE_DIR="/Users/runner/miniconda3/envs/p4build/lib/python3.11/site-packages/numpy/_core/include"
             # Notes:
             # * libiomp5 is picking up naturally but left here as guide
             #    -D OpenMP_C_FLAG="-fopenmp=libiomp5"
@@ -57,31 +57,31 @@ jobs:
             #    -D CMAKE_OSX_SYSROOT="/opt/MacOSX${{ matrix.cfg.target-sdk }}.sdk" \
             # * numpy/_core in py310 vs numpy/core in py39 (or maybe a np v1/v2 thing)
 
-          - label: "Conda Clang (M-Silicon)"
-            runs-on: macos-latest
-            python-version: "3.10"
-            mkl-version: ""
-            platform: osx-64
-            pytest-marker-expr: "addon and not (medlong or long)"
-            pytest-name-expr: "not (pe_ecp or v2rdm6 or v2rdm7 or snowflake)"
-            target-sdk: "10.10"
-            cmargs: >
-              -D CMAKE_VERBOSE_MAKEFILE=OFF
-              -D ENABLE_v2rdm_casscf=ON
-              -D CMAKE_DISABLE_FIND_PACKAGE_v2rdm_casscf=ON
+          #- label: "Conda Clang (M-Silicon)"
+          #  runs-on: macos-latest
+          #  python-version: "3.10"
+          #  mkl-version: ""
+          #  platform: osx-64
+          #  pytest-marker-expr: "addon and not (medlong or long)"
+          #  pytest-name-expr: "not (pe_ecp or v2rdm6 or v2rdm7 or snowflake)"
+          #  target-sdk: "10.10"
+          #  cmargs: >
+          #    -D CMAKE_VERBOSE_MAKEFILE=OFF
+          #    -D ENABLE_v2rdm_casscf=ON
+          #    -D CMAKE_DISABLE_FIND_PACKAGE_v2rdm_casscf=ON
 
           - label: "LLVM clang-cl (W)"
             runs-on: windows-latest
             python-version: "3.12"
             mkl-version: ""
-            llvm-version: "17.0.6"  # known good: "17.0.6"; omp problem: 19, 20
+            #llvm-version: "17.0.6"  # known good: "17.0.6"; omp problem: 19, 20
             platform: win-64
             pytest-marker-expr: "addon and not (medlong or long) and not d2ints"
             pytest-name-expr: "not pe_ecp"
             cmargs: >
               -D CMAKE_VERBOSE_MAKEFILE=OFF
               -D psi4_SKIP_ENABLE_Fortran=ON
-              -D CMAKE_CXX_FLAGS="-IC:\Miniconda\envs\p4build\opt\compiler\include"
+              #-D CMAKE_CXX_FLAGS="-IC:\Miniconda\envs\p4build\opt\compiler\include"
 
             # Notes:
             # * When not using cache file, need to additionally specify the following:

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -18,33 +18,33 @@ jobs:
       matrix:
         cfg:
 
-          #- label: "Conda GNU (L)"
-          #  runs-on: ubuntu-latest
-          #  python-version: "3.13"
-          #  mkl-version: ""
-          #  platform: linux-64
-          #  pytest-marker-expr: "addon and not (medlong or long)"
-          #  pytest-name-expr: "not (pe_ecp or pvdz_adc2_any_6)"
-          #  cmargs: >
-          #    -D CMAKE_VERBOSE_MAKEFILE=OFF
-          #    -D ENABLE_v2rdm_casscf=ON
-          #    -D CMAKE_DISABLE_FIND_PACKAGE_v2rdm_casscf=ON
+          - label: "Conda GNU (L)"
+            runs-on: ubuntu-latest
+            python-version: "3.13"
+            mkl-version: ""
+            platform: linux-64
+            pytest-marker-expr: "addon and not (medlong or long)"
+            pytest-name-expr: "not (pe_ecp or pvdz_adc2_any_6)"
+            cmargs: >
+              -D CMAKE_VERBOSE_MAKEFILE=OFF
+              -D ENABLE_v2rdm_casscf=ON
+              -D CMAKE_DISABLE_FIND_PACKAGE_v2rdm_casscf=ON
             # Notes:
             # * for all three lanes, can consider:
             #    -D BUILD_SHARED_LIBS=ON
             #    -D ENABLE_XHOST=OFF
 
-          #- label: "Conda Clang (M-Intel)"
-          #  runs-on: macos-15-intel
-          #  python-version: "3.11"
-          #  mkl-version: ""
-          #  platform: osx-64
-          #  pytest-marker-expr: "addon and not (medlong or long)"
-          #  pytest-name-expr: "not (pe_ecp or pvdz_adc2_any_6 or v2rdm6 or v2rdm7)"
-          #  target-sdk: "10.10"
-          #  cmargs: >
-          #    -D CMAKE_VERBOSE_MAKEFILE=OFF
-          #    -D Python_NumPy_INCLUDE_DIR="/Users/runner/miniconda3/envs/p4build/lib/python3.11/site-packages/numpy/_core/include"
+          - label: "Conda Clang (M-Intel)"
+            runs-on: macos-15-intel
+            python-version: "3.11"
+            mkl-version: ""
+            platform: osx-64
+            pytest-marker-expr: "addon and not (medlong or long)"
+            pytest-name-expr: "not (pe_ecp or pvdz_adc2_any_6 or v2rdm6 or v2rdm7)"
+            target-sdk: "10.10"
+            cmargs: >
+              -D CMAKE_VERBOSE_MAKEFILE=OFF
+              -D Python_NumPy_INCLUDE_DIR="/Users/runner/miniconda3/envs/p4build/lib/python3.11/site-packages/numpy/_core/include"
             # Notes:
             # * libiomp5 is picking up naturally but left here as guide
             #    -D OpenMP_C_FLAG="-fopenmp=libiomp5"
@@ -57,32 +57,30 @@ jobs:
             #    -D CMAKE_OSX_SYSROOT="/opt/MacOSX${{ matrix.cfg.target-sdk }}.sdk" \
             # * numpy/_core in py310 vs numpy/core in py39 (or maybe a np v1/v2 thing)
 
-          #- label: "Conda Clang (M-Silicon)"
-          #  runs-on: macos-latest
-          #  python-version: "3.10"
-          #  mkl-version: ""
-          #  platform: osx-64
-          #  pytest-marker-expr: "addon and not (medlong or long)"
-          #  pytest-name-expr: "not (pe_ecp or v2rdm6 or v2rdm7 or snowflake)"
-          #  target-sdk: "10.10"
-          #  cmargs: >
-          #    -D CMAKE_VERBOSE_MAKEFILE=OFF
-          #    -D ENABLE_v2rdm_casscf=ON
-          #    -D CMAKE_DISABLE_FIND_PACKAGE_v2rdm_casscf=ON
+          - label: "Conda Clang (M-Silicon)"
+            runs-on: macos-latest
+            python-version: "3.10"
+            mkl-version: ""
+            platform: osx-64
+            pytest-marker-expr: "addon and not (medlong or long)"
+            pytest-name-expr: "not (pe_ecp or v2rdm6 or v2rdm7 or snowflake)"
+            target-sdk: "10.10"
+            cmargs: >
+              -D CMAKE_VERBOSE_MAKEFILE=OFF
+              -D ENABLE_v2rdm_casscf=ON
+              -D CMAKE_DISABLE_FIND_PACKAGE_v2rdm_casscf=ON
 
           - label: "LLVM clang-cl (W)"
             runs-on: windows-latest
             python-version: "3.12"
             mkl-version: ""
-            #llvm-version: "17.0.6"  # known good: "17.0.6"; omp problem: 19, 20
             platform: win-64
             pytest-marker-expr: "addon and not (medlong or long) and not d2ints"
             pytest-name-expr: "not pe_ecp"
             cmargs: >
               -D CMAKE_VERBOSE_MAKEFILE=OFF
               -D psi4_SKIP_ENABLE_Fortran=ON
-              #-D CMAKE_CXX_FLAGS="-IC:\Miniconda\envs\p4build\opt\compiler\include"
-
+ 
             # Notes:
             # * When not using cache file, need to additionally specify the following:
             #    -D CMAKE_C_COMPILER=clang-cl
@@ -94,6 +92,9 @@ jobs:
             #    -D BUILD_SHARED_LIBS=OFF
             # * See OpenMP_LIBRARY_DIRS below. no longer needed
             #    -D OpenMP_LIBRARY_DIRS="D:/a/psi4/psi4/iomp5md/conda/win/2019.1"
+            # * [Jan 2026] with intel-openmp and MKL 2024.1 (2024.2 gave dysev errors),
+            #   llvm-version: "17.0.6"  # known good: "17.0.6"; omp problem: 19, 20
+            #   -D CMAKE_CXX_FLAGS="-IC:\Miniconda\envs\p4build\opt\compiler\include"
 
     name: "Eco • 🐍 ${{ matrix.cfg.python-version }} • ${{ matrix.cfg.label }}"
     runs-on: ${{ matrix.cfg.runs-on }}
@@ -181,7 +182,6 @@ jobs:
         fi
         if [[ "${{ runner.os }}" == "Windows" ]]; then
           :
-          sed -i "s;- resp;#- resp;g" env_p4build.yaml
           # sed -i "s;#- dpcpp_linux-64;- clangdev ${{ matrix.cfg.llvm-version }};g" env_p4build.yaml
         fi
         echo "  - pygments" >> env_p4build.yaml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ trigger:
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-windows.yml
-  #- template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-linux.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ trigger:
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-windows.yml
-  - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  #- template: ./.azure-pipelines/azure-pipelines-linux.yml

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -97,12 +97,12 @@ data:
       aux_build_names:
         linux-64:
           - "//dpcpp_linux-64"
-        win-64:
-          - "libgcc<14.3"
-          - "clangdev=17.0.6"
-      aux_build_names_note:
-        "libgcc<14.3": "Avoid 'specified procedure could not be found' DLL error."
-        "clangdev=17.0.6": "Avoid omp problem with v19, v20."
+        #win-64:
+          #- "libgcc<14.3"
+          #- "clangdev=17.0.6"
+      #aux_build_names_note:
+      #  "libgcc<14.3": "Avoid 'specified procedure could not be found' DLL error."
+      #  "clangdev=17.0.6": "Avoid omp problem with v19, v20."
       cmake:
         # {CMAKE_CXX_COMPILER_ID}_{Conda_platform}
         GNU_linux-64:

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -97,11 +97,11 @@ data:
       aux_build_names:
         linux-64:
           - "//dpcpp_linux-64"
-        #win-64:
-          #- "libgcc<14.3"
+        win-64:
+          - "libgcc<14.3"
           #- "clangdev=17.0.6"
-      #aux_build_names_note:
-      #  "libgcc<14.3": "Avoid 'specified procedure could not be found' DLL error."
+      aux_build_names_note:
+        "libgcc<14.3": "Avoid 'specified procedure could not be found' DLL error."
       #  "clangdev=17.0.6": "Avoid omp problem with v19, v20."
       cmake:
         # {CMAKE_CXX_COMPILER_ID}_{Conda_platform}
@@ -958,6 +958,7 @@ data:
       constraint: null
       cmake: null
       cmake_note: "Primarily OTF runtime detected."
+      skip_win: true
 
   - project: openfermionpsi4
     use:

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -399,7 +399,6 @@ data:
         osx-64: "=*=*mkl"
         osx-arm64: "=*=*accelerate"
         win-64: "=*=*mkl"
-      constraint_note: "On Windows, MKL 2024.2.2 gives wrong results, so 24*mkl requests 2024.1.0."
       aux_build_names:
         - blas-devel
       aux_build_names_note:

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -399,7 +399,7 @@ data:
         linux-64: "=*=*mkl"
         osx-64: "=*=*mkl"
         osx-arm64: "=*=*accelerate"
-        win-64: "=*=24*mkl"
+        win-64: "=*=*mkl"
       constraint_note: "On Windows, MKL 2024.2.2 gives wrong results, so 24*mkl requests 2024.1.0."
       aux_build_names:
         - blas-devel
@@ -550,7 +550,7 @@ data:
         linux-64: llvm-openmp
         osx-64: llvm-openmp
         osx-arm64: llvm-openmp
-        win-64: intel-openmp
+        win-64: llvm-openmp
       constraint: null
       cmake:
         ENABLE_OPENMP: true

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -99,10 +99,9 @@ data:
           - "//dpcpp_linux-64"
         win-64:
           - "libgcc<14.3"
-          #- "clangdev=17.0.6"
       aux_build_names_note:
         "libgcc<14.3": "Avoid 'specified procedure could not be found' DLL error."
-      #  "clangdev=17.0.6": "Avoid omp problem with v19, v20."
+        "clangdev=17.0.6": "For win-64, this clang (avoid omp problem with v19, v20) intel-openmp for openmp, and =*=24*mkl for libblas constraint (MKL 2024.2.2 gives wrong results, so 24*mkl requests 2024.1.0.) worked well together."
       cmake:
         # {CMAKE_CXX_COMPILER_ID}_{Conda_platform}
         GNU_linux-64:
@@ -959,6 +958,7 @@ data:
       cmake: null
       cmake_note: "Primarily OTF runtime detected."
       skip_win: true
+      skip_win_note: "Temporary until a llvm-openmp psi4 package available on Windows to satisfy solving resp's deps."
 
   - project: openfermionpsi4
     use:

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -261,9 +261,13 @@ elseif(UNIX)
 endif()
 
 # add -pedantic-errors flag here, if FORCE_PEDANTIC is enabled 
-if(${FORCE_PEDANTIC}) 
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic-errors")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")
+if(${FORCE_PEDANTIC})
+  if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /WX")
+  else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic-errors")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")
+  endif()
 endif()
 
 # <<<  Build  >>>

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -263,7 +263,7 @@ endif()
 # add -pedantic-errors flag here, if FORCE_PEDANTIC is enabled 
 if(${FORCE_PEDANTIC})
   if(MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /WX")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
   else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic-errors")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")


### PR DESCRIPTION
Updated Windows constraints for MKL and OpenMP.

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Give MKL 2025 a try. 🤞 all the Windows trouble with 2024.2 is healed in '25.
On Windows were were hitting limits and stuck at
- [x] MKL <=2024.1, `intel-openmp` (iomp5), and clang 17.0.6 --- wrong answers and dysev errors with newer MKL and omp errors with clang 18 & 19
thanks to a kindly maintainer at c-f determined to get mkl 2025 working (PR linked below) which also switches to `llvm-openmp`, psi4 can now use roughly current packages on windows
- [x] MKL 2025, `llvm-openmp`, clang v19

## Status
- [x] Ready for review
- [x] Ready for merge
