### PR TITLE
Fix correctness bugs found by static analysis audit

### DIFF
--- a/psi4/src/psi4/cc/cclambda/get_params.cc
+++ b/psi4/src/psi4/cc/cclambda/get_params.cc
@@ -103,7 +103,7 @@ void CCLambdaWavefunction::get_params(Options &options) {
     params.aobasis = 0; /* AO basis code not yet working for lambda */
 
     params.abcd = options.get_str("ABCD");
-    if (params.abcd == "NEW" && params.abcd == "OLD") {
+    if (params.abcd != "NEW" && params.abcd != "OLD") {
         outfile->Printf("Invalid ABCD algorithm: %s\n", params.abcd.c_str());
         throw PsiException("cclambda: error", __FILE__, __LINE__);
     }
@@ -134,7 +134,7 @@ void CCLambdaWavefunction::get_params(Options &options) {
     local.cutoff = options.get_double("LOCAL_CUTOFF");
     if (options["LOCAL_METHOD"].has_changed()) {
         local.method = options.get_str("LOCAL_METHOD");
-        if (local.method == "AOBASIS" && local.method == "WERNER") {
+        if (local.method != "AOBASIS" && local.method != "WERNER") {
             outfile->Printf("Invalid local correlation method: %s\n", local.method.c_str());
             throw PsiException("cclambda: error", __FILE__, __LINE__);
         }

--- a/psi4/src/psi4/libmints/cdsalclist.cc
+++ b/psi4/src/psi4/libmints/cdsalclist.cc
@@ -99,7 +99,7 @@ CdSalcList::CdSalcList(std::shared_ptr<Molecule> mol, int needed_irreps, bool pr
     // Immediately create the rotation and translation vectors to be projected out.
     Matrix constraints("COM & Rotational Constraints", 6, ncd_);
 
-    SharedMatrix pI(molecule_->inertia_tensor());
+    SharedMatrix pI = molecule_->inertia_tensor();
     Vector ev(3);
     Matrix X(3, 3);
     pI->diagonalize(X, ev);
@@ -384,7 +384,7 @@ SharedMatrix CdSalcList::matrix_projected_out() const
 
     Matrix constraints("COM & Rotational Constraints", 6, 3*natom);
 
-    SharedMatrix pI(molecule_->inertia_tensor());
+    SharedMatrix pI = molecule_->inertia_tensor();
     Vector ev(3);
     Matrix X(3, 3);
     pI->diagonalize(X, ev);

--- a/psi4/src/psi4/libmints/chartab.cc
+++ b/psi4/src/psi4/libmints/chartab.cc
@@ -107,6 +107,8 @@ CharacterTable::~CharacterTable() {
 }
 
 CharacterTable& CharacterTable::operator=(const CharacterTable& ct) {
+    if (this == &ct) return *this;
+
     nt = ct.nt;
     pg = ct.pg;
     nirrep_ = ct.nirrep_;

--- a/psi4/src/psi4/libmints/deriv.cc
+++ b/psi4/src/psi4/libmints/deriv.cc
@@ -231,9 +231,9 @@ SharedMatrix Deriv::compute_df(const std::string& ref_aux_name, const std::strin
     // In einsum notation i,ijk -> jk
     auto st = cdsalcs_.matrix();
     auto B = st->pointer(0);
-    auto *cart = new double[3 * natom_];
-    C_DGEMM('n', 'n', 1, 3 * natom_, cdsalcs_.ncd(), 1.0, Xcont.data(), cdsalcs_.ncd(), B[0], 3 * natom_, 0.0, cart,
-            3 * natom_);
+    std::vector<double> cart(3 * natom_);
+    C_DGEMM('n', 'n', 1, 3 * natom_, cdsalcs_.ncd(), 1.0, Xcont.data(), cdsalcs_.ncd(), B[0], 3 * natom_, 0.0,
+            cart.data(), 3 * natom_);
     auto x_contr = factory_->create_shared_matrix("Lagrangian contribution to gradient", natom_, 3);
     for (int a = 0; a < natom_; ++a)
         for (int xyz = 0; xyz < 3; ++xyz) x_contr->set(a, xyz, cart[3 * a + xyz]);
@@ -402,36 +402,36 @@ SharedMatrix Deriv::compute(DerivCalcType deriv_calc_type) {
     // Transform the SALCs back to cartesian space
     auto st = cdsalcs_.matrix();
     auto B = st->pointer(0);
-    auto *cart = new double[3 * natom_];
+    std::vector<double> cart(3 * natom_);
 
     if (TPDM_ref_cont) {
         // B^t g_q^t = g_x^t -> g_q B = g_x
         C_DGEMM('n', 'n', 1, 3 * natom_, cdsalcs_.ncd(), 1.0, TPDM_ref_cont, cdsalcs_.ncd(), B[0], 3 * natom_, 0.0,
-                cart, 3 * natom_);
+                cart.data(), 3 * natom_);
 
         for (int a = 0; a < natom_; ++a)
             for (int xyz = 0; xyz < 3; ++xyz) tpdm_ref_contr_->set(a, xyz, cart[3 * a + xyz]);
     } else {
         // B^t g_q^t = g_x^t -> g_q B = g_x
-        C_DGEMM('n', 'n', 1, 3 * natom_, cdsalcs_.ncd(), 1.0, TPDMcont, cdsalcs_.ncd(), B[0], 3 * natom_, 0.0, cart,
-                3 * natom_);
+        C_DGEMM('n', 'n', 1, 3 * natom_, cdsalcs_.ncd(), 1.0, TPDMcont, cdsalcs_.ncd(), B[0], 3 * natom_, 0.0,
+                cart.data(), 3 * natom_);
 
         for (int a = 0; a < natom_; ++a)
             for (int xyz = 0; xyz < 3; ++xyz) tpdm_contr_->set(a, xyz, cart[3 * a + xyz]);
     }
 
     // B^t g_q^t = g_x^t -> g_q B = g_x
-    C_DGEMM('n', 'n', 1, 3 * natom_, cdsalcs_.ncd(), 1.0, Xcont, cdsalcs_.ncd(), B[0], 3 * natom_, 0.0, cart,
-            3 * natom_);
-    
+    C_DGEMM('n', 'n', 1, 3 * natom_, cdsalcs_.ncd(), 1.0, Xcont, cdsalcs_.ncd(), B[0], 3 * natom_, 0.0,
+            cart.data(), 3 * natom_);
+
     auto x_contr = factory_->create_shared_matrix("Lagrangian contribution to gradient", natom_, 3);
     for (int a = 0; a < natom_; ++a)
         for (int xyz = 0; xyz < 3; ++xyz) x_contr->set(a, xyz, cart[3 * a + xyz]);
 
     if (X_ref_cont) {
         // B^t g_q^t = g_x^t -> g_q B = g_x
-        C_DGEMM('n', 'n', 1, 3 * natom_, cdsalcs_.ncd(), 1.0, X_ref_cont, cdsalcs_.ncd(), B[0], 3 * natom_, 0.0, cart,
-                3 * natom_);
+        C_DGEMM('n', 'n', 1, 3 * natom_, cdsalcs_.ncd(), 1.0, X_ref_cont, cdsalcs_.ncd(), B[0], 3 * natom_, 0.0,
+                cart.data(), 3 * natom_);
 
         for (int a = 0; a < natom_; ++a)
             for (int xyz = 0; xyz < 3; ++xyz) x_ref_contr_->set(a, xyz, cart[3 * a + xyz]);

--- a/psi4/src/psi4/libmints/local.cc
+++ b/psi4/src/psi4/libmints/local.cc
@@ -29,6 +29,7 @@
 #include "local.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <random>
 
 #include "psi4/libqt/qt.h"
@@ -44,6 +45,25 @@
 using namespace psi;
 
 namespace psi {
+
+namespace {
+// Portable, unbiased draw of a uniform integer in [0, n).
+//
+// std::mt19937 produces values in [0, 2^32 - 1] by C++ standard, but
+// std::uniform_int_distribution is not required to map those outputs the same
+// way across libstdc++/libc++/MSVC. To keep the Jacobi-sweep ordering exactly
+// reproducible across platforms, we do rejection sampling ourselves using
+// only the engine output, %, and comparison.
+int bounded_uniform(std::mt19937& rng, int n) {
+    const std::uint64_t two32 = std::uint64_t{1} << 32;
+    const std::uint64_t cutoff = two32 - (two32 % static_cast<std::uint64_t>(n));
+    std::uint64_t r;
+    do {
+        r = rng();
+    } while (r >= cutoff);
+    return static_cast<int>(r % static_cast<std::uint64_t>(n));
+}
+}  // namespace
 
 Localizer::Localizer(std::shared_ptr<BasisSet> primary, std::shared_ptr<Matrix> C) : primary_(primary), C_(C) {
     if (C->nirrep() != 1) {
@@ -227,8 +247,7 @@ void BoysLocalizer::localize() {
         }
         std::vector<int> order2;
         for (int i = 0; i < nmo; i++) {
-            std::uniform_int_distribution<int> dist(0, nmo - i - 1);
-            int pivot = dist(rng);
+            int pivot = bounded_uniform(rng, nmo - i);
             int i2 = order[pivot];
             order[pivot] = order[nmo - i - 1];
             order2.push_back(i2);
@@ -432,8 +451,7 @@ void PMLocalizer::localize() {
         }
         std::vector<int> order2;
         for (int i = 0; i < nmo; i++) {
-            std::uniform_int_distribution<int> dist(0, nmo - i - 1);
-            int pivot = dist(rng);
+            int pivot = bounded_uniform(rng, nmo - i);
             int i2 = order[pivot];
             order[pivot] = order[nmo - i - 1];
             order2.push_back(i2);

--- a/psi4/src/psi4/libmints/local.cc
+++ b/psi4/src/psi4/libmints/local.cc
@@ -29,6 +29,7 @@
 #include "local.h"
 
 #include <algorithm>
+#include <random>
 
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/matrix.h"
@@ -199,7 +200,7 @@ void BoysLocalizer::localize() {
 
     // => Seed the random idempotently <= //
 
-    srand(0L);
+    std::mt19937 rng(0);
 
     // => Metric <= //
 
@@ -226,7 +227,8 @@ void BoysLocalizer::localize() {
         }
         std::vector<int> order2;
         for (int i = 0; i < nmo; i++) {
-            int pivot = (1L * (nmo - i) * rand()) / RAND_MAX;
+            std::uniform_int_distribution<int> dist(0, nmo - i - 1);
+            int pivot = dist(rng);
             int i2 = order[pivot];
             order[pivot] = order[nmo - i - 1];
             order2.push_back(i2);
@@ -398,7 +400,7 @@ void PMLocalizer::localize() {
 
     // => Seed the random idempotently <= //
 
-    srand(0L);
+    std::mt19937 rng(0);
 
     // => Metric <= //
 
@@ -430,7 +432,8 @@ void PMLocalizer::localize() {
         }
         std::vector<int> order2;
         for (int i = 0; i < nmo; i++) {
-            int pivot = (1L * (nmo - i) * rand()) / RAND_MAX;
+            std::uniform_int_distribution<int> dist(0, nmo - i - 1);
+            int pivot = dist(rng);
             int i2 = order[pivot];
             order[pivot] = order[nmo - i - 1];
             order2.push_back(i2);

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -89,6 +89,8 @@ Matrix::Matrix(const Matrix &c) : rowspi_(c.rowspi_), colspi_(c.colspi_) {
 }
 
 Matrix &Matrix::operator=(const Matrix &c) {
+    if (this == &c) return *this;
+
     release();
     nirrep_ = c.nirrep_;
     symmetry_ = c.symmetry_;

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -2470,19 +2470,17 @@ SharedMatrix MintsHelper::embpot_grad(SharedMatrix D) {
     double **Gp = ret->pointer();
     double **Dp = D->pointer();
 
-    FILE* input = fopen("EMBPOT", "r");
+    std::unique_ptr<FILE, decltype(&fclose)> input(fopen("EMBPOT", "r"), &fclose);
     if (input == nullptr) {
         throw PSIEXCEPTION("MintsHelper::embpot_grad error: could not open EMBPOT file for reading");
     }
     size_t npoints;
-    int statusvalue = fscanf(input, "%zu", &npoints);
+    int statusvalue = fscanf(input.get(), "%zu", &npoints);
     if (statusvalue != 1) {
-        fclose(input);
         throw PSIEXCEPTION("MintsHelper::embpot_grad error: EOF or wrong number of inputs read from EMBPOT header, return=" +
                            std::to_string(statusvalue) + " (expected 1)");
     }
     if (npoints*5*8 > Process::environment.get_memory()) {
-        fclose(input);
         throw PSIEXCEPTION("MintsHelper::embpot_grad error: Size of EMBPOT file exceeds memory allocation, " +
                            std::to_string(npoints*5*8) + " bytes > " + std::to_string(Process::environment.get_memory()) + " bytes");
     }
@@ -2493,9 +2491,8 @@ SharedMatrix MintsHelper::embpot_grad(SharedMatrix D) {
 
     // Pull out data
     for (size_t k = 0; k < npoints; k++) {
-        statusvalue = fscanf(input, "%lf %lf %lf %lf %lf", &x, &y, &z, &w, &v);
+        statusvalue = fscanf(input.get(), "%lf %lf %lf %lf %lf", &x, &y, &z, &w, &v);
         if (statusvalue != 5) {
-            fclose(input);
             throw PSIEXCEPTION("MintsHelper::embpot_grad error: EOF or wrong number of inputs read from EMBPOT, return=" +
                                std::to_string(statusvalue) + " (expected 5)");
         }
@@ -2575,7 +2572,6 @@ SharedMatrix MintsHelper::embpot_grad(SharedMatrix D) {
             }
         }
     }
-    fclose(input);
     return ret;
 }
 

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -2471,13 +2471,18 @@ SharedMatrix MintsHelper::embpot_grad(SharedMatrix D) {
     double **Dp = D->pointer();
 
     FILE* input = fopen("EMBPOT", "r");
+    if (input == nullptr) {
+        throw PSIEXCEPTION("MintsHelper::embpot_grad error: could not open EMBPOT file for reading");
+    }
     size_t npoints;
     int statusvalue = fscanf(input, "%zu", &npoints);
     if (statusvalue != 1) {
+        fclose(input);
         throw PSIEXCEPTION("MintsHelper::embpot_grad error: EOF or wrong number of inputs read from EMBPOT header, return=" +
                            std::to_string(statusvalue) + " (expected 1)");
     }
     if (npoints*5*8 > Process::environment.get_memory()) {
+        fclose(input);
         throw PSIEXCEPTION("MintsHelper::embpot_grad error: Size of EMBPOT file exceeds memory allocation, " +
                            std::to_string(npoints*5*8) + " bytes > " + std::to_string(Process::environment.get_memory()) + " bytes");
     }
@@ -2490,6 +2495,7 @@ SharedMatrix MintsHelper::embpot_grad(SharedMatrix D) {
     for (size_t k = 0; k < npoints; k++) {
         statusvalue = fscanf(input, "%lf %lf %lf %lf %lf", &x, &y, &z, &w, &v);
         if (statusvalue != 5) {
+            fclose(input);
             throw PSIEXCEPTION("MintsHelper::embpot_grad error: EOF or wrong number of inputs read from EMBPOT, return=" +
                                std::to_string(statusvalue) + " (expected 5)");
         }
@@ -3514,10 +3520,9 @@ std::vector<SharedMatrix> MintsHelper::ao_elec_dip_deriv1_helper(int atom) {
 
     std::vector<SharedMatrix> grad;
     for (int p = 0; p < 3; p++) {
-        std::stringstream sstream;
-        sstream << "ao_mu" << cartcomp[p] << "_deriv1_";
         for (int q = 0; q < 3; q++) {
-            sstream << atom << cartcomp[q];
+            std::stringstream sstream;
+            sstream << "ao_mu" << cartcomp[p] << "_deriv1_" << atom << cartcomp[q];
             grad.push_back(std::make_shared<Matrix>(sstream.str(), nbf1, nbf2));
         }
     }
@@ -4314,12 +4319,15 @@ std::vector<SharedMatrix> MintsHelper::mo_elec_dip_deriv1(int atom, SharedMatrix
     int nbf2 = ao_grad[0]->coldim();
 
     std::vector<SharedMatrix> mo_grad;
-    for (int p = 0; p < 9; p++) {
-        std::stringstream sstream;
-        sstream << "mo_elec_dip_deriv1_" << atom << cartcomp[p];
-        auto temp = std::make_shared<Matrix>(sstream.str(), nbf1, nbf2);
-        temp->transform(C1, ao_grad[p], C2);
-        mo_grad.push_back(temp);
+    for (int mu_cart = 0; mu_cart < 3; mu_cart++) {
+        for (int atom_cart = 0; atom_cart < 3; atom_cart++) {
+            int p = 3 * mu_cart + atom_cart;
+            std::stringstream sstream;
+            sstream << "mo_mu" << cartcomp[mu_cart] << "_deriv1_" << atom << cartcomp[atom_cart];
+            auto temp = std::make_shared<Matrix>(sstream.str(), nbf1, nbf2);
+            temp->transform(C1, ao_grad[p], C2);
+            mo_grad.push_back(temp);
+        }
     }
 
     return mo_grad;

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -2501,13 +2501,18 @@ SharedMatrix MintsHelper::embpot_grad(SharedMatrix D) {
     double **Dp = D->pointer();
 
     FILE* input = fopen("EMBPOT", "r");
+    if (input == nullptr) {
+        throw PSIEXCEPTION("MintsHelper::embpot_grad error: could not open EMBPOT file for reading");
+    }
     size_t npoints;
     int statusvalue = fscanf(input, "%zu", &npoints);
     if (statusvalue != 1) {
+        fclose(input);
         throw PSIEXCEPTION("MintsHelper::embpot_grad error: EOF or wrong number of inputs read from EMBPOT header, return=" +
                            std::to_string(statusvalue) + " (expected 1)");
     }
     if (npoints*5*8 > Process::environment.get_memory()) {
+        fclose(input);
         throw PSIEXCEPTION("MintsHelper::embpot_grad error: Size of EMBPOT file exceeds memory allocation, " +
                            std::to_string(npoints*5*8) + " bytes > " + std::to_string(Process::environment.get_memory()) + " bytes");
     }
@@ -2520,6 +2525,7 @@ SharedMatrix MintsHelper::embpot_grad(SharedMatrix D) {
     for (size_t k = 0; k < npoints; k++) {
         statusvalue = fscanf(input, "%lf %lf %lf %lf %lf", &x, &y, &z, &w, &v);
         if (statusvalue != 5) {
+            fclose(input);
             throw PSIEXCEPTION("MintsHelper::embpot_grad error: EOF or wrong number of inputs read from EMBPOT, return=" +
                                std::to_string(statusvalue) + " (expected 5)");
         }
@@ -3544,10 +3550,9 @@ std::vector<SharedMatrix> MintsHelper::ao_elec_dip_deriv1_helper(int atom) {
 
     std::vector<SharedMatrix> grad;
     for (int p = 0; p < 3; p++) {
-        std::stringstream sstream;
-        sstream << "ao_mu" << cartcomp[p] << "_deriv1_";
         for (int q = 0; q < 3; q++) {
-            sstream << atom << cartcomp[q];
+            std::stringstream sstream;
+            sstream << "ao_mu" << cartcomp[p] << "_deriv1_" << atom << cartcomp[q];
             grad.push_back(std::make_shared<Matrix>(sstream.str(), nbf1, nbf2));
         }
     }
@@ -4344,12 +4349,15 @@ std::vector<SharedMatrix> MintsHelper::mo_elec_dip_deriv1(int atom, SharedMatrix
     int nbf2 = ao_grad[0]->coldim();
 
     std::vector<SharedMatrix> mo_grad;
-    for (int p = 0; p < 9; p++) {
-        std::stringstream sstream;
-        sstream << "mo_elec_dip_deriv1_" << atom << cartcomp[p];
-        auto temp = std::make_shared<Matrix>(sstream.str(), nbf1, nbf2);
-        temp->transform(C1, ao_grad[p], C2);
-        mo_grad.push_back(temp);
+    for (int mu_cart = 0; mu_cart < 3; mu_cart++) {
+        for (int atom_cart = 0; atom_cart < 3; atom_cart++) {
+            int p = 3 * mu_cart + atom_cart;
+            std::stringstream sstream;
+            sstream << "mo_mu" << cartcomp[mu_cart] << "_deriv1_" << atom << cartcomp[atom_cart];
+            auto temp = std::make_shared<Matrix>(sstream.str(), nbf1, nbf2);
+            temp->transform(C1, ao_grad[p], C2);
+            mo_grad.push_back(temp);
+        }
     }
 
     return mo_grad;

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -2500,19 +2500,17 @@ SharedMatrix MintsHelper::embpot_grad(SharedMatrix D) {
     double **Gp = ret->pointer();
     double **Dp = D->pointer();
 
-    FILE* input = fopen("EMBPOT", "r");
+    std::unique_ptr<FILE, decltype(&fclose)> input(fopen("EMBPOT", "r"), &fclose);
     if (input == nullptr) {
         throw PSIEXCEPTION("MintsHelper::embpot_grad error: could not open EMBPOT file for reading");
     }
     size_t npoints;
-    int statusvalue = fscanf(input, "%zu", &npoints);
+    int statusvalue = fscanf(input.get(), "%zu", &npoints);
     if (statusvalue != 1) {
-        fclose(input);
         throw PSIEXCEPTION("MintsHelper::embpot_grad error: EOF or wrong number of inputs read from EMBPOT header, return=" +
                            std::to_string(statusvalue) + " (expected 1)");
     }
     if (npoints*5*8 > Process::environment.get_memory()) {
-        fclose(input);
         throw PSIEXCEPTION("MintsHelper::embpot_grad error: Size of EMBPOT file exceeds memory allocation, " +
                            std::to_string(npoints*5*8) + " bytes > " + std::to_string(Process::environment.get_memory()) + " bytes");
     }
@@ -2523,9 +2521,8 @@ SharedMatrix MintsHelper::embpot_grad(SharedMatrix D) {
 
     // Pull out data
     for (size_t k = 0; k < npoints; k++) {
-        statusvalue = fscanf(input, "%lf %lf %lf %lf %lf", &x, &y, &z, &w, &v);
+        statusvalue = fscanf(input.get(), "%lf %lf %lf %lf %lf", &x, &y, &z, &w, &v);
         if (statusvalue != 5) {
-            fclose(input);
             throw PSIEXCEPTION("MintsHelper::embpot_grad error: EOF or wrong number of inputs read from EMBPOT, return=" +
                                std::to_string(statusvalue) + " (expected 5)");
         }
@@ -2605,7 +2602,6 @@ SharedMatrix MintsHelper::embpot_grad(SharedMatrix D) {
             }
         }
     }
-    fclose(input);
     return ret;
 }
 

--- a/psi4/src/psi4/libmints/molecule.cc
+++ b/psi4/src/psi4/libmints/molecule.cc
@@ -1318,9 +1318,9 @@ std::string Molecule::save_string_xyz() const {
     return ss.str();
 }
 
-Matrix *Molecule::inertia_tensor() const {
+SharedMatrix Molecule::inertia_tensor() const {
     int i;
-    Matrix *tensor = new Matrix("Inertia Tensor", 3, 3);
+    auto tensor = std::make_shared<Matrix>("Inertia Tensor", 3, 3);
     Matrix &temp = *tensor;
 
     for (i = 0; i < natom(); i++) {
@@ -1351,7 +1351,7 @@ Matrix *Molecule::inertia_tensor() const {
 }
 
 Vector Molecule::rotational_constants(double zero_tol) const {
-    SharedMatrix pI(inertia_tensor());
+    SharedMatrix pI = inertia_tensor();
     Vector evals(3);
     auto eigenvectors = std::make_shared<Matrix>(3, 3);
     pI->diagonalize(*eigenvectors, evals, ascending);
@@ -2561,7 +2561,7 @@ void Molecule::set_full_point_group(double zero_tol) {
             outfile->Printf("\t\tWarning: Cannot determine point group.\n");
     } else if (rotor == RT_SYMMETRIC_TOP) {
         // Find principal axis that is unique and make it z-axis.
-        SharedMatrix It(inertia_tensor());
+        SharedMatrix It = inertia_tensor();
         Vector I_evals(3);
         auto I_evects = std::make_shared<Matrix>(3, 3);
         It->diagonalize(*I_evects, I_evals, ascending);

--- a/psi4/src/psi4/libmints/molecule.h
+++ b/psi4/src/psi4/libmints/molecule.h
@@ -402,7 +402,7 @@ class PSI_API Molecule {
     Matrix distance_matrix() const;
 
     /// Compute inertia tensor.
-    Matrix* inertia_tensor() const;
+    SharedMatrix inertia_tensor() const;
 
     /// Compute the rotational constants and return them in wavenumbers
     Vector rotational_constants(double tol = FULL_PG_TOL) const;

--- a/psi4/src/psi4/libmints/shellrotation.cc
+++ b/psi4/src/psi4/libmints/shellrotation.cc
@@ -86,6 +86,8 @@ ShellRotation::ShellRotation(int a, SymmetryOperation& so, const IntegralFactory
 ShellRotation::~ShellRotation() { done(); }
 
 ShellRotation& ShellRotation::operator=(const ShellRotation& other) {
+    if (this == &other) return *this;
+
     done();
 
     n_ = other.n_;

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -657,10 +657,11 @@ void MOWriter::write() {
     }
 
     delete[] skip;
-    delete occ;
-    delete sym;
-    delete eps;
-    delete Ca_pointer;
+    delete[] map;
+    delete[] occ;
+    delete[] sym;
+    delete[] eps;
+    delete[] Ca_pointer;
 }
 
 void MOWriter::write_mos(Molecule &mol) {

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -553,9 +553,8 @@ void MOWriter::write() {
     int minorb;
     nmo = mos.sum();
 
-    map = new int[nmo];
-    auto *skip = new bool[nmo];
-    for (int orb = 0; orb < nmo; orb++) skip[orb] = false;
+    map.assign(nmo, 0);
+    std::vector<bool> skip(nmo, false);
     for (int orb = 0; orb < nmo; orb++) {
         int count = 0;
         double minen = 1.0e9;
@@ -579,11 +578,10 @@ void MOWriter::write() {
 
     // reorder orbitals:
     nso = wavefunction_->nso();
-    eps = new double[nmo];
-    sym = new int[nmo];
-    occ = new int[nmo];
-    Ca_pointer = new double[nmo * nso];
-    for (int i = 0; i < nmo * nso; i++) Ca_pointer[i] = 0.0;
+    eps.assign(nmo, 0.0);
+    sym.assign(nmo, 0);
+    occ.assign(nmo, 0);
+    C_data.assign(nmo * nso, 0.0);
 
     int count = 0;
     int extra = restricted_ ? 1 : 0;
@@ -595,7 +593,7 @@ void MOWriter::write() {
             eps[count] = Ea.get(h, n);
             sym[count] = h;
             for (int mu = 0; mu < nso; mu++) {
-                Ca_pointer[mu * nmo + count] = Ca_old[mu][n];
+                C_data[mu * nmo + count] = Ca_old[mu][n];
             }
             count++;
         }
@@ -614,7 +612,7 @@ void MOWriter::write() {
     // now for beta spin
     if (!restricted_) {
         // order orbitals in terms of energy
-        for (int orb = 0; orb < nmo; orb++) skip[orb] = false;
+        std::fill(skip.begin(), skip.end(), false);
         for (int orb = 0; orb < nmo; orb++) {
             int count = 0;
             double minen = 1.0e9;
@@ -637,7 +635,7 @@ void MOWriter::write() {
         }
 
         // reorder orbitals:
-        for (int i = 0; i < nmo * nso; i++) Ca_pointer[i] = 0.0;
+        std::fill(C_data.begin(), C_data.end(), 0.0);
         count = 0;
         for (int h = 0; h < nirrep; h++) {
             double **Ca_old = Cb_ao_mo->pointer(h);
@@ -646,7 +644,7 @@ void MOWriter::write() {
                 eps[count] = Eb.get(h, n);
                 sym[count] = h;
                 for (int mu = 0; mu < nso; mu++) {
-                    Ca_pointer[mu * nmo + count] = Ca_old[mu][n];
+                    C_data[mu * nmo + count] = Ca_old[mu][n];
                 }
                 count++;
             }
@@ -658,13 +656,6 @@ void MOWriter::write() {
         outfile->Printf("\n");
         write_mos(mol);
     }
-
-    delete[] skip;
-    delete[] map;
-    delete[] occ;
-    delete[] sym;
-    delete[] eps;
-    delete[] Ca_pointer;
 }
 
 void MOWriter::write_mos(Molecule &mol) {
@@ -727,7 +718,7 @@ void MOWriter::write_mos(Molecule &mol) {
             // print ao labels
             outfile->Printf(" %-4d %-10s", mu + 1, ao_labels[mu].c_str());
             for (int j = 0; j < ncols; j++) {
-                outfile->Printf("%13.7lf", Ca_pointer[mu * nmo + map[count + j]]);
+                outfile->Printf("%13.7lf", C_data[mu * nmo + map[count + j]]);
             }
             outfile->Printf("\n");
         }
@@ -770,7 +761,7 @@ void MOWriter::write_mos(Molecule &mol) {
             // print ao labels
             outfile->Printf(" %-4d %-10s", mu + 1, ao_labels[mu].c_str());
             for (int j = 0; j < ncolsleft; j++) {
-                outfile->Printf("%13.7lf", Ca_pointer[mu * nmo + map[count + j]]);
+                outfile->Printf("%13.7lf", C_data[mu * nmo + map[count + j]]);
             }
             outfile->Printf("\n");
         }

--- a/psi4/src/psi4/libmints/writer.cc
+++ b/psi4/src/psi4/libmints/writer.cc
@@ -129,6 +129,9 @@ void FCHKWriter::set_postscf_density_label(const std::string &label) {
 
 void FCHKWriter::write(const std::string &filename) {
     chk_ = fopen(filename.c_str(), "w");
+    if (chk_ == nullptr) {
+        throw PSIEXCEPTION("FCHKWriter::write: could not open " + filename + " for writing");
+    }
     std::shared_ptr<BasisSet> basis = wavefunction_->basisset();
     int maxam = basis->max_am();
     std::shared_ptr<Molecule> mol = wavefunction_->molecule();

--- a/psi4/src/psi4/libmints/writer.h
+++ b/psi4/src/psi4/libmints/writer.h
@@ -31,6 +31,7 @@
 
 #include "psi4/pragma.h"
 #include <memory>
+#include <vector>
 #include "psi4/libmints/vector.h"
 #include <string>
 #include "typedefs.h"
@@ -73,8 +74,9 @@ class PSI_API MOWriter {
     bool restricted_;
 
    private:
-    double *Ca_pointer, *eps;
-    int *map, *sym, *occ, nmo, nso;
+    std::vector<double> C_data, eps;
+    std::vector<int> map, sym, occ;
+    int nmo, nso;
     void write_mos(Molecule &mol);
 
    public:

--- a/psi4/src/psi4/liboptions/liboptions.cc
+++ b/psi4/src/psi4/liboptions/liboptions.cc
@@ -233,10 +233,7 @@ int StringDataType::to_integer() const { return static_cast<int>(std::strtod(str
 double StringDataType::to_double() const { return std::strtod(str_.c_str(), nullptr); }
 
 void StringDataType::assign(bool b) {
-    if (b)
-        assign("TRUE");
-    else
-        assign("FALSE");
+    assign(std::string(b ? "TRUE" : "FALSE"));
 }
 
 void StringDataType::assign(int i) {
@@ -291,10 +288,7 @@ int IStringDataType::to_integer() const { return static_cast<int>(std::strtod(st
 double IStringDataType::to_double() const { return std::strtod(str_.c_str(), nullptr); }
 
 void IStringDataType::assign(bool b) {
-    if (b)
-        assign("TRUE");
-    else
-        assign("FALSE");
+    assign(std::string(b ? "TRUE" : "FALSE"));
 }
 
 void IStringDataType::assign(int i) {

--- a/tests/pytests/test_mints.py
+++ b/tests/pytests/test_mints.py
@@ -84,6 +84,56 @@ def test_export_ao_elec_dip_deriv():
     G_python_MU_mat = psi4.core.Matrix.from_array(MU_Gradient)
     assert psi4.compare_matrices(PSI4_MU_Grad, G_python_MU_mat, 10, "DIPOLE_GRADIENT_TEST")  # TEST
 
+    # Matrix names from ao_elec_dip_deriv1_helper: must be ao_mu{X,Y,Z}_deriv1_{atom}{X,Y,Z},
+    # not the accumulating names a previous bug produced ("ao_muX_deriv1_0X0Y0Z").
+    for atom in range(natoms):
+        ao_mats = deriv1_mat["MU_" + str(atom)]
+        for mu_cart in range(3):
+            for atom_cart in range(3):
+                expected = "ao_mu" + ["X", "Y", "Z"][mu_cart] + "_deriv1_" + str(atom) + ["X", "Y", "Z"][atom_cart]
+                actual = ao_mats[3 * mu_cart + atom_cart].name()
+                assert actual == expected, f"AO dipole-deriv matrix name mismatch: got {actual!r}, expected {expected!r}"
+
+def test_export_mo_elec_dip_deriv():
+    h2o = psi4.geometry("""
+        O
+        H 1 1.0
+        H 1 1.0 2 101.5
+        symmetry c1
+    """)
+
+    rhf_e, wfn = psi4.energy('SCF/cc-pVDZ', molecule=h2o, return_wfn=True)
+    C = wfn.Ca_subset("AO", "ALL")
+
+    mints = psi4.core.MintsHelper(wfn.basisset())
+
+    natoms = h2o.natom()
+    cart = ["X", "Y", "Z"]
+
+    for atom in range(natoms):
+        ao_mats = mints.ao_elec_dip_deriv1(atom)
+        mo_mats = mints.mo_elec_dip_deriv1(atom, C, C)
+
+        # mo_elec_dip_deriv1 must return 9 matrices indexed as 3*mu_cart + atom_cart.
+        # A previous bug looped p in [0,9) and indexed cartcomp[p] (size 3), which is OOB.
+        assert len(mo_mats) == 9, f"mo_elec_dip_deriv1 returned {len(mo_mats)} matrices, expected 9"
+        for mu_cart in range(3):
+            for atom_cart in range(3):
+                p = 3 * mu_cart + atom_cart
+
+                # Name: mo_mu{X,Y,Z}_deriv1_{atom}{X,Y,Z}
+                expected_name = "mo_mu" + cart[mu_cart] + "_deriv1_" + str(atom) + cart[atom_cart]
+                actual_name = mo_mats[p].name()
+                assert actual_name == expected_name, \
+                    f"MO dipole-deriv matrix name mismatch: got {actual_name!r}, expected {expected_name!r}"
+
+                # MO derivative must equal C^T @ AO derivative @ C.
+                ao = np.asarray(ao_mats[p])
+                mo = np.asarray(mo_mats[p])
+                Cnp = np.asarray(C)
+                assert compare_arrays(mo, Cnp.T @ ao @ Cnp), \
+                    f"mo_elec_dip_deriv1[{p}] != C^T @ ao_elec_dip_deriv1[{p}] @ C"
+
 def test_export_ao_overlap_half_deriv():
     h2o = psi4.geometry("""
         O

--- a/tests/pytests/test_mints.py
+++ b/tests/pytests/test_mints.py
@@ -84,6 +84,56 @@ def test_export_ao_elec_dip_deriv():
     G_python_MU_mat = psi4.core.Matrix.from_array(MU_Gradient)
     assert psi4.compare_matrices(PSI4_MU_Grad, G_python_MU_mat, 10, "DIPOLE_GRADIENT_TEST")  # TEST
 
+    # Matrix names from ao_elec_dip_deriv1_helper: must be ao_mu{X,Y,Z}_deriv1_{atom}{X,Y,Z},
+    # not the accumulating names a previous bug produced ("ao_muX_deriv1_0X0Y0Z").
+    for atom in range(natoms):
+        ao_mats = deriv1_mat["MU_" + str(atom)]
+        for mu_cart in range(3):
+            for atom_cart in range(3):
+                expected = "ao_mu" + ["X", "Y", "Z"][mu_cart] + "_deriv1_" + str(atom) + ["X", "Y", "Z"][atom_cart]
+                actual = ao_mats[3 * mu_cart + atom_cart].name
+                assert actual == expected, f"AO dipole-deriv matrix name mismatch: got {actual!r}, expected {expected!r}"
+
+def test_export_mo_elec_dip_deriv():
+    h2o = psi4.geometry("""
+        O
+        H 1 1.0
+        H 1 1.0 2 101.5
+        symmetry c1
+    """)
+
+    rhf_e, wfn = psi4.energy('SCF/cc-pVDZ', molecule=h2o, return_wfn=True)
+    C = wfn.Ca_subset("AO", "ALL")
+
+    mints = psi4.core.MintsHelper(wfn.basisset())
+
+    natoms = h2o.natom()
+    cart = ["X", "Y", "Z"]
+
+    for atom in range(natoms):
+        ao_mats = mints.ao_elec_dip_deriv1(atom)
+        mo_mats = mints.mo_elec_dip_deriv1(atom, C, C)
+
+        # mo_elec_dip_deriv1 must return 9 matrices indexed as 3*mu_cart + atom_cart.
+        # A previous bug looped p in [0,9) and indexed cartcomp[p] (size 3), which is OOB.
+        assert len(mo_mats) == 9, f"mo_elec_dip_deriv1 returned {len(mo_mats)} matrices, expected 9"
+        for mu_cart in range(3):
+            for atom_cart in range(3):
+                p = 3 * mu_cart + atom_cart
+
+                # Name: mo_mu{X,Y,Z}_deriv1_{atom}{X,Y,Z}
+                expected_name = "mo_mu" + cart[mu_cart] + "_deriv1_" + str(atom) + cart[atom_cart]
+                actual_name = mo_mats[p].name
+                assert actual_name == expected_name, \
+                    f"MO dipole-deriv matrix name mismatch: got {actual_name!r}, expected {expected_name!r}"
+
+                # MO derivative must equal C^T @ AO derivative @ C.
+                ao = np.asarray(ao_mats[p])
+                mo = np.asarray(mo_mats[p])
+                Cnp = np.asarray(C)
+                assert compare_arrays(mo, Cnp.T @ ao @ Cnp), \
+                    f"mo_elec_dip_deriv1[{p}] != C^T @ ao_elec_dip_deriv1[{p}] @ C"
+
 def test_export_ao_overlap_half_deriv():
     h2o = psi4.geometry("""
         O


### PR DESCRIPTION
## Summary

Eleven fixes uncovered by a `cppcheck` + `clang-tidy` pass over the C++ tree
(with a deeper read of `libmints`). Each was opened in the source and
verified before being patched.

### Correctness bugs (commit 1)

- **`libmints/writer.cc`** — `MOWriter::write()` freed four `new T[]`
  allocations (`eps`, `sym`, `occ`, `Ca_pointer`) with scalar `delete`
  (UB) and leaked `map` entirely. All five are now `delete[]`, plus the
  missing `delete[] map`.
- **`libmints/mintshelper.cc::mo_elec_dip_deriv1`** — loop indexed
  `cartcomp[p]` with `p ∈ [0,9)` while `cartcomp` only holds 3 entries
  (X/Y/Z). Rewritten as a 3×3 nested loop with the same naming convention
  used by the AO helper.
- **`libmints/mintshelper.cc::ao_elec_dip_deriv1_helper`** — the inner
  `stringstream` was not reset, so matrix names accumulated
  (`ao_muX_deriv1_0X` → `ao_muX_deriv1_0X0Y` → `ao_muX_deriv1_0X0Y0Z`).
  Moved the stream inside the inner loop.
- **`libmints/mintshelper.cc::embpot_grad`** — no null check after
  `fopen("EMBPOT", "r")` (a missing file led to `fscanf(NULL, …)`), and
  the `FILE*` leaked on every throw path. Added the null check and
  `fclose` before each throw.
- **`liboptions/liboptions.cc`** — `StringDataType::assign(bool)` and
  `IStringDataType::assign(bool)` called `assign("TRUE")` /
  `assign("FALSE")`. `const char*` → `bool` is a standard conversion and
  outranks the user-defined conversion to `std::string`, so each call
  resolved back to `assign(bool)` → infinite recursion. Now passes an
  explicit `std::string`.
- **`cc/cclambda/get_params.cc`** — two input-validation checks used
  `== "X" && == "Y"` on the same variable, which is always false, so
  invalid `ABCD` / `LOCAL_METHOD` values were silently accepted. Changed
  to `!= "X" && != "Y"`.
- **`f12/mp2.cc::MP2F12::t_`** — fell off the end of a `double`-returning
  function for non-matching `(p,q,r,s)` index tuples (UB). Returns 0.0,
  which matches the SP-ansatz rational generator amplitudes for
  non-contributing patterns.

### Cleanup (commit 2)

- **`libmints/local.cc`** — replaced `srand(0L)` + `rand()` in
  `BoysLocalizer::localize` and `PMLocalizer::localize` with
  `std::mt19937` seeded at 0 + `std::uniform_int_distribution`.
  - C's `rand()` is implementation-defined (glibc / MSVC / libc++ / BSD
    each ship a different generator), so the old fixed seed was only
    reproducible per-platform. `std::mt19937` is specified by the C++
    standard and yields the same sequence everywhere.
  - The old pivot formula `(1L * (nmo - i) * rand()) / RAND_MAX` produced
    a value in `[0, nmo - i]` inclusive, which would read one past
    `order` on the upper bound. The new
    `uniform_int_distribution<int>(0, nmo - i - 1)` matches the
    Fisher-Yates intent and removes the latent OOB.

### Defensive fixes from a second libmints pass (commit 3)

- **`libmints/writer.cc::FCHKWriter::write`** — `fopen(filename, "w")` had
  no null check; a failed open (bad path, permissions, full disk) led to
  `fprintf(NULL, …)` in the ~50 subsequent writes. Throws on failure now.
  The other libmints `fopen` sites (`oeprop.cc` grid_esp / grid_field)
  already null-checked; only this one didn't.
- **`libmints/chartab.cc::CharacterTable::operator=`** — no
  self-assignment guard. The body `delete[]`s the existing arrays then
  reads from `ct.gamma_/symop/_inv`, which would be use-after-free on
  self-assignment.
- **`libmints/shellrotation.cc::ShellRotation::operator=`** — same shape:
  `done()` frees `this->r_`, then `memcpy` reads from `other.r_[i]`.

No current call site does literal self-assignment of either class, so the
last two are latent; the FCHK one is reachable on any I/O failure.

### Two `cart` leaks and a Matrix self-assignment guard (commit 4)

- **`libmints/deriv.cc`** — `Deriv::compute_df` and `Deriv::compute` each
  allocated a `cart = new double[3 * natom_]` SALC→Cartesian scratch
  buffer and never freed it before returning. Every density-fitted and
  every correlated gradient leaked 24·natom bytes. Converted to
  `std::vector<double>` so the lifetime is automatic and exception-safe.
- **`libmints/matrix.cc::Matrix::operator=`** — same shape as the
  CharacterTable/ShellRotation fixes: `release()` frees `matrix_`, then
  `copy_from(c.matrix_)` would memcpy from the just-reallocated buffer
  to itself on `m = m` (UB per memcpy's no-overlap contract). `Matrix`
  is the central libmints data type, so guard it the same way.

### `Molecule::inertia_tensor` API change (commit 5)

- **`libmints/molecule.{h,cc}`, `libmints/cdsalclist.cc`** —
  `Molecule::inertia_tensor()` returned a raw `Matrix*` allocated with
  `new`, with no convention enforcing cleanup. Four of five callers
  remembered to wrap the result in `SharedMatrix`; `cc/ccresponse/scatter.cc`
  forgot (`I->copy(molecule->inertia_tensor())`), leaking the matrix on
  every call. Changed the signature to return `SharedMatrix` so
  ownership is unambiguous and the leak is impossible at the type level.
  The leaking caller binds the returned temporary to the existing
  `Matrix::copy(const SharedMatrix&)` overload — no change in
  `scatter.cc` itself. Pybind11 binding unchanged (Matrix's holder type
  is already `shared_ptr<Matrix>`).

## How they were found

- `cppcheck 2.20 --enable=warning,performance,portability` over
  `psi4/src/`, filtered to high-value categories (`memleak`,
  `nullPointer`, `incorrectLogicOperator`, `containerOutOfBounds`,
  `missingReturn`, `oppositeInnerCondition`,
  `incorrectStringBooleanError`, `resourceLeak`, `operatorEqToSelf`,
  `publicAllocationError`, …).
- `clang-tidy 22` with `clang-analyzer-*`, `bugprone-*`, `cert-*`,
  selected `misc-*` and `readability-*` checks, on every `libmints`
  translation unit via the project's `compile_commands.json`.
- Manual ownership audit of `new`/`delete` sites and Matrix-returning
  APIs across libmints.

Several other static-analysis hits were investigated and intentionally
**not** patched — either they're false positives (the documented
`b[-1]` offset trick in `cubature.cc`, the `shared_ptr`-owned grid
returns) or they involve domain judgment that should go through normal
review (a possible iterator overrun in `ccresponse/scatter.cc`,
virtual-call-in-constructor sites in `integral.cc` / `transform.cc` /
`potential_erf.cc`, a dead-code block in `oeprop.cc`, dead defensive
branches in `libdpd`). I can open separate issues for those if useful.

## Test plan

- [ ] CTest pass on a build that exercises `libmints`, `cclambda`, `f12`,
  the MO-writer paths, and gradient codes that go through
  `Deriv::compute` / `compute_df`.
- [ ] Sanity-check that `mo_elec_dip_deriv1` callers (electric-dipole
  derivative properties) still produce expected matrix shapes — the
  loop body is preserved, only the indexing is corrected.
- [ ] Localization reference values: any Boys/PM test pinned to a
  specific Jacobi-sweep ordering will drift because the RNG sequence
  changes (mt19937 vs glibc `rand()`). Converged localized orbitals
  should match within tolerance since the random permutation only
  orders sweeps.
- [ ] Verify that Python code calling `molecule.inertia_tensor()` still
  works (pybind11 holder type unchanged, so the return-type change is
  transparent on the Python side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)