### PR TITLE
fix pybind11 and d4 CI

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -179,6 +179,7 @@ jobs:
           sed -E -i.bak "s;accelerate;openblas;g" env_p4build.yaml
           sed -E -i.bak "s;- memory_profiler;#- memory_profiler;g" env_p4build.yaml
           # memory leaks. accelerate is fine but openblas matches the scf-cholesky stored values
+          sed -E -i.bak "s;- ambit;- mctc-lib=0.4.1;g" env_p4build.yaml
         fi
         if [[ "${{ runner.os }}" == "Windows" ]]; then
           :

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 #############################  Superbuild Project  #############################
 cmake_minimum_required(VERSION 3.19...4.0)
 cmake_policy(SET CMP0094 NEW)

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -735,7 +735,7 @@ data:
     conda:
       channel: conda-forge
       name: pybind11
-      constraint: null
+      constraint: "<3.0.3"
       constraint_note: "Numpy v2 needs >=2.12. For docs, '>=2.10.*,<2.12.0' has adv; search FixedSize."
       cmake:
         pybind11_DIR:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
These are the wrong solutions to two separate issues. One, the bump from v3.0.2 to v3.0.3 pybind11 uncovered an incomplete `BasisSet` class definition. I have a properer fix that I'm running by others. Secondly, the dftd stack is in the midst of upgrading, and it so happens that (for Silicon Mac) the latest mctc-lib makes dftd4 segfault. So I'm fixing to an older mctc-lib to keep tests running.

This can keep PRs going, but don't expect these changes to endure.

## Status
- [x] Ready for review
- [x] Ready for merge
