### PR TITLE
basic forced unity build

### DIFF
--- a/psi4/src/psi4/CMakeLists.txt
+++ b/psi4/src/psi4/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_UNITY_BUILD ON)
+
 foreach(dir_name
   lib3index
   libciomr

--- a/psi4/src/psi4/cc/CMakeLists.txt
+++ b/psi4/src/psi4/cc/CMakeLists.txt
@@ -42,3 +42,4 @@ foreach(dir_name IN LISTS _ccmodules)
 endforeach ()
 
 set_property(GLOBAL APPEND PROPERTY BINLIST cc)
+set_property(TARGET cc PROPERTY UNITY_BUILD OFF)

--- a/psi4/src/psi4/cc/ccdensity/CMakeLists.txt
+++ b/psi4/src/psi4/cc/ccdensity/CMakeLists.txt
@@ -65,6 +65,7 @@ target_sources(cc
     ${CMAKE_CURRENT_SOURCE_DIR}/fold_UHF.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_frozen.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_moinfo.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/globals.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_params.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_rho_params.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_td_params.cc

--- a/psi4/src/psi4/cc/ccdensity/G.cc
+++ b/psi4/src/psi4/cc/ccdensity/G.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/G_norm.cc
+++ b/psi4/src/psi4/cc/ccdensity/G_norm.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Gabcd.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gabcd.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Gciab.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gciab.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Gibja.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gibja.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Gijab.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijab.cc
@@ -33,7 +33,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Gijab_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijab_RHF.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Gijab_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijab_ROHF.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Gijab_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijab_UHF.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Gijka.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijka.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Gijkl.cc
+++ b/psi4/src/psi4/cc/ccdensity/Gijkl.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Iab.cc
+++ b/psi4/src/psi4/cc/ccdensity/Iab.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Iai.cc
+++ b/psi4/src/psi4/cc/ccdensity/Iai.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Iia.cc
+++ b/psi4/src/psi4/cc/ccdensity/Iia.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/Iij.cc
+++ b/psi4/src/psi4/cc/ccdensity/Iij.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/V.cc
+++ b/psi4/src/psi4/cc/ccdensity/V.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/V_cc2.cc
+++ b/psi4/src/psi4/cc/ccdensity/V_cc2.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/add_core_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/add_core_ROHF.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/add_core_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/add_core_UHF.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/add_ref_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/add_ref_RHF.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/add_ref_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/add_ref_ROHF.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/add_ref_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/add_ref_UHF.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/build_A.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_A.cc
@@ -33,7 +33,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/build_A_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_A_RHF.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/build_A_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_A_ROHF.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/build_A_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_A_UHF.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/build_X.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_X.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 #include <cmath>

--- a/psi4/src/psi4/cc/ccdensity/build_Z.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_Z.cc
@@ -33,7 +33,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/build_Z_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_Z_RHF.cc
@@ -38,7 +38,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/build_Z_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_Z_ROHF.cc
@@ -37,7 +37,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/build_Z_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_Z_UHF.cc
@@ -44,7 +44,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/build_ex_tdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/build_ex_tdensity.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/cache.cc
+++ b/psi4/src/psi4/cc/ccdensity/cache.cc
@@ -37,7 +37,6 @@
 #include "psi4/psifiles.h"
 
 namespace psi {
-extern FILE *outfile;
 namespace ccdensity {
 
 void cache_abcd_rhf(int **cachelist);

--- a/psi4/src/psi4/cc/ccdensity/classify.cc
+++ b/psi4/src/psi4/cc/ccdensity/classify.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/deanti.cc
+++ b/psi4/src/psi4/cc/ccdensity/deanti.cc
@@ -33,7 +33,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/deanti_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/deanti_RHF.cc
@@ -37,7 +37,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 #include <cstdio>

--- a/psi4/src/psi4/cc/ccdensity/deanti_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/deanti_ROHF.cc
@@ -38,7 +38,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/deanti_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/deanti_UHF.cc
@@ -38,7 +38,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/distribute.cc
+++ b/psi4/src/psi4/cc/ccdensity/distribute.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/dump_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/dump_RHF.cc
@@ -38,7 +38,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/dump_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/dump_ROHF.cc
@@ -38,7 +38,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/dump_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/dump_UHF.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/energy.cc
+++ b/psi4/src/psi4/cc/ccdensity/energy.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/energy_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/energy_RHF.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/energy_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/energy_ROHF.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/energy_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/energy_UHF.cc
@@ -37,7 +37,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/ex_oscillator_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_oscillator_strength.cc
@@ -45,7 +45,6 @@
 #include "Frozen.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/ex_rotational_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_rotational_strength.cc
@@ -45,7 +45,6 @@
 #include "Frozen.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/ex_sort_td_rohf.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_sort_td_rohf.cc
@@ -37,7 +37,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/ex_sort_td_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_sort_td_uhf.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/ex_td_cleanup.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_td_cleanup.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/ex_td_print.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_td_print.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/ex_td_setup.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_td_setup.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/ex_tdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_tdensity.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/ex_tdensity_intermediates.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_tdensity_intermediates.cc
@@ -33,7 +33,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/file_build.cc
+++ b/psi4/src/psi4/cc/ccdensity/file_build.cc
@@ -42,7 +42,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/fold.cc
+++ b/psi4/src/psi4/cc/ccdensity/fold.cc
@@ -33,7 +33,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/fold_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/fold_RHF.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/fold_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/fold_ROHF.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/fold_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/fold_UHF.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/get_frozen.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_frozen.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
@@ -44,7 +44,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/get_params.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_params.cc
@@ -44,7 +44,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/get_rho_params.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_rho_params.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/get_td_params.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_td_params.cc
@@ -38,7 +38,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/globals.cc
+++ b/psi4/src/psi4/cc/ccdensity/globals.cc
@@ -1,0 +1,50 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+/*! \file
+    \ingroup CCDENSITY
+    \brief Global variable definitions
+*/
+
+#include "MOInfo.h"
+#include "Params.h"
+#include "Frozen.h"
+#include "globals.h"
+
+namespace psi {
+namespace ccdensity {
+
+// Global variable definitions
+struct MOInfo moinfo;
+struct Frozen frozen;
+struct Params params;
+struct RHO_Params *rho_params;
+std::vector<TD_Params> td_params;
+
+}
+}  // namespace psi

--- a/psi4/src/psi4/cc/ccdensity/globals.h
+++ b/psi4/src/psi4/cc/ccdensity/globals.h
@@ -45,21 +45,14 @@ namespace psi {
 namespace ccdensity {
 
 /* Global variables */
-#ifdef EXTERN
-#undef EXTERN
-#define EXTERN extern
-#else
-#define EXTERN
-#endif
-
 /* #define DEBUG_XI (1)*/
 
-EXTERN struct MOInfo moinfo;
-EXTERN struct Frozen frozen;
-EXTERN struct Params params;
-EXTERN struct RHO_Params *rho_params;
-EXTERN std::vector<TD_Params> td_params;
-// EXTERN std::vector<struct XTD_Params> xtd_params;
+extern struct MOInfo moinfo;
+extern struct Frozen frozen;
+extern struct Params params;
+extern struct RHO_Params *rho_params;
+extern std::vector<TD_Params> td_params;
+// extern std::vector<struct XTD_Params> xtd_params;
 }
 }  // namespace psi
 

--- a/psi4/src/psi4/cc/ccdensity/kinetic.cc
+++ b/psi4/src/psi4/cc/ccdensity/kinetic.cc
@@ -43,7 +43,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/lag.cc
+++ b/psi4/src/psi4/cc/ccdensity/lag.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/ltdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ltdensity.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/ltdensity_intermediates.cc
+++ b/psi4/src/psi4/cc/ccdensity/ltdensity_intermediates.cc
@@ -33,7 +33,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/norm.cc
+++ b/psi4/src/psi4/cc/ccdensity/norm.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/onepdm.cc
+++ b/psi4/src/psi4/cc/ccdensity/onepdm.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/oscillator_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/oscillator_strength.cc
@@ -44,7 +44,6 @@
 #include "Frozen.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/relax_D.cc
+++ b/psi4/src/psi4/cc/ccdensity/relax_D.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/relax_I.cc
+++ b/psi4/src/psi4/cc/ccdensity/relax_I.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/relax_I_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/relax_I_RHF.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/relax_I_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/relax_I_ROHF.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/relax_I_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/relax_I_UHF.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/resort_gamma.cc
+++ b/psi4/src/psi4/cc/ccdensity/resort_gamma.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/resort_tei.cc
+++ b/psi4/src/psi4/cc/ccdensity/resort_tei.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/rotational_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/rotational_strength.cc
@@ -46,7 +46,6 @@
 #include "Frozen.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/rtdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/rtdensity.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/setup_LR.cc
+++ b/psi4/src/psi4/cc/ccdensity/setup_LR.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/sortI.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI.cc
@@ -34,7 +34,6 @@
 #include "Params.h"
 #include "Frozen.h"
 #include "psi4/libmints/wavefunction.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/sortI_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_RHF.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/sortI_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_ROHF.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/sortI_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_UHF.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/sort_ltd_rohf.cc
+++ b/psi4/src/psi4/cc/ccdensity/sort_ltd_rohf.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/sort_ltd_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/sort_ltd_uhf.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/sort_rtd_rohf.cc
+++ b/psi4/src/psi4/cc/ccdensity/sort_rtd_rohf.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/sort_rtd_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/sort_rtd_uhf.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/sortone.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone.cc
@@ -33,7 +33,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/sortone_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone_RHF.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/sortone_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone_ROHF.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/sortone_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone_UHF.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/td_cleanup.cc
+++ b/psi4/src/psi4/cc/ccdensity/td_cleanup.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/td_print.cc
+++ b/psi4/src/psi4/cc/ccdensity/td_print.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/td_setup.cc
+++ b/psi4/src/psi4/cc/ccdensity/td_setup.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/tdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/tdensity.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/transL.cc
+++ b/psi4/src/psi4/cc/ccdensity/transL.cc
@@ -42,7 +42,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/transdip.cc
+++ b/psi4/src/psi4/cc/ccdensity/transdip.cc
@@ -42,7 +42,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/transp.cc
+++ b/psi4/src/psi4/cc/ccdensity/transp.cc
@@ -42,7 +42,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/twopdm.cc
+++ b/psi4/src/psi4/cc/ccdensity/twopdm.cc
@@ -31,7 +31,6 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#define EXTERN
 #include "globals.h"
 namespace psi {
 namespace ccdensity {

--- a/psi4/src/psi4/cc/ccdensity/wfn_saver.cc
+++ b/psi4/src/psi4/cc/ccdensity/wfn_saver.cc
@@ -35,7 +35,6 @@
 #include "psi4/cc/ccwave.h"
 #include "ccdensity.h"
 #include "MOInfo.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_Gabcd.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gabcd.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_Gciab.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gciab.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_Gciab_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gciab_uhf.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_Gibja.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gibja.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_Gibja_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gibja_uhf.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_Gijab.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gijab.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_Gijab_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gijab_uhf.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_Gijka.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gijka.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_Gijka_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gijka_uhf.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_Gijkl.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_Gijkl.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_V.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_V.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_oe_intermediates.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_oe_intermediates.cc
@@ -33,7 +33,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_oe_intermediates_rhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_oe_intermediates_rhf.cc
@@ -33,7 +33,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_onepdm.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_onepdm.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_onepdm_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_onepdm_uhf.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_te_intermediates.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_te_intermediates.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_te_intermediates_rhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_te_intermediates_rhf.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_xi1.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi1.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_xi1_connected.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi1_connected.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_xi1_rhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi1_rhf.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_xi1_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi1_uhf.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_xi2.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi2.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_xi2_rhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi2_rhf.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_xi2_uhf.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi2_uhf.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_xi_check.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi_check.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/x_xi_intermediates.cc
+++ b/psi4/src/psi4/cc/ccdensity/x_xi_intermediates.cc
@@ -33,7 +33,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccdensity/zero_pdm.cc
+++ b/psi4/src/psi4/cc/ccdensity/zero_pdm.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/CMakeLists.txt
+++ b/psi4/src/psi4/cc/cceom/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_eom_params.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_moinfo.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_params.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/globals.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/hbar_extra.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/hbar_norms.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/local.cc

--- a/psi4/src/psi4/cc/cceom/FDD.cc
+++ b/psi4/src/psi4/cc/cceom/FDD.cc
@@ -38,7 +38,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/FSD.cc
+++ b/psi4/src/psi4/cc/cceom/FSD.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/WabefDD.cc
+++ b/psi4/src/psi4/cc/cceom/WabefDD.cc
@@ -40,7 +40,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/WabejDS.cc
+++ b/psi4/src/psi4/cc/cceom/WabejDS.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/WamefSD.cc
+++ b/psi4/src/psi4/cc/cceom/WamefSD.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/WbmfeDS.cc
+++ b/psi4/src/psi4/cc/cceom/WbmfeDS.cc
@@ -38,7 +38,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/WmaijDS.cc
+++ b/psi4/src/psi4/cc/cceom/WmaijDS.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/WmbejDD.cc
+++ b/psi4/src/psi4/cc/cceom/WmbejDD.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/WmnefDD.cc
+++ b/psi4/src/psi4/cc/cceom/WmnefDD.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/WmnieSD.cc
+++ b/psi4/src/psi4/cc/cceom/WmnieSD.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/WmnijDD.cc
+++ b/psi4/src/psi4/cc/cceom/WmnijDD.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/WnmjeDS.cc
+++ b/psi4/src/psi4/cc/cceom/WnmjeDS.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/amp_write.cc
+++ b/psi4/src/psi4/cc/cceom/amp_write.cc
@@ -44,7 +44,6 @@
 
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 // minimum magnitude of amplitude to include in output

--- a/psi4/src/psi4/cc/cceom/c_clean.cc
+++ b/psi4/src/psi4/cc/cceom/c_clean.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/cc2_hbar_extra.cc
+++ b/psi4/src/psi4/cc/cceom/cc2_hbar_extra.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/cc2_sigma.cc
+++ b/psi4/src/psi4/cc/cceom/cc2_sigma.cc
@@ -37,7 +37,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/cc3_HC1.cc
+++ b/psi4/src/psi4/cc/cceom/cc3_HC1.cc
@@ -37,7 +37,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/cc3_HC1ET1.cc
+++ b/psi4/src/psi4/cc/cceom/cc3_HC1ET1.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/check_sum.cc
+++ b/psi4/src/psi4/cc/cceom/check_sum.cc
@@ -38,7 +38,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/dgeev_eom.cc
+++ b/psi4/src/psi4/cc/cceom/dgeev_eom.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/diag.cc
+++ b/psi4/src/psi4/cc/cceom/diag.cc
@@ -51,7 +51,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 #include "psi4/psi4-dec.h"
 

--- a/psi4/src/psi4/cc/cceom/diagSS.cc
+++ b/psi4/src/psi4/cc/cceom/diagSS.cc
@@ -42,7 +42,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/follow_root.cc
+++ b/psi4/src/psi4/cc/cceom/follow_root.cc
@@ -41,7 +41,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/form_diagonal.cc
+++ b/psi4/src/psi4/cc/cceom/form_diagonal.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/get_eom_params.cc
+++ b/psi4/src/psi4/cc/cceom/get_eom_params.cc
@@ -45,7 +45,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cceom/get_moinfo.cc
@@ -41,7 +41,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 #include <cctype> 

--- a/psi4/src/psi4/cc/cceom/get_params.cc
+++ b/psi4/src/psi4/cc/cceom/get_params.cc
@@ -42,7 +42,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/globals.cc
+++ b/psi4/src/psi4/cc/cceom/globals.cc
@@ -1,0 +1,50 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+/*! \file
+    \ingroup CCEOM
+    \brief Global variable definitions
+*/
+
+#include "MOInfo.h"
+#include "Params.h"
+#include "Local.h"
+#include "globals.h"
+
+namespace psi {
+namespace cceom {
+
+// Global variable definitions
+struct MOInfo moinfo;
+struct Params params;
+struct Eom_params eom_params;
+struct Local local;
+int ***dpd_dp;
+
+}
+}  // namespace psi

--- a/psi4/src/psi4/cc/cceom/globals.h
+++ b/psi4/src/psi4/cc/cceom/globals.h
@@ -43,26 +43,20 @@ namespace psi {
 namespace cceom {
 
 /* Global variables */
-#ifdef EXTERN
-#undef EXTERN
-#define EXTERN extern
-#else
-#define EXTERN
-#endif
-
-EXTERN void check_sum(const char *term_lbl, int index, int irrep);
+void check_sum(const char *term_lbl, int index, int irrep);
 
 //#define EOM_DEBUG (0)
 
-#define H_IRR (0)
-#define MAX(I, J) ((I > J) ? I : J)
-#define MIN(I, J) ((I < J) ? I : J)
+// Use constexpr variables and inline functions instead of unsafe macros
+inline constexpr int H_IRR = 0;
+inline constexpr int MAX(int I, int J) { return (I > J) ? I : J; }
+inline constexpr int MIN(int I, int J) { return (I < J) ? I : J; }
 
-EXTERN struct MOInfo moinfo;
-EXTERN struct Params params;
-EXTERN struct Eom_params eom_params;
-EXTERN struct Local local;
-EXTERN int ***dpd_dp;
+extern struct MOInfo moinfo;
+extern struct Params params;
+extern struct Eom_params eom_params;
+extern struct Local local;
+extern int ***dpd_dp;
 }
 }  // namespace psi
 

--- a/psi4/src/psi4/cc/cceom/hbar_extra.cc
+++ b/psi4/src/psi4/cc/cceom/hbar_extra.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/hbar_norms.cc
+++ b/psi4/src/psi4/cc/cceom/hbar_norms.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/local.cc
+++ b/psi4/src/psi4/cc/cceom/local.cc
@@ -46,7 +46,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/local_guess.cc
+++ b/psi4/src/psi4/cc/cceom/local_guess.cc
@@ -40,7 +40,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/norm.cc
+++ b/psi4/src/psi4/cc/cceom/norm.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/norm_HC1.cc
+++ b/psi4/src/psi4/cc/cceom/norm_HC1.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/overlap.cc
+++ b/psi4/src/psi4/cc/cceom/overlap.cc
@@ -41,7 +41,6 @@
 #include "psi4/libciomr/libciomr.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/precondition.cc
+++ b/psi4/src/psi4/cc/cceom/precondition.cc
@@ -41,7 +41,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/read_guess.cc
+++ b/psi4/src/psi4/cc/cceom/read_guess.cc
@@ -38,7 +38,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/restart.cc
+++ b/psi4/src/psi4/cc/cceom/restart.cc
@@ -40,7 +40,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/restart_with_root.cc
+++ b/psi4/src/psi4/cc/cceom/restart_with_root.cc
@@ -42,7 +42,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/rzero.cc
+++ b/psi4/src/psi4/cc/cceom/rzero.cc
@@ -37,7 +37,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/schmidt_add.cc
+++ b/psi4/src/psi4/cc/cceom/schmidt_add.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/sigmaCC3.cc
+++ b/psi4/src/psi4/cc/cceom/sigmaCC3.cc
@@ -33,7 +33,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/sigmaCC3_RHF.cc
+++ b/psi4/src/psi4/cc/cceom/sigmaCC3_RHF.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/sigmaDD.cc
+++ b/psi4/src/psi4/cc/cceom/sigmaDD.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/sigmaDS.cc
+++ b/psi4/src/psi4/cc/cceom/sigmaDS.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/sigmaSD.cc
+++ b/psi4/src/psi4/cc/cceom/sigmaSD.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/sigmaSS.cc
+++ b/psi4/src/psi4/cc/cceom/sigmaSS.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/sigma_full.cc
+++ b/psi4/src/psi4/cc/cceom/sigma_full.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/sort_C.cc
+++ b/psi4/src/psi4/cc/cceom/sort_C.cc
@@ -37,7 +37,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/sort_amps.cc
+++ b/psi4/src/psi4/cc/cceom/sort_amps.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cceom/write_Rs.cc
+++ b/psi4/src/psi4/cc/cceom/write_Rs.cc
@@ -41,7 +41,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/CMakeLists.txt
+++ b/psi4/src/psi4/cc/cchbar/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(cc
     ${CMAKE_CURRENT_SOURCE_DIR}/cchbar.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_moinfo.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_params.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/globals.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/norm_HET1.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/purge.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/reference.cc

--- a/psi4/src/psi4/cc/cchbar/F.cc
+++ b/psi4/src/psi4/cc/cchbar/F.cc
@@ -41,7 +41,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Fai.cc
+++ b/psi4/src/psi4/cc/cchbar/Fai.cc
@@ -37,7 +37,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/HET1_Wabef.cc
+++ b/psi4/src/psi4/cc/cchbar/HET1_Wabef.cc
@@ -37,7 +37,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Wabei.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei.cc
@@ -36,7 +36,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Wabei_AAAA_UHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_AAAA_UHF.cc
@@ -35,7 +35,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Wabei_ABAB_UHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_ABAB_UHF.cc
@@ -35,7 +35,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Wabei_BABA_UHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_BABA_UHF.cc
@@ -35,7 +35,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Wabei_BBBB_UHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_BBBB_UHF.cc
@@ -35,7 +35,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Wabei_RHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_RHF.cc
@@ -40,7 +40,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Wabei_ROHF.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabei_ROHF.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Wabij.cc
+++ b/psi4/src/psi4/cc/cchbar/Wabij.cc
@@ -38,7 +38,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Wamef.cc
+++ b/psi4/src/psi4/cc/cchbar/Wamef.cc
@@ -36,7 +36,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Wmbej.cc
+++ b/psi4/src/psi4/cc/cchbar/Wmbej.cc
@@ -36,7 +36,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Wmbij.cc
+++ b/psi4/src/psi4/cc/cchbar/Wmbij.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/Wmnie.cc
+++ b/psi4/src/psi4/cc/cchbar/Wmnie.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/cache.cc
+++ b/psi4/src/psi4/cc/cchbar/cache.cc
@@ -37,7 +37,6 @@
 #include "psi4/libpsi4util/exception.h"
 
 namespace psi {
-extern FILE *outfile;
 namespace cchbar {
 
 void cache_abcd_rhf(int **cachelist);

--- a/psi4/src/psi4/cc/cchbar/cc2_Wabei.cc
+++ b/psi4/src/psi4/cc/cchbar/cc2_Wabei.cc
@@ -35,7 +35,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/cc2_Wmbej.cc
+++ b/psi4/src/psi4/cc/cchbar/cc2_Wmbej.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/cc2_Wmbij.cc
+++ b/psi4/src/psi4/cc/cchbar/cc2_Wmbij.cc
@@ -37,7 +37,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/cc2_Zmbej.cc
+++ b/psi4/src/psi4/cc/cchbar/cc2_Zmbej.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/cc3_HET1.cc
+++ b/psi4/src/psi4/cc/cchbar/cc3_HET1.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cchbar/get_moinfo.cc
@@ -41,7 +41,6 @@
 #include "psi4/libmints/molecule.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/get_params.cc
+++ b/psi4/src/psi4/cc/cchbar/get_params.cc
@@ -41,7 +41,6 @@
 #include "psi4/psi4-dec.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/globals.cc
+++ b/psi4/src/psi4/cc/cchbar/globals.cc
@@ -1,0 +1,46 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+/*! \file
+    \ingroup CCHBAR
+    \brief Global variable definitions
+*/
+
+#include "MOInfo.h"
+#include "Params.h"
+#include "globals.h"
+
+namespace psi {
+namespace cchbar {
+
+// Global variable definitions
+struct MOInfo moinfo;
+struct Params params;
+
+}
+}  // namespace psi

--- a/psi4/src/psi4/cc/cchbar/globals.h
+++ b/psi4/src/psi4/cc/cchbar/globals.h
@@ -42,15 +42,8 @@ namespace psi {
 namespace cchbar {
 
 /* Global variables */
-#ifdef EXTERN
-#undef EXTERN
-#define EXTERN extern
-#else
-#define EXTERN
-#endif
-
-EXTERN struct MOInfo moinfo;
-EXTERN struct Params params;
+extern struct MOInfo moinfo;
+extern struct Params params;
 }
 }  // namespace psi
 

--- a/psi4/src/psi4/cc/cchbar/norm_HET1.cc
+++ b/psi4/src/psi4/cc/cchbar/norm_HET1.cc
@@ -35,7 +35,6 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/purge.cc
+++ b/psi4/src/psi4/cc/cchbar/purge.cc
@@ -35,7 +35,6 @@
 #include <cmath>
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/reference.cc
+++ b/psi4/src/psi4/cc/cchbar/reference.cc
@@ -38,7 +38,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/sort_amps.cc
+++ b/psi4/src/psi4/cc/cchbar/sort_amps.cc
@@ -35,7 +35,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/tau.cc
+++ b/psi4/src/psi4/cc/cchbar/tau.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cchbar/taut.cc
+++ b/psi4/src/psi4/cc/cchbar/taut.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/BL2_AO.cc
+++ b/psi4/src/psi4/cc/cclambda/BL2_AO.cc
@@ -44,7 +44,6 @@
 #include "psi4/psifiles.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/CMakeLists.txt
+++ b/psi4/src/psi4/cc/cclambda/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources(cc
     ${CMAKE_CURRENT_SOURCE_DIR}/dijabL2.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_moinfo.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_params.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/globals.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/halftrans.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/hbar_extra.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/init_amps.cc

--- a/psi4/src/psi4/cc/cclambda/DL2.cc
+++ b/psi4/src/psi4/cc/cclambda/DL2.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/FaeL2.cc
+++ b/psi4/src/psi4/cc/cclambda/FaeL2.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/FmiL2.cc
+++ b/psi4/src/psi4/cc/cclambda/FmiL2.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/G.cc
+++ b/psi4/src/psi4/cc/cclambda/G.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/GL2.cc
+++ b/psi4/src/psi4/cc/cclambda/GL2.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/L1.cc
+++ b/psi4/src/psi4/cc/cclambda/L1.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/L1FL2.cc
+++ b/psi4/src/psi4/cc/cclambda/L1FL2.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/L2.cc
+++ b/psi4/src/psi4/cc/cclambda/L2.cc
@@ -35,7 +35,6 @@
 #include "cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/Lamp_write.cc
+++ b/psi4/src/psi4/cc/cclambda/Lamp_write.cc
@@ -37,7 +37,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/Lmag.cc
+++ b/psi4/src/psi4/cc/cclambda/Lmag.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/Lnorm.cc
+++ b/psi4/src/psi4/cc/cclambda/Lnorm.cc
@@ -36,7 +36,6 @@
 
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/Lsave.cc
+++ b/psi4/src/psi4/cc/cclambda/Lsave.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/WabeiL1.cc
+++ b/psi4/src/psi4/cc/cclambda/WabeiL1.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/WefabL2.cc
+++ b/psi4/src/psi4/cc/cclambda/WefabL2.cc
@@ -39,7 +39,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/WejabL2.cc
+++ b/psi4/src/psi4/cc/cclambda/WejabL2.cc
@@ -36,7 +36,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/WijmbL2.cc
+++ b/psi4/src/psi4/cc/cclambda/WijmbL2.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/WijmnL2.cc
+++ b/psi4/src/psi4/cc/cclambda/WijmnL2.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/WmbejL2.cc
+++ b/psi4/src/psi4/cc/cclambda/WmbejL2.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/c_clean.cc
+++ b/psi4/src/psi4/cc/cclambda/c_clean.cc
@@ -34,7 +34,6 @@
 #include <cmath>
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/cc2_Gai.cc
+++ b/psi4/src/psi4/cc/cclambda/cc2_Gai.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/cc2_L1.cc
+++ b/psi4/src/psi4/cc/cclambda/cc2_L1.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/cc2_L2.cc
+++ b/psi4/src/psi4/cc/cclambda/cc2_L2.cc
@@ -35,7 +35,6 @@
 #include "cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/cc2_faeL2.cc
+++ b/psi4/src/psi4/cc/cclambda/cc2_faeL2.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/cc2_fmiL2.cc
+++ b/psi4/src/psi4/cc/cclambda/cc2_fmiL2.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/cc2_hbar_extra.cc
+++ b/psi4/src/psi4/cc/cclambda/cc2_hbar_extra.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/cc3_l3l1.cc
+++ b/psi4/src/psi4/cc/cclambda/cc3_l3l1.cc
@@ -34,7 +34,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/cc3_l3l2.cc
+++ b/psi4/src/psi4/cc/cclambda/cc3_l3l2.cc
@@ -37,7 +37,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/cc3_t3x.cc
+++ b/psi4/src/psi4/cc/cclambda/cc3_t3x.cc
@@ -36,7 +36,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/cc3_t3z.cc
+++ b/psi4/src/psi4/cc/cclambda/cc3_t3z.cc
@@ -56,7 +56,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/check_ortho.cc
+++ b/psi4/src/psi4/cc/cclambda/check_ortho.cc
@@ -36,7 +36,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/check_sum.cc
+++ b/psi4/src/psi4/cc/cclambda/check_sum.cc
@@ -36,7 +36,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/converged.cc
+++ b/psi4/src/psi4/cc/cclambda/converged.cc
@@ -37,7 +37,6 @@
 #include "cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/denom.cc
+++ b/psi4/src/psi4/cc/cclambda/denom.cc
@@ -36,7 +36,6 @@
 #include "cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/diis.cc
+++ b/psi4/src/psi4/cc/cclambda/diis.cc
@@ -42,7 +42,6 @@
 #include "psi4/psifiles.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/dijabL2.cc
+++ b/psi4/src/psi4/cc/cclambda/dijabL2.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cclambda/get_moinfo.cc
@@ -41,7 +41,6 @@
 #include "cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/get_params.cc
+++ b/psi4/src/psi4/cc/cclambda/get_params.cc
@@ -47,7 +47,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/globals.cc
+++ b/psi4/src/psi4/cc/cclambda/globals.cc
@@ -1,0 +1,49 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+/*! \file
+    \ingroup CCLAMBDA
+    \brief Global variable definitions
+*/
+
+#include "MOInfo.h"
+#include "Params.h"
+#include "Local.h"
+#include "globals.h"
+
+namespace psi {
+namespace cclambda {
+
+// Global variable definitions
+struct MOInfo moinfo;
+struct Params params;
+struct L_Params *pL_params;
+struct Local local;
+
+}
+}  // namespace psi

--- a/psi4/src/psi4/cc/cclambda/globals.h
+++ b/psi4/src/psi4/cc/cclambda/globals.h
@@ -44,19 +44,12 @@ namespace psi {
 namespace cclambda {
 
 /* Global variables */
-#ifdef EXTERN
-#undef EXTERN
-#define EXTERN extern
-#else
-#define EXTERN
-#endif
-
 /* #define EOM_DEBUG (1) */
 
-EXTERN struct MOInfo moinfo;
-EXTERN struct Params params;
-EXTERN struct L_Params *pL_params;
-EXTERN struct Local local;
+extern struct MOInfo moinfo;
+extern struct Params params;
+extern struct L_Params *pL_params;
+extern struct Local local;
 void check_sum(char *lbl, int L_irr);
 }
 }  // namespace psi

--- a/psi4/src/psi4/cc/cclambda/hbar_extra.cc
+++ b/psi4/src/psi4/cc/cclambda/hbar_extra.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/init_amps.cc
+++ b/psi4/src/psi4/cc/cclambda/init_amps.cc
@@ -35,7 +35,6 @@
 #include "cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/local.cc
+++ b/psi4/src/psi4/cc/cclambda/local.cc
@@ -46,7 +46,6 @@
 #include "Params.h"
 #include "Local.h"
 #include "cclambda.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/ortho_Rs.cc
+++ b/psi4/src/psi4/cc/cclambda/ortho_Rs.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/overlap.cc
+++ b/psi4/src/psi4/cc/cclambda/overlap.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/projections.cc
+++ b/psi4/src/psi4/cc/cclambda/projections.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/pseudoenergy.cc
+++ b/psi4/src/psi4/cc/cclambda/pseudoenergy.cc
@@ -35,7 +35,6 @@
 #include <cmath>
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/sort_amps.cc
+++ b/psi4/src/psi4/cc/cclambda/sort_amps.cc
@@ -35,7 +35,6 @@
 #include "cclambda.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/spinad_amps.cc
+++ b/psi4/src/psi4/cc/cclambda/spinad_amps.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cclambda/update.cc
+++ b/psi4/src/psi4/cc/cclambda/update.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "cclambda.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/CMakeLists.txt
+++ b/psi4/src/psi4/cc/ccresponse/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(cc
     ${CMAKE_CURRENT_SOURCE_DIR}/diis.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_moinfo.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_params.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/globals.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/hbar_extra.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/init_X.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/lambda_residuals.cc

--- a/psi4/src/psi4/cc/ccresponse/HXY.cc
+++ b/psi4/src/psi4/cc/ccresponse/HXY.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/LCX.cc
+++ b/psi4/src/psi4/cc/ccresponse/LCX.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/LHX1Y1.cc
+++ b/psi4/src/psi4/cc/ccresponse/LHX1Y1.cc
@@ -38,7 +38,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/LHX1Y2.cc
+++ b/psi4/src/psi4/cc/ccresponse/LHX1Y2.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/LHX2Y2.cc
+++ b/psi4/src/psi4/cc/ccresponse/LHX2Y2.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/X1.cc
+++ b/psi4/src/psi4/cc/ccresponse/X1.cc
@@ -37,7 +37,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/X2.cc
+++ b/psi4/src/psi4/cc/ccresponse/X2.cc
@@ -41,7 +41,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/amp_write.cc
+++ b/psi4/src/psi4/cc/ccresponse/amp_write.cc
@@ -40,7 +40,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/analyze.cc
+++ b/psi4/src/psi4/cc/ccresponse/analyze.cc
@@ -39,7 +39,6 @@
 #include "Params.h"
 #include "MOInfo.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/cache.cc
+++ b/psi4/src/psi4/cc/ccresponse/cache.cc
@@ -37,7 +37,6 @@
 #include "psi4/psifiles.h"
 
 namespace psi {
-extern FILE *outfile;
 namespace ccresponse {
 
 void cache_abcd_rhf(int **cachelist);

--- a/psi4/src/psi4/cc/ccresponse/cc2_LHX1Y1.cc
+++ b/psi4/src/psi4/cc/ccresponse/cc2_LHX1Y1.cc
@@ -41,7 +41,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/cc2_LHX1Y2.cc
+++ b/psi4/src/psi4/cc/ccresponse/cc2_LHX1Y2.cc
@@ -38,7 +38,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/cc2_X1.cc
+++ b/psi4/src/psi4/cc/ccresponse/cc2_X1.cc
@@ -37,7 +37,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/cc2_X2.cc
+++ b/psi4/src/psi4/cc/ccresponse/cc2_X2.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/cc2_hbar_extra.cc
+++ b/psi4/src/psi4/cc/ccresponse/cc2_hbar_extra.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/cc2_sort_X.cc
+++ b/psi4/src/psi4/cc/ccresponse/cc2_sort_X.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/compute_X.cc
+++ b/psi4/src/psi4/cc/ccresponse/compute_X.cc
@@ -42,7 +42,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/converged.cc
+++ b/psi4/src/psi4/cc/ccresponse/converged.cc
@@ -37,7 +37,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/denom.cc
+++ b/psi4/src/psi4/cc/ccresponse/denom.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/diis.cc
+++ b/psi4/src/psi4/cc/ccresponse/diis.cc
@@ -43,7 +43,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccresponse/get_moinfo.cc
@@ -44,7 +44,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/get_params.cc
+++ b/psi4/src/psi4/cc/ccresponse/get_params.cc
@@ -51,7 +51,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/globals.cc
+++ b/psi4/src/psi4/cc/ccresponse/globals.cc
@@ -1,0 +1,48 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+/*! \file
+    \ingroup ccresponse
+    \brief Global variable definitions
+*/
+
+#include "MOInfo.h"
+#include "Params.h"
+#include "Local.h"
+#include "globals.h"
+
+namespace psi {
+namespace ccresponse {
+
+// Global variable definitions
+struct MOInfo moinfo;
+struct Params params;
+struct Local local;
+
+}
+}  // namespace psi

--- a/psi4/src/psi4/cc/ccresponse/globals.h
+++ b/psi4/src/psi4/cc/ccresponse/globals.h
@@ -41,18 +41,12 @@ namespace psi {
 namespace ccresponse {
 
 /* Global variables */
-#ifdef EXTERN
-#undef EXTERN
-#define EXTERN extern
-#else
-#define EXTERN
-#endif
+extern struct MOInfo moinfo;
+extern struct Params params;
+extern struct Local local;
 
-EXTERN struct MOInfo moinfo;
-EXTERN struct Params params;
-EXTERN struct Local local;
-
-#define MIN0(a, b) (((a) < (b)) ? (a) : (b))
+// Use inline function instead of unsafe macro
+inline constexpr int MIN0(int a, int b) { return ((a) < (b)) ? (a) : (b); }
 }
 }  // namespace psi
 

--- a/psi4/src/psi4/cc/ccresponse/hbar_extra.cc
+++ b/psi4/src/psi4/cc/ccresponse/hbar_extra.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/init_X.cc
+++ b/psi4/src/psi4/cc/ccresponse/init_X.cc
@@ -37,7 +37,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/lambda_residuals.cc
+++ b/psi4/src/psi4/cc/ccresponse/lambda_residuals.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/linresp.cc
+++ b/psi4/src/psi4/cc/ccresponse/linresp.cc
@@ -39,7 +39,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/local.cc
+++ b/psi4/src/psi4/cc/ccresponse/local.cc
@@ -45,7 +45,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/optrot.cc
+++ b/psi4/src/psi4/cc/ccresponse/optrot.cc
@@ -84,7 +84,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 #include "psi4/physconst.h"
 #include "psi4/libmints/matrix.h"

--- a/psi4/src/psi4/cc/ccresponse/pertbar.cc
+++ b/psi4/src/psi4/cc/ccresponse/pertbar.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/polar.cc
+++ b/psi4/src/psi4/cc/ccresponse/polar.cc
@@ -46,7 +46,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 #include "psi4/libmints/matrix.h"
 

--- a/psi4/src/psi4/cc/ccresponse/preppert.cc
+++ b/psi4/src/psi4/cc/ccresponse/preppert.cc
@@ -43,7 +43,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/print_X.cc
+++ b/psi4/src/psi4/cc/ccresponse/print_X.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/pseudopolar.cc
+++ b/psi4/src/psi4/cc/ccresponse/pseudopolar.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/roa.cc
+++ b/psi4/src/psi4/cc/ccresponse/roa.cc
@@ -50,7 +50,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/save_X.cc
+++ b/psi4/src/psi4/cc/ccresponse/save_X.cc
@@ -35,7 +35,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/scatter.cc
+++ b/psi4/src/psi4/cc/ccresponse/scatter.cc
@@ -50,7 +50,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 #include <vector>
 #include "psi4/psi4-dec.h"

--- a/psi4/src/psi4/cc/ccresponse/scatter2.cc
+++ b/psi4/src/psi4/cc/ccresponse/scatter2.cc
@@ -47,7 +47,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 /*

--- a/psi4/src/psi4/cc/ccresponse/sort_X.cc
+++ b/psi4/src/psi4/cc/ccresponse/sort_X.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/sort_lamps.cc
+++ b/psi4/src/psi4/cc/ccresponse/sort_lamps.cc
@@ -34,7 +34,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/sort_pert.cc
+++ b/psi4/src/psi4/cc/ccresponse/sort_pert.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/ccresponse/update_X.cc
+++ b/psi4/src/psi4/cc/ccresponse/update_X.cc
@@ -36,7 +36,6 @@
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/CMakeLists.txt
+++ b/psi4/src/psi4/cc/cctriples/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(cc
     ${CMAKE_CURRENT_SOURCE_DIR}/cache.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/count_ijk.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/get_moinfo.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/globals.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/test_abc_loops.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/transpose_integrals.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/triples.cc

--- a/psi4/src/psi4/cc/cctriples/ET_AAA.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_AAA.cc
@@ -38,7 +38,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/ET_AAB.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_AAB.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/ET_ABB.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_ABB.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/ET_BBB.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_BBB.cc
@@ -35,7 +35,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/ET_RHF.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_RHF.cc
@@ -42,7 +42,6 @@
 
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 // MKL Header

--- a/psi4/src/psi4/cc/cctriples/ET_UHF_AAA.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_UHF_AAA.cc
@@ -37,7 +37,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/ET_UHF_AAB.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_UHF_AAB.cc
@@ -38,7 +38,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/ET_UHF_ABB.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_UHF_ABB.cc
@@ -37,7 +37,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/ET_UHF_BBB.cc
+++ b/psi4/src/psi4/cc/cctriples/ET_UHF_BBB.cc
@@ -37,7 +37,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/EaT_RHF.cc
+++ b/psi4/src/psi4/cc/cctriples/EaT_RHF.cc
@@ -42,7 +42,6 @@
 
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 // MKL Header

--- a/psi4/src/psi4/cc/cctriples/T3_grad_RHF.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_RHF.cc
@@ -39,7 +39,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/T3_grad_UHF_AAA.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_UHF_AAA.cc
@@ -37,7 +37,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/T3_grad_UHF_AAB.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_UHF_AAB.cc
@@ -38,7 +38,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/T3_grad_UHF_BBA.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_UHF_BBA.cc
@@ -37,7 +37,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/T3_grad_UHF_BBB.cc
+++ b/psi4/src/psi4/cc/cctriples/T3_grad_UHF_BBB.cc
@@ -37,7 +37,6 @@
 #include "psi4/libqt/qt.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/count_ijk.cc
+++ b/psi4/src/psi4/cc/cctriples/count_ijk.cc
@@ -33,7 +33,6 @@
 #include <cstdio>
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 

--- a/psi4/src/psi4/cc/cctriples/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cctriples/get_moinfo.cc
@@ -46,7 +46,6 @@
 
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/globals.cc
+++ b/psi4/src/psi4/cc/cctriples/globals.cc
@@ -1,0 +1,46 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+/*! \file
+    \ingroup CCTRIPLES
+    \brief Global variable definitions
+*/
+
+#include "MOInfo.h"
+#include "Params.h"
+#include "globals.h"
+
+namespace psi {
+namespace cctriples {
+
+// Global variable definitions
+struct MOInfo moinfo;
+struct Params params;
+
+}
+}  // namespace psi

--- a/psi4/src/psi4/cc/cctriples/globals.h
+++ b/psi4/src/psi4/cc/cctriples/globals.h
@@ -44,15 +44,8 @@ namespace psi {
 namespace cctriples {
 
 /* Global variables */
-#ifdef EXTERN
-#undef EXTERN
-#define EXTERN extern
-#else
-#define EXTERN
-#endif
-
-EXTERN struct MOInfo moinfo;
-EXTERN struct Params params;
+extern struct MOInfo moinfo;
+extern struct Params params;
 }
 }  // namespace psi
 #endif

--- a/psi4/src/psi4/cc/cctriples/test_abc_loops.cc
+++ b/psi4/src/psi4/cc/cctriples/test_abc_loops.cc
@@ -39,7 +39,6 @@
 
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/cc/cctriples/transpose_integrals.cc
+++ b/psi4/src/psi4/cc/cctriples/transpose_integrals.cc
@@ -31,7 +31,6 @@
 #include "psi4/libdpd/dpd.h"
 #include "MOInfo.h"
 #include "Params.h"
-#define EXTERN
 #include "globals.h"
 
 namespace psi {

--- a/psi4/src/psi4/psimrcc/CMakeLists.txt
+++ b/psi4/src/psi4/psimrcc/CMakeLists.txt
@@ -80,3 +80,4 @@ list(APPEND sources
   updater_mk.cc
   )
 psi4_add_module(bin psimrcc sources)
+set_property(TARGET psimrcc PROPERTY UNITY_BUILD OFF)

--- a/psi4/src/psi4/psimrcc/psimrcc_wfn.h
+++ b/psi4/src/psi4/psimrcc/psimrcc_wfn.h
@@ -32,8 +32,12 @@
 #include "psi4/libmints/wavefunction.h"
 
 #include "psi4/libqt/qt.h"
+#ifndef START_TIMER
 #define START_TIMER(a) timer_on((a));
+#endif
+#ifndef END_TIMER
 #define END_TIMER(a) timer_off((a));
+#endif
 
 namespace psi {
 

--- a/psi4/src/psi4/psimrcc/sort.h
+++ b/psi4/src/psi4/psimrcc/sort.h
@@ -54,7 +54,9 @@ class CCMatrix;
 #ifndef INDEX
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
 #endif
+#ifndef four
 #define four(i, j, k, l) INDEX(INDEX(i, j), INDEX(k, l))
+#endif
 
 enum SortAlgorithm { out_of_core_sort, mrpt2_sort };
 

--- a/psi4/src/psi4/psimrcc/transform.cc
+++ b/psi4/src/psi4/psimrcc/transform.cc
@@ -34,6 +34,10 @@
 
 #define CCTRANSFORM_USE_BLAS
 
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
 #define MAX(i, j) ((i > j) ? i : j)
 #define MIN(i, j) ((i > j) ? j : i)
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
@@ -143,3 +147,9 @@ void CCTransform::transform_oei_so_integrals() {
 
 }  // namespace psimrcc
 }  // namespace psi
+
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
+#undef CCTRANSFORM_USE_BLAS

--- a/psi4/src/psi4/psimrcc/transform_block.cc
+++ b/psi4/src/psi4/psimrcc/transform_block.cc
@@ -35,6 +35,10 @@
 
 #define CCTRANSFORM_USE_BLAS
 
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
 #define MAX(i, j) ((i > j) ? i : j)
 #define MIN(i, j) ((i > j) ? j : i)
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
@@ -132,3 +136,9 @@ double CCTransform::tei_block(int p, int q, int r, int s) {
 
 }  // namespace psimrcc
 }  // namespace psi
+
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
+#undef CCTRANSFORM_USE_BLAS

--- a/psi4/src/psi4/psimrcc/transform_mrpt2.cc
+++ b/psi4/src/psi4/psimrcc/transform_mrpt2.cc
@@ -38,6 +38,10 @@
 
 #define CCTRANSFORM_USE_BLAS
 
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
 #define MAX(i, j) ((i > j) ? i : j)
 #define MIN(i, j) ((i > j) ? j : i)
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
@@ -170,3 +174,9 @@ double CCTransform::tei_mrpt2(int p, int q, int r, int s) {
 
 }  // namespace psimrcc
 }  // namespace psi
+
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
+#undef CCTRANSFORM_USE_BLAS

--- a/psi4/src/psi4/psimrcc/transform_presort.cc
+++ b/psi4/src/psi4/psimrcc/transform_presort.cc
@@ -42,6 +42,10 @@
 #include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/psifiles.h"
 
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
 #define MAX(i, j) ((i > j) ? i : j)
 #define MIN(i, j) ((i > j) ? j : i)
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
@@ -170,3 +174,8 @@ void CCTransform::presort_blocks(int first_irrep, int last_irrep) {
 
 }  // namespace psimrcc
 }  // namespace psi
+
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four

--- a/psi4/src/psi4/psimrcc/transform_read_so.cc
+++ b/psi4/src/psi4/psimrcc/transform_read_so.cc
@@ -41,6 +41,10 @@
 
 #define CCTRANSFORM_USE_BLAS
 
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
 #define MAX(i, j) ((i > j) ? i : j)
 #define MIN(i, j) ((i > j) ? j : i)
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
@@ -77,3 +81,9 @@ void CCTransform::read_oei_so_integrals() {
 
 }  // namespace psimrcc
 }  // namespace psi
+
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
+#undef CCTRANSFORM_USE_BLAS


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

 * It's not generally recommended to default enable unity builds because they'll be slower on high-core boxes with enough threads per file AND b/c developers want minimal files compiled for incremental builds. batch size (number of files to combine) tends to want a bigger number for few cores and a smaller number for many cores; default 8.
 * first table shows even on a 20-core machine, unity build is much faster than non-unity build
 * pretty overwhelmingly positive so turning on by default but allow users to turnoff with PSI_UNITY TODO
 * first table shows the block size doesn't matter much, perhaps because psi4 has plenty of modules to keep the pipelines full
 * second table shows that bigger batch size has pleasing effect on 2-core build. but on CI that hit an OOM error.
 * so no good reason not to stick with default 8
 * fourth table shows that withholding cc* modules from the unity build isn't too painful


all on a 20-core

special | max threads | batch size | time
---- | ---- | ---- | ----:
no unity build | ~22 (ninja default) | | 9:25
|| ~22 (ninja default) | 5 | 4:10
|| ~22 (ninja default) | 8 (def) | 3:55
|| ~22 (ninja default) | 12 | 3:35
|| 20 | 12 | 3:58

special | max threads | batch size | time
---- | ---- | ---- | ----:
|| 2 | 5 | 22:26
|| 2 | 8 | 19:07
OOM error on CI | 2 | 12 | 16:35
|| 2 | 15 | 16:08


special | max threads | batch size | time
---- | ---- | ---- | ----:
|| 1 | 8 (def) | 35:20
|| 4 | 8 (def) | 10:48
|| 8 | 8 (def) | 6:52
|| 12 | 8 (def) | 5:25
|| ~22 (ninja default) | 8 (def) | 3:55

special | max threads | batch size | time
---- | ---- | ---- | ----:
|| ~22 (ninja default) | 8 (def) | 3:55
no unity build for cc* | ~22 (ninja default) | 8 | 4:21







max threads through `CMAKE_BUILD_PARALLEL_LEVEL`

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
