### PR TITLE
Fix for pybind11 v3.0.3

### DIFF
--- a/psi4/driver/qcdb/molecule.py
+++ b/psi4/driver/qcdb/molecule.py
@@ -1292,7 +1292,7 @@ class Molecule(LibmintsMolecule):
         """
         raise RuntimeError("Using `Molecule.run_dftd3` instead of `Molecule.run_sdftd3` is obsolete as of 1.10. Note that parameters do not translate directly -- see docstring. Also aliases are not available for dashlvl. The new run_sdftd3 is analogous to run_dftd4. Alternately, you could access these routines by running `qcengine.compute(atomicinput, 's-dftd3')` directly.")
 
-    def run_sdftd3(self, func: Optional[str] = None, dashlvl: Optional[str] = None, dashparam: Optional[Dict] = None, dertype: Union[int, str, None] = None, verbose: int = 1):
+    def run_sdftd3(self, func: Optional[str] = None, dashlvl: Optional[str] = None, dashparam: Optional[Dict] = None, dertype: Union[int, str, None] = None, verbose: int = 1, return_dict: bool = False):
         """Compute dispersion correction via Grimme's new simple-dftd3 program, not the classic DFTD3 executable.
 
         Parameters
@@ -1379,11 +1379,18 @@ class Molecule(LibmintsMolecule):
                     core.set_variable(k, float(qca))
 
         if derint == -1:
+            if return_dict:
+                return (float(jobrec['extras']['qcvars']['DISPERSION CORRECTION ENERGY']),
+                        jobrec['extras']['qcvars']['DISPERSION CORRECTION GRADIENT'], jobrec)
             return (float(jobrec['extras']['qcvars']['DISPERSION CORRECTION ENERGY']),
                     jobrec['extras']['qcvars']['DISPERSION CORRECTION GRADIENT'])
         elif derint == 0:
+            if return_dict:
+                return float(jobrec['extras']['qcvars']['DISPERSION CORRECTION ENERGY']), jobrec
             return float(jobrec['extras']['qcvars']['DISPERSION CORRECTION ENERGY'])
         elif derint == 1:
+            if return_dict:
+                return jobrec['extras']['qcvars']['DISPERSION CORRECTION GRADIENT'], jobrec
             return jobrec['extras']['qcvars']['DISPERSION CORRECTION GRADIENT']
 
     def run_dftd4(self, func: Optional[str] = None, dashlvl: Optional[str] = None, dashparam: Optional[Dict] = None, dertype: Union[int, str, None] = None, verbose: int = 1):

--- a/psi4/src/psi4/libmints/basisset.h
+++ b/psi4/src/psi4/libmints/basisset.h
@@ -177,6 +177,9 @@ class PSI_API BasisSet {
              std::map<std::string, std::map<std::string, std::vector<ShellInfo> > > &shell_map,
              std::map<std::string, std::map<std::string, std::vector<ShellInfo> > > &ecp_shell_map);
 
+    BasisSet(const BasisSet&) = delete;
+    BasisSet& operator=(const BasisSet&) = delete;
+
     ~BasisSet();
 
     /** Builder factory method

--- a/tests/dftd3/version/input.dat
+++ b/tests/dftd3/version/input.dat
@@ -215,8 +215,8 @@ for dlvl in ['d3zero2b']:
     s9 = 0.0
     E, atres = qeeee.run_sdftd3(fctl, dlvl, dertype=der, return_dict=True)
     compare_values(refs[dlvl[:-2]]['d'], E, 7, 'dimer ' + dlvl)  #TEST
-    compare_values(s9, atres["extras"]["info"]["dashparams"]["s9"], 9, f"2b s9={s9}")
     if nu_qcng:
+        compare_values(s9, atres["extras"]["info"]["dashparams"]["s9"], 9, f"2b s9={s9}")
         compare_values(s9, atres["keywords"]["params_tweaks"]["s9"], 9, f"2b s9={s9}")
 
 # <<<  Part 4  >>>

--- a/tests/dftd3/version/input.dat
+++ b/tests/dftd3/version/input.dat
@@ -185,10 +185,39 @@ for dlvl in ['d3zero', 'd3bj', 'd3mzero', 'd3mbj']:
     compare_values(refs[dlvl]['m'], E, 7, 'monoA ' + dlvl)  #TEST
     E = qmBcp.run_sdftd3(fctl, dlvl, dertype=der)
     compare_values(refs[dlvl]['m'], E, 7, 'monoB(CP) ' + dlvl)  #TEST
-for dlvl in ['d3zeroatm']:
-    E = qeeee.run_sdftd3(fctl, dlvl, dertype=der)
-    compare_values(refs[dlvl[:-3]]['d'] + refs['3b']['d'], E, 7, 'dimer ' + dlvl)  #TEST
 
+# s-dftd3 v1.3.0 switches 3-body to False. QCEngine v0.50.0rc4 compensates. Some logic keeps the test working in the gap.
+from dftd3 import __version__ as d3ver
+from qcengine import __version__ as qcngver
+nu_qcng = qcel.util.parse_version(qcngver) >= qcel.util.parse_version("0.50.0rc4")
+atm_false = qcel.util.parse_version(d3ver) >= qcel.util.parse_version("1.3.0")
+badatm = atm_false and not nu_qcng
+
+for dlvl in ['d3zeroatm']:
+    s9 = 1.0
+    E, atres = qeeee.run_sdftd3(fctl, dlvl, dertype=der, return_dict=True)
+    if badatm:
+        compare_values(refs[dlvl[:-3]]['d'], E, 7, 'EXPECTED FAIL dimer ' + dlvl)  #TEST
+    else:
+        compare_values(refs[dlvl[:-3]]['d'] + refs['3b']['d'], E, 7, 'dimer ' + dlvl)  #TEST
+    compare_values(s9, atres["input_data"]["specification"]["extras"]["info"]["dashparams"]["s9"], 9, f"atm s9={s9}")
+    if nu_qcng:
+        compare_values(s9, atres["input_data"]["specification"]["keywords"]["params_tweaks"]["s9"], 9, f"atm s9={s9}")
+for dlvl in ['d3zeroatm']:
+    # note empty first param
+    s9 = 0.5
+    E, atres = qeeee.run_sdftd3("", dlvl, dertype=der, dashparam={'alpha6': 14.0, 's6': 1.0, 's8': 1.703, 's9': s9, 'sr6': 1.261, 'sr8': 1.0}, return_dict=True)
+    compare_values(refs[dlvl[:-3]]['d'] + s9 * refs['3b']['d'], E, 7, 'dimer ' + dlvl + f'-mod {s9}')  #TEST
+    compare_values(s9, atres["input_data"]["specification"]["extras"]["info"]["dashparams"]["s9"], 9, f"atm-mod s9={s9}")
+    if nu_qcng:
+        compare_values(s9, atres["input_data"]["specification"]["keywords"]["params_tweaks"]["s9"], 9, f"atm-mod s9={s9}")
+for dlvl in ['d3zero2b']:
+    s9 = 0.0
+    E, atres = qeeee.run_sdftd3(fctl, dlvl, dertype=der, return_dict=True)
+    compare_values(refs[dlvl[:-2]]['d'], E, 7, 'dimer ' + dlvl)  #TEST
+    compare_values(s9, atres["input_data"]["specification"]["extras"]["info"]["dashparams"]["s9"], 9, f"2b s9={s9}")
+    if nu_qcng:
+        compare_values(s9, atres["input_data"]["specification"]["keywords"]["params_tweaks"]["s9"], 9, f"2b s9={s9}")
 
 # <<<  Part 4  >>>
 

--- a/tests/dftd3/version/input.dat
+++ b/tests/dftd3/version/input.dat
@@ -200,24 +200,24 @@ for dlvl in ['d3zeroatm']:
         compare_values(refs[dlvl[:-3]]['d'], E, 7, 'EXPECTED FAIL dimer ' + dlvl)  #TEST
     else:
         compare_values(refs[dlvl[:-3]]['d'] + refs['3b']['d'], E, 7, 'dimer ' + dlvl)  #TEST
-    compare_values(s9, atres["input_data"]["specification"]["extras"]["info"]["dashparams"]["s9"], 9, f"atm s9={s9}")
+    compare_values(s9, atres["extras"]["info"]["dashparams"]["s9"], 9, f"atm s9={s9}")
     if nu_qcng:
-        compare_values(s9, atres["input_data"]["specification"]["keywords"]["params_tweaks"]["s9"], 9, f"atm s9={s9}")
+        compare_values(s9, atres["keywords"]["params_tweaks"]["s9"], 9, f"atm s9={s9}")
 for dlvl in ['d3zeroatm']:
     # note empty first param
     s9 = 0.5
     E, atres = qeeee.run_sdftd3("", dlvl, dertype=der, dashparam={'alpha6': 14.0, 's6': 1.0, 's8': 1.703, 's9': s9, 'sr6': 1.261, 'sr8': 1.0}, return_dict=True)
     compare_values(refs[dlvl[:-3]]['d'] + s9 * refs['3b']['d'], E, 7, 'dimer ' + dlvl + f'-mod {s9}')  #TEST
-    compare_values(s9, atres["input_data"]["specification"]["extras"]["info"]["dashparams"]["s9"], 9, f"atm-mod s9={s9}")
+    compare_values(s9, atres["extras"]["info"]["dashparams"]["s9"], 9, f"atm-mod s9={s9}")
     if nu_qcng:
-        compare_values(s9, atres["input_data"]["specification"]["keywords"]["params_tweaks"]["s9"], 9, f"atm-mod s9={s9}")
+        compare_values(s9, atres["keywords"]["params_tweaks"]["s9"], 9, f"atm-mod s9={s9}")
 for dlvl in ['d3zero2b']:
     s9 = 0.0
     E, atres = qeeee.run_sdftd3(fctl, dlvl, dertype=der, return_dict=True)
     compare_values(refs[dlvl[:-2]]['d'], E, 7, 'dimer ' + dlvl)  #TEST
-    compare_values(s9, atres["input_data"]["specification"]["extras"]["info"]["dashparams"]["s9"], 9, f"2b s9={s9}")
+    compare_values(s9, atres["extras"]["info"]["dashparams"]["s9"], 9, f"2b s9={s9}")
     if nu_qcng:
-        compare_values(s9, atres["input_data"]["specification"]["keywords"]["params_tweaks"]["s9"], 9, f"2b s9={s9}")
+        compare_values(s9, atres["keywords"]["params_tweaks"]["s9"], 9, f"2b s9={s9}")
 
 # <<<  Part 4  >>>
 


### PR DESCRIPTION
These are the proper fixes to last week's hasty fixes.
closes #3377

## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Delete copy constructor and assignment operator for BasisSet to prevent copying. It was trying to build this constructor and finding an incomplete class that was the cause of L2 shell build errors with pybind11 v3.0.3 . @jturney approves
- [x] The new `simple-dftd3` v1.3.0 implements “match default in Python API with CLI to require opt-in for ATM”. So 3-body not included. Mostly psi4 side-steps this setting by setting all params explicitly. The last dftd3/version test case in section III uses the `run_sdftd3` interface and hits the change. It's fine for longstanding v1.2.1 and compensated-for in the WIP QCEngine v0.50.0, but in the narrow meantime, we need to skip this test. Anyone running the `simple-dftd3` program other than through psi4 total energies (i.e., `psi4.energy("b3lyp-d3")` is in the clear) should check your versions and parameters to make sure you're using what you think you are.

## Status
- [x] Ready for review
- [x] Ready for merge
