### PR TITLE
libscf_solver: correctness fixes from static-analysis audit

### DIFF
--- a/psi4/src/psi4/libscf_solver/cuhf.cc
+++ b/psi4/src/psi4/libscf_solver/cuhf.cc
@@ -138,8 +138,8 @@ void CUHF::finalize() {
 }
 
 void CUHF::save_density_and_energy() {
-    Da_old_->copy(Dt_);
-    Db_old_->copy(Dt_);
+    Da_old_->copy(Da_);
+    Db_old_->copy(Db_);
     Dt_old_->copy(Dt_);
 }
 

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -572,9 +572,12 @@ void HF::form_H() {
             Matrix V_eff(nso, nso);
 
             if (dipole_field_type_ == embpot) {
-                FILE* input = fopen("EMBPOT", "r");
+                std::unique_ptr<FILE, decltype(&fclose)> input(fopen("EMBPOT", "r"), &fclose);
+                if (input == nullptr) {
+                    throw PSIEXCEPTION("HF::form_H error: could not open EMBPOT file for reading");
+                }
                 size_t npoints;
-                int statusvalue = fscanf(input, "%zu", &npoints);
+                int statusvalue = fscanf(input.get(), "%zu", &npoints);
                 if (statusvalue != 1) {
                     throw PSIEXCEPTION("HF::form_H error: EOF or wrong number of inputs read from EMBPOT header, return=" +
                                        std::to_string(statusvalue) + " (expected 1)");
@@ -587,7 +590,7 @@ void HF::form_H() {
                 double x, y, z, w, v;
                 double max = 0;
                 for (size_t k = 0; k < npoints; k++) {
-                    statusvalue = fscanf(input, "%lf %lf %lf %lf %lf", &x, &y, &z, &w, &v);
+                    statusvalue = fscanf(input.get(), "%lf %lf %lf %lf %lf", &x, &y, &z, &w, &v);
                     if (statusvalue != 5) {
                         throw PSIEXCEPTION("HF::form_H error: EOF or wrong number of inputs read from EMBPOT, return=" +
                                            std::to_string(statusvalue) + " (expected 5)");
@@ -602,9 +605,6 @@ void HF::form_H() {
                     }
                 }  // npoints
                 outfile->Printf("  Max. embpot value = %20.10f\n", max);
-                fclose(input);
-
-
             }  // embpot
             else if (dipole_field_type_ == dx) {
                 dx_read(V_eff.pointer(), phi_ao.pointer(), phi_so.pointer(), nao, nso, u.pointer());

--- a/psi4/src/psi4/libscf_solver/rohf.cc
+++ b/psi4/src/psi4/libscf_solver/rohf.cc
@@ -1271,7 +1271,12 @@ bool ROHF::stability_analysis() {
             global_dpd_->buf4_mat_irrep_close(&A, h);
             int mindim = rank < 15 ? rank : 15;
             for (int i = 0; i < mindim; i++) eval_sym.push_back(std::make_pair(evals[i], h));
-            for (int i = 0; i < nsave; ++i) pEvals[i][0] = evals[i];
+            // `evals` has only `rank` entries; if the user asked for more
+            // SOLVER_N_ROOT eigenvalues than the algorithm produced, copy
+            // what we have and zero-pad the rest.
+            int nsave_h = std::min(nsave, rank);
+            for (int i = 0; i < nsave_h; ++i) pEvals[i][0] = evals[i];
+            for (int i = nsave_h; i < nsave; ++i) pEvals[i][0] = 0.0;
 
             free_block(evecs);
             delete[] evals;

--- a/psi4/src/psi4/libscf_solver/sad.cc
+++ b/psi4/src/psi4/libscf_solver/sad.cc
@@ -259,7 +259,7 @@ void SADGuess::common_init() {
     print_ = options_.get_int("SAD_PRINT");
     debug_ = options_.get_int("DEBUG");
     if (options_["SOCC"].size() > 0 || options_["DOCC"].size() > 0)
-        PSIEXCEPTION("SAD guess not implemented for user-specified SOCCs and/or DOCCs yet");
+        throw PSIEXCEPTION("SAD guess not implemented for user-specified SOCCs and/or DOCCs yet");
 }
 void SADGuess::compute_guess() {
     timer_on("SAD Guess");


### PR DESCRIPTION
## Summary

Four fixes in `psi4/src/psi4/libscf_solver/` uncovered by a cppcheck + clang-tidy pass plus manual review of the SCF density / orbital pipeline. Each was opened in the source and verified before being patched. Companion to #3395 (libmints) and #3396 (libfock).

### Real, reachable correctness bugs

- **`cuhf.cc::save_density_and_energy`** (commit `72440e874`) — wrong source for `Da_old_`/`Db_old_`:
  ```cpp
  void CUHF::save_density_and_energy() {
      Da_old_->copy(Dt_);   // should be Da_
      Db_old_->copy(Dt_);   // should be Db_
      Dt_old_->copy(Dt_);
  }
  ```
  `damping_update` then does `Da_->axpy(α, Da_old_); Db_->axpy(α, Db_old_)`, so a damped CUHF iteration mixed the previous iteration's *total* density into the new alpha and beta densities. For open-shell CUHF that injects beta contributions into Da on every damped step (and vice versa); for closed shell it effectively doubles the damping coefficient because `Dt_old = 2·Da_old`. UHF (`uhf.cc:162-165`) and ROHF (`rohf.cc:286-288`) both correctly save `Da_`/`Db_` into the `_old` buffers. Bug present since commit `3f26f0f7d` in 2017 — never caught because (a) static analyzers don't catch semantic copy mismatches and (b) the default `DAMPING_PERCENTAGE=0` doesn't exercise it.

- **`sad.cc:262`** (commit `afa2eeeaa`) — missing `throw` keyword:
  ```cpp
  if (options_["SOCC"].size() > 0 || options_["DOCC"].size() > 0)
      PSIEXCEPTION("SAD guess not implemented for user-specified SOCCs and/or DOCCs yet");
  ```
  Constructs the exception object and immediately destroys it; SAD then silently proceeds and produces initial orbitals that do **not** honor the user's requested SOCC/DOCC. One-character fix.

- **`hf.cc::form_H` embpot branch** (commit `15aed5f3b`) — identical pattern to the `MintsHelper::embpot_grad` fix in #3395: `fopen("EMBPOT", "r")` had no null check (→ `fscanf(NULL,…)` if the file is missing), and the `FILE*` leaked on each of two `throw PSIEXCEPTION` paths. Wrapped in `std::unique_ptr<FILE, decltype(&fclose)>` for RAII closure.

- **`rohf.cc::stability_analysis`** (commit `84897e6a5`) — out-of-bounds read flagged by `clang-analyzer-security.ArrayBound`:
  ```cpp
  auto* evals = new double[rank];
  ...
  int nsave = options_.get_int("SOLVER_N_ROOT");  // user-controlled
  ...
  for (int i = 0; i < nsave; ++i) pEvals[i][0] = evals[i];
  ```
  If `SOLVER_N_ROOT > rank` (the active orbital-pair rank), the loop reads past the end of `evals`. Clamped to `min(nsave, rank)` and zero-padded the remaining slots of the user-visible output.

## How they were found

- `cppcheck 2.20 --enable=warning,performance,portability` on `psi4/src/psi4/libscf_solver/`.
- `clang-tidy 22` with `clang-analyzer-*`, `bugprone-*`, `cert-*` checks on every libscf_solver TU via `compile_commands.json`.
- Manual review of `save_density_and_energy` / `damping_update` symmetry across the four SCF flavors (RHF / UHF / ROHF / CUHF) — that's how the CUHF copy mismatch surfaced.

False positives / minor items intentionally not patched and noted in the audit:
- `frac.cc:107-114` stale comment ("Throw…" but code increments).
- `frac.cc:271-272` "@S Observed" displays Expected; cosmetic.
- `cuhf.cc:193` `S2 = nm * (nm + 1.0)` doesn't `fabs` (only matters if nbeta > nalpha; cosmetic printout).
- `hf.cc:811,837` `frzcpi_[pairs[i].second]++` could OOB if `NUM_FROZEN_DOCC > total orbitals`; defensive.
- `mom.cc:70-77` aliased Cb_old_/Ca_old_ copy when same_a_b_orbs; harmless no-op for RHF.
- `hf.cc:629-631` float loop counters (style only).
- Various dead stores (`rhf.cc:346 two_electron_E`, `sad.cc:584 Z`, etc.).

## Test plan

- [ ] CTest pass on a build that exercises CUHF (any CUHF reference + an open-shell molecule).
- [ ] CUHF with explicit `DAMPING_PERCENTAGE=20` on an open-shell case — confirms the iteration intermediates now match the corrected Da_old/Db_old semantics. Convergence behavior may differ from before (in a good way — the previous code was mixing alpha/beta).
- [ ] SAD guess with SOCC/DOCC set — confirms the `throw` actually fires and gives the diagnostic.
- [ ] ROHF stability analysis with `SOLVER_N_ROOT` larger than the active rank — confirms the clamp prevents the OOB.
- [ ] Any embpot test with a missing `EMBPOT` file — confirms the clean error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)