### PR TITLE
Fix deprecation warnings + cleanup in `libscf_solver`

### DIFF
--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -308,20 +308,16 @@ void CUHF::form_C(double shift) {
         diagonalize_F(Fa_, Ca_, epsilon_a_);
         diagonalize_F(Fb_, Cb_, epsilon_b_);
     } else {
-        auto shifted_F = SharedMatrix(factory_->create_matrix("F"));
-
         auto Cvir = Ca_subset("SO", "VIR");
-        auto SCvir = std::make_shared<Matrix>(nirrep_, S_->rowspi(), Cvir->colspi());
-        SCvir->gemm(false, false, 1.0, S_, Cvir, 0.0);
-        shifted_F->gemm(false, true, shift, SCvir, SCvir, 0.0);
-        shifted_F->add(Fa_);
+        auto SCvir = linalg::doublet(S_, Cvir, false, false);
+        auto shifted_F = Fa_->clone();
+        shifted_F->gemm(false, true, shift, SCvir, SCvir, 1.0);
         diagonalize_F(shifted_F, Ca_, epsilon_a_);
 
         Cvir = Cb_subset("SO", "VIR");
-        SCvir = std::make_shared<Matrix>(nirrep_, S_->rowspi(), Cvir->colspi());
-        SCvir->gemm(false, false, 1.0, S_, Cvir, 0.0);
-        shifted_F->gemm(false, true, shift, SCvir, SCvir, 0.0);
-        shifted_F->add(Fb_);
+        SCvir = linalg::doublet(S_, Cvir, false, false);
+        shifted_F->copy(Fb_);
+        shifted_F->gemm(false, true, shift, SCvir, SCvir, 1.0);
         diagonalize_F(shifted_F, Cb_, epsilon_b_);
     }
     find_occupation();

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -292,7 +292,7 @@ void HF::damping_update(double damping_percentage) {
         "type of SCF wavefunction yet.");
 }
 
-int HF::soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print) {
+int HF::soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, bool soscf_print) {
     throw PSIEXCEPTION(
         "Sorry, second-order convergence has not been implemented for this "
         "type of SCF wavefunction yet.");
@@ -323,7 +323,7 @@ void HF::form_F() { throw PSIEXCEPTION("Sorry, the base HF wavefunction does not
 double HF::compute_E() { throw PSIEXCEPTION("Sorry, the base HF wavefunction does not understand Hall."); }
 void HF::rotate_orbitals(SharedMatrix C, const SharedMatrix x) {
     // => Rotate orbitals <= //
-    auto U = std::make_shared<Matrix>("Ck", nirrep_, nmopi_, nmopi_);
+    auto U = std::make_shared<Matrix>("Ck", nmopi_, nmopi_);
     std::string reference = options_.get_str("REFERENCE");
 
     // We guess occ x vir block size by the size of x to make this method easy to use
@@ -726,7 +726,7 @@ void HF::form_Shalf() {
         brianInt computeOverlapRoot = BRIAN_FALSE;
         brianInt computeOverlapInverseRoot = BRIAN_TRUE;
         brianInt basisRank;
-        SharedMatrix buffer = std::make_shared<Matrix>(nirrep_, nsopi_, nsopi_);
+        SharedMatrix buffer = std::make_shared<Matrix>(nsopi_, nsopi_);
         brianSCFComputeOverlapRoot(&brianCookie, &computeOverlapRoot, &computeOverlapInverseRoot, S_->get_pointer(),
                                    &S_cutoff, &basisRank, nullptr, buffer->get_pointer());
         checkBrian();
@@ -734,7 +734,7 @@ void HF::form_Shalf() {
         nmo_ = basisRank;
         nmopi_[0] = basisRank;
 
-        X_->init(nirrep_, nsopi_, nmopi_, "X (Canonical Orthogonalization)");
+        X_->init(nsopi_, nmopi_, "X (Canonical Orthogonalization)");
         for (int i = 0; i < nso_; i++) {
             for (int j = 0; j < nmo_; j++) {
                 X_->set(i, j, buffer->get(nmo_ - 1 - j, i));
@@ -1350,7 +1350,7 @@ void HF::diagonalize_F(const SharedMatrix& Fm, SharedMatrix& Cm, std::shared_ptr
     auto diag_F_temp = linalg::triplet(X_, Fm, X_, true, false, false);
 
     // Form C' = eig(F')
-    auto diag_C_temp = std::make_shared<Matrix>(nirrep_, nmopi_, nmopi_);
+    auto diag_C_temp = std::make_shared<Matrix>(nmopi_, nmopi_);
     diag_F_temp->diagonalize(diag_C_temp, epsm);
 
     // Form C = XC'

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -326,7 +326,7 @@ class HF : public Wavefunction {
     virtual double compute_E();
 
     /** Applies second-order convergence acceleration */
-    virtual int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print);
+    virtual int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, bool soscf_print);
 
     /// Figure out how to occupy the orbitals in the absence of DOCC and SOCC
     void find_occupation();

--- a/psi4/src/psi4/libscf_solver/mom.cc
+++ b/psi4/src/psi4/libscf_solver/mom.cc
@@ -66,9 +66,9 @@ void HF::MOM_start() {
     MOM_performed_ = true;  // Gets printed next iteration
 
     // Build Ca_old_ matrices
-    Ca_old_ = std::make_shared<Matrix>("C Alpha Old (SO Basis)", nirrep_, nsopi_, nmopi_);
+    Ca_old_ = std::make_shared<Matrix>("C Alpha Old (SO Basis)", nsopi_, nmopi_);
     if (!same_a_b_orbs()) {
-        Cb_old_ = std::make_shared<Matrix>("C Beta Old (SO Basis)", nirrep_, nsopi_, nmopi_);
+        Cb_old_ = std::make_shared<Matrix>("C Beta Old (SO Basis)", nsopi_, nmopi_);
     } else {
         Cb_old_ = Ca_old_;
     }

--- a/psi4/src/psi4/libscf_solver/rhf.h
+++ b/psi4/src/psi4/libscf_solver/rhf.h
@@ -76,7 +76,7 @@ class RHF : public HF {
     void openorbital_scf() override;
   
     void damping_update(double) override;
-    int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print) override;
+    int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, bool soscf_print) override;
     bool stability_analysis() override;
 
     std::shared_ptr<VBase> V_potential() const override { return potential_; };

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -774,7 +774,7 @@ void ROHF::damping_update(double damping_percentage) {
     Dt_->add(Db_);
 }
 
-int ROHF::soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print) {
+int ROHF::soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, bool soscf_print) {
     std::time_t start, stop;
     start = std::time(nullptr);
 
@@ -789,7 +789,7 @@ int ROHF::soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter
 
     auto Gradient = moFeff_->get_block({dim_zero, occpi}, {docc, nmopi_});
     Gradient->scale(-4.0);
-    auto Precon = std::make_shared<Matrix>("Precon", nirrep_, occpi, virpi);
+    auto Precon = std::make_shared<Matrix>("Precon", occpi, virpi);
 
     for (size_t h = 0; h < nirrep_; h++) {
         if (!occpi[h] || !virpi[h]) continue;
@@ -850,7 +850,7 @@ int ROHF::soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter
 
     // Calc hessian vector product, find residual and conditioned residual
     auto r = Gradient->clone();
-    auto Ap = std::make_shared<Matrix>("Ap", nirrep_, occpi, virpi);
+    auto Ap = std::make_shared<Matrix>("Ap", occpi, virpi);
     Hx(x, Ap);
     r->subtract(Ap);
 

--- a/psi4/src/psi4/libscf_solver/rohf.h
+++ b/psi4/src/psi4/libscf_solver/rohf.h
@@ -91,7 +91,7 @@ class ROHF : public HF {
     void compute_SAD_guess(bool natorb) override;
 
     void damping_update(double) override;
-    int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print) override;
+    int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, bool soscf_print) override;
     bool stability_analysis() override;
 
     std::shared_ptr<VBase> V_potential() const override { return nullptr; };

--- a/psi4/src/psi4/libscf_solver/uhf.h
+++ b/psi4/src/psi4/libscf_solver/uhf.h
@@ -87,7 +87,7 @@ class UHF : public HF {
     void openorbital_scf() override;
 
     void damping_update(double) override;
-    int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, int soscf_print) override;
+    int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, bool soscf_print) override;
 
     std::shared_ptr<VBase> V_potential() const override { return potential_; };
 


### PR DESCRIPTION
## Description
This PR fixes the deprecation warnings that I found in `libscf_solver` and also does some miscellaneous code cleanup. Please pay attention to my changes in the level shift procedure.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Fixes several deprecation warnings involving casts to pointer in `libscf`.
- [x] This PR does create a merge conflict with #3351 because the `HF::form_Fia` signature changes. The solution of this PR is preferred.

## Checklist
- [x] Quicktests pass

## Status
- [x] Ready for review
- [x] Ready for merge
