### PR TITLE
Add include guard to the scf.h.template file.

### DIFF
--- a/psi4/share/psi4/plugin/scf/scf.h.template
+++ b/psi4/share/psi4/plugin/scf/scf.h.template
@@ -1,3 +1,6 @@
+#ifndef PLUGIN_SCF_H
+#define PLUGIN_SCF_H
+
 /*
  * @BEGIN LICENSE
  *
@@ -27,8 +30,6 @@
  *
  * @END LICENSE
  */
-
-#pragma once
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libmints/wavefunction.h"
@@ -91,3 +92,5 @@ class SCF : public Wavefunction {
 };
 
 }} //End namespaces
+
+#endif


### PR DESCRIPTION
## Description
I noticed that the scf.h.template file for the SCF plugin was missing an include guard. I added one.


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Added `#pragma once` to the `scf.h` file in the SCF plugin template.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Added `#pragma once` to the `scf.h` file in the SCF plugin template.

## Questions
- [x] Would the often-supported but unofficial  `#pragma once` be better, or would a standards-conformant `#ifndef MACRO_NAME` guard be more appropriate?

## Checklist
- [x] Includes guarded.

## Status
- [x] Ready for review
- [x] Ready for merge
