### PR TITLE
cmake: fix HDF5 2.x detection (resolve imported targets to file paths)

### DIFF
--- a/external/common/hdf5/CMakeLists.txt
+++ b/external/common/hdf5/CMakeLists.txt
@@ -6,8 +6,38 @@ if(ENABLE_ambit OR ENABLE_CheMPS2 OR ENABLE_Einsums)
 
     find_package(HDF5 QUIET REQUIRED)
 
+    # HDF5 1.x's FindHDF5 sets HDF5_LIBRARIES to absolute library file paths,
+    # but HDF5 2.x ships its own HDF5Config.cmake which (in config mode) sets
+    # HDF5_LIBRARIES to imported-target names like 'hdf5-shared'. Those
+    # targets are only visible in the scope of the HDF5 config file, so once
+    # we stash them into our INTERFACE library and re-export it for
+    # downstream consumers the bare names fall through as link library
+    # names ('-lhdf5-shared'), and the link fails. Resolve any imported
+    # targets to their actual library file paths before storing.
+    set(_HDF5_RESOLVED_LIBS)
+    foreach(_lib IN LISTS HDF5_LIBRARIES)
+        if(TARGET ${_lib})
+            get_target_property(_imp_cfgs ${_lib} IMPORTED_CONFIGURATIONS)
+            set(_loc)
+            if(_imp_cfgs)
+                list(GET _imp_cfgs 0 _first_cfg)
+                get_target_property(_loc ${_lib} IMPORTED_LOCATION_${_first_cfg})
+            endif()
+            if(NOT _loc)
+                get_target_property(_loc ${_lib} IMPORTED_LOCATION)
+            endif()
+            if(_loc)
+                list(APPEND _HDF5_RESOLVED_LIBS ${_loc})
+            else()
+                list(APPEND _HDF5_RESOLVED_LIBS ${_lib})
+            endif()
+        else()
+            list(APPEND _HDF5_RESOLVED_LIBS ${_lib})
+        endif()
+    endforeach()
+
     add_library(hdf5 INTERFACE)
-    set_property(TARGET hdf5 PROPERTY INTERFACE_LINK_LIBRARIES ${HDF5_LIBRARIES})
+    set_property(TARGET hdf5 PROPERTY INTERFACE_LINK_LIBRARIES ${_HDF5_RESOLVED_LIBS})
     set_property(TARGET hdf5 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${HDF5_INCLUDE_DIRS})
     set (${PN}_VERSION ${HDF5_VERSION})
 


### PR DESCRIPTION
## Summary

HDF5 2.x ships its own \`HDF5Config.cmake\` (config mode) and populates \`HDF5_LIBRARIES\` with imported-target names like \`hdf5-shared\` instead of the absolute library file paths that HDF5 1.x's \`FindHDF5.cmake\` returned. Our \`external/common/hdf5/CMakeLists.txt\` stored those names into \`tgt::hdf5\`'s \`INTERFACE_LINK_LIBRARIES\` and re-exported the target. Downstream consumers (ambit, chemps2, einsums, psi4-core) imported \`tgt::hdf5\` from a scope where \`hdf5-shared\` was never an imported target, so the bare names fell through to the linker as \`-lhdf5-shared\`:

\`\`\`
/usr/bin/ld.bfd: cannot find -lhdf5-shared: No such file or directory
\`\`\`

This PR resolves any imported targets in \`HDF5_LIBRARIES\` to their actual library file paths (preferring \`IMPORTED_LOCATION_<config>\` from the first \`IMPORTED_CONFIGURATIONS\` entry, falling back to \`IMPORTED_LOCATION\`) before storing them in \`tgt::hdf5\`. Non-target entries pass through unchanged, so HDF5 1.x builds keep working.

Reported against HDF5 2.1.1 on Fedora.

## Test plan

- [x] Configure with \`ENABLE_CheMPS2=ON\` (or \`ENABLE_ambit\`/\`ENABLE_Einsums\`) against system HDF5 2.x; \`Found HDF5\` line should now print an absolute \`/usr/lib*/libhdf5*.so\` path; \`psi4-core\` link succeeds.
- [ ] Repeat against a system HDF5 1.x — output and link both unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)