### PR TITLE
fix multiple defs for psimrcc for unity builds

### DIFF
--- a/psi4/src/psi4/psimrcc/psimrcc_wfn.h
+++ b/psi4/src/psi4/psimrcc/psimrcc_wfn.h
@@ -32,8 +32,12 @@
 #include "psi4/libmints/wavefunction.h"
 
 #include "psi4/libqt/qt.h"
+#ifndef START_TIMER
 #define START_TIMER(a) timer_on((a));
+#endif
+#ifndef END_TIMER
 #define END_TIMER(a) timer_off((a));
+#endif
 
 namespace psi {
 

--- a/psi4/src/psi4/psimrcc/sort.h
+++ b/psi4/src/psi4/psimrcc/sort.h
@@ -54,7 +54,9 @@ class CCMatrix;
 #ifndef INDEX
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
 #endif
+#ifndef four
 #define four(i, j, k, l) INDEX(INDEX(i, j), INDEX(k, l))
+#endif
 
 enum SortAlgorithm { out_of_core_sort, mrpt2_sort };
 

--- a/psi4/src/psi4/psimrcc/transform.cc
+++ b/psi4/src/psi4/psimrcc/transform.cc
@@ -34,6 +34,10 @@
 
 #define CCTRANSFORM_USE_BLAS
 
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
 #define MAX(i, j) ((i > j) ? i : j)
 #define MIN(i, j) ((i > j) ? j : i)
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
@@ -143,3 +147,9 @@ void CCTransform::transform_oei_so_integrals() {
 
 }  // namespace psimrcc
 }  // namespace psi
+
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
+#undef CCTRANSFORM_USE_BLAS

--- a/psi4/src/psi4/psimrcc/transform_block.cc
+++ b/psi4/src/psi4/psimrcc/transform_block.cc
@@ -35,6 +35,10 @@
 
 #define CCTRANSFORM_USE_BLAS
 
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
 #define MAX(i, j) ((i > j) ? i : j)
 #define MIN(i, j) ((i > j) ? j : i)
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
@@ -132,3 +136,9 @@ double CCTransform::tei_block(int p, int q, int r, int s) {
 
 }  // namespace psimrcc
 }  // namespace psi
+
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
+#undef CCTRANSFORM_USE_BLAS

--- a/psi4/src/psi4/psimrcc/transform_mrpt2.cc
+++ b/psi4/src/psi4/psimrcc/transform_mrpt2.cc
@@ -38,6 +38,10 @@
 
 #define CCTRANSFORM_USE_BLAS
 
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
 #define MAX(i, j) ((i > j) ? i : j)
 #define MIN(i, j) ((i > j) ? j : i)
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
@@ -170,3 +174,9 @@ double CCTransform::tei_mrpt2(int p, int q, int r, int s) {
 
 }  // namespace psimrcc
 }  // namespace psi
+
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
+#undef CCTRANSFORM_USE_BLAS

--- a/psi4/src/psi4/psimrcc/transform_presort.cc
+++ b/psi4/src/psi4/psimrcc/transform_presort.cc
@@ -42,6 +42,10 @@
 #include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/psifiles.h"
 
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
 #define MAX(i, j) ((i > j) ? i : j)
 #define MIN(i, j) ((i > j) ? j : i)
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
@@ -170,3 +174,8 @@ void CCTransform::presort_blocks(int first_irrep, int last_irrep) {
 
 }  // namespace psimrcc
 }  // namespace psi
+
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four

--- a/psi4/src/psi4/psimrcc/transform_read_so.cc
+++ b/psi4/src/psi4/psimrcc/transform_read_so.cc
@@ -41,6 +41,10 @@
 
 #define CCTRANSFORM_USE_BLAS
 
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
 #define MAX(i, j) ((i > j) ? i : j)
 #define MIN(i, j) ((i > j) ? j : i)
 #define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
@@ -77,3 +81,9 @@ void CCTransform::read_oei_so_integrals() {
 
 }  // namespace psimrcc
 }  // namespace psi
+
+#undef MAX
+#undef MIN
+#undef INDEX
+#undef four
+#undef CCTRANSFORM_USE_BLAS


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- @fevangelista , I've had significant success speeding up the psi4 build (2-3x) with unity/jumbo builds, but for the psimrcc module I hit some multiple definition errors when it concatenates the files together. This PR is AI's solution. Does it look ok or make you uneasy? Tests pass, but I haven't explored farther.
- It's a one-liner to exempt psimrcc from the unity build at a reproducible but not hefty cost, so that's the easy backup if this PR needs a lot of work. See https://github.com/psi4/psi4/commit/7c61b21d8f9bd339eef0fae91f3e7435d00bedca for commands to quickly force the unity build if you want to try it out.
- I've run a full test suite with these changes under unity build, and it's clean.

## Status
- [x] Ready for review
- [x] Ready for merge
