### PR TITLE
Pybind11v3.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -138,7 +138,7 @@ jobs:
                         ninja ^
                         numpy ^
                         pint ^
-                        pybind11>=3.0.0 ^
+                        "pybind11>=3.0.0" ^
                         pytest=7 ^
                         pytest-xdist ^
                         python=%PYTHON_VERSION% ^

--- a/.azure-pipelines/azure-pipelines-windows.yml
+++ b/.azure-pipelines/azure-pipelines-windows.yml
@@ -138,7 +138,7 @@ jobs:
                         ninja ^
                         numpy ^
                         pint ^
-                        pybind11 ^
+                        pybind11>=3.0.0 ^
                         pytest=7 ^
                         pytest-xdist ^
                         python=%PYTHON_VERSION% ^

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -735,16 +735,16 @@ data:
       host: github
       account: pybind
       name: pybind11
-      commit: v2.13.1
+      commit: v3.0.0
     cmake:
       name: pybind11  # detect Python before pybind11
-      constraint: 2.12.0
+      constraint: 3.0.0
       target: pybind11::module
     conda:
       channel: conda-forge
       name: pybind11
-      constraint: null
-      constraint_note: "Numpy v2 needs >=2.12. For docs, '>=2.10.*,<2.12.0' has adv; search FixedSize."
+      constraint: ">=3.0.0"
+      constraint_note: "v3.0.0 required for py::classh and py::native_enum support."
       cmake:
         pybind11_DIR:
           unix: ${CONDA_PREFIX}/share/cmake/pybind11

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -735,7 +735,7 @@ data:
       host: github
       account: pybind
       name: pybind11
-      commit: v3.0.0
+      commit: v3.0.3
     cmake:
       name: pybind11  # detect Python before pybind11
       constraint: 3.0.0

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -15,7 +15,7 @@ dependencies:
   - libboost-headers          # req'd with libint
   - llvm-openmp
   - numpy
-  - pybind11>=2.10.*
+  - pybind11>=3.0.0
   - python
     # qc buildtime required
   - gau2grid

--- a/external/upstream/pybind11/CMakeLists.txt
+++ b/external/upstream/pybind11/CMakeLists.txt
@@ -1,13 +1,5 @@
 
-if(${Python_NumPy_VERSION} GREATER_EQUAL "2")
-        find_package(pybind11 2.12.0 CONFIG QUIET)  # edit in codedeps
-else()
-    if(${Python_VERSION_MINOR} GREATER_EQUAL "11")
-        find_package( pybind11 2.10.1 CONFIG QUIET)
-    else()
-        find_package( pybind11 2.6.2 CONFIG QUIET)
-    endif()
-endif()
+find_package(pybind11 3.0.0 CONFIG QUIET)  # edit in codedeps
 
 if(${pybind11_FOUND})
     message(STATUS "${Cyan}Found pybind11${ColourReset}: ${pybind11_INCLUDE_DIR} (found version ${pybind11_VERSION})")
