### PR TITLE
cmake: add opt-in psi4_ENABLE_IPO for interprocedural / link-time optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,15 @@ option_with_default(gauxc_ENABLE_MAGMA "Enable MAGMA support for GauXC. Required
 option_with_print(psi4_CMAKE_UNITY_BUILD "Enable unity/jumbo build to reduce compile units. Effective to at least 20 cores. 2-3x full rebuild speedup. For dev, can turn off overall or per-module" ON)
 option_with_default(psi4_CMAKE_UNITY_BUILD_BATCH_SIZE "Adjust unity build size from CMake default" 8)
 option_with_print(psi4_ENABLE_PRECOMPILE_HEADERS "Enable reusing preprocessed libmints and other headers for build performance. 15-20% full rebuild speedup. For dev, can turn off for finer incr rebuild" OFF)
+option_with_print(psi4_ENABLE_IPO "Enable interprocedural / link-time optimization (LTO) for psi4 modules and core. Expensive: substantial extra link-time CPU and multi-GB linker memory. Off by default." OFF)
+if(psi4_ENABLE_IPO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT _psi4_ipo_supported OUTPUT _psi4_ipo_msg LANGUAGES CXX)
+    if(NOT _psi4_ipo_supported)
+        message(WARNING "psi4_ENABLE_IPO=ON requested but not supported by this toolchain — disabling. Reason: ${_psi4_ipo_msg}")
+        set(psi4_ENABLE_IPO OFF CACHE BOOL "" FORCE)
+    endif()
+endif()
 
 include(custom_int_orderings)
 
@@ -296,6 +305,7 @@ ExternalProject_Add(psi4-core
               -DCMAKE_UNITY_BUILD=${psi4_CMAKE_UNITY_BUILD}
               -DCMAKE_UNITY_BUILD_BATCH_SIZE=${psi4_CMAKE_UNITY_BUILD_BATCH_SIZE}
               -Dpsi4_ENABLE_PRECOMPILE_HEADERS=${psi4_ENABLE_PRECOMPILE_HEADERS}
+              -Dpsi4_ENABLE_IPO=${psi4_ENABLE_IPO}
               -DPYMOD_INSTALL_LIBDIR=${PYMOD_INSTALL_LIBDIR}
               -DMAX_AM_ERI=${MAX_AM_ERI}
               -DPython_EXECUTABLE=${Python_EXECUTABLE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,15 @@ option_with_default(gauxc_ENABLE_MAGMA "Enable MAGMA support for GauXC. Required
 option_with_print(psi4_CMAKE_UNITY_BUILD "Enable unity/jumbo build to reduce compile units. Effective to at least 20 cores. 2-3x full rebuild speedup. For dev, can turn off overall or per-module" ON)
 option_with_default(psi4_CMAKE_UNITY_BUILD_BATCH_SIZE "Adjust unity build size from CMake default" 8)
 option_with_print(psi4_ENABLE_PRECOMPILE_HEADERS "Enable reusing preprocessed libmints and other headers for build performance. 15-20% full rebuild speedup. For dev, can turn off for finer incr rebuild" OFF)
+option_with_print(psi4_ENABLE_IPO "Enable interprocedural / link-time optimization (LTO) for psi4 modules and core. Expensive: substantial extra link-time CPU and multi-GB linker memory. Off by default." OFF)
+if(psi4_ENABLE_IPO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT _psi4_ipo_supported OUTPUT _psi4_ipo_msg LANGUAGES CXX)
+    if(NOT _psi4_ipo_supported)
+        message(WARNING "psi4_ENABLE_IPO=ON requested but not supported by this toolchain — disabling. Reason: ${_psi4_ipo_msg}")
+        set(psi4_ENABLE_IPO OFF CACHE BOOL "" FORCE)
+    endif()
+endif()
 
 include(custom_int_orderings)
 
@@ -315,6 +324,7 @@ ExternalProject_Add(psi4-core
               -DCMAKE_UNITY_BUILD=${psi4_CMAKE_UNITY_BUILD}
               -DCMAKE_UNITY_BUILD_BATCH_SIZE=${psi4_CMAKE_UNITY_BUILD_BATCH_SIZE}
               -Dpsi4_ENABLE_PRECOMPILE_HEADERS=${psi4_ENABLE_PRECOMPILE_HEADERS}
+              -Dpsi4_ENABLE_IPO=${psi4_ENABLE_IPO}
               -DPYMOD_INSTALL_LIBDIR=${PYMOD_INSTALL_LIBDIR}
               -DMAX_AM_ERI=${MAX_AM_ERI}
               -DPython_EXECUTABLE=${Python_EXECUTABLE}

--- a/cmake/psi4OptionsTools.cmake
+++ b/cmake/psi4OptionsTools.cmake
@@ -56,6 +56,9 @@ macro(psi4_add_module binlib libname sources)
       POSITION_INDEPENDENT_CODE 1
       VISIBILITY_INLINES_HIDDEN 1
     )
+  if(psi4_ENABLE_IPO)
+    set_target_properties(${libname} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+  endif()
 
   # Link required and optional dependencies interface libraries
   # This ensures all modules get:

--- a/psi4/src/CMakeLists.txt
+++ b/psi4/src/CMakeLists.txt
@@ -19,9 +19,19 @@ target_link_libraries(core
   PRIVATE
     # pybind11::module includes Python headers, pybind11::headers, Python::Module
     pybind11::module
-    pybind11::lto
     pybind11::windows_extras
 )
+# pybind11::lto would attach -flto only to core.cc + export_*.cc, which is a
+# small slice of the codebase since the per-module static libs built by
+# psi4_add_module aren't LTO-compiled. When psi4_ENABLE_IPO is ON, full IPO
+# is applied to every module and to core via INTERPROCEDURAL_OPTIMIZATION, so
+# pybind11::lto would be redundant (and double-toggling LTO has been a
+# source of linker warnings).
+if(NOT psi4_ENABLE_IPO)
+    target_link_libraries(core PRIVATE pybind11::lto)
+else()
+    set_target_properties(core PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()
 pybind11_extension(core)
 if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
     # Strip unnecessary sections of the binary on Linux/macOS


### PR DESCRIPTION
## Summary

Today the only LTO in the build comes from `pybind11::lto` attached to the `core` shared library. It covers `core.cc` and the `export_*.cc` files but stops there, because the per-module static libraries built by `psi4_add_module` are compiled without `INTERPROCEDURAL_OPTIMIZATION`. So LTO only touches the export layer; the bulk of compute-heavy code (libmints, libfock, cc/*, dfocc, dlpno, ...) never sees cross-TU optimization.

This PR adds an opt-in **`psi4_ENABLE_IPO`** (default OFF) that flips full IPO on:

- gates on `check_ipo_supported()` and disables itself with a `WARNING` if the toolchain doesn't support IPO
- sets `INTERPROCEDURAL_OPTIMIZATION` on every static lib produced by `psi4_add_module`, so all module object files contribute bitcode to the LTO link
- sets `INTERPROCEDURAL_OPTIMIZATION` on the `core` SHARED library and drops `pybind11::lto` from its link line when `psi4_ENABLE_IPO=ON` (the two would double-toggle LTO)
- is forwarded into the psi4-core subbuild alongside the other `psi4_*` build options

## Why opt-in, not default

- LTO links use substantially more CPU and multi-GB of linker memory; that's unwelcome for the typical multi-hour psi4 build and for conda-forge packagers.
- Unity build (already on by default, batch size 8) already provides intra-batch cross-TU inlining, so the marginal LTO win on top of unity is smaller than on a non-unity build.
- The codebase has had ODR issues recently surfaced by unity build (e.g. #3386 "avoid ODR errors in cc/ for unity build", #3387 "fix multiple defs for psimrcc for unity builds"). LTO is even more ODR-sensitive — flipping the default would likely surface a fresh round of duplicate-symbol diagnostics that would need to be fixed first.
- CI has never exercised a fully LTO-linked psi4, so flipping the default would be a blind change.

When `psi4_ENABLE_IPO=OFF` (the default), behavior is unchanged: `pybind11::lto` stays attached as before.

## Test plan

- [ ] `cmake -S. -Bobjdir` with no options — behavior unchanged, `pybind11::lto` still attached.
- [ ] `cmake -S. -Bobjdir -Dpsi4_ENABLE_IPO=ON` — builds with the toolchain's LTO; benchmark runtime on a tight CC / SCF case for a perf-sanity check.
- [ ] `cmake -S. -Bobjdir -Dpsi4_ENABLE_IPO=ON -DCMAKE_CXX_COMPILER=<compiler-without-LTO>` — `check_ipo_supported` reports unsupported, option auto-flips to OFF with the documented warning, build succeeds normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)