### PR TITLE
accommodate pkg_resources decease 

### DIFF
--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -668,6 +668,7 @@ data:
         - autodoc-pydantic=1
         - qcportal
         - "gxx_linux-64=14.3.0=hc876b51_14"
+        - "setuptools<82.0.0"
       aux_build_names_note:
         qcportal: "Required for docs to resolve objects in pydantic classes."
         "gxx_linux-64=14.3.0=hc876b51_14": "Temporary for Linux only; rm for Mac."

--- a/external/upstream/bse/CMakeLists.txt
+++ b/external/upstream/bse/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(${ENABLE_bse})
     if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_bse}))
         include(FindPythonModule)
-        find_python_module(basis_set_exchange ATLEAST 0.9.0)  # edit in codedeps
+        find_python_module(basis_set_exchange ATLEAST 0.9.0 QUIET)  # edit in codedeps
     endif()
     
     if(${basis_set_exchange_FOUND})

--- a/external/upstream/qcelemental/CMakeLists.txt
+++ b/external/upstream/qcelemental/CMakeLists.txt
@@ -1,9 +1,9 @@
 if(NOT (${CMAKE_DISABLE_FIND_PACKAGE_qcelemental}))
     include(FindPythonModule)
     if(${Python_NumPy_VERSION} GREATER_EQUAL "2")
-        find_python_module(qcelemental ATLEAST 0.28.0)  # edit in codedeps
+        find_python_module(qcelemental ATLEAST 0.28.0 QUIET)  # edit in codedeps
     else()
-        find_python_module( qcelemental ATLEAST 0.26.0)
+        find_python_module( qcelemental ATLEAST 0.26.0 QUIET)
     endif()
 endif()
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

### Note: this can hit newly created local environments, too. To fix, either downgrade your setuptools or incorporate these two lines into your psi4 code.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] setuptools 82.0 finally kicked out pkg_resources which we were still using deep under the hood, so update that usage https://setuptools.pypa.io/en/stable/history.html#v82-0-0
- [x] one of the docs extensions also uses it. the docs pkgs are somewhat frozen in the past to accommodate pydantic v1, so pinning that to sub-82 for now

## Status
- [x] Ready for review
- [x] Ready for merge