@@ -25,7 +17,7 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable pybind11 could not be located, ${Magenta}Building pybind11${ColourReset} instead.")
     ExternalProject_Add(pybind11_external
-        URL https://github.com/pybind/pybind11/archive/v2.13.1.tar.gz  # edit in codedeps
+        URL https://github.com/pybind/pybind11/archive/v3.0.0.tar.gz  # edit in codedeps
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/external/upstream/pybind11/CMakeLists.txt
+++ b/external/upstream/pybind11/CMakeLists.txt
@@ -17,7 +17,7 @@ else()
     include(ExternalProject)
     message(STATUS "Suitable pybind11 could not be located, ${Magenta}Building pybind11${ColourReset} instead.")
     ExternalProject_Add(pybind11_external
-        URL https://github.com/pybind/pybind11/archive/v3.0.0.tar.gz  # edit in codedeps
+        URL https://github.com/pybind/pybind11/archive/v3.0.3.tar.gz  # edit in codedeps
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 #  <<  Pybind11 & Python  >>
 find_package(Python 3.10 COMPONENTS Interpreter Development NumPy REQUIRED)
-find_package( pybind11 2.6.2 CONFIG REQUIRED)  # edit in codedeps (fix spacing when even lower bound)
+find_package(pybind11 3.0.0 CONFIG REQUIRED)  # edit in codedeps
 message(STATUS "${Cyan}Using pybind11${ColourReset}: ${pybind11_INCLUDE_DIR} (version ${pybind11_VERSION} for Py${Python_VERSION} and ${CMAKE_CXX_STANDARD})")
 message(STATUS "${Cyan}Using Python ${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}${ColourReset}: ${Python_EXECUTABLE}")
 

--- a/psi4/include/psi4/pybind11.h
+++ b/psi4/include/psi4/pybind11.h
@@ -36,6 +36,7 @@
 #include <memory>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/native_enum.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/operators.h>

--- a/psi4/include/psi4/pybind11.h
+++ b/psi4/include/psi4/pybind11.h
@@ -43,6 +43,4 @@
 
 namespace py = pybind11;
 
-PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
-
 #endif  // PSI4_CORE_PYBIND11_H_H

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -138,21 +138,21 @@ void handleBrianOption(bool value) {
 #endif
 
 // Python helper wrappers
-void export_benchmarks(py::module&);
-void export_blas_lapack(py::module&);
-void export_cubeprop(py::module&);
-void export_dpd(py::module&);
-void export_fock(py::module&);
-void export_functional(py::module&);
-void export_mints(py::module&);
-void export_misc(py::module&);
-void export_oeprop(py::module&);
-void export_pcm(py::module&);
-void export_plugins(py::module&);
-void export_psio(py::module&);
-void export_wavefunction(py::module&);
-void export_options(py::module&);
-void export_trans(py::module&);
+void export_benchmarks(py::module_&);
+void export_blas_lapack(py::module_&);
+void export_cubeprop(py::module_&);
+void export_dpd(py::module_&);
+void export_fock(py::module_&);
+void export_functional(py::module_&);
+void export_mints(py::module_&);
+void export_misc(py::module_&);
+void export_oeprop(py::module_&);
+void export_pcm(py::module_&);
+void export_plugins(py::module_&);
+void export_psio(py::module_&);
+void export_wavefunction(py::module_&);
+void export_options(py::module_&);
+void export_trans(py::module_&);
 
 // In export_plugins.cc
 void py_psi_plugin_close_all();

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -1198,10 +1198,11 @@ PYBIND11_MODULE(core, core) {
     core.def("initialize", &psi4_python_module_initialize, "Called upon psi4 module import to initialize timers, singletons, and I/O. Idempotent");
     core.def("finalize", &psi4_python_module_finalize, "Called upon psi4 module exit to closes timers and I/O.");
 
-    py::enum_<PsiReturnType>(core, "PsiReturnType", "Return status.")  // after C-OptKing, only Failure slightly used
+    py::native_enum<PsiReturnType>(core, "PsiReturnType", "enum.IntEnum", "Return status.")  // after C-OptKing, only Failure slightly used
         .value("Success", Success)
         .value("Failure", Failure)
-        .export_values();
+        .export_values()
+        .finalize();
 
     core.def("version", []() { PyErr_SetString(PyExc_AttributeError, "psi4.core.version removed since hasn't been working as intended."); }, ".. deprecated:: 1.4");
     core.def("git_version", []() { PyErr_SetString(PyExc_AttributeError, "psi4.core.git_version removed since hasn't been working as intended."); }, ".. deprecated:: 1.4");

--- a/psi4/src/export_benchmarks.cc
+++ b/psi4/src/export_benchmarks.cc
@@ -32,7 +32,7 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
- void export_benchmarks(py::module& m) {
+ void export_benchmarks(py::module_& m) {
     m.def("benchmark_blas1", &psi::benchmark_blas1, "max_dim"_a, "min_time"_a,
           "Perform benchmark traverse of BLAS 1 routines. Use up to *max_dim* with each routine run at least *min_time* [s].");
     m.def("benchmark_blas2", &psi::benchmark_blas2, "max_dim"_a, "min_time"_a,

--- a/psi4/src/export_blas_lapack.cc
+++ b/psi4/src/export_blas_lapack.cc
@@ -33,7 +33,7 @@
 
 namespace py = pybind11;
 
-void export_blas_lapack(py::module& m) {
+void export_blas_lapack(py::module_& m) {
     // BLAS Static Wrappers
     m.def("DGBMV", &psi::PSI_DGBMV, "docstring");
     m.def("DGEMM", &psi::PSI_DGEMM, "docstring");

--- a/psi4/src/export_cubeprop.cc
+++ b/psi4/src/export_cubeprop.cc
@@ -39,7 +39,7 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 void export_cubeprop(py::module_& m) {
-    py::class_<CubeProperties, std::shared_ptr<CubeProperties>>(m, "CubeProperties", "docstring")
+    py::classh<CubeProperties>(m, "CubeProperties", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>>())
         .def("compute_density", &CubeProperties::compute_density, "Compute and dump a cube file for a density matrix",
              "D"_a, "key"_a)

--- a/psi4/src/export_cubeprop.cc
+++ b/psi4/src/export_cubeprop.cc
@@ -38,7 +38,7 @@ using namespace psi;
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-void export_cubeprop(py::module& m) {
+void export_cubeprop(py::module_& m) {
     py::class_<CubeProperties, std::shared_ptr<CubeProperties>>(m, "CubeProperties", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>>())
         .def("compute_density", &CubeProperties::compute_density, "Compute and dump a cube file for a density matrix",

--- a/psi4/src/export_dpd.cc
+++ b/psi4/src/export_dpd.cc
@@ -36,7 +36,7 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 void export_dpd(py::module_ &m) {
-    py::class_<dpdbuf4, std::shared_ptr<dpdbuf4>>(m, "dpdbuf4", "docstring")
+    py::classh<dpdbuf4>(m, "dpdbuf4", "docstring")
         .def("axpy_matrix", &dpdbuf4::axpy_matrix, "Add 'a' times a Matrix to this.")
         .def("zero", &dpdbuf4::zero, "Fill all with entries.")
         .def("rowdim", [](dpdbuf4& buf) {
@@ -54,7 +54,7 @@ void export_dpd(py::module_ &m) {
                 return Dimension(dim);
             }, "Return the dimensions of the column index.");
 
-    py::class_<dpdfile2, std::shared_ptr<dpdfile2>>(m, "dpdfile2", "docstring")
+    py::classh<dpdfile2>(m, "dpdfile2", "docstring")
         .def("axpy_matrix", &dpdfile2::axpy_matrix, "Add 'a' times a Matrix to this.")
         .def("zero", &dpdfile2::zero, "Fill all entries with zeroes.")
         .def("rowdim", [](dpdfile2& file) {

--- a/psi4/src/export_dpd.cc
+++ b/psi4/src/export_dpd.cc
@@ -35,7 +35,7 @@ using namespace psi;
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-void export_dpd(py::module &m) {
+void export_dpd(py::module_ &m) {
     py::class_<dpdbuf4, std::shared_ptr<dpdbuf4>>(m, "dpdbuf4", "docstring")
         .def("axpy_matrix", &dpdbuf4::axpy_matrix, "Add 'a' times a Matrix to this.")
         .def("zero", &dpdbuf4::zero, "Fill all with entries.")

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -46,7 +46,7 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 void export_fock(py::module_ &m) {
-    py::class_<JK, std::shared_ptr<JK>>(m, "JK", "docstring")
+    py::classh<JK>(m, "JK", "docstring")
         .def_static("build_JK",
                     [](std::shared_ptr<BasisSet> basis, std::shared_ptr<BasisSet> aux) {
                         return JK::build_JK(basis, aux, Process::environment.options);
@@ -96,17 +96,17 @@ void export_fock(py::module_ &m) {
         .def("computed_shells_per_iter", py::overload_cast<const std::string&>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
         .def("print_header", &JK::print_header, "Prints information about the type and config of the JK object into the output file. Print verbosity may depend on the value of JK::print\\_.");
 
-    py::class_<LaplaceDenominator, std::shared_ptr<LaplaceDenominator>>(m, "LaplaceDenominator", "Computer class for a Laplace factorization of the four-index energy denominator in MP2 and coupled-cluster")
+    py::classh<LaplaceDenominator>(m, "LaplaceDenominator", "Computer class for a Laplace factorization of the four-index energy denominator in MP2 and coupled-cluster")
         .def(py::init<std::shared_ptr<Vector>, std::shared_ptr<Vector>, double>())
         .def("denominator_occ", &LaplaceDenominator::denominator_occ, "Returns the occupied orbital Laplace weights of the factorized doubles denominator (nweights * nocc)")
         .def("denominator_vir", &LaplaceDenominator::denominator_vir, "Returns the virtual orbital Laplace weights of the factorized doubles denominator (nweights * nvirt)");
 
-    py::class_<TLaplaceDenominator, std::shared_ptr<TLaplaceDenominator>>(m, "TLaplaceDenominator", "Computer class for a Laplace factorization of the six-index energy denominator in coupled-cluster theory")
+    py::classh<TLaplaceDenominator>(m, "TLaplaceDenominator", "Computer class for a Laplace factorization of the six-index energy denominator in coupled-cluster theory")
         .def(py::init<std::shared_ptr<Vector>, std::shared_ptr<Vector>, double>())
         .def("denominator_occ", &TLaplaceDenominator::denominator_occ, "Returns the occupied orbital Laplace weights of the factorized triples denominator (nweights * nocc)")
         .def("denominator_vir", &TLaplaceDenominator::denominator_vir, "Returns the virtual orbital Laplace weights of the factorized triples denominator (nweights * nvirt)");
 
-    py::class_<DFTensor, std::shared_ptr<DFTensor>>(m, "DFTensor", "docstring")
+    py::classh<DFTensor>(m, "DFTensor", "docstring")
         .def(py::init<std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>, std::shared_ptr<Matrix>, int, int>())
         .def("Qso", &DFTensor::Qso, "doctsring")
         .def("Qmo", &DFTensor::Qmo, "doctsring")
@@ -116,7 +116,7 @@ void export_fock(py::module_ &m) {
         .def("Imo", &DFTensor::Imo, "doctsring")
         .def("Idfmo", &DFTensor::Idfmo, "doctsring");
 
-    py::class_<FittingMetric, std::shared_ptr<FittingMetric>>(m, "FittingMetric", "docstring")
+    py::classh<FittingMetric>(m, "FittingMetric", "docstring")
         .def(py::init<std::shared_ptr<BasisSet>, bool>())
         .def("get_algorithm", &FittingMetric::get_algorithm, "docstring")
         .def("is_poisson", &FittingMetric::is_poisson, "docstring")
@@ -130,7 +130,7 @@ void export_fock(py::module_ &m) {
         .def("form_eig_inverse", &FittingMetric::form_eig_inverse, "docstring")
         .def("form_full_inverse", &FittingMetric::form_full_inverse, "docstring");
 
-    py::class_<SOMCSCF, std::shared_ptr<SOMCSCF>>(m, "SOMCSCF", "docstring")
+    py::classh<SOMCSCF>(m, "SOMCSCF", "docstring")
         // .def(init<std::shared_ptr<JK>, SharedMatrix, SharedMatrix >())
         .def("Ck", &SOMCSCF::Ck)
         .def("form_rotation_matrix", &SOMCSCF::form_rotation_matrix, "x"_a, "order"_a = 2)
@@ -152,15 +152,15 @@ void export_fock(py::module_ &m) {
         .def("gradient", &SOMCSCF::gradient)
         .def("gradient_rms", &SOMCSCF::gradient_rms);
 
-    py::class_<DFSOMCSCF, std::shared_ptr<DFSOMCSCF>, SOMCSCF>(m, "DFSOMCSCF", "docstring");
-    py::class_<DiskSOMCSCF, std::shared_ptr<DiskSOMCSCF>, SOMCSCF>(m, "DiskSOMCSCF", "docstring");
+    py::classh<DFSOMCSCF, SOMCSCF>(m, "DFSOMCSCF", "docstring");
+    py::classh<DiskSOMCSCF, SOMCSCF>(m, "DiskSOMCSCF", "docstring");
 
     // DF Helper
     typedef SharedMatrix (DFHelper::*take_string)(std::string);
     typedef SharedMatrix (DFHelper::*tensor_access3)(std::string, std::vector<size_t>, std::vector<size_t>,
                                                      std::vector<size_t>);
 
-    py::class_<DFHelper, std::shared_ptr<DFHelper>>(m, "DFHelper", "docstring")
+    py::classh<DFHelper>(m, "DFHelper", "docstring")
         .def(py::init<std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet> >())
         .def("set_memory", &DFHelper::set_memory)
         .def("get_memory", &DFHelper::get_memory)
@@ -190,20 +190,20 @@ void export_fock(py::module_ &m) {
         .def("get_tensor", take_string(&DFHelper::get_tensor))
         .def("get_tensor", tensor_access3(&DFHelper::get_tensor));
 
-    py::class_<MemDFJK, std::shared_ptr<MemDFJK>, JK>(m, "MemDFJK", "docstring")
+    py::classh<MemDFJK, JK>(m, "MemDFJK", "docstring")
         .def("dfh", &MemDFJK::dfh, "Return the DFHelper object.");
 
-    py::class_<DirectJK, std::shared_ptr<DirectJK>, JK>(m, "DirectJK", "docstring")
+    py::classh<DirectJK, JK>(m, "DirectJK", "docstring")
         .def("do_incfock_iter", &DirectJK::do_incfock_iter, "Was the last Fock build incremental?");
 
-    py::class_<CompositeJK, std::shared_ptr<CompositeJK>, JK>(m, "CompositeJK", "docstring")
+    py::classh<CompositeJK, JK>(m, "CompositeJK", "docstring")
         .def("do_incfock_iter", &CompositeJK::do_incfock_iter, "Was the last Fock build incremental?")
         .def("clear_D_prev", &CompositeJK::clear_D_prev, "Clear previous D matrices.")
         .def("set_COSX_grid", &CompositeJK::set_COSX_grid, "Set grid to use for COSX for this SCF iteration.")
         .def("get_COSX_grid", &CompositeJK::get_COSX_grid, "Return grid used for COSX for this SCF iteration.")
         .def("get_snLinK_max_am", &CompositeJK::get_snLinK_max_am, "Return maximum AM supported by current GauXC instance, if GauXC support is enabled.");
 
-    py::class_<scf::SADGuess, std::shared_ptr<scf::SADGuess>>(m, "SADGuess", "docstring")
+    py::classh<scf::SADGuess>(m, "SADGuess", "docstring")
         .def_static("build_SAD",
                     [](std::shared_ptr<BasisSet> basis, std::vector<std::shared_ptr<BasisSet>> atomic_bases) { return scf::SADGuess(basis, atomic_bases, Process::environment.options); })
         .def("compute_guess", &scf::SADGuess::compute_guess)

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -45,7 +45,7 @@ using namespace psi;
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-void export_fock(py::module &m) {
+void export_fock(py::module_ &m) {
     py::class_<JK, std::shared_ptr<JK>>(m, "JK", "docstring")
         .def_static("build_JK",
                     [](std::shared_ptr<BasisSet> basis, std::shared_ptr<BasisSet> aux) {

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -48,7 +48,7 @@ using namespace psi;
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-void export_functional(py::module &m) {
+void export_functional(py::module_ &m) {
     py::class_<Functional, std::shared_ptr<Functional>>(m, "Functional", "docstring")
         .def_static("build_base", &Functional::build_base, "alias"_a, "docstring")
         .def("compute_functional", &Functional::compute_functional, "docstring")

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -49,7 +49,7 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 void export_functional(py::module_ &m) {
-    py::class_<Functional, std::shared_ptr<Functional>>(m, "Functional", "docstring")
+    py::classh<Functional>(m, "Functional", "docstring")
         .def_static("build_base", &Functional::build_base, "alias"_a, "docstring")
         .def("compute_functional", &Functional::compute_functional, "docstring")
         .def("name", &Functional::name, "docstring")
@@ -77,7 +77,7 @@ void export_functional(py::module_ &m) {
         .def("print_out", &Functional::py_print, "docstring")
         .def("print_detail", &Functional::py_print_detail, "docstring");
 
-    py::class_<BasisExtents, std::shared_ptr<BasisExtents>>(m, "BasisExtents", "docstring")
+    py::classh<BasisExtents>(m, "BasisExtents", "docstring")
         .def(py::init<std::shared_ptr<BasisSet>, double>())
         .def("set_delta", &BasisExtents::set_delta, "docstring")
         .def("delta", &BasisExtents::delta, "docstring")
@@ -85,7 +85,7 @@ void export_functional(py::module_ &m) {
         .def("shell_extents", &BasisExtents::shell_extents, "docstring")
         .def("maxR", &BasisExtents::maxR, "docstring");
 
-    py::class_<BlockOPoints, std::shared_ptr<BlockOPoints>>(m, "BlockOPoints", "docstring")
+    py::classh<BlockOPoints>(m, "BlockOPoints", "docstring")
         .def(py::init<SharedVector, SharedVector, SharedVector, SharedVector, std::shared_ptr<BasisExtents>>())
         .def("x",
              [](BlockOPoints &grid) {
@@ -118,7 +118,7 @@ void export_functional(py::module_ &m) {
         .def("shells_local_to_global", &BlockOPoints::shells_local_to_global, "docstring")
         .def("functions_local_to_global", &BlockOPoints::functions_local_to_global, "docstring");
 
-    py::class_<SuperFunctional, std::shared_ptr<SuperFunctional>>(m, "SuperFunctional", "docstring")
+    py::classh<SuperFunctional>(m, "SuperFunctional", "docstring")
 
         .def(py::init<>())
         .def_static("blank", &SuperFunctional::blank, "Initialize a blank SuperFunctional.")
@@ -197,7 +197,7 @@ void export_functional(py::module_ &m) {
     typedef void (LibXCFunctional::*tweak_set1)(std::vector<double>, bool);
     typedef void (LibXCFunctional::*tweak_set2)(std::map<std::string, double>, bool);
 
-    py::class_<LibXCFunctional, std::shared_ptr<LibXCFunctional>, Functional>(m, "LibXCFunctional", "docstring")
+    py::classh<LibXCFunctional, Functional>(m, "LibXCFunctional", "docstring")
         .def(py::init<std::string, bool>())
         .def("get_mix_data", &LibXCFunctional::get_mix_data, "docstring")
         .def("set_tweak", tweak_set1(&LibXCFunctional::set_tweak), "tweaks"_a, "quiet"_a = false,
@@ -210,7 +210,7 @@ void export_functional(py::module_ &m) {
         .def("xclib_description", &LibXCFunctional::xclib_description, "query libxc for version and citation")
         .def("query_libxc", &LibXCFunctional::query_libxc, "query libxc regarding functional parameters.");
 
-    py::class_<BasisFunctions, std::shared_ptr<BasisFunctions>>(m, "BasisFunctions", "docstring")
+    py::classh<BasisFunctions>(m, "BasisFunctions", "docstring")
         .def(py::init<std::shared_ptr<BasisSet>, int, int>())
         .def("max_functions", &BasisFunctions::max_functions, "docstring")
         .def("max_points", &BasisFunctions::max_points, "docstring")
@@ -222,7 +222,7 @@ void export_functional(py::module_ &m) {
     typedef void (PointFunctions::*matrix_set1)(SharedMatrix);
     typedef void (PointFunctions::*matrix_set2)(SharedMatrix, SharedMatrix);
 
-    py::class_<PointFunctions, std::shared_ptr<PointFunctions>, BasisFunctions>(m, "PointFunctions", "docstring")
+    py::classh<PointFunctions, BasisFunctions>(m, "PointFunctions", "docstring")
         .def("print_out", &PointFunctions::print, "out_fname"_a = "outfile", "print"_a = 2, "docstring")
         .def("ansatz", &PointFunctions::ansatz, "docstring")
         .def("set_ansatz", &PointFunctions::set_ansatz, "docstring")
@@ -232,7 +232,7 @@ void export_functional(py::module_ &m) {
         .def("point_values", &PointFunctions::point_values, "docstring")
         .def("orbital_values", &PointFunctions::orbital_values, "docstring");
 
-    py::class_<MolecularGrid, std::shared_ptr<MolecularGrid>>(m, "MolecularGrid", "docstring")
+    py::classh<MolecularGrid>(m, "MolecularGrid", "docstring")
         .def("print", &MolecularGrid::print, "Prints grid information.")
         .def("orientation", &MolecularGrid::orientation, "Returns the orientation of the grid.")
         .def("npoints", &MolecularGrid::npoints, "Returns the number of grid points.")
@@ -242,7 +242,7 @@ void export_functional(py::module_ &m) {
         .def("blocks", &MolecularGrid::blocks, "Returns a list of blocks.")
         .def("atomic_blocks", &MolecularGrid::atomic_blocks, "Returns a list of blocks.");
 
-    py::class_<DFTGrid, std::shared_ptr<DFTGrid>, MolecularGrid>(m, "DFTGrid", "docstring")
+    py::classh<DFTGrid, MolecularGrid>(m, "DFTGrid", "docstring")
         .def_static("build",
                     [](std::shared_ptr<Molecule> &mol, std::shared_ptr<BasisSet> &basis) {
                         return std::make_shared<DFTGrid>(mol, basis, Process::environment.options);
@@ -252,7 +252,7 @@ void export_functional(py::module_ &m) {
             return std::make_shared<DFTGrid>(mol, basis, int_opts, string_opts, Process::environment.options);
         });
 
-    py::class_<VBase, std::shared_ptr<VBase>>(m, "VBase", "docstring")
+    py::classh<VBase>(m, "VBase", "docstring")
         .def_static("build",
                     [](std::shared_ptr<BasisSet> &basis, std::shared_ptr<SuperFunctional> &func, std::string type) {
                         return VBase::build_V(basis, func, Process::environment.options, type);
@@ -283,13 +283,13 @@ void export_functional(py::module_ &m) {
         .def("finalize", &VBase::finalize, "Finalizes the V object.")
         .def("print_header", &VBase::print_header, "Prints the objects header.");
 
-    py::class_<RKSFunctions, std::shared_ptr<RKSFunctions>, PointFunctions>(m, "RKSFunctions", "docstring")
+    py::classh<RKSFunctions, PointFunctions>(m, "RKSFunctions", "docstring")
         .def(py::init<std::shared_ptr<BasisSet>, int, int>());
 
-    py::class_<UKSFunctions, std::shared_ptr<UKSFunctions>, PointFunctions>(m, "UKSFunctions", "docstring")
+    py::classh<UKSFunctions, PointFunctions>(m, "UKSFunctions", "docstring")
         .def(py::init<std::shared_ptr<BasisSet>, int, int>());
 
-    py::class_<Dispersion, std::shared_ptr<Dispersion>>(m, "Dispersion", "docstring")
+    py::classh<Dispersion>(m, "Dispersion", "docstring")
         .def_static("build", &Dispersion::build, "type"_a, "s6"_a = 0.0, "alpha6"_a = 0.0, "sr6"_a = 0.0,
                     "Initialize instance capable of computing a dispersion correction of *type*")
         .def("name", &Dispersion::name, "docstring")
@@ -314,7 +314,7 @@ void export_functional(py::module_ &m) {
         .def("a2", &Dispersion::get_a2, "docstring")
         .def("print_out", &Dispersion::py_print, "docstring");
 
-    py::class_<sapt::FDDS_Dispersion, std::shared_ptr<sapt::FDDS_Dispersion>>(m, "FDDS_Dispersion", "docstring")
+    py::classh<sapt::FDDS_Dispersion>(m, "FDDS_Dispersion", "docstring")
         .def(py::init<std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>, std::map<std::string, SharedMatrix>,
                       std::map<std::string, SharedVector>, bool>())
         .def("metric", &sapt::FDDS_Dispersion::metric, "Obtains the FDDS metric.")
@@ -333,7 +333,7 @@ void export_functional(py::module_ &m) {
         .def("R_A", &sapt::FDDS_Dispersion::R_A, "Obtains (R^t)^-1 for monomer A.")
         .def("R_B", &sapt::FDDS_Dispersion::R_B, "Obtains (R^t)^-1 for monomer B.");
 
-     py::class_<NumIntHelper, std::shared_ptr<NumIntHelper>>(m, "NumIntHelper",
+     py::classh<NumIntHelper>(m, "NumIntHelper",
                                                              "Computes numerical integrals using a DFT grid.")
          .def(py::init<std::shared_ptr<DFTGrid>>())
          .def("numint_grid", &NumIntHelper::numint_grid)

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -500,9 +500,9 @@ void export_mints(py::module_& m) {
         .finalize();
 
     py::native_enum<Molecule::FragmentType>(m, "FragmentType", "enum.IntEnum", "Fragment activation status")
-        .value("Absent", Molecule::Absent)
-        .value("Real", Molecule::Real)
-        .value("Ghost", Molecule::Ghost)
+        .value("Absent", Molecule::Absent, "Neglect completely")
+        .value("Real", Molecule::Real, "Include, as normal")
+        .value("Ghost", Molecule::Ghost, "Include, but with ghost atoms")
         .export_values()
         .finalize();
 

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -327,7 +327,7 @@ std::shared_ptr<Molecule> from_dict(py::dict molrec) {
     return mol;
 }
 
-void export_mints(py::module& m) {
+void export_mints(py::module_& m) {
     typedef void (Vector::*vector_setitem_1)(int, double);
     typedef void (Vector::*vector_setitem_2)(int, int, double);
     typedef double (Vector::*vector_getitem_1)(int) const;

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -336,7 +336,7 @@ void export_mints(py::module_& m) {
     typedef void (Vector::*vector_two)(double scale, const Vector& other);
     typedef void (Vector::*vector_three)(double alpha, double beta, const Vector &other);
 
-    py::class_<Dimension>(m, "Dimension", "Initializes and defines Dimension Objects")
+    py::classh<Dimension>(m, "Dimension", "Initializes and defines Dimension Objects")
         .def(py::init<size_t>())
         .def(py::init<size_t, const std::string&>())
         .def(py::init<const std::vector<int>&>())
@@ -361,7 +361,7 @@ void export_mints(py::module_& m) {
         .def("__getitem__", &Dimension::get, py::return_value_policy::copy, "Get the i'th value", "i"_a)
         .def("__setitem__", &Dimension::set, "Set element i to value val", "i"_a, "val"_a);
 
-    py::class_<Slice>(m, "Slice", "Slicing for Matrix and Vector objects")
+    py::classh<Slice>(m, "Slice", "Slicing for Matrix and Vector objects")
         .def(py::init<Dimension&, Dimension&>())
         .def("begin", &Slice::begin, "Get the first element of this slice")
         .def("end", &Slice::end, "Get the past-the-end element of this slice");
@@ -775,7 +775,7 @@ void export_mints(py::module_& m) {
              "Returns a new Matrix object named name with default dimensions");
     //              "name"_a, "symmetry"_a);
 
-    py::class_<Vector3>(m, "Vector3",
+    py::classh<Vector3>(m, "Vector3",
                         "Class for vectors of length three, often Cartesian coordinate vectors, "
                         "and their common operations")
         .def(py::init<double>())
@@ -803,7 +803,7 @@ void export_mints(py::module_& m) {
     typedef void (SymmetryOperation::*intFunction)(int);
     typedef void (SymmetryOperation::*doubleFunction)(double);
 
-    py::class_<SymmetryOperation>(m, "SymmetryOperation",
+    py::classh<SymmetryOperation>(m, "SymmetryOperation",
                                   "Class to provide a 3 by 3 matrix representation of a symmetry "
                                   "operation, such as a rotation or reflection.")
         .def(py::init<const SymmetryOperation&>())
@@ -1335,8 +1335,8 @@ void export_mints(py::module_& m) {
         .def("shell_significant", compute_shell_significant(&TwoBodyAOInt::shell_significant),
              "Determines if the P,Q,R,S shell combination is significant");
 
-    py::class_<Libint2ERI, std::unique_ptr<Libint2ERI>>(m, "ERI", pyTwoBodyAOInt,
-                                                        "Computes normal two electron repulsion integrals");
+    py::classh<Libint2ERI>(m, "ERI", pyTwoBodyAOInt,
+                          "Computes normal two electron repulsion integrals");
 
     py::classh<AOShellCombinationsIterator>(m,
                                                                                           "AOShellCombinationsIterator")
@@ -1622,7 +1622,7 @@ void export_mints(py::module_& m) {
              "Gradient of MO basis electric dipole integrals: returns (3 * natoms) matrices", "atom"_a, "C1"_a, "C2"_a);
 
 
-    py::class_<OrbitalSpace>(m, "OrbitalSpace", "Contains information about the orbitals")
+    py::classh<OrbitalSpace>(m, "OrbitalSpace", "Contains information about the orbitals")
         .def(py::init<const std::string&, const std::string&, const SharedMatrix&, const SharedVector&,
                       const std::shared_ptr<BasisSet>&, const std::shared_ptr<IntegralFactory>&>())
         .def(py::init<const std::string&, const std::string&, const SharedMatrix&, const std::shared_ptr<BasisSet>&,

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -366,9 +366,9 @@ void export_mints(py::module_& m) {
         .def("begin", &Slice::begin, "Get the first element of this slice")
         .def("end", &Slice::end, "Get the past-the-end element of this slice");
 
-    py::class_<IrreppedVector<double>, std::shared_ptr<IrreppedVector<double>>>(m, "ProtoVector");
+    py::classh<IrreppedVector<double>>(m, "ProtoVector");
 
-    py::class_<Vector, std::shared_ptr<Vector>, IrreppedVector<double>>(m, "Vector", "Class for creating and manipulating vectors",
+    py::classh<Vector, IrreppedVector<double>>(m, "Vector", "Class for creating and manipulating vectors",
                                                 py::dynamic_attr())
         .def(py::init<int>())
         .def(py::init<const Dimension&>())
@@ -449,13 +449,13 @@ void export_mints(py::module_& m) {
             },
             py::return_value_policy::reference_internal);
 
-    py::class_<IrreppedVector<int>, std::shared_ptr<IrreppedVector<int>>>(m, "ProtoIntVector");
+    py::classh<IrreppedVector<int>>(m, "ProtoIntVector");
 
     typedef int (IntVector::*int_vector_get_1)(int) const;
     typedef int (IntVector::*int_vector_get_2)(int, int) const;
     typedef void (IntVector::*int_vector_set_1)(int, int);
     typedef void (IntVector::*int_vector_set_2)(int, int, int);
-    py::class_<IntVector, std::shared_ptr<IntVector>, IrreppedVector<int>>(m, "IntVector", "Class handling vectors with integer values")
+    py::classh<IntVector, IrreppedVector<int>>(m, "IntVector", "Class handling vectors with integer values")
         .def(py::init<int>())
         .def(py::init<const Dimension&>())
         .def(py::init<const std::string&, int>())
@@ -487,21 +487,24 @@ void export_mints(py::module_& m) {
         .def("set_block", &IntVector::set_block, "Set a vector block", "slice"_a, "block"_a)
         .def_static("iota", &IntVector::iota);
 
-    py::enum_<diagonalize_order>(m, "DiagonalizeOrder", "Defines ordering of eigenvalues after diagonalization")
+    py::native_enum<diagonalize_order>(m, "DiagonalizeOrder", "enum.IntEnum", "Defines ordering of eigenvalues after diagonalization")
         .value("Ascending", ascending)
         .value("Descending", descending)
-        .export_values();
+        .export_values()
+        .finalize();
 
-    py::enum_<Molecule::GeometryUnits>(m, "GeometryUnits", "The units used to define the geometry")
+    py::native_enum<Molecule::GeometryUnits>(m, "GeometryUnits", "enum.IntEnum", "The units used to define the geometry")
         .value("Angstrom", Molecule::Angstrom)
         .value("Bohr", Molecule::Bohr)
-        .export_values();
+        .export_values()
+        .finalize();
 
-    py::enum_<Molecule::FragmentType>(m, "FragmentType", "Fragment activation status")
-        .value("Absent", Molecule::Absent)  // Neglect completely
-        .value("Real", Molecule::Real)      // Include, as normal
-        .value("Ghost", Molecule::Ghost)    // Include, but with ghost atoms
-        .export_values();
+    py::native_enum<Molecule::FragmentType>(m, "FragmentType", "enum.IntEnum", "Fragment activation status")
+        .value("Absent", Molecule::Absent)
+        .value("Real", Molecule::Real)
+        .value("Ghost", Molecule::Ghost)
+        .export_values()
+        .finalize();
 
     typedef void (Matrix::*matrix_multiply)(bool, bool, double, const SharedMatrix&, const SharedMatrix&, double);
     typedef void (Matrix::*matrix_diagonalize)(SharedMatrix&, std::shared_ptr<Vector>&, diagonalize_order);
@@ -522,12 +525,13 @@ void export_mints(py::module_& m) {
     typedef void (Matrix::*set_block_shared)(const Slice&, const Slice&, SharedMatrix);
     typedef SharedMatrix (Matrix::*get_block_shared)(const Slice&, const Slice&) const;
 
-    py::enum_<Matrix::SaveType>(m, "SaveType", "The layout of the matrix for saving")
+    py::native_enum<Matrix::SaveType>(m, "SaveType", "enum.IntEnum", "The layout of the matrix for saving")
         .value("SubBlocks", Matrix::SaveType::SubBlocks)
         .value("LowerTriangle", Matrix::SaveType::LowerTriangle)
-        .export_values();
+        .export_values()
+        .finalize();
 
-    py::class_<Matrix, std::shared_ptr<Matrix>>(m, "Matrix", "Class for creating and manipulating matrices",
+    py::classh<Matrix>(m, "Matrix", "Class for creating and manipulating matrices",
                                                 py::dynamic_attr(), py::buffer_protocol())
         .def(py::init<int, int>())
         .def(py::init<const std::string&, int, int>())
@@ -743,11 +747,12 @@ void export_mints(py::module_& m) {
             * If A, B, C not of the the same symmetry, always computed as ``(AB)C``.
             )pbdoc");
 
-    py::enum_<DerivCalcType>(m, "DerivCalcType")
+    py::native_enum<DerivCalcType>(m, "DerivCalcType", "enum.IntEnum")
         .value("Default", DerivCalcType::Default, "Use internal logic.")
-        .value("Correlated", DerivCalcType::Correlated, "Correlated methods that write RDMs and Lagrangian to disk.");
+        .value("Correlated", DerivCalcType::Correlated, "Correlated methods that write RDMs and Lagrangian to disk.")
+        .finalize();
 
-    py::class_<Deriv, std::shared_ptr<Deriv>>(m, "Deriv", "Computes gradients of wavefunctions")
+    py::classh<Deriv>(m, "Deriv", "Computes gradients of wavefunctions")
         .def(py::init<std::shared_ptr<Wavefunction>>())
         .def(py::init<std::shared_ptr<Wavefunction>, char, bool, bool>())
         .def("set_tpdm_presorted", &Deriv::set_tpdm_presorted, "Is the TPDM already presorted? Default is False",
@@ -762,7 +767,7 @@ void export_mints(py::module_& m) {
     typedef SharedMatrix (MatrixFactory::*create_shared_matrix)() const;
     typedef SharedMatrix (MatrixFactory::*create_shared_matrix_name)(const std::string&) const;
     // Something here is wrong. These will not work with py::args defined, not sure why
-    py::class_<MatrixFactory, std::shared_ptr<MatrixFactory>>(m, "MatrixFactory", "Creates Matrix objects")
+    py::classh<MatrixFactory>(m, "MatrixFactory", "Creates Matrix objects")
         .def("create_matrix", create_shared_matrix(&MatrixFactory::create_shared_matrix),
              "Returns a new matrix object with default dimensions")
         //             "Returns a new matrix object with default dimensions", "symmetry"_a);
@@ -823,13 +828,13 @@ void export_mints(py::module_& m) {
         .def("__getitem__",
              [](const SymmetryOperation& self, size_t i) { return std::vector<double>(self[i], self[i] + 3); });
 
-    py::class_<IrreducibleRepresentation, std::shared_ptr<IrreducibleRepresentation>>(
+    py::classh<IrreducibleRepresentation>(
         m, "IrreducibleRepresentation", "An irreducible representation of the point group")
         .def("character", &IrreducibleRepresentation::character,
              "Return the character of the i'th symmetry operation for the irrep. 0-indexed.")
         .def("symbol", &IrreducibleRepresentation::symbol, "Return the symbol for the irrep");
 
-    py::class_<CharacterTable, std::shared_ptr<CharacterTable>>(m, "CharacterTable",
+    py::classh<CharacterTable>(m, "CharacterTable",
                                                                 "Contains the character table of the point group")
         .def(py::init<const unsigned char>())
         .def(py::init<const std::string&>())
@@ -837,7 +842,7 @@ void export_mints(py::module_& m) {
         .def("order", &CharacterTable::order, "Return the order of the point group")
         .def("symm_operation", &CharacterTable::symm_operation, "Return the i'th symmetry operation. 0-indexed.");
 
-    py::class_<PointGroup, std::shared_ptr<PointGroup>>(m, "PointGroup", "Contains information about the point group")
+    py::classh<PointGroup>(m, "PointGroup", "Contains information about the point group")
         .def(py::init<const std::string&>())
         .def("symbol", &PointGroup::symbol, "Returns Schoenflies symbol for point group")
         .def("order", &PointGroup::order, "Return the order of the point group")
@@ -852,7 +857,7 @@ void export_mints(py::module_& m) {
     typedef Vector3 (Molecule::*nuclear_dipole2)() const;
     typedef Vector3 (Molecule::*vector_by_index)(int) const;
 
-    py::class_<Molecule, std::shared_ptr<Molecule>>(m, "Molecule", py::dynamic_attr(),
+    py::classh<Molecule>(m, "Molecule", py::dynamic_attr(),
                                                     "Class to store the elements, coordinates, "
                                                     "fragmentation pattern, basis sets, charge, "
                                                     "multiplicity, etc. of a molecule.")
@@ -1089,14 +1094,14 @@ void export_mints(py::module_& m) {
         .def("set_full_geometry", matrix_set_geometry(&Molecule::set_full_geometry),
              "Sets the geometry, given a (Natom X 3) matrix arg0 of coordinates (in Bohr) (including dummies");
 
-    py::class_<CdSalc::Component, std::shared_ptr<CdSalc::Component>>(
+    py::classh<CdSalc::Component>(
         m, "SalcComponent", "Component of a Cartesian displacement SALC in the basis of atomic displacements.")
         .def_readwrite("coef", &CdSalc::Component::coef, "The coefficient of the displacement")
         .def_readwrite("atom", &CdSalc::Component::atom, "The index of the atom being displaced. 0-indexed.")
         .def_readwrite("xyz", &CdSalc::Component::xyz,
                        "The direction of the displacement, given by x as 0, y as 1, z as 2.");
 
-    py::class_<CdSalc, std::shared_ptr<CdSalc>>(m, "CdSalc", "Cartesian displacement SALC")
+    py::classh<CdSalc>(m, "CdSalc", "Cartesian displacement SALC")
         .def("irrep", &CdSalc::irrep, "Return the irrep bit representation")
         .def(
             "irrep_index", [](const CdSalc& salc) { return static_cast<int>(salc.irrep()); }, "Return the irrep index")
@@ -1109,7 +1114,7 @@ void export_mints(py::module_& m) {
             "__iter__", [](const CdSalc& salc) { return py::make_iterator(salc.get_components()); },
             py::keep_alive<0, 1>());
 
-    py::class_<CdSalcList, std::shared_ptr<CdSalcList>>(
+    py::classh<CdSalcList>(
         m, "CdSalcList", "Class for generating symmetry adapted linear combinations of Cartesian displacements")
         .def(py::init<std::shared_ptr<Molecule>, int, bool, bool>())
         .def("ncd", &CdSalcList::ncd, "Return the number of cartesian displacements SALCs")
@@ -1128,7 +1133,7 @@ void export_mints(py::module_& m) {
         .def("matrix_irrep", &CdSalcList::matrix_irrep,
              "Return the matrix that transforms Cartesian displacements to SALCs of irrep h", "h"_a);
 
-    py::class_<GaussianShell, std::shared_ptr<GaussianShell>>(m, "GaussianShell",
+    py::classh<GaussianShell>(m, "GaussianShell",
                                                               "Class containing information about basis functions")
         .def_property_readonly("nprimitive", py::cpp_function(&GaussianShell::nprimitive),
                                "The number of primitive gaussians")
@@ -1166,20 +1171,22 @@ void export_mints(py::module_& m) {
         .def("erd_coef", &GaussianShell::erd_coef, "Return ERD normalized coefficient of pi'th primitive", "pi"_a)
         .def("coef", &GaussianShell::coef, "Return coefficient of the pi'th primitive", "pi"_a);
 
-    py::enum_<PrimitiveType>(m, "PrimitiveType", "May be Normalized or Unnormalized")
+    py::native_enum<PrimitiveType>(m, "PrimitiveType", "enum.IntEnum", "May be Normalized or Unnormalized")
         .value("Normalized", Normalized)
         .value("Unnormalized", Unnormalized)
-        .export_values();
+        .export_values()
+        .finalize();
 
-    py::enum_<GaussianType>(m, "GaussianType", "0 if Cartesian, 1 if Pure")
+    py::native_enum<GaussianType>(m, "GaussianType", "enum.IntEnum", "0 if Cartesian, 1 if Pure")
         .value("Cartesian", Cartesian, "(n+1)(n+2)/2 functions")
         .value("Pure", Pure, "2n+1 functions")
-        .export_values();
+        .export_values()
+        .finalize();
 
-    py::class_<ShellInfo, std::shared_ptr<ShellInfo>>(m, "ShellInfo")
+    py::classh<ShellInfo>(m, "ShellInfo")
         .def(py::init<int, const std::vector<double>&, const std::vector<double>&, GaussianType, PrimitiveType>());
 
-    py::bind_vector<std::vector<ShellInfo>>(m, "BSVec");
+    py::bind_vector<std::vector<ShellInfo>, py::smart_holder>(m, "BSVec");
 
     typedef void (BasisSet::*basis_print_out)() const;
     typedef const GaussianShell& (BasisSet::*no_center_version)(int) const;
@@ -1188,7 +1195,7 @@ void export_mints(py::module_& m) {
     typedef int (BasisSet::*ncore_no_args)() const;
     typedef int (BasisSet::*ncore_one_arg)(const std::string&) const;
 
-    py::class_<BasisSet, std::shared_ptr<BasisSet>>(m, "BasisSet", "Contains basis set information", py::dynamic_attr())
+    py::classh<BasisSet>(m, "BasisSet", "Contains basis set information", py::dynamic_attr())
         .def(py::init<const std::string&, std::shared_ptr<Molecule>,
                       std::map<std::string, std::map<std::string, std::vector<ShellInfo>>>&,
                       std::map<std::string, std::map<std::string, std::vector<ShellInfo>>>&>())
@@ -1261,7 +1268,7 @@ void export_mints(py::module_& m) {
         .def("negative_gaussian_normalization_to_coefficients", &BasisSet::negative_gaussian_normalization_to_coefficients, "Remove normalization from an s-function basis set and negate. Not idempotent");
 
     typedef void (OneBodyAOInt::*vecmatrix_version)(std::vector<SharedMatrix>&);
-    py::class_<OneBodyAOInt, std::shared_ptr<OneBodyAOInt>> pyOneBodyAOInt(
+    py::classh<OneBodyAOInt> pyOneBodyAOInt(
         m, "OneBodyAOInt", "Basis class for all one-electron integrals");
     pyOneBodyAOInt
         .def("compute_shell", &OneBodyAOInt::compute_shell,
@@ -1275,7 +1282,7 @@ void export_mints(py::module_& m) {
         .def_property_readonly("basis2", py::cpp_function(&OneBodyAOInt::basis2),
                                "The basis set on center two");  // <-- Added semicolon
 
-    py::class_<OneBodySOInt, std::shared_ptr<OneBodySOInt>>(m, "OneBodySOInt")
+    py::classh<OneBodySOInt>(m, "OneBodySOInt")
         .def(py::init<std::shared_ptr<OneBodyAOInt>, std::shared_ptr<IntegralFactory>>())
         .def_property_readonly("basis", py::cpp_function(&OneBodySOInt::basis), "The basis set on center one")
         .def_property_readonly("basis1", py::cpp_function(&OneBodySOInt::basis1), "The basis set on center one")
@@ -1292,28 +1299,28 @@ void export_mints(py::module_& m) {
     //        add_property("basis1", &OneBodySOInt::basis1, "The basis set on center one").
     //        add_property("basis2", &OneBodySOInt::basis2, "The basis set on center two");
 
-    py::class_<OverlapInt, std::shared_ptr<OverlapInt>>(m, "OverlapInt", pyOneBodyAOInt, "Computes overlap integrals");
-    py::class_<DipoleInt, std::shared_ptr<DipoleInt>>(m, "DipoleInt", pyOneBodyAOInt, "Computes dipole integrals");
-    py::class_<QuadrupoleInt, std::shared_ptr<QuadrupoleInt>>(m, "QuadrupoleInt", pyOneBodyAOInt,
+    py::classh<OverlapInt>(m, "OverlapInt", pyOneBodyAOInt, "Computes overlap integrals");
+    py::classh<DipoleInt>(m, "DipoleInt", pyOneBodyAOInt, "Computes dipole integrals");
+    py::classh<QuadrupoleInt>(m, "QuadrupoleInt", pyOneBodyAOInt,
                                                               "Computes quadrupole integrals");
-    py::class_<MultipoleInt, std::shared_ptr<MultipoleInt>>(m, "MultipoleInt", pyOneBodyAOInt,
+    py::classh<MultipoleInt>(m, "MultipoleInt", pyOneBodyAOInt,
                                                             "Computes arbitrary-order multipole integrals");
-    py::class_<TracelessQuadrupoleInt, std::shared_ptr<TracelessQuadrupoleInt>>(
+    py::classh<TracelessQuadrupoleInt>(
         m, "TracelessQuadrupoleInt", pyOneBodyAOInt, "Computes traceless quadrupole integrals");
-    py::class_<ElectricFieldInt, std::shared_ptr<ElectricFieldInt>>(m, "ElectricFieldInt", pyOneBodyAOInt,
+    py::classh<ElectricFieldInt>(m, "ElectricFieldInt", pyOneBodyAOInt,
                                                                     "Computes electric field integrals");
-    py::class_<KineticInt, std::shared_ptr<KineticInt>>(m, "KineticInt", pyOneBodyAOInt, "Computes kinetic integrals");
-    py::class_<PotentialInt, std::shared_ptr<PotentialInt>>(m, "PotentialInt", pyOneBodyAOInt,
+    py::classh<KineticInt>(m, "KineticInt", pyOneBodyAOInt, "Computes kinetic integrals");
+    py::classh<PotentialInt>(m, "PotentialInt", pyOneBodyAOInt,
                                                             "Computes potential integrals");
-    py::class_<ElectrostaticInt, std::shared_ptr<ElectrostaticInt>>(m, "ElectrostaticInt", pyOneBodyAOInt,
+    py::classh<ElectrostaticInt>(m, "ElectrostaticInt", pyOneBodyAOInt,
                                                                     "Computes electrostatic integrals");
-    py::class_<NablaInt, std::shared_ptr<NablaInt>>(m, "NablaInt", pyOneBodyAOInt, "Computes nabla integrals");
-    py::class_<AngularMomentumInt, std::shared_ptr<AngularMomentumInt>>(m, "AngularMomentumInt", pyOneBodyAOInt,
+    py::classh<NablaInt>(m, "NablaInt", pyOneBodyAOInt, "Computes nabla integrals");
+    py::classh<AngularMomentumInt>(m, "AngularMomentumInt", pyOneBodyAOInt,
                                                                         "Computes angular momentum integrals");
 
     typedef bool (TwoBodyAOInt::*compute_shell_significant)(int, int, int, int);
     typedef size_t (TwoBodyAOInt::*compute_shell_ints)(int, int, int, int);
-    py::class_<TwoBodyAOInt, std::shared_ptr<TwoBodyAOInt>> pyTwoBodyAOInt(m, "TwoBodyAOInt",
+    py::classh<TwoBodyAOInt> pyTwoBodyAOInt(m, "TwoBodyAOInt",
                                                                            "Two body integral base class");
     pyTwoBodyAOInt
         .def("compute_shell", compute_shell_ints(&TwoBodyAOInt::compute_shell), "Compute ERIs between 4 shells")
@@ -1322,7 +1329,7 @@ void export_mints(py::module_& m) {
         .def("update_density", &TwoBodyAOInt::update_density,
              "Update density matrix (c1 symmetry) for Density-matrix based integral screening");
 
-    py::class_<Libint2TwoElectronInt, std::shared_ptr<Libint2TwoElectronInt>>(
+    py::classh<Libint2TwoElectronInt>(
         m, "TwoElectronInt", pyTwoBodyAOInt, "Computes two-electron repulsion integrals")
         .def("compute_shell", compute_shell_ints(&TwoBodyAOInt::compute_shell), "Compute ERIs between 4 shells")
         .def("shell_significant", compute_shell_significant(&TwoBodyAOInt::shell_significant),
@@ -1331,7 +1338,7 @@ void export_mints(py::module_& m) {
     py::class_<Libint2ERI, std::unique_ptr<Libint2ERI>>(m, "ERI", pyTwoBodyAOInt,
                                                         "Computes normal two electron repulsion integrals");
 
-    py::class_<AOShellCombinationsIterator, std::shared_ptr<AOShellCombinationsIterator>>(m,
+    py::classh<AOShellCombinationsIterator>(m,
                                                                                           "AOShellCombinationsIterator")
         .def_property_readonly("p", py::cpp_function(&AOShellCombinationsIterator::p), "Returns current P index")
         .def_property_readonly("q", py::cpp_function(&AOShellCombinationsIterator::q), "Returns current Q index")
@@ -1341,11 +1348,11 @@ void export_mints(py::module_& m) {
         .def("next", &AOShellCombinationsIterator::next, "docstring")  // these are not documented C++ side
         .def("is_done", &AOShellCombinationsIterator::is_done, "docstring");
 
-    py::class_<ThreeCenterOverlapInt, std::shared_ptr<ThreeCenterOverlapInt>>(m, "ThreeCenterOverlapInt",
+    py::classh<ThreeCenterOverlapInt>(m, "ThreeCenterOverlapInt",
                                                                               "Three center overlap integrals")
         .def("compute_shell", &ThreeCenterOverlapInt::compute_shell, "Compute the integrals of the form (a|b|c)");
 
-    py::class_<IntegralFactory, std::shared_ptr<IntegralFactory>>(m, "IntegralFactory", "Computes integrals")
+    py::classh<IntegralFactory>(m, "IntegralFactory", "Computes integrals")
         .def(py::init<std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>,
                       std::shared_ptr<BasisSet>>())
         .def(py::init<std::shared_ptr<BasisSet>>())
@@ -1435,17 +1442,17 @@ void export_mints(py::module_& m) {
     typedef SharedMatrix (MintsHelper::*perturb_grad_options)(SharedMatrix);
     typedef SharedMatrix (MintsHelper::*perturb_grad_xyz)(SharedMatrix, double, double, double);
 
-    py::class_<PetiteList, std::shared_ptr<PetiteList>>(m, "PetiteList", "Handles symmetry transformations")
+    py::classh<PetiteList>(m, "PetiteList", "Handles symmetry transformations")
         .def("aotoso", &PetiteList::aotoso, "Return the AO->SO coefficient matrix")
         .def("sotoao", &PetiteList::sotoao, "Return the SO->AO coefficient matrix")
         .def("print", &PetiteList::print, "Print to outfile");
 
-    py::class_<SOBasisSet, std::shared_ptr<SOBasisSet>>(
+    py::classh<SOBasisSet>(
         m, "SOBasisSet",
         "An SOBasis object describes the transformation from an atomic orbital basis to a symmetry orbital basis.")
         .def("petite_list", &SOBasisSet::petite_list, "Return the PetiteList object used in creating this SO basis");
 
-    py::class_<MintsHelper, std::shared_ptr<MintsHelper>>(m, "MintsHelper", "Computes integrals")
+    py::classh<MintsHelper>(m, "MintsHelper", "Computes integrals")
         .def(py::init<std::shared_ptr<BasisSet>>())
         .def(py::init<std::shared_ptr<Wavefunction>>())
 
@@ -1643,7 +1650,7 @@ void export_mints(py::module_& m) {
                     The second argument, lindep_tol, is the tolerance for linear dependencies",
                     "combined"_a, "lindep_tol"_a = 1.e-6);
 
-    py::class_<ExternalPotential, std::shared_ptr<ExternalPotential>>(
+    py::classh<ExternalPotential>(
         m, "ExternalPotential", "Stores external potential field, computes external potential matrix")
         .def(py::init<>())
         .def("setName", &ExternalPotential::setName, "Sets the name")
@@ -1674,7 +1681,7 @@ void export_mints(py::module_& m) {
     typedef std::shared_ptr<Localizer> (*localizer_with_type)(const std::string&, std::shared_ptr<BasisSet>,
                                                               std::shared_ptr<Matrix>);
 
-    py::class_<Localizer, std::shared_ptr<Localizer>>(m, "Localizer",
+    py::classh<Localizer>(m, "Localizer",
                                                       "Class containing orbital localization procedures")
         .def_static("build", localizer_with_type(&Localizer::build), "Build the localization scheme")
         .def("localize", &Localizer::localize, "Perform the localization procedure")
@@ -1683,12 +1690,12 @@ void export_mints(py::module_& m) {
         .def_property_readonly("converged", py::cpp_function(&Localizer::converged),
                                "Did the localization procedure converge?");
 
-    py::class_<BoysLocalizer, std::shared_ptr<BoysLocalizer>, Localizer>(m, "BoysLocalizer",
+    py::classh<BoysLocalizer, Localizer>(m, "BoysLocalizer",
                                                                          "Performs Boys orbital localization");
-    py::class_<PMLocalizer, std::shared_ptr<PMLocalizer>, Localizer>(m, "PMLocalizer",
+    py::classh<PMLocalizer, Localizer>(m, "PMLocalizer",
                                                                      "Performs Pipek-Mezey orbital localization");
 
-    py::class_<FCHKWriter, std::shared_ptr<FCHKWriter>>(m, "FCHKWriter",
+    py::classh<FCHKWriter>(m, "FCHKWriter",
                                                         "Extracts information from a wavefunction object, \
                                                                           and writes it to an FCHK file")
         .def(py::init<std::shared_ptr<Wavefunction>>())
@@ -1697,26 +1704,26 @@ void export_mints(py::module_& m) {
         .def("set_postscf_density_label", &FCHKWriter::set_postscf_density_label,
              "Set base label for post-SCF density, e.g. ' CC Density'.", "label"_a);
 
-    py::class_<MOWriter, std::shared_ptr<MOWriter>>(m, "MOWriter", "Writes the MOs")
+    py::classh<MOWriter>(m, "MOWriter", "Writes the MOs")
         .def(py::init<std::shared_ptr<Wavefunction>>())
         .def("write", &MOWriter::write, "Write the MOs");  // should the writer.h file take a filename as an argument?
 
-    py::class_<OperatorSymmetry, std::shared_ptr<OperatorSymmetry>>(m, "MultipoleSymmetry", "docstring")
+    py::classh<OperatorSymmetry>(m, "MultipoleSymmetry", "docstring")
         .def(py::init<int, const std::shared_ptr<Molecule>&, const std::shared_ptr<IntegralFactory>&,
                       const std::shared_ptr<MatrixFactory>&>())
         .def("create_matrices", &OperatorSymmetry::create_matrices, "docstring");
 
-    py::class_<CorrelationFactor, std::shared_ptr<CorrelationFactor>>(m, "CorrelationFactor", "docstring")
+    py::classh<CorrelationFactor>(m, "CorrelationFactor", "docstring")
         .def(py::init<size_t>())
         .def(py::init<std::shared_ptr<Vector>, std::shared_ptr<Vector>>())
         .def("set_params", &CorrelationFactor::set_params, "Set coefficient and exponent", "coeff"_a, "exponent"_a);
 
-    py::class_<FittedSlaterCorrelationFactor, std::shared_ptr<FittedSlaterCorrelationFactor>, CorrelationFactor>(
+    py::classh<FittedSlaterCorrelationFactor, CorrelationFactor>(
         m, "FittedSlaterCorrelationFactor", "docstring")
         .def(py::init<double>())
         .def("exponent", &FittedSlaterCorrelationFactor::exponent);
 
-    py::class_<CorrelationTable, std::shared_ptr<CorrelationTable>>(
+    py::classh<CorrelationTable>(
         m, "CorrelationTable", "Provides a correlation table between two point groups")
         .def(py::init<std::shared_ptr<PointGroup>, std::shared_ptr<PointGroup>>())
         .def("group", &CorrelationTable::group, "Returns higher order point group")
@@ -1743,7 +1750,7 @@ void export_mints(py::module_& m) {
         },
         "The solid harmonics setting of Libint2 currently active for Psi4");
 
-    py::class_<LS_THC_Computer, std::shared_ptr<LS_THC_Computer>>(m, "LS_THC_Computer",
+    py::classh<LS_THC_Computer>(m, "LS_THC_Computer",
             "Computer class for grid-based tensor hypercontraction (THC) of two-electron integrals (Parrish 2012)")
             .def(py::init([] (std::shared_ptr<Molecule> mol, std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary) {
                     return new LS_THC_Computer(mol, primary, auxiliary, Process::environment.options); 

--- a/psi4/src/export_misc.cc
+++ b/psi4/src/export_misc.cc
@@ -35,7 +35,7 @@ using namespace psi;
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-void export_misc(py::module &m) {
+void export_misc(py::module_ &m) {
     m.def("timer_on", timer_on, "label"_a, "Start timer with *label*. Needs to be paired with :func:`psi4.core.timer_off`.");
     m.def("timer_off", timer_off, "label"_a, "Stop timer with *label*.");
     m.def("tstart", tstart, "Start module-level timer. Only one active at once.");

--- a/psi4/src/export_oeprop.cc
+++ b/psi4/src/export_oeprop.cc
@@ -38,9 +38,9 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 void export_oeprop(py::module_ &m) {
-    py::class_<Prop, std::shared_ptr<Prop> >(m, "Prop", "docstring");
+    py::classh<Prop>(m, "Prop", "docstring");
 
-    py::class_<ESPPropCalc, std::shared_ptr<ESPPropCalc>, Prop>(
+    py::classh<ESPPropCalc, Prop>(
         m, "ESPPropCalc", "ESPPropCalc gives access to routines calculating the ESP on a grid")
         .def(py::init<std::shared_ptr<Wavefunction> >())
         .def("compute_esp_over_grid_in_memory", &ESPPropCalc::compute_esp_over_grid_in_memory,
@@ -48,7 +48,7 @@ void export_oeprop(py::module_ &m) {
         .def("compute_field_over_grid_in_memory", &ESPPropCalc::compute_field_over_grid_in_memory,
              "Computes field on specified grid Nx3 (as SharedMatrix, in input units)");
 
-    py::class_<OEProp, std::shared_ptr<OEProp>>(m, "OEProp", "docstring")
+    py::classh<OEProp>(m, "OEProp", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction> >())
         .def("add", py::overload_cast<const std::string&>(&OEProp::add), "Append the given task to the list of properties to compute.")
         .def("compute", &OEProp::compute, "Compute the properties.")

--- a/psi4/src/export_oeprop.cc
+++ b/psi4/src/export_oeprop.cc
@@ -37,7 +37,7 @@ using namespace psi;
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-void export_oeprop(py::module &m) {
+void export_oeprop(py::module_ &m) {
     py::class_<Prop, std::shared_ptr<Prop> >(m, "Prop", "docstring");
 
     py::class_<ESPPropCalc, std::shared_ptr<ESPPropCalc>, Prop>(

--- a/psi4/src/export_options.cc
+++ b/psi4/src/export_options.cc
@@ -33,7 +33,7 @@
 
 using namespace psi;
 
-void export_options(py::module& m) {
+void export_options(py::module_& m) {
     py::class_<Options>(m, "Options", "docstring", py::dynamic_attr())
         .def("add_bool", &Options::add_bool, "add bool option")
         .def("add_int", &Options::add_int, "add int option")

--- a/psi4/src/export_options.cc
+++ b/psi4/src/export_options.cc
@@ -34,7 +34,7 @@
 using namespace psi;
 
 void export_options(py::module_& m) {
-    py::class_<Options>(m, "Options", "docstring", py::dynamic_attr())
+    py::classh<Options>(m, "Options", "docstring", py::dynamic_attr())
         .def("add_bool", &Options::add_bool, "add bool option")
         .def("add_int", &Options::add_int, "add int option")
         .def("add_str", &Options::add_str, "add string option")

--- a/psi4/src/export_pcm.cc
+++ b/psi4/src/export_pcm.cc
@@ -39,12 +39,13 @@ using namespace pybind11::literals;
 #ifdef USING_PCMSolver
 
 void export_pcm(py::module_& m) {
-    py::class_<PCM, std::shared_ptr<PCM>> pcm(m, "PCM", "Class interfacing with PCMSolver");
+    py::classh<PCM> pcm(m, "PCM", "Class interfacing with PCMSolver");
 
-    py::enum_<PCM::CalcType>(pcm, "CalcType")
+    py::native_enum<PCM::CalcType>(pcm, "CalcType", "enum.IntEnum")
         .value("Total", PCM::CalcType::Total)
         .value("NucAndEle", PCM::CalcType::NucAndEle)
-        .value("EleOnly", PCM::CalcType::EleOnly);
+        .value("EleOnly", PCM::CalcType::EleOnly)
+        .finalize();
 
     pcm.def(py::init<std::string, int, std::shared_ptr<BasisSet>>())
         .def("compute_PCM_terms", &PCM::compute_PCM_terms, "Compute PCM contributions to energy and Fock matrix", "D"_a,

--- a/psi4/src/export_pcm.cc
+++ b/psi4/src/export_pcm.cc
@@ -38,7 +38,7 @@ using namespace pybind11::literals;
 
 #ifdef USING_PCMSolver
 
-void export_pcm(py::module& m) {
+void export_pcm(py::module_& m) {
     py::class_<PCM, std::shared_ptr<PCM>> pcm(m, "PCM", "Class interfacing with PCMSolver");
 
     py::enum_<PCM::CalcType>(pcm, "CalcType")

--- a/psi4/src/export_plugins.cc
+++ b/psi4/src/export_plugins.cc
@@ -151,7 +151,7 @@ void py_psi_plugin_close_all() {
  * End of Plug-In functions                                               *
  **************************************************************************/
 
-void export_plugins(py::module &m) {
+void export_plugins(py::module_ &m) {
     // plugins
     m.def("plugin_load", py_psi_plugin_load,
           "Load the plugin of name arg0. Returns 0 if not loaded, 1 if loaded, 2 if already loaded");

--- a/psi4/src/export_psio.cc
+++ b/psi4/src/export_psio.cc
@@ -36,9 +36,9 @@ using namespace pybind11::literals;
 
 void export_psio(py::module_ &m) {
 
-    py::class_<psio_entry, std::shared_ptr<psio_entry>>(m, "psio_entry", "docstring");
+    py::classh<psio_entry>(m, "psio_entry", "docstring");
 
-    py::class_<PSIO, std::shared_ptr<PSIO> >(m, "IO", "docstring")
+    py::classh<PSIO>(m, "IO", "docstring")
         .def("state", &PSIO::state, "Return 1 if PSIO library is activated")
         .def("open", &PSIO::open,
              "Open unit. Status can be PSIO_OPEN_OLD (if existing file is to be opened) or PSIO_OPEN_NEW if new file "
@@ -69,7 +69,7 @@ void export_psio(py::module_ &m) {
         .def_static("change_file_namespace", &PSIO::change_file_namespace, "Change file number from ns1 to ns2",
                     "fileno"_a, "ns1"_a, "ns2"_a);
 
-    py::class_<PSIOManager, std::shared_ptr<PSIOManager> >(m, "IOManager",
+    py::classh<PSIOManager>(m, "IOManager",
                                                            "PSIOManager is a class designed to be used as a static "
                                                            "object to track all PSIO operations in a given PSI4 "
                                                            "computation")

--- a/psi4/src/export_psio.cc
+++ b/psi4/src/export_psio.cc
@@ -34,7 +34,7 @@ using namespace psi;
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-void export_psio(py::module &m) {
+void export_psio(py::module_ &m) {
 
     py::class_<psio_entry, std::shared_ptr<psio_entry>>(m, "psio_entry", "docstring");
 

--- a/psi4/src/export_trans.cc
+++ b/psi4/src/export_trans.cc
@@ -44,7 +44,7 @@ using namespace psi;
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-void export_trans(py::module& m) {
+void export_trans(py::module_& m) {
     py::class_<MOSpace, std::shared_ptr<MOSpace>>(m, "MOSpace",
                                                   "Defines orbital spaces in which to transform integrals")
         .def(py::init<const char>())

--- a/psi4/src/export_trans.cc
+++ b/psi4/src/export_trans.cc
@@ -45,7 +45,7 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 void export_trans(py::module_& m) {
-    py::class_<MOSpace, std::shared_ptr<MOSpace>>(m, "MOSpace",
+    py::classh<MOSpace>(m, "MOSpace",
                                                   "Defines orbital spaces in which to transform integrals")
         .def(py::init<const char>())
         .def(py::init<const char, const std::vector<int>, const std::vector<int>, const std::vector<int>,
@@ -70,34 +70,40 @@ void export_trans(py::module_& m) {
         .def("aIndex", &MOSpace::aIndex, "Get the alpha orbital indexing array")
         .def("bIndex", &MOSpace::bIndex, "Get the beta orbital indexing array");
 
-    py::class_<IntegralTransform, std::shared_ptr<IntegralTransform>> int_trans_bind(
+    py::classh<IntegralTransform> int_trans_bind(
         m, "IntegralTransform", "IntegralTransform transforms one- and two-electron integrals within general spaces",
         py::dynamic_attr());
 
-    py::enum_<IntegralTransform::HalfTrans>(int_trans_bind, "HalfTrans")
+    py::native_enum<IntegralTransform::HalfTrans>(int_trans_bind, "HalfTrans", "enum.IntEnum")
         .value("MakeAndKeep", IntegralTransform::HalfTrans::MakeAndKeep)
         .value("ReadAndKeep", IntegralTransform::HalfTrans::ReadAndKeep)
         .value("MakeAndNuke", IntegralTransform::HalfTrans::MakeAndNuke)
-        .value("ReadAndNuke", IntegralTransform::HalfTrans::ReadAndNuke);
-    py::enum_<IntegralTransform::TransformationType>(int_trans_bind, "TransformationType")
+        .value("ReadAndNuke", IntegralTransform::HalfTrans::ReadAndNuke)
+        .finalize();
+    py::native_enum<IntegralTransform::TransformationType>(int_trans_bind, "TransformationType", "enum.IntEnum")
         .value("Restricted", IntegralTransform::TransformationType::Restricted)
         .value("Unrestricted", IntegralTransform::TransformationType::Unrestricted)
-        .value("SemiCanonical", IntegralTransform::TransformationType::SemiCanonical);
-    py::enum_<IntegralTransform::MOOrdering>(int_trans_bind, "MOOrdering")
+        .value("SemiCanonical", IntegralTransform::TransformationType::SemiCanonical)
+        .finalize();
+    py::native_enum<IntegralTransform::MOOrdering>(int_trans_bind, "MOOrdering", "enum.IntEnum")
         .value("QTOrder", IntegralTransform::MOOrdering::QTOrder)
-        .value("PitzerOrder", IntegralTransform::MOOrdering::PitzerOrder);
-    py::enum_<IntegralTransform::OutputType>(int_trans_bind, "OutputType")
+        .value("PitzerOrder", IntegralTransform::MOOrdering::PitzerOrder)
+        .finalize();
+    py::native_enum<IntegralTransform::OutputType>(int_trans_bind, "OutputType", "enum.IntEnum")
         .value("DPDOnly", IntegralTransform::OutputType::DPDOnly)
         .value("IWLOnly", IntegralTransform::OutputType::IWLOnly)
-        .value("IWLAndDPD", IntegralTransform::OutputType::IWLAndDPD);
-    py::enum_<IntegralTransform::FrozenOrbitals>(int_trans_bind, "FrozenOrbitals")
+        .value("IWLAndDPD", IntegralTransform::OutputType::IWLAndDPD)
+        .finalize();
+    py::native_enum<IntegralTransform::FrozenOrbitals>(int_trans_bind, "FrozenOrbitals", "enum.IntEnum")
         .value("None", IntegralTransform::FrozenOrbitals::None)
         .value("OccOnly", IntegralTransform::FrozenOrbitals::OccOnly)
         .value("VirOnly", IntegralTransform::FrozenOrbitals::VirOnly)
-        .value("OccAndVir", IntegralTransform::FrozenOrbitals::OccAndVir);
-    py::enum_<IntegralTransform::SpinType>(int_trans_bind, "SpinType")
+        .value("OccAndVir", IntegralTransform::FrozenOrbitals::OccAndVir)
+        .finalize();
+    py::native_enum<IntegralTransform::SpinType>(int_trans_bind, "SpinType", "enum.IntEnum")
         .value("Alpha", IntegralTransform::SpinType::Alpha)
-        .value("Beta", IntegralTransform::SpinType::Beta);
+        .value("Beta", IntegralTransform::SpinType::Beta)
+        .finalize();
 
     int_trans_bind.def(py::init<std::shared_ptr<Wavefunction>, std::vector<std::shared_ptr<MOSpace>>,
                                 IntegralTransform::TransformationType, IntegralTransform::OutputType,

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -82,7 +82,7 @@ using namespace pybind11::literals;
 
 void export_wavefunction(py::module_& m) {
     typedef void (Wavefunction::*take_sharedwfn)(SharedWavefunction);
-    py::class_<Wavefunction, std::shared_ptr<Wavefunction>>(m, "Wavefunction", "docstring", py::dynamic_attr())
+    py::classh<Wavefunction>(m, "Wavefunction", "docstring", py::dynamic_attr())
         .def(py::init<std::shared_ptr<Molecule>, std::shared_ptr<BasisSet>, Options&>())
         .def(py::init<std::shared_ptr<Molecule>, std::shared_ptr<BasisSet>>())
         .def(py::init<std::shared_ptr<Molecule>, std::shared_ptr<BasisSet>,
@@ -319,7 +319,7 @@ void export_wavefunction(py::module_& m) {
         .def("PCM_enabled", &Wavefunction::PCM_enabled, "Whether running a PCM calculation")
         .def("get_density", [](Wavefunction& wfn, std::string name) {return wfn.density_map_[name] ;}, "Experimental!");
 
-    py::class_<scf::HF, std::shared_ptr<scf::HF>, Wavefunction>(m, "HF", "docstring")
+    py::classh<scf::HF, Wavefunction>(m, "HF", "docstring")
         .def("compute_fvpi", &scf::HF::compute_fvpi, "Update number of frozen virtuals")
         .def("form_C", &scf::HF::form_C, "Forms the Orbital Matrices from the current Fock Matrices.", "shift"_a = 0.0)
         .def("form_initial_C", &scf::HF::form_initial_C,
@@ -402,7 +402,7 @@ void export_wavefunction(py::module_& m) {
         .def("openorbital_scf", &scf::HF::openorbital_scf, "Runs the SCF with OpenOrbitalOptimizer");
 
     /// HF Functions
-    py::class_<scf::RHF, std::shared_ptr<scf::RHF>, scf::HF>(m, "RHF", "docstring")
+    py::classh<scf::RHF, scf::HF>(m, "RHF", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
         .def("c1_deep_copy", &scf::RHF::c1_deep_copy,
              "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed "
@@ -411,7 +411,7 @@ void export_wavefunction(py::module_& m) {
         .def("twoel_Hx_full", &scf::RHF::twoel_Hx_full, "Two-electron Hessian-vector products. Triplet supported.")
         .def("mintshelper", &Wavefunction::mintshelper, "The MintsHelper object");
 
-    py::class_<scf::ROHF, std::shared_ptr<scf::ROHF>, scf::HF>(m, "ROHF", "docstring")
+    py::classh<scf::ROHF, scf::HF>(m, "ROHF", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
         .def("soFeff", &scf::ROHF::soFeff,
              "Returns the effective Fock matrix in the orthogonalized SO basis. See libscf_solver/rohf.cc::form_C"
@@ -427,7 +427,7 @@ void export_wavefunction(py::module_& m) {
              "basis"_a)
         .def("mintshelper", &Wavefunction::mintshelper, "The MintsHelper object");
 
-    py::class_<scf::UHF, std::shared_ptr<scf::UHF>, scf::HF>(m, "UHF", "docstring")
+    py::classh<scf::UHF, scf::HF>(m, "UHF", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
         .def("c1_deep_copy", &scf::UHF::c1_deep_copy,
              "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed "
@@ -435,7 +435,7 @@ void export_wavefunction(py::module_& m) {
              "basis"_a)
         .def("mintshelper", &Wavefunction::mintshelper, "The MintsHelper object");
 
-    py::class_<scf::CUHF, std::shared_ptr<scf::CUHF>, scf::HF>(m, "CUHF", "docstring")
+    py::classh<scf::CUHF, scf::HF>(m, "CUHF", "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>, std::shared_ptr<SuperFunctional>>())
         .def("c1_deep_copy", &scf::CUHF::c1_deep_copy,
              "Returns a new wavefunction with internal data converted to C_1 symmetry, using pre-c1-constructed "
@@ -444,14 +444,14 @@ void export_wavefunction(py::module_& m) {
         .def("mintshelper", &Wavefunction::mintshelper, "The MintsHelper object");
 
     /// EP2 functions
-    py::class_<dfep2::DFEP2Wavefunction, std::shared_ptr<dfep2::DFEP2Wavefunction>, Wavefunction>(
+    py::classh<dfep2::DFEP2Wavefunction, Wavefunction>(
         m, "DFEP2Wavefunction", "A density-fitted second-order Electron Propagator Wavefunction.")
         .def(py::init<std::shared_ptr<Wavefunction>>())
         .def("compute", &dfep2::DFEP2Wavefunction::compute,
              "Computes the density-fitted EP2 energy for the input orbitals");
 
     /// FISAPT functions
-    py::class_<fisapt::FISAPT, std::shared_ptr<fisapt::FISAPT>>(m, "FISAPT", "A Fragment-SAPT Wavefunction")
+    py::classh<fisapt::FISAPT>(m, "FISAPT", "A Fragment-SAPT Wavefunction")
         .def(py::init<std::shared_ptr<Wavefunction>>())
         .def("molecule", &fisapt::FISAPT::molecule, "Returns the FISAPT's molecule.")
         .def("scalars", &fisapt::FISAPT::scalars, "Return the interally computed scalars (not copied).")
@@ -488,7 +488,7 @@ void export_wavefunction(py::module_& m) {
     void (detci::CIvect::*py_civ_copy)(std::shared_ptr<psi::detci::CIvect>, int, int) = &detci::CIvect::copy;
     void (detci::CIvect::*py_civ_scale)(double, int) = &detci::CIvect::scale;
 
-    py::class_<detci::CIvect, std::shared_ptr<detci::CIvect>>(m, "CIVector", py::buffer_protocol(), "docstring")
+    py::classh<detci::CIvect>(m, "CIVector", py::buffer_protocol(), "docstring")
         .def("vdot", &detci::CIvect::vdot, "docstring")
         .def("axpy", &detci::CIvect::axpy, "docstring")
         .def("vector_multiply", &detci::CIvect::vector_multiply, "docstring")
@@ -516,7 +516,7 @@ void export_wavefunction(py::module_& m) {
     typedef std::vector<SharedMatrix> (detci::CIWavefunction::*form_density_sig)(
         std::shared_ptr<psi::detci::CIvect>, std::shared_ptr<psi::detci::CIvect>, int, int);
 
-    py::class_<detci::CIWavefunction, std::shared_ptr<detci::CIWavefunction>, Wavefunction>(m, "CIWavefunction",
+    py::classh<detci::CIWavefunction, Wavefunction>(m, "CIWavefunction",
                                                                                             "docstring")
         .def(py::init<std::shared_ptr<Wavefunction>>())
         .def("get_dimension", &detci::CIWavefunction::get_dimension, R"pbdoc(
@@ -603,7 +603,7 @@ void export_wavefunction(py::module_& m) {
         .def("cleanup_dpd", &detci::CIWavefunction::cleanup_dpd, "docstring")
         .def("set_ci_guess", &detci::CIWavefunction::set_ci_guess, "docstring");
 
-    py::class_<ccenergy::CCEnergyWavefunction, std::shared_ptr<ccenergy::CCEnergyWavefunction>, Wavefunction>(
+    py::classh<ccenergy::CCEnergyWavefunction, Wavefunction>(
         m, "CCWavefunction", "Specialized Wavefunction used by the ccenergy, cceom, ccgradient, etc. modules.")
         .def(py::init<std::shared_ptr<Wavefunction>, Options&>())
         .def("total_index", [](ccenergy::CCEnergyWavefunction& wfn, int i, int h) { return wfn.total_indices[{i, h}]; },
@@ -645,7 +645,7 @@ void export_wavefunction(py::module_& m) {
         )pbdoc");
 
 #ifdef USING_CheMPS2
-        py::class_<dmrg::DMRGSolver, std::shared_ptr<dmrg::DMRGSolver>, Wavefunction>(
+        py::classh<dmrg::DMRGSolver, Wavefunction>(
           m, "DMRGSolver", "Specialized Wavefunction used by CheMPS2.")
           .def(py::init<std::shared_ptr<Wavefunction>, Options&>())
           .def("occupation_a", &dmrg::DMRGSolver::occupation_a, "Returns the occupation numbers of the current alpha orbitals using the spin-averaged density.")

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -80,7 +80,7 @@ using namespace pybind11::literals;
 
 #include <pybind11/functional.h>
 
-void export_wavefunction(py::module& m) {
+void export_wavefunction(py::module_& m) {
     typedef void (Wavefunction::*take_sharedwfn)(SharedWavefunction);
     py::class_<Wavefunction, std::shared_ptr<Wavefunction>>(m, "Wavefunction", "docstring", py::dynamic_attr())
         .def(py::init<std::shared_ptr<Molecule>, std::shared_ptr<BasisSet>, Options&>())

--- a/psi4/src/psi4/libfock/snLinK.cc
+++ b/psi4/src/psi4/libfock/snLinK.cc
@@ -240,7 +240,7 @@ snLinK::snLinK(std::shared_ptr<BasisSet> primary, Options& options) : SplitJK(pr
 
     // cross-check supported L2 and GauXC AMs
     // yoinking L2 AM from psi4/driver/p4util/util.py's libint2_configuration() function 
-    auto p4util = py::module::import("psi4").attr("p4util"); // from psi4 import p4util
+    auto p4util = py::module_::import("psi4").attr("p4util"); // from psi4 import p4util
     auto libint2_configuration = p4util.attr("libint2_configuration")(); // p4util.libint2_configuration
     int l2_max_am = libint2_configuration["eri"][py::int_(0)].cast<int>();
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Upgrades psi4 to pybind11 v3.0 APIs.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Pybind11 v3.0 is required

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Updated `CMakeLists.txt` files to reflect pybind11 v3.0 requirement
- [x] Replaced `py::module` with`py::module_`
- [x] Replaced `py::class_` with `py::classh`
- [x] Migrated `py::enum_` to `py::native_enum`

## Questions

## Checklist
- [ ] Tests added for any new features
- [x] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- [ ] Ready for merge
