### PR TITLE
Backport pybind11 v3.0.3 compatibility fix to the 1.10.x release branch

### DIFF
--- a/psi4/src/psi4/libmints/basisset.h
+++ b/psi4/src/psi4/libmints/basisset.h
@@ -177,6 +177,9 @@ class PSI_API BasisSet {
              std::map<std::string, std::map<std::string, std::vector<ShellInfo> > > &shell_map,
              std::map<std::string, std::map<std::string, std::vector<ShellInfo> > > &ecp_shell_map);
 
+    BasisSet(const BasisSet&) = delete;
+    BasisSet& operator=(const BasisSet&) = delete;
+
     ~BasisSet();
 
     /** Builder factory method


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Since the version of pybind11 is not pinned, new builds of the 1.10.0 release from source that follow the instructions on the Psi4 website are failing due to pybind11 v3.0.3 not being compatible with the 1.10.0 release.
This PR backports the fix from master.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] A fix has been backported that enables Psi4 1.10 to be built with pybind11 v3.0.3. Prior to this fix, the highest supported pybind11 version was  v3.0.2.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Delete the copy constructor and copy assignment operator of the `BasisSet `object in `libmints` to avoid trying to build this constructor and finding an incomplete class when pybind11 v3.0.3 is used.

## Checklist
- [x] No new features
- [x] The 1.10.0 release build and tests fine if pinned to pybind11 v3.0.2
- [ ] Full tests run with pybind11 v3.0.3 after this fix is applied

## Status
- [x] Ready for review
- [ ] Ready for merge
