### PR TITLE
Adds Einsums interfaces to MintsHelper and DFTensor

### DIFF
--- a/psi4/__init__.py
+++ b/psi4/__init__.py
@@ -93,7 +93,25 @@ atexit.register(core.finalize)
 from .driver import endorsed_plugins
 
 # Manage threads. Must be after endorsed plugins, honestly.
-core.set_num_threads(1, quiet=True)
+#
+# Importing psi4 sets the thread count for the whole PROCESS, not just for
+# psi4: set_num_threads calls omp_set_num_threads, so every other OpenMP
+# library loaded alongside it - numpy's BLAS, an embedding application's own
+# kernels - is silently reconfigured by an import that ran no calculation.
+# Defaulting to 1 is right when psi4 is the driver, because it stops psi4's
+# own threading from oversubscribing against a threaded BLAS underneath it.
+# It is wrong when psi4 is a library in someone else's process, where it
+# overrides a deliberate choice and does so invisibly.
+#
+# So an explicitly set OMP_NUM_THREADS is honoured, and the default is
+# otherwise unchanged. A caller who wants the old behaviour unconditionally
+# can still say so with set_num_threads.
+_omp_num_threads = os.environ.get("OMP_NUM_THREADS", "").strip()
+if _omp_num_threads.isdigit() and int(_omp_num_threads) > 0:
+    core.set_num_threads(int(_omp_num_threads), quiet=True)
+else:
+    core.set_num_threads(1, quiet=True)
+del _omp_num_threads
 
 # Load driver and outfile paraphernalia
 from .driver import *

--- a/psi4/src/core.cc
+++ b/psi4/src/core.cc
@@ -368,7 +368,9 @@ SharedWavefunction py_psi_dlpno(SharedWavefunction ref_wfn) {
     return dlpno::dlpno(ref_wfn, Process::environment.options);
 }
 
-#ifdef USING_Einsums
+// f12 subdir skipped (pre-2.0 Einsums API); gate on USING_f12 so its symbol is
+// never referenced even though USING_Einsums is now defined for the mints bridge.
+#if defined(USING_Einsums) && defined(USING_f12)
 SharedWavefunction py_psi_f12(SharedWavefunction ref_wfn) {
     py_psi_prepare_options_for_module("F12");
     return f12::f12(ref_wfn, Process::environment.options);
@@ -513,7 +515,10 @@ SharedWavefunction py_psi_psimrcc(SharedWavefunction ref_wfn) {
     return psimrcc::psimrcc(ref_wfn, Process::environment.options);
 }
 
-#ifdef USING_Einsums
+// NOTE: USING_Einsums now signals the libmints TiledRuntimeTensor bridge, not the
+// old dummy_einsums placeholder module (skipped — it targets the pre-2.0 Einsums
+// API). Keep the disabled wrapper so the dummy_einsums symbol is never referenced.
+#if defined(USING_Einsums) && defined(USING_dummy_einsums)
 SharedWavefunction py_psi_dummy_einsums(SharedWavefunction ref_wfn) {
     py_psi_prepare_options_for_module("EINSUMS");
     return dummy_einsums::dummy_einsums(ref_wfn, Process::environment.options);

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -41,9 +41,39 @@
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libscf_solver/sad.h"
 
+#ifdef USING_Einsums
+#include <Einsums/Tensor/RuntimeTensor.hpp>
+#include <algorithm>
+#endif
+
 using namespace psi;
 namespace py = pybind11;
 using namespace pybind11::literals;
+
+#ifdef USING_Einsums
+namespace {
+// Reshape a flat DF block (naux x d2*d3, the matrix is row-major in p,q) into a
+// dense rank-3 einsums::RuntimeTensor (naux, d2, d3). DF integrals carry no
+// point-group symmetry, so a dense tensor (not a tiled one) is the natural
+// representation — and a dense RuntimeTensor is sliceable in Python, which the
+// pair/batch-driven DF correlation methods need. A directly-constructed
+// row-major RuntimeTensor matches the matrix's row-major layout, so each
+// auxiliary row copies contiguously.
+einsums::RuntimeTensor<double> df_block_to_tensor(const std::string &name, SharedMatrix M, int d2, int d3) {
+    const int    naux = M->nrow();
+    einsums::RuntimeTensor<double> T(
+        name, std::vector<size_t>{static_cast<size_t>(naux), static_cast<size_t>(d2), static_cast<size_t>(d3)},
+        /*row_major=*/true);
+    double      *td   = T.data();
+    double     **Mp   = M->pointer();
+    const size_t ncol = static_cast<size_t>(d2) * static_cast<size_t>(d3);
+    for (int Q = 0; Q < naux; ++Q) {
+        std::copy(Mp[Q], Mp[Q] + ncol, td + static_cast<size_t>(Q) * ncol);
+    }
+    return T;
+}
+} // namespace
+#endif
 
 void export_fock(py::module &m) {
     py::class_<JK, std::shared_ptr<JK>>(m, "JK", "docstring")
@@ -114,7 +144,30 @@ void export_fock(py::module &m) {
         .def("Qov", &DFTensor::Qov, "doctsring")
         .def("Qvv", &DFTensor::Qvv, "doctsring")
         .def("Imo", &DFTensor::Imo, "doctsring")
-        .def("Idfmo", &DFTensor::Idfmo, "doctsring");
+        .def("Idfmo", &DFTensor::Idfmo, "doctsring")
+#ifdef USING_Einsums
+        // einsums variants of the 3-index blocks: dense rank-3
+        // einsums::RuntimeTensor (naux, d2, d3). DF carries no point-group
+        // symmetry, so these are plain dense tensors (sliceable for the
+        // pair/batch-driven DF correlation methods). Same fitted integrals as
+        // the matrix accessors.
+        .def(
+            "Qso_einsums", [](DFTensor &self) { return df_block_to_tensor("DF (Q|pq) SO", self.Qso(), self.nbf(), self.nbf()); },
+            "AO DF 3-index (Q|pq) as a dense rank-3 einsums RuntimeTensor (naux, nbf, nbf)")
+        .def(
+            "Qmo_einsums", [](DFTensor &self) { return df_block_to_tensor("DF (Q|pq) MO", self.Qmo(), self.nmo(), self.nmo()); },
+            "MO DF 3-index (Q|pq) as a dense rank-3 einsums RuntimeTensor (naux, nmo, nmo)")
+        .def(
+            "Qoo_einsums", [](DFTensor &self) { return df_block_to_tensor("DF (Q|ij) OO", self.Qoo(), self.naocc(), self.naocc()); },
+            "occ-occ DF 3-index as a dense rank-3 einsums RuntimeTensor (naux, naocc, naocc)")
+        .def(
+            "Qov_einsums", [](DFTensor &self) { return df_block_to_tensor("DF (Q|ia) OV", self.Qov(), self.naocc(), self.navir()); },
+            "occ-vir DF 3-index as a dense rank-3 einsums RuntimeTensor (naux, naocc, navir)")
+        .def(
+            "Qvv_einsums", [](DFTensor &self) { return df_block_to_tensor("DF (Q|ab) VV", self.Qvv(), self.navir(), self.navir()); },
+            "vir-vir DF 3-index as a dense rank-3 einsums RuntimeTensor (naux, navir, navir)")
+#endif
+        ;
 
     py::class_<FittingMetric, std::shared_ptr<FittingMetric>>(m, "FittingMetric", "docstring")
         .def(py::init<std::shared_ptr<BasisSet>, bool>())

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -33,6 +33,7 @@
 #include "psi4/lib3index/denominator.h"
 #include "psi4/lib3index/dftensor.h"
 #include "psi4/lib3index/dfhelper.h"
+#include "psi4/lib3index/local_qia.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/vector.h"
@@ -41,39 +42,11 @@
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libscf_solver/sad.h"
 
-#ifdef USING_Einsums
-#include <Einsums/Tensor/RuntimeTensor.hpp>
-#include <algorithm>
-#endif
 
 using namespace psi;
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-#ifdef USING_Einsums
-namespace {
-// Reshape a flat DF block (naux x d2*d3, the matrix is row-major in p,q) into a
-// dense rank-3 einsums::RuntimeTensor (naux, d2, d3). DF integrals carry no
-// point-group symmetry, so a dense tensor (not a tiled one) is the natural
-// representation — and a dense RuntimeTensor is sliceable in Python, which the
-// pair/batch-driven DF correlation methods need. A directly-constructed
-// row-major RuntimeTensor matches the matrix's row-major layout, so each
-// auxiliary row copies contiguously.
-einsums::RuntimeTensor<double> df_block_to_tensor(const std::string &name, SharedMatrix M, int d2, int d3) {
-    const int    naux = M->nrow();
-    einsums::RuntimeTensor<double> T(
-        name, std::vector<size_t>{static_cast<size_t>(naux), static_cast<size_t>(d2), static_cast<size_t>(d3)},
-        /*row_major=*/true);
-    double      *td   = T.data();
-    double     **Mp   = M->pointer();
-    const size_t ncol = static_cast<size_t>(d2) * static_cast<size_t>(d3);
-    for (int Q = 0; Q < naux; ++Q) {
-        std::copy(Mp[Q], Mp[Q] + ncol, td + static_cast<size_t>(Q) * ncol);
-    }
-    return T;
-}
-} // namespace
-#endif
 
 void export_fock(py::module &m) {
     py::class_<JK, std::shared_ptr<JK>>(m, "JK", "docstring")
@@ -145,28 +118,6 @@ void export_fock(py::module &m) {
         .def("Qvv", &DFTensor::Qvv, "doctsring")
         .def("Imo", &DFTensor::Imo, "doctsring")
         .def("Idfmo", &DFTensor::Idfmo, "doctsring")
-#ifdef USING_Einsums
-        // einsums variants of the 3-index blocks: dense rank-3
-        // einsums::RuntimeTensor (naux, d2, d3). DF carries no point-group
-        // symmetry, so these are plain dense tensors (sliceable for the
-        // pair/batch-driven DF correlation methods). Same fitted integrals as
-        // the matrix accessors.
-        .def(
-            "Qso_einsums", [](DFTensor &self) { return df_block_to_tensor("DF (Q|pq) SO", self.Qso(), self.nbf(), self.nbf()); },
-            "AO DF 3-index (Q|pq) as a dense rank-3 einsums RuntimeTensor (naux, nbf, nbf)")
-        .def(
-            "Qmo_einsums", [](DFTensor &self) { return df_block_to_tensor("DF (Q|pq) MO", self.Qmo(), self.nmo(), self.nmo()); },
-            "MO DF 3-index (Q|pq) as a dense rank-3 einsums RuntimeTensor (naux, nmo, nmo)")
-        .def(
-            "Qoo_einsums", [](DFTensor &self) { return df_block_to_tensor("DF (Q|ij) OO", self.Qoo(), self.naocc(), self.naocc()); },
-            "occ-occ DF 3-index as a dense rank-3 einsums RuntimeTensor (naux, naocc, naocc)")
-        .def(
-            "Qov_einsums", [](DFTensor &self) { return df_block_to_tensor("DF (Q|ia) OV", self.Qov(), self.naocc(), self.navir()); },
-            "occ-vir DF 3-index as a dense rank-3 einsums RuntimeTensor (naux, naocc, navir)")
-        .def(
-            "Qvv_einsums", [](DFTensor &self) { return df_block_to_tensor("DF (Q|ab) VV", self.Qvv(), self.navir(), self.navir()); },
-            "vir-vir DF 3-index as a dense rank-3 einsums RuntimeTensor (naux, navir, navir)")
-#endif
         ;
 
     py::class_<FittingMetric, std::shared_ptr<FittingMetric>>(m, "FittingMetric", "docstring")
@@ -221,10 +172,17 @@ void export_fock(py::module &m) {
         .def("get_method", &DFHelper::get_method)
         .def("set_subalgo", &DFHelper::set_subalgo)
         .def("get_AO_size", &DFHelper::get_AO_size)
+        .def("get_AO_tensor", &DFHelper::get_AO_tensor,
+             "Raw, Schwarz-screened three-index AO integrals (Q|mn) as a (naux, nbf * nbf) matrix. No "
+             "fitting metric is applied, so these are the integrals rather than B tensors, which is what a "
+             "method fitting per domain rather than globally needs. Requires in-core AO integrals and the "
+             "DIRECT or DIRECT_iaQ method; STORE contracts the metric in as it builds.")
         .def("set_nthreads", &DFHelper::set_nthreads)
         .def("hold_met", &DFHelper::hold_met)
         .def("set_schwarz_cutoff", &DFHelper::set_schwarz_cutoff)
         .def("get_schwarz_cutoff", &DFHelper::get_schwarz_cutoff)
+        .def("set_metric_pow", &DFHelper::set_metric_pow)
+        .def("get_metric_pow", &DFHelper::get_metric_pow)
         .def("set_AO_core", &DFHelper::set_AO_core)
         .def("get_AO_core", &DFHelper::get_AO_core)
         .def("set_MO_core", &DFHelper::set_MO_core)
@@ -242,6 +200,61 @@ void export_fock(py::module &m) {
         .def("get_tensor_shape", &DFHelper::get_tensor_shape)
         .def("get_tensor", take_string(&DFHelper::get_tensor))
         .def("get_tensor", tensor_access3(&DFHelper::get_tensor));
+
+    // Domain-restricted three-index builder for local correlation methods.
+    py::class_<LocalQiaBuilder, std::shared_ptr<LocalQiaBuilder>>(m, "LocalQiaBuilder",
+        "Three-index integrals (Q|iu) built only where a local method will read them.\n\n"
+        "Same quantity a density-fitted method half-transforms out of the AO integrals, with no "
+        "fitting metric applied, because a local method fits per domain rather than globally. What "
+        "differs from DFHelper or MintsHelper is that the caller declares, per atom of the "
+        "auxiliary basis, which LMO and PAO columns it will read against that atom's auxiliary "
+        "functions; nothing outside that demand is computed, and neither are the AO integrals it "
+        "does not imply.")
+        .def(py::init<std::shared_ptr<BasisSet>, std::shared_ptr<BasisSet>>(), "primary"_a, "aux"_a)
+        .def("set_nthreads", &LocalQiaBuilder::set_nthreads,
+             "Threads for the auxiliary-shell loop. Defaults to the process thread count, so an "
+             "unset builder still uses the machine psi4 was told about.")
+        .def("nthreads", &LocalQiaBuilder::nthreads)
+        .def("set_ints_tolerance", &LocalQiaBuilder::set_ints_tolerance,
+             "Shell-pair screening on the AO integrals, in the units of DLPNO_AO_INTS_TOL: a shell "
+             "pair is skipped when max (Q|Q) times the Schwarz factor falls below tol^2. This is "
+             "the controlled screening - the error goes to zero with the tolerance - and zero or "
+             "negative turns it off entirely.")
+        .def("ints_tolerance", &LocalQiaBuilder::ints_tolerance)
+        .def("set_coef_tolerance_lmo", &LocalQiaBuilder::set_coef_tolerance_lmo,
+             "T_CUT_CLMO: an atom enters the LMO-side domain when a requested LMO has a "
+             "coefficient above this on one of its functions. Unlike the integral tolerance this "
+             "is an approximation rather than a screening - it drops transform contributions, not "
+             "just negligible integrals. Negative admits everything.")
+        .def("coef_tolerance_lmo", &LocalQiaBuilder::coef_tolerance_lmo)
+        .def("set_coef_tolerance_pao", &LocalQiaBuilder::set_coef_tolerance_pao,
+             "T_CUT_CPAO: the same for the PAO-side domain.")
+        .def("coef_tolerance_pao", &LocalQiaBuilder::coef_tolerance_pao)
+        .def("set_bp_refit", &LocalQiaBuilder::set_bp_refit,
+             "Refit the LMO coefficients onto each restricted basis-function domain before "
+             "transforming (Boughton and Pulay 1992 JCC, eq. 3). On by default: it is what lets "
+             "the coefficient screening be aggressive without the dropped tail costing accuracy. "
+             "Off transforms with the plain coefficient slice, which is what an exactness check "
+             "against a dense reference wants.")
+        .def("bp_refit", &LocalQiaBuilder::bp_refit)
+        .def("set_domains", &LocalQiaBuilder::set_domains, "atom_to_lmos"_a, "atom_to_paos"_a,
+             "The demand: two lists per atom of the auxiliary basis, naming the LMO and PAO "
+             "columns that will be read against that atom's auxiliary functions. Atom indices "
+             "follow the auxiliary basis's molecule and both lists must cover every atom; an atom "
+             "given empty lists is skipped and answers with None. Each list's own ordering is "
+             "preserved in the output, so it can be used directly to scatter.")
+        .def("compute", &LocalQiaBuilder::compute, "C_lmo"_a, "C_pao"_a, "S"_a = SharedMatrix(),
+             "Build the declared blocks. C_lmo is (nbf, nlmo) and C_pao is (nbf, npao) in the "
+             "primary basis; S is the AO overlap, read only when the refit is on. Returns one "
+             "matrix per auxiliary atom of shape (naux on that atom, len(lmos) * len(paos)), the "
+             "second axis row-major in (lmo, pao) with the caller's list ordering, and None for "
+             "atoms with an empty domain or no auxiliary functions.")
+        .def("atom_aux_ranges", &LocalQiaBuilder::atom_aux_ranges,
+             "The [first, last) auxiliary function range of each atom, which is where that atom's "
+             "block belongs in a full-size tensor.")
+        .def("last_shell_pair_counts", &LocalQiaBuilder::last_shell_pair_counts,
+             "(computed, offered) AO shell pairs from the last compute(): what the integral "
+             "screening actually skipped, against what the domains alone asked for.");
 
     py::class_<MemDFJK, std::shared_ptr<MemDFJK>, JK>(m, "MemDFJK", "docstring")
         .def("dfh", &MemDFJK::dfh, "Return the DFHelper object.");

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -52,6 +52,9 @@
 #include "psi4/libmints/sointegral_onebody.h"
 #include "psi4/libmints/sointegral_twobody.h"
 #include "psi4/libmints/mintshelper.h"
+#ifdef USING_Einsums
+#include <Einsums/Tensor/TiledRuntimeTensor.hpp>
+#endif
 #include "psi4/libmints/multipolesymmetry.h"
 #include "psi4/libmints/eri.h"
 #include "psi4/libmints/molecule.h"
@@ -537,6 +540,13 @@ void export_mints(py::module& m) {
         .def(py::init<dpdbuf4*>())
         .def(py::init<dpdfile2*>())
         .def("clone", &Matrix::clone, "Creates exact copy of the matrix and returns it")
+#ifdef USING_Einsums
+        .def("to_einsums_tiled", &Matrix::to_einsums_tiled, "name"_a = "",
+             "Alias this symmetry-blocked matrix as a rank-2 einsums TiledRuntimeTensor "
+             "(zero-copy; irrep block h -> tile (h, h^symmetry)). The matrix must outlive "
+             "the returned tensor; data is shared.",
+             py::keep_alive<0, 1>())
+#endif
         .def_property("name", py::cpp_function(&Matrix::name), py::cpp_function(&Matrix::set_name),
                       "The name of the Matrix. Used in printing.")
 
@@ -1480,6 +1490,22 @@ void export_mints(py::module& m) {
         .def("ao_potential", oneelectron_mixed_basis(&MintsHelper::ao_potential), "AO mixed basis potential integrals")
         .def("so_potential", &MintsHelper::so_potential, "SO basis potential integrals",
              "include_perturbations"_a = true)
+#ifdef USING_Einsums
+        .def("so_overlap_tiled", &MintsHelper::so_overlap_tiled,
+             "SO overlap integrals as an einsums TiledRuntimeTensor (irrep blocks -> tiles)")
+        .def("so_kinetic_tiled", &MintsHelper::so_kinetic_tiled, "SO kinetic integrals as an einsums TiledRuntimeTensor")
+        .def("so_potential_tiled", &MintsHelper::so_potential_tiled, "SO potential integrals as an einsums TiledRuntimeTensor")
+        .def("so_eri_tiled", &MintsHelper::so_eri_tiled,
+             "SO two-electron integrals (pq|rs) as a rank-4 einsums TiledRuntimeTensor (irrep quadruples -> tiles)")
+        .def("ao_eri_einsums", &MintsHelper::ao_eri_einsums,
+             "AO two-electron integrals (pq|rs) as a dense rank-4 einsums RuntimeTensor (shell-batched)")
+        .def("mo_bra_half_transform_einsums", &MintsHelper::mo_bra_half_transform_einsums,
+             "Integral-direct first-half (bra) MO transform (pq|ls) = sum_mn C1[m,p] C2[n,q] (mn|ls) as a dense "
+             "rank-4 einsums RuntimeTensor (n1, n2, nbf, nbf); the N^4 AO tensor is never materialized",
+             "C1"_a, "C2"_a)
+        .def("tiled_from_matrix", &MintsHelper::tiled_from_matrix,
+             "Copy a symmetry-blocked Matrix into an einsums TiledRuntimeTensor", "mat"_a, "name"_a)
+#endif
 #ifdef USING_ecpint
         .def("ao_ecp", oneelectron(&MintsHelper::ao_ecp), "AO basis effective core potential integrals.")
         .def("ao_ecp", oneelectron_mixed_basis(&MintsHelper::ao_ecp), "AO basis effective core potential integrals.")

--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -52,9 +52,6 @@
 #include "psi4/libmints/sointegral_onebody.h"
 #include "psi4/libmints/sointegral_twobody.h"
 #include "psi4/libmints/mintshelper.h"
-#ifdef USING_Einsums
-#include <Einsums/Tensor/TiledRuntimeTensor.hpp>
-#endif
 #include "psi4/libmints/multipolesymmetry.h"
 #include "psi4/libmints/eri.h"
 #include "psi4/libmints/molecule.h"
@@ -540,13 +537,6 @@ void export_mints(py::module& m) {
         .def(py::init<dpdbuf4*>())
         .def(py::init<dpdfile2*>())
         .def("clone", &Matrix::clone, "Creates exact copy of the matrix and returns it")
-#ifdef USING_Einsums
-        .def("to_einsums_tiled", &Matrix::to_einsums_tiled, "name"_a = "",
-             "Alias this symmetry-blocked matrix as a rank-2 einsums TiledRuntimeTensor "
-             "(zero-copy; irrep block h -> tile (h, h^symmetry)). The matrix must outlive "
-             "the returned tensor; data is shared.",
-             py::keep_alive<0, 1>())
-#endif
         .def_property("name", py::cpp_function(&Matrix::name), py::cpp_function(&Matrix::set_name),
                       "The name of the Matrix. Used in printing.")
 
@@ -1490,22 +1480,15 @@ void export_mints(py::module& m) {
         .def("ao_potential", oneelectron_mixed_basis(&MintsHelper::ao_potential), "AO mixed basis potential integrals")
         .def("so_potential", &MintsHelper::so_potential, "SO basis potential integrals",
              "include_perturbations"_a = true)
-#ifdef USING_Einsums
-        .def("so_overlap_tiled", &MintsHelper::so_overlap_tiled,
-             "SO overlap integrals as an einsums TiledRuntimeTensor (irrep blocks -> tiles)")
-        .def("so_kinetic_tiled", &MintsHelper::so_kinetic_tiled, "SO kinetic integrals as an einsums TiledRuntimeTensor")
-        .def("so_potential_tiled", &MintsHelper::so_potential_tiled, "SO potential integrals as an einsums TiledRuntimeTensor")
-        .def("so_eri_tiled", &MintsHelper::so_eri_tiled,
-             "SO two-electron integrals (pq|rs) as a rank-4 einsums TiledRuntimeTensor (irrep quadruples -> tiles)")
-        .def("ao_eri_einsums", &MintsHelper::ao_eri_einsums,
-             "AO two-electron integrals (pq|rs) as a dense rank-4 einsums RuntimeTensor (shell-batched)")
-        .def("mo_bra_half_transform_einsums", &MintsHelper::mo_bra_half_transform_einsums,
-             "Integral-direct first-half (bra) MO transform (pq|ls) = sum_mn C1[m,p] C2[n,q] (mn|ls) as a dense "
-             "rank-4 einsums RuntimeTensor (n1, n2, nbf, nbf); the N^4 AO tensor is never materialized",
+        .def("so_eri_blocked", &MintsHelper::so_eri_blocked,
+             "SO two-electron integrals (pq|rs) as symmetry-allowed irrep-quadruple blocks: a list of "
+             "([hp, hq, hr, hs], Matrix) pairs, each Matrix a dense row-major (d1*d2, d3*d4) block over "
+             "the within-irrep compound indices")
+        .def("mo_bra_half_transform", &MintsHelper::mo_bra_half_transform,
+             "Integral-direct first-half (bra) MO transform (pq|ls) = sum_mn C1[m,p] C2[n,q] (mn|ls), "
+             "returned as the rank-4 (n1, n2, nbf, nbf) row-major array flattened to a (n1*n2, nbf*nbf) "
+             "Matrix; the N^4 AO tensor is never materialized",
              "C1"_a, "C2"_a)
-        .def("tiled_from_matrix", &MintsHelper::tiled_from_matrix,
-             "Copy a symmetry-blocked Matrix into an einsums TiledRuntimeTensor", "mat"_a, "name"_a)
-#endif
 #ifdef USING_ecpint
         .def("ao_ecp", oneelectron(&MintsHelper::ao_ecp), "AO basis effective core potential integrals.")
         .def("ao_ecp", oneelectron_mixed_basis(&MintsHelper::ao_ecp), "AO basis effective core potential integrals.")

--- a/psi4/src/psi4/CMakeLists.txt
+++ b/psi4/src/psi4/CMakeLists.txt
@@ -118,8 +118,11 @@ foreach(dir_name
   psimrcc
   sapt
   scfgrad
-  f12
-  dummy_einsums
+  # Temporarily skipped: f12 and dummy_einsums consume Einsums and target the
+  # pre-2.0 API. We're building against Einsums 2.x (for TiledRuntimeTensor in
+  # the libmints bridge); re-enable these once they're ported to 2.x.
+  # f12
+  # dummy_einsums
   dummy_integratorxx
   )
   add_subdirectory(${dir_name})

--- a/psi4/src/psi4/lib3index/CMakeLists.txt
+++ b/psi4/src/psi4/lib3index/CMakeLists.txt
@@ -4,6 +4,7 @@ set(sources
   denominator.cc
   fittingmetric.cc
   cholesky.cc
+  local_qia.cc
   )
 psi4_add_module(lib 3index sources)
 

--- a/psi4/src/psi4/lib3index/dfhelper.cc
+++ b/psi4/src/psi4/lib3index/dfhelper.cc
@@ -1459,6 +1459,51 @@ double* DFHelper::metric_prep_core(double m_pow) {
     }
     return metrics_[power]->pointer()[0];
 }
+SharedMatrix DFHelper::get_AO_tensor() {
+    if (!built_) {
+        throw PSIEXCEPTION("DFHelper::get_AO_tensor: call initialize() first.");
+    }
+    if (!AO_core_) {
+        throw PSIEXCEPTION(
+            "DFHelper::get_AO_tensor: the AO integrals are not held in core. Raise the memory given to "
+            "set_memory(), or call set_AO_core(true).");
+    }
+    if (!(direct_ || direct_iaQ_)) {
+        throw PSIEXCEPTION(
+            "DFHelper::get_AO_tensor: the STORE method contracts the fitting metric into the AO integrals as it "
+            "builds them, so they are no longer raw. Use set_method(\"DIRECT\") or set_method(\"DIRECT_iaQ\").");
+    }
+
+    auto out = std::make_shared<Matrix>("(Q|mn)", naux_, nbf_ * nbf_);
+    double** outp = out->pointer();
+
+    if (direct_iaQ_) {
+        // Already dense and already (Q, m, n).
+        C_DCOPY(naux_ * nbf_ * nbf_, Ppq_.get(), 1, outp[0], 1);
+        return out;
+    }
+
+    // Sparse pQq: for basis function p, a (naux, small_skips_[p]) block starting
+    // at big_skips_[p], whose second axis is indexed by the position of q among
+    // p's significant partners. schwarz_fun_index_ is one-based so that zero can
+    // mean "screened out"; those elements stay at the zero Matrix starts with.
+    double const* ppq = Ppq_.get();
+#pragma omp parallel for num_threads(nthreads_) schedule(static)
+    for (size_t p = 0; p < nbf_; p++) {
+        size_t const skips = small_skips_[p];
+        size_t const base = big_skips_[p];
+        for (size_t q = 0; q < nbf_; q++) {
+            size_t const compressed = schwarz_fun_index_[p * nbf_ + q];
+            if (!compressed) {
+                continue;
+            }
+            for (size_t Q = 0; Q < naux_; Q++) {
+                outp[Q][p * nbf_ + q] = ppq[base + Q * skips + (compressed - 1)];
+            }
+        }
+    }
+    return out;
+}
 void DFHelper::prepare_metric() {
     // construct metric
     FittingMetric J(aux_, true);

--- a/psi4/src/psi4/lib3index/dfhelper.h
+++ b/psi4/src/psi4/lib3index/dfhelper.h
@@ -91,6 +91,24 @@ class PSI_API DFHelper {
     /// Returns the number of doubles in the *screened* AO integrals
     size_t get_AO_size() { return big_skips_[nbf_]; }
 
+    /// Raw three-index AO integrals (Q|mn), as a dense (naux, nbf * nbf) matrix.
+    ///
+    /// "Raw" is the point: no fitting metric is applied, so these are the
+    /// integrals themselves rather than the B tensors the transformations
+    /// produce. Local correlation methods fit per domain rather than globally,
+    /// and so need the unfitted quantity; recovering it from a J^-1/2 fitted
+    /// tensor means multiplying by J^1/2, which round-trips every element
+    /// through the metric's condition number for no reason.
+    ///
+    /// What this gives over building the same integrals with MintsHelper::ao_eri
+    /// is that DFHelper's AO construction is threaded and Schwarz screened.
+    /// Screened-out elements are returned as exact zeros.
+    ///
+    /// Requires in-core AO integrals and a method that leaves them unfitted:
+    /// STORE contracts the metric into the AO integrals as it builds them, so
+    /// only DIRECT and DIRECT_iaQ can answer this.
+    SharedMatrix get_AO_tensor();
+
     /// Returns the size of the in-core version in doubles
     size_t get_core_size() {
         AO_core(false);

--- a/psi4/src/psi4/lib3index/dftensor.h
+++ b/psi4/src/psi4/lib3index/dftensor.h
@@ -186,6 +186,16 @@ class PSI_API DFTensor {
 
     SharedMatrix Imo();
     SharedMatrix Idfmo();
+
+    /// Dimensions of the three-index blocks (needed to reshape the flat
+    /// (naux x d2*d3) matrices into proper rank-3 tensors). naux: auxiliary
+    /// functions; nbf: primary AO functions; nmo: MO functions; naocc/navir:
+    /// active occupied / virtual MO counts.
+    int naux() const { return naux_; }
+    int nbf() const { return nbf_; }
+    int nmo() const { return nmo_; }
+    int naocc() const { return naocc_; }
+    int navir() const { return navir_; }
 };
 }
 #endif

--- a/psi4/src/psi4/lib3index/local_qia.cc
+++ b/psi4/src/psi4/lib3index/local_qia.cc
@@ -1,0 +1,493 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include "local_qia.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#include "psi4/libmints/basisset.h"
+#include "psi4/libmints/integral.h"
+#include "psi4/libmints/matrix.h"
+#include "psi4/libmints/molecule.h"
+#include "psi4/libmints/twobody.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
+#include "psi4/libpsi4util/process.h"
+#include "psi4/libqt/qt.h"
+#include "psi4/psi4-dec.h"
+
+namespace psi {
+
+namespace {
+
+/// Solve A X = B in place on B, with A symmetric and both stored row-major.
+///
+/// A is symmetric here (an overlap block), so it needs no transposition to be
+/// read as Fortran-ordered; B does, which is what the two copies are for.
+void solve_in_place(double* A, double* B, int n, int nrhs) {
+    if (n == 0 || nrhs == 0) return;
+
+    std::vector<double> B_fortran(static_cast<size_t>(n) * nrhs);
+    for (int i = 0; i < n; i++) {
+        for (int k = 0; k < nrhs; k++) {
+            B_fortran[static_cast<size_t>(k) * n + i] = B[static_cast<size_t>(i) * nrhs + k];
+        }
+    }
+
+    std::vector<int> ipiv(n);
+    int errcode = C_DGESV(n, nrhs, A, n, ipiv.data(), B_fortran.data(), n);
+    if (errcode != 0) {
+        throw PSIEXCEPTION(
+            "LocalQiaBuilder: the Boughton-Pulay refit of the LMO coefficients hit a singular "
+            "overlap block. Either the primary basis is linearly dependent on this domain or the "
+            "coefficient tolerance is admitting a degenerate set; set_bp_refit(false) transforms "
+            "with the raw coefficient slice instead.");
+    }
+
+    for (int i = 0; i < n; i++) {
+        for (int k = 0; k < nrhs; k++) {
+            B[static_cast<size_t>(i) * nrhs + k] = B_fortran[static_cast<size_t>(k) * n + i];
+        }
+    }
+}
+
+}  // namespace
+
+LocalQiaBuilder::LocalQiaBuilder(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> aux)
+    : primary_(primary),
+      aux_(aux),
+      ints_tolerance_(1.0e-10),
+      coef_tol_lmo_(1.0e-4),
+      coef_tol_pao_(1.0e-4),
+      bp_refit_(true),
+      domains_set_(false),
+      shell_pairs_computed_(0),
+      shell_pairs_offered_(0) {
+    if (!primary_ || !aux_) {
+        throw PSIEXCEPTION("LocalQiaBuilder: both a primary and an auxiliary basis set are required.");
+    }
+    if (primary_->molecule()->natom() != aux_->molecule()->natom()) {
+        throw PSIEXCEPTION(
+            "LocalQiaBuilder: the primary and auxiliary basis sets are on different molecules. The "
+            "domains are expressed per atom, so the two have to agree on what the atoms are.");
+    }
+
+    natom_ = aux_->molecule()->natom();
+    nbf_ = primary_->nbf();
+    naux_ = aux_->nbf();
+
+    nthread_ = Process::environment.get_n_threads();
+
+    // Which primary functions and shells sit on each atom. Fixed by the basis
+    // sets, so this is the one map that never depends on the demand.
+    atom_to_bf_.assign(natom_, {});
+    for (int mu = 0; mu < nbf_; mu++) {
+        atom_to_bf_[primary_->function_to_center(mu)].push_back(mu);
+    }
+    atom_to_shell_.assign(natom_, {});
+    for (int M = 0; M < primary_->nshell(); M++) {
+        atom_to_shell_[primary_->shell_to_center(M)].push_back(M);
+    }
+
+    // The auxiliary function range of each atom. Shells are ordered by center,
+    // so an atom's auxiliary functions are contiguous, which is what lets a
+    // caller scatter a whole block with one slice; check it rather than
+    // assuming it, because a caller that trusted a wrong range would get a
+    // silently misplaced block rather than an error.
+    atom_aux_range_.assign(natom_, {0, 0});
+    std::vector<int> aux_count(natom_, 0);
+    std::vector<int> aux_first(natom_, naux_);
+    std::vector<int> aux_last(natom_, 0);
+    for (int Q = 0; Q < aux_->nshell(); Q++) {
+        int center = aux_->shell_to_center(Q);
+        int start = aux_->shell(Q).function_index();
+        int nq = aux_->shell(Q).nfunction();
+        aux_count[center] += nq;
+        aux_first[center] = std::min(aux_first[center], start);
+        aux_last[center] = std::max(aux_last[center], start + nq);
+    }
+    for (int A = 0; A < natom_; A++) {
+        if (aux_count[A] == 0) continue;
+        if (aux_last[A] - aux_first[A] != aux_count[A]) {
+            throw PSIEXCEPTION(
+                "LocalQiaBuilder: the auxiliary basis functions of an atom are not contiguous, "
+                "which the per-atom blocking assumes.");
+        }
+        atom_aux_range_[A] = {aux_first[A], aux_last[A]};
+    }
+}
+
+void LocalQiaBuilder::set_nthreads(int nthread) {
+    if (nthread < 1) {
+        throw PSIEXCEPTION("LocalQiaBuilder: set_nthreads needs a positive thread count.");
+    }
+    nthread_ = nthread;
+}
+
+void LocalQiaBuilder::set_ints_tolerance(double tol) {
+    ints_tolerance_ = tol;
+    metric_shell_diag_.clear();
+}
+
+void LocalQiaBuilder::set_coef_tolerance_lmo(double tol) { coef_tol_lmo_ = tol; }
+
+void LocalQiaBuilder::set_coef_tolerance_pao(double tol) { coef_tol_pao_ = tol; }
+
+void LocalQiaBuilder::set_bp_refit(bool on) { bp_refit_ = on; }
+
+void LocalQiaBuilder::set_domains(const std::vector<std::vector<int>>& atom_to_lmos,
+                                  const std::vector<std::vector<int>>& atom_to_paos) {
+    if (static_cast<int>(atom_to_lmos.size()) != natom_ || static_cast<int>(atom_to_paos.size()) != natom_) {
+        throw PSIEXCEPTION(
+            "LocalQiaBuilder: set_domains needs one LMO list and one PAO list per atom of the "
+            "auxiliary basis's molecule.");
+    }
+    atom_to_lmos_ = atom_to_lmos;
+    atom_to_paos_ = atom_to_paos;
+    domains_set_ = true;
+}
+
+void LocalQiaBuilder::build_metric_shell_diag() {
+    // Only the diagonal of the auxiliary metric is wanted, so only the diagonal
+    // shell blocks are computed: nshell integral blocks rather than the
+    // nshell^2 a full metric would take. The screening estimate reads it as a
+    // per-shell maximum anyway.
+    metric_shell_diag_.assign(aux_->nshell(), 0.0);
+
+    auto zero = BasisSet::zero_ao_basis_set();
+    auto factory = std::make_shared<IntegralFactory>(aux_, zero, aux_, zero);
+
+    std::vector<std::shared_ptr<TwoBodyAOInt>> eris(nthread_);
+    eris[0] = std::shared_ptr<TwoBodyAOInt>(factory->eri());
+    for (int thread = 1; thread < nthread_; thread++) {
+        eris[thread] = std::shared_ptr<TwoBodyAOInt>(eris.front()->clone());
+    }
+
+#pragma omp parallel for schedule(dynamic, 1) num_threads(nthread_)
+    for (int Q = 0; Q < aux_->nshell(); Q++) {
+        int thread = 0;
+#ifdef _OPENMP
+        thread = omp_get_thread_num();
+#endif
+        int nq = aux_->shell(Q).nfunction();
+        eris[thread]->compute_shell(Q, 0, Q, 0);
+        const double* buffer = eris[thread]->buffer();
+        double diag = 0.0;
+        for (int q = 0; q < nq; q++) {
+            diag = std::max(diag, buffer[q * nq + q]);
+        }
+        metric_shell_diag_[Q] = diag;
+    }
+}
+
+void LocalQiaBuilder::build_bf_domains(SharedMatrix C_lmo, SharedMatrix C_pao) {
+    atom_in_domain1_.assign(natom_, {});
+    atom_in_domain2_.assign(natom_, {});
+    domain_shells1_.assign(natom_, {});
+    domain_shells2_.assign(natom_, {});
+    domain_bfs1_.assign(natom_, {});
+    domain_bfs2_.assign(natom_, {});
+
+    double** Clmo = C_lmo->pointer();
+    double** Cpao = C_pao->pointer();
+
+    // Which atoms an orbital lives on, by the coefficient tolerance. Atom
+    // granularity rather than basis-function granularity, matching DLPNO: a
+    // shell has to be computed whole in any case, and keeping whole atoms is
+    // what makes the refit's overlap block well conditioned.
+    auto orbital_atoms = [&](double** C, int col, double tol, std::vector<char>& into) {
+        for (int A = 0; A < natom_; A++) {
+            if (into[A]) continue;
+            for (int mu : atom_to_bf_[A]) {
+                if (std::fabs(C[mu][col]) > tol) {
+                    into[A] = 1;
+                    break;
+                }
+            }
+        }
+    };
+
+#pragma omp parallel for schedule(dynamic, 1) num_threads(nthread_)
+    for (int A = 0; A < natom_; A++) {
+        if (atom_to_lmos_[A].empty() || atom_to_paos_[A].empty()) continue;
+
+        std::vector<char> in1(natom_, 0);
+        std::vector<char> in2(natom_, 0);
+        for (int i : atom_to_lmos_[A]) orbital_atoms(Clmo, i, coef_tol_lmo_, in1);
+        for (int u : atom_to_paos_[A]) orbital_atoms(Cpao, u, coef_tol_pao_, in2);
+
+        for (int B = 0; B < natom_; B++) {
+            if (in1[B]) {
+                domain_shells1_[A].insert(domain_shells1_[A].end(), atom_to_shell_[B].begin(),
+                                          atom_to_shell_[B].end());
+                domain_bfs1_[A].insert(domain_bfs1_[A].end(), atom_to_bf_[B].begin(), atom_to_bf_[B].end());
+            }
+            if (in2[B]) {
+                domain_shells2_[A].insert(domain_shells2_[A].end(), atom_to_shell_[B].begin(),
+                                          atom_to_shell_[B].end());
+                domain_bfs2_[A].insert(domain_bfs2_[A].end(), atom_to_bf_[B].begin(), atom_to_bf_[B].end());
+            }
+        }
+        atom_in_domain1_[A] = std::move(in1);
+        atom_in_domain2_[A] = std::move(in2);
+    }
+}
+
+std::vector<SharedMatrix> LocalQiaBuilder::compute(SharedMatrix C_lmo, SharedMatrix C_pao, SharedMatrix S) {
+    if (!domains_set_) {
+        throw PSIEXCEPTION("LocalQiaBuilder: call set_domains() before compute().");
+    }
+    if (!C_lmo || !C_pao) {
+        throw PSIEXCEPTION("LocalQiaBuilder: compute() needs both coefficient matrices.");
+    }
+    if (C_lmo->nrow() != nbf_ || C_pao->nrow() != nbf_) {
+        throw PSIEXCEPTION(
+            "LocalQiaBuilder: the coefficient matrices must have one row per primary basis "
+            "function.");
+    }
+    if (bp_refit_ && (!S || S->nrow() != nbf_ || S->ncol() != nbf_)) {
+        throw PSIEXCEPTION(
+            "LocalQiaBuilder: the Boughton-Pulay refit needs the (nbf, nbf) AO overlap. Pass it, or "
+            "set_bp_refit(false) to transform with the raw coefficient slice.");
+    }
+
+    const int nlmo_total = C_lmo->ncol();
+    const int npao_total = C_pao->ncol();
+    for (int A = 0; A < natom_; A++) {
+        for (int i : atom_to_lmos_[A]) {
+            if (i < 0 || i >= nlmo_total) {
+                throw PSIEXCEPTION("LocalQiaBuilder: an LMO index in the domains is out of range.");
+            }
+        }
+        for (int u : atom_to_paos_[A]) {
+            if (u < 0 || u >= npao_total) {
+                throw PSIEXCEPTION("LocalQiaBuilder: a PAO index in the domains is out of range.");
+            }
+        }
+    }
+
+    build_bf_domains(C_lmo, C_pao);
+
+    const bool screening = ints_tolerance_ > 0.0;
+    if (screening && metric_shell_diag_.empty()) build_metric_shell_diag();
+
+    // S C_lmo once for the whole run: the refit's right-hand side is a slice of
+    // it, and slicing is cheaper than re-forming it per atom.
+    SharedMatrix SC_lmo;
+    if (bp_refit_) SC_lmo = linalg::doublet(S, C_lmo, false, false);
+
+    // Per-atom transform matrices. Both depend only on the atom, so they are
+    // built once here rather than once per auxiliary shell as DLPNO does - an
+    // atom carries several auxiliary shells and the refit is a linear solve.
+    std::vector<SharedMatrix> X(natom_);          // (|bfs1|, |lmos|)
+    std::vector<SharedMatrix> Cpao_dom(natom_);   // (|bfs2|, |paos|)
+    std::vector<SharedMatrix> out(natom_);
+
+    double** Clmo = C_lmo->pointer();
+    double** Cpao = C_pao->pointer();
+
+#pragma omp parallel for schedule(dynamic, 1) num_threads(nthread_)
+    for (int A = 0; A < natom_; A++) {
+        const auto& lmos = atom_to_lmos_[A];
+        const auto& paos = atom_to_paos_[A];
+        if (lmos.empty() || paos.empty()) continue;
+        if (atom_aux_range_[A].second == atom_aux_range_[A].first) continue;
+
+        const auto& bfs1 = domain_bfs1_[A];
+        const auto& bfs2 = domain_bfs2_[A];
+        const int nbf1 = bfs1.size();
+        const int nbf2 = bfs2.size();
+        const int nlmo = lmos.size();
+        const int npao = paos.size();
+
+        out[A] = std::make_shared<Matrix>("(Q|iu) domain", atom_aux_range_[A].second - atom_aux_range_[A].first,
+                                          nlmo * npao);
+
+        // A domain can come out empty if the coefficient tolerance admits
+        // nothing for any requested orbital. The block is then exactly zero,
+        // which the freshly allocated matrix already is, and there is no
+        // transform to set up.
+        if (nbf1 == 0 || nbf2 == 0) continue;
+
+        Cpao_dom[A] = std::make_shared<Matrix>("C_pao domain", nbf2, npao);
+        double** Cp = Cpao_dom[A]->pointer();
+        for (int n = 0; n < nbf2; n++) {
+            for (int u = 0; u < npao; u++) Cp[n][u] = Cpao[bfs2[n]][paos[u]];
+        }
+
+        X[A] = std::make_shared<Matrix>("C_lmo domain", nbf1, nlmo);
+        double** Xp = X[A]->pointer();
+        // The refit is the identity when the domain is the whole basis - it
+        // solves S X = S C - so skip it there. That is not only faster: running
+        // it anyway would push every element through the full overlap's
+        // condition number for a result already known exactly, which is what an
+        // exactness check would then be measuring.
+        const bool refit = bp_refit_ && nbf1 < nbf_;
+        if (refit) {
+            double** SC = SC_lmo->pointer();
+            for (int m = 0; m < nbf1; m++) {
+                for (int i = 0; i < nlmo; i++) Xp[m][i] = SC[bfs1[m]][lmos[i]];
+            }
+            auto S_dom = std::make_shared<Matrix>("S domain", nbf1, nbf1);
+            double** Sd = S_dom->pointer();
+            double** Sp = S->pointer();
+            for (int m = 0; m < nbf1; m++) {
+                for (int n = 0; n < nbf1; n++) Sd[m][n] = Sp[bfs1[m]][bfs1[n]];
+            }
+            solve_in_place(Sd[0], Xp[0], nbf1, nlmo);
+        } else {
+            for (int m = 0; m < nbf1; m++) {
+                for (int i = 0; i < nlmo; i++) Xp[m][i] = Clmo[bfs1[m]][lmos[i]];
+            }
+        }
+    }
+
+    auto factory = std::make_shared<IntegralFactory>(aux_, BasisSet::zero_ao_basis_set(), primary_, primary_);
+    std::vector<std::shared_ptr<TwoBodyAOInt>> eris(nthread_);
+    eris[0] = std::shared_ptr<TwoBodyAOInt>(factory->eri());
+    for (int thread = 1; thread < nthread_; thread++) {
+        eris[thread] = std::shared_ptr<TwoBodyAOInt>(eris.front()->clone());
+    }
+
+    size_t computed = 0;
+    size_t offered = 0;
+
+    // One auxiliary shell per task. Shells of the same atom write disjoint rows
+    // of that atom's block, so nothing is shared across tasks but the integral
+    // engines, which are per thread.
+#pragma omp parallel for schedule(dynamic, 1) num_threads(nthread_) reduction(+ : computed, offered)
+    for (int Q = 0; Q < aux_->nshell(); Q++) {
+        const int centerQ = aux_->shell_to_center(Q);
+        if (!out[centerQ] || !X[centerQ]) continue;
+
+        int thread = 0;
+#ifdef _OPENMP
+        thread = omp_get_thread_num();
+#endif
+        const int nq = aux_->shell(Q).nfunction();
+        const int qstart = aux_->shell(Q).function_index();
+
+        const auto& bfs1 = domain_bfs1_[centerQ];
+        const auto& bfs2 = domain_bfs2_[centerQ];
+        const int nbf1 = bfs1.size();
+        const int nbf2 = bfs2.size();
+        const int nlmo = atom_to_lmos_[centerQ].size();
+        const int npao = atom_to_paos_[centerQ].size();
+
+        // Global basis function to position within this atom's domain, -1 when
+        // outside it. Dense because the scatter below is in the inner loop.
+        std::vector<int> pos1(nbf_, -1);
+        std::vector<int> pos2(nbf_, -1);
+        for (int m = 0; m < nbf1; m++) pos1[bfs1[m]] = m;
+        for (int n = 0; n < nbf2; n++) pos2[bfs2[n]] = n;
+
+        // (mn|Q) for this shell's auxiliary functions, zeroed because every
+        // screened-out or out-of-domain shell pair contributes exactly zero.
+        std::vector<double> block(static_cast<size_t>(nq) * nbf1 * nbf2, 0.0);
+
+        for (int M : domain_shells1_[centerQ]) {
+            const int nm = primary_->shell(M).nfunction();
+            const int mstart = primary_->shell(M).function_index();
+            const int centerM = primary_->shell_to_center(M);
+
+            for (int N : domain_shells2_[centerQ]) {
+                const int nn = primary_->shell(N).nfunction();
+                const int nstart = primary_->shell(N).function_index();
+                const int centerN = primary_->shell_to_center(N);
+
+                // (MN|Q) and (NM|Q) are the same integrals. When both orderings
+                // are in domain, compute one and scatter it twice.
+                const bool MN_symmetry =
+                    atom_in_domain1_[centerQ][centerN] && atom_in_domain2_[centerQ][centerM];
+                if (N < M && MN_symmetry) continue;
+                offered++;
+
+                if (screening &&
+                    metric_shell_diag_[Q] * eris[thread]->shell_pair_value(M, N) <
+                        ints_tolerance_ * ints_tolerance_) {
+                    continue;
+                }
+                computed++;
+
+                eris[thread]->compute_shell(Q, 0, M, N);
+                const double* buffer = eris[thread]->buffer();
+
+                for (int q = 0, index = 0; q < nq; q++) {
+                    double* dest = block.data() + static_cast<size_t>(q) * nbf1 * nbf2;
+                    for (int m = 0; m < nm; m++) {
+                        for (int n = 0; n < nn; n++, index++) {
+                            dest[static_cast<size_t>(pos1[mstart + m]) * nbf2 + pos2[nstart + n]] = buffer[index];
+                        }
+                    }
+                }
+
+                if (N > M && MN_symmetry) {
+                    for (int q = 0, index = 0; q < nq; q++) {
+                        double* dest = block.data() + static_cast<size_t>(q) * nbf1 * nbf2;
+                        for (int m = 0; m < nm; m++) {
+                            for (int n = 0; n < nn; n++, index++) {
+                                dest[static_cast<size_t>(pos1[nstart + n]) * nbf2 + pos2[mstart + m]] =
+                                    buffer[index];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // X^T (mn|Q) C_pao, straight into the atom's output rows: the second
+        // axis of a row is already (lmo, pao) row-major, which is what the
+        // second GEMM writes.
+        std::vector<double> half(static_cast<size_t>(nlmo) * nbf2);
+        double** Xp = X[centerQ]->pointer();
+        double** Cp = Cpao_dom[centerQ]->pointer();
+        double** dest = out[centerQ]->pointer();
+        const int row0 = atom_aux_range_[centerQ].first;
+
+        for (int q = 0; q < nq; q++) {
+            const double* src = block.data() + static_cast<size_t>(q) * nbf1 * nbf2;
+            C_DGEMM('T', 'N', nlmo, nbf2, nbf1, 1.0, Xp[0], nlmo, const_cast<double*>(src), nbf2, 0.0,
+                    half.data(), nbf2);
+            C_DGEMM('N', 'N', nlmo, npao, nbf2, 1.0, half.data(), nbf2, Cp[0], npao, 0.0,
+                    dest[qstart + q - row0], npao);
+        }
+    }
+
+    shell_pairs_computed_ = computed;
+    shell_pairs_offered_ = offered;
+
+    return out;
+}
+
+}  // namespace psi

--- a/psi4/src/psi4/lib3index/local_qia.h
+++ b/psi4/src/psi4/lib3index/local_qia.h
@@ -1,0 +1,211 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#ifndef three_index_local_qia_h_
+#define three_index_local_qia_h_
+
+#include "psi4/pragma.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace psi {
+
+class BasisSet;
+class Matrix;
+typedef std::shared_ptr<Matrix> SharedMatrix;
+
+/// Three-index integrals transformed into per-atom orbital domains, built only
+/// where a local correlation method will read them.
+///
+/// The quantity is the same one a density-fitted method half-transforms out of
+/// the AO integrals,
+///
+///     (Q|iu) = sum_{mn} C_lmo(m,i) (mn|Q) C_pao(n,u),
+///
+/// with no fitting metric applied, because a local method fits per domain
+/// rather than globally. What differs from building it through DFHelper or
+/// MintsHelper is that the caller says up front which (i, u) pairs it will read
+/// against the auxiliary functions of each atom, and nothing outside that
+/// demand is ever computed. For a local method the demand is a vanishing
+/// fraction of the full tensor at large system size, and the AO integrals it
+/// implies are a vanishing fraction of the screened AO integrals, so this is
+/// where a linear-scaling method's three-index phase wants to live.
+///
+/// Two screenings are in force and they are not the same kind of thing:
+///
+///   - the shell-pair tolerance (set_ints_tolerance) drops AO integrals that
+///     are numerically negligible. It is controlled: the error goes to zero
+///     with the tolerance, and at zero the result is the exact transform.
+///   - the domain restriction drops contributions from basis functions outside
+///     the extended domain of the requested orbitals. That is an approximation
+///     even at exact arithmetic, mitigated but not removed by the
+///     Boughton-Pulay refit. Its size is controlled by the coefficient
+///     tolerances.
+///
+/// With both coefficient tolerances negative, the integral tolerance zero and
+/// the refit off, the domains become the full basis and the result is the exact
+/// transform of the full AO integrals - which is how a caller can check its
+/// indexing against a dense reference.
+///
+/// Usage mirrors DFHelper: construct, set, declare the demand, compute.
+///
+///     LocalQiaBuilder builder(primary, aux);
+///     builder.set_nthreads(nthread);
+///     builder.set_domains(atom_to_lmos, atom_to_paos);
+///     auto blocks = builder.compute(C_lmo, C_pao, S);
+///
+/// This is a standalone builder rather than a method on DFHelper because
+/// DFHelper's subject is the fitted B tensors of a full screened AO build, and
+/// this never forms that build: the two share an integral factory and nothing
+/// else. It is deliberately not coupled to psi4's own DLPNO code either, though
+/// the algorithm is that of DLPNO::compute_qia, so that a caller supplying its
+/// own domains does not inherit DLPNO's option handling or its member state.
+class PSI_API LocalQiaBuilder {
+   public:
+    LocalQiaBuilder(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> aux);
+
+    /// Threads for the auxiliary-shell loop. Defaults to the process thread
+    /// count, so a caller that forgets this still gets the machine it asked
+    /// psi4 for.
+    void set_nthreads(int nthread);
+    int nthreads() const { return nthread_; }
+
+    /// Shell-pair screening on the AO integrals, in the same units as DLPNO's
+    /// DLPNO_AO_INTS_TOL: a shell pair is skipped when
+    /// max_Q (Q|Q) * (MN|MN)^1/2 < tol^2. Zero or negative disables it.
+    void set_ints_tolerance(double tol);
+    double ints_tolerance() const { return ints_tolerance_; }
+
+    /// A basis function enters an atom's LMO-side domain when some requested
+    /// LMO has |C_lmo| above this on any function of the same atom. DLPNO's
+    /// T_CUT_CLMO. Negative admits every basis function.
+    void set_coef_tolerance_lmo(double tol);
+    double coef_tolerance_lmo() const { return coef_tol_lmo_; }
+
+    /// The same for the PAO-side domain. DLPNO's T_CUT_CPAO.
+    void set_coef_tolerance_pao(double tol);
+    double coef_tolerance_pao() const { return coef_tol_pao_; }
+
+    /// Refit the LMO coefficients onto each restricted basis-function domain
+    /// before transforming, Boughton and Pulay 1992 JCC eq. 3. On by default:
+    /// it is what lets the coefficient screening be aggressive without the
+    /// dropped tail costing accuracy. Turning it off makes the transform a
+    /// plain slice of C_lmo, which is what an exactness check wants.
+    void set_bp_refit(bool on);
+    bool bp_refit() const { return bp_refit_; }
+
+    /// The demand: for each ATOM of the auxiliary basis, which LMO columns and
+    /// which PAO columns will be read against the auxiliary functions on that
+    /// atom. Atom indices follow aux->molecule(), and both vectors must have
+    /// one entry per atom; an atom given empty lists is skipped entirely and
+    /// answers with a null block.
+    ///
+    /// The ordering of each list is the caller's and is preserved in the
+    /// output, so a caller can scatter with it directly.
+    void set_domains(const std::vector<std::vector<int>>& atom_to_lmos,
+                     const std::vector<std::vector<int>>& atom_to_paos);
+
+    /// Build the declared blocks.
+    ///
+    /// C_lmo is (nbf, nlmo) and C_pao is (nbf, npao) in the primary basis. S is
+    /// the AO overlap, read only when the Boughton-Pulay refit is on; it may be
+    /// null otherwise.
+    ///
+    /// Returns one matrix per auxiliary atom, of shape
+    /// (naux on that atom, |lmos| * |paos|), the second axis row-major in
+    /// (lmo, pao) with the caller's own list ordering. Atoms with an empty
+    /// domain, and atoms carrying no auxiliary functions, answer with nullptr.
+    std::vector<SharedMatrix> compute(SharedMatrix C_lmo, SharedMatrix C_pao, SharedMatrix S);
+
+    /// The [first, last) auxiliary function index range of each atom, so a
+    /// caller can scatter each block into a full-size tensor. Empty atoms give
+    /// an empty range.
+    std::vector<std::pair<int, int>> atom_aux_ranges() const { return atom_aux_range_; }
+
+    /// How many AO shell pairs the last compute() actually evaluated, against
+    /// how many the domains alone would have asked for. The honest measure of
+    /// what the screening bought, and zero-zero before the first compute().
+    std::pair<size_t, size_t> last_shell_pair_counts() const {
+        return {shell_pairs_computed_, shell_pairs_offered_};
+    }
+
+   private:
+    /// Max of the auxiliary metric diagonal over each auxiliary shell, the
+    /// (Q|Q) factor of the screening estimate. Built on first use and only when
+    /// screening is on.
+    void build_metric_shell_diag();
+
+    /// Per-atom basis-function and shell domains implied by the declared
+    /// orbital domains and the coefficient tolerances.
+    void build_bf_domains(SharedMatrix C_lmo, SharedMatrix C_pao);
+
+    std::shared_ptr<BasisSet> primary_;
+    std::shared_ptr<BasisSet> aux_;
+
+    int natom_;
+    int nbf_;
+    int naux_;
+
+    int nthread_;
+    double ints_tolerance_;
+    double coef_tol_lmo_;
+    double coef_tol_pao_;
+    bool bp_refit_;
+
+    bool domains_set_;
+    std::vector<std::vector<int>> atom_to_lmos_;
+    std::vector<std::vector<int>> atom_to_paos_;
+
+    /// atom_to_bf_[A] / atom_to_shell_[A]: the primary basis functions and
+    /// shells centered on atom A. Static, built in the constructor.
+    std::vector<std::vector<int>> atom_to_bf_;
+    std::vector<std::vector<int>> atom_to_shell_;
+    std::vector<std::pair<int, int>> atom_aux_range_;
+
+    /// Per auxiliary atom, the LMO-side (1) and PAO-side (2) domains: which
+    /// primary atoms contribute, and the shells and basis functions those
+    /// imply. Rebuilt by each compute() because they depend on the
+    /// coefficients.
+    std::vector<std::vector<char>> atom_in_domain1_;
+    std::vector<std::vector<char>> atom_in_domain2_;
+    std::vector<std::vector<int>> domain_shells1_;
+    std::vector<std::vector<int>> domain_shells2_;
+    std::vector<std::vector<int>> domain_bfs1_;
+    std::vector<std::vector<int>> domain_bfs2_;
+
+    std::vector<double> metric_shell_diag_;
+
+    size_t shell_pairs_computed_;
+    size_t shell_pairs_offered_;
+};
+
+}  // namespace psi
+
+#endif

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -140,3 +140,34 @@ if(TARGET OpenOrbitalOptimizer::OpenOrbitalOptimizer)
       USING_OpenOrbitalOptimizer
     )
 endif()
+
+# Einsums tensor bridge: MintsHelper's so_*_tiled() / tiled_from_matrix() expose
+# psi4 integrals as einsums::TiledRuntimeTensor. PUBLIC so USING_Einsums and the
+# Einsums link propagate to modules that call these methods; guarded so libmints
+# still builds when Einsums is disabled. mintshelper.h only forward-declares the
+# tensor type, so non-Einsums consumers pay nothing.
+if(TARGET Einsums::Einsums)
+  # Einsums links HDF5 (DiskTensor/TensorIO), so consuming Einsums forces a real
+  # libhdf5 link. psi4's TargetHDF5 wrapper sets tgt::hdf5's interface to the bare
+  # name "hdf5-shared", but a config-less conda HDF5 never defines that target, so
+  # it leaks as a dangling `-lhdf5-shared`. Define it ourselves against the real
+  # library when nothing else has. (psi4 normally uses HDF5 header-only and never
+  # exercises this reference.)
+  if(NOT TARGET hdf5-shared)
+    find_library(EINSUMS_REAL_HDF5_LIB NAMES hdf5 hdf5-shared)
+    if(EINSUMS_REAL_HDF5_LIB)
+      add_library(hdf5-shared SHARED IMPORTED GLOBAL)
+      set_target_properties(hdf5-shared PROPERTIES
+        IMPORTED_LOCATION "${EINSUMS_REAL_HDF5_LIB}")
+    endif()
+  endif()
+  target_link_libraries(mints PUBLIC Einsums::Einsums)
+  target_compile_definitions(mints PUBLIC USING_Einsums)
+  if(DEFINED ENV{CONDA_TOOLCHAIN_BUILD} AND APPLE)
+    target_compile_definitions(mints
+      PUBLIC
+        _LIBCPP_DISABLE_AVAILABILITY
+        H5CPP_USE_OMP_ALIGNED_ALLOC
+      )
+  endif()
+endif()

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -140,34 +140,3 @@ if(TARGET OpenOrbitalOptimizer::OpenOrbitalOptimizer)
       USING_OpenOrbitalOptimizer
     )
 endif()
-
-# Einsums tensor bridge: MintsHelper's so_*_tiled() / tiled_from_matrix() expose
-# psi4 integrals as einsums::TiledRuntimeTensor. PUBLIC so USING_Einsums and the
-# Einsums link propagate to modules that call these methods; guarded so libmints
-# still builds when Einsums is disabled. mintshelper.h only forward-declares the
-# tensor type, so non-Einsums consumers pay nothing.
-if(TARGET Einsums::Einsums)
-  # Einsums links HDF5 (DiskTensor/TensorIO), so consuming Einsums forces a real
-  # libhdf5 link. psi4's TargetHDF5 wrapper sets tgt::hdf5's interface to the bare
-  # name "hdf5-shared", but a config-less conda HDF5 never defines that target, so
-  # it leaks as a dangling `-lhdf5-shared`. Define it ourselves against the real
-  # library when nothing else has. (psi4 normally uses HDF5 header-only and never
-  # exercises this reference.)
-  if(NOT TARGET hdf5-shared)
-    find_library(EINSUMS_REAL_HDF5_LIB NAMES hdf5 hdf5-shared)
-    if(EINSUMS_REAL_HDF5_LIB)
-      add_library(hdf5-shared SHARED IMPORTED GLOBAL)
-      set_target_properties(hdf5-shared PROPERTIES
-        IMPORTED_LOCATION "${EINSUMS_REAL_HDF5_LIB}")
-    endif()
-  endif()
-  target_link_libraries(mints PUBLIC Einsums::Einsums)
-  target_compile_definitions(mints PUBLIC USING_Einsums)
-  if(DEFINED ENV{CONDA_TOOLCHAIN_BUILD} AND APPLE)
-    target_compile_definitions(mints
-      PUBLIC
-        _LIBCPP_DISABLE_AVAILABILITY
-        H5CPP_USE_OMP_ALIGNED_ALLOC
-      )
-  endif()
-endif()

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -41,6 +41,9 @@
 #include "psi4/libiwl/iwl.hpp"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/matrix.h"
+#ifdef USING_Einsums
+#include <Einsums/Tensor/TiledRuntimeTensor.hpp>
+#endif
 #include "psi4/libmints/integral.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
@@ -811,6 +814,28 @@ SharedMatrix Matrix::to_block_sharedmatrix() const {
     free_block(temp);
     return ret;
 }
+
+#ifdef USING_Einsums
+einsums::TiledRuntimeTensor<double> Matrix::to_einsums_tiled(const std::string &name) {
+    // Grid: one tile partition per axis, from the per-irrep row/column dims.
+    std::vector<int> rows(nirrep_), cols(nirrep_);
+    for (int h = 0; h < nirrep_; ++h) {
+        rows[h] = rowspi_[h];
+        cols[h] = colspi_[h];
+    }
+    einsums::TiledRuntimeTensor<double> T(name.empty() ? name_ : name, {rows, cols}, /*row_major=*/true);
+
+    // Block h has rowspi[h] rows and colspi[h^symmetry] columns and lives at tile
+    // (h, h^symmetry). Alias its contiguous row-major buffer (matrix_[h][0]) —
+    // no copy; the tensor shares this matrix's storage.
+    for (int h = 0; h < nirrep_; ++h) {
+        const int hc = h ^ symmetry_;
+        if (rowspi_[h] == 0 || colspi_[hc] == 0) continue;
+        T.add_alias_tile({h, hc}, matrix_[h][0], /*row_major=*/true);
+    }
+    return T;
+}
+#endif
 
 void Matrix::print_mat(const double *const *const a, int m, int n, std::string out) const {
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -41,9 +41,6 @@
 #include "psi4/libiwl/iwl.hpp"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/matrix.h"
-#ifdef USING_Einsums
-#include <Einsums/Tensor/TiledRuntimeTensor.hpp>
-#endif
 #include "psi4/libmints/integral.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
@@ -815,27 +812,6 @@ SharedMatrix Matrix::to_block_sharedmatrix() const {
     return ret;
 }
 
-#ifdef USING_Einsums
-einsums::TiledRuntimeTensor<double> Matrix::to_einsums_tiled(const std::string &name) {
-    // Grid: one tile partition per axis, from the per-irrep row/column dims.
-    std::vector<int> rows(nirrep_), cols(nirrep_);
-    for (int h = 0; h < nirrep_; ++h) {
-        rows[h] = rowspi_[h];
-        cols[h] = colspi_[h];
-    }
-    einsums::TiledRuntimeTensor<double> T(name.empty() ? name_ : name, {rows, cols}, /*row_major=*/true);
-
-    // Block h has rowspi[h] rows and colspi[h^symmetry] columns and lives at tile
-    // (h, h^symmetry). Alias its contiguous row-major buffer (matrix_[h][0]) —
-    // no copy; the tensor shares this matrix's storage.
-    for (int h = 0; h < nirrep_; ++h) {
-        const int hc = h ^ symmetry_;
-        if (rowspi_[h] == 0 || colspi_[hc] == 0) continue;
-        T.add_alias_tile({h, hc}, matrix_[h][0], /*row_major=*/true);
-    }
-    return T;
-}
-#endif
 
 void Matrix::print_mat(const double *const *const a, int m, int n, std::string out) const {
     std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -53,6 +53,16 @@ namespace arma {
 }
 #endif
 
+#ifdef USING_Einsums
+// Forward declaration only — keeps Einsums headers out of matrix.h (and the
+// shared PCH). Callers of to_einsums_tiled() include
+// <Einsums/Tensor/TiledRuntimeTensor.hpp> themselves.
+namespace einsums {
+template <typename T>
+struct TiledRuntimeTensor;
+}
+#endif
+
 
 namespace psi {
 
@@ -584,6 +594,17 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * @returns the SharedMatrix
      */
     SharedMatrix to_block_sharedmatrix() const;
+#ifdef USING_Einsums
+    /**
+     * Expose this symmetry-blocked matrix as a rank-2 einsums::TiledRuntimeTensor
+     * that ALIASES the irrep blocks (zero-copy) — block h maps to tile
+     * (h, h^symmetry), aliasing the contiguous row-major buffer matrix_[h][0].
+     * The returned tensor borrows this matrix's storage, so the matrix must
+     * outlive it (and the data is shared: writes through either are visible to
+     * both). This is the zero-copy bridge toward an Einsums tensor backend.
+     */
+    einsums::TiledRuntimeTensor<double> to_einsums_tiled(const std::string &name = "");
+#endif
     /**
      * Returns a copy of the current matrix in lower triangle form.
      *

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -53,15 +53,6 @@ namespace arma {
 }
 #endif
 
-#ifdef USING_Einsums
-// Forward declaration only — keeps Einsums headers out of matrix.h (and the
-// shared PCH). Callers of to_einsums_tiled() include
-// <Einsums/Tensor/TiledRuntimeTensor.hpp> themselves.
-namespace einsums {
-template <typename T>
-struct TiledRuntimeTensor;
-}
-#endif
 
 
 namespace psi {
@@ -594,17 +585,6 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * @returns the SharedMatrix
      */
     SharedMatrix to_block_sharedmatrix() const;
-#ifdef USING_Einsums
-    /**
-     * Expose this symmetry-blocked matrix as a rank-2 einsums::TiledRuntimeTensor
-     * that ALIASES the irrep blocks (zero-copy) — block h maps to tile
-     * (h, h^symmetry), aliasing the contiguous row-major buffer matrix_[h][0].
-     * The returned tensor borrows this matrix's storage, so the matrix must
-     * outlive it (and the data is shared: writes through either are visible to
-     * both). This is the zero-copy bridge toward an Einsums tensor backend.
-     */
-    einsums::TiledRuntimeTensor<double> to_einsums_tiled(const std::string &name = "");
-#endif
     /**
      * Returns a copy of the current matrix in lower triangle form.
      *

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -34,6 +34,9 @@
 #include "psi4/libmints/molecule.h"
 
 #include "psi4/libmints/matrix.h"
+#ifdef USING_Einsums
+#include <Einsums/Tensor/TiledRuntimeTensor.hpp>
+#endif
 #include "psi4/psifiles.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libiwl/iwl.hpp"
@@ -1400,6 +1403,281 @@ SharedMatrix MintsHelper::so_potential(bool include_perturbations) {
     }
     return cached_oe_ints_[p];
 }
+
+#ifdef USING_Einsums
+namespace {
+// Fills a rank-4 einsums::TiledRuntimeTensor with SO two-electron integrals
+// (pq|rs), Mulliken/chemists' notation. TwoBodySOInt emits each integral once
+// in canonical (8-fold-reduced) form; we scatter it into all eight
+// permutation-equivalent positions so the resulting tensor is fully dense
+// within each symmetry-allowed block. Tiles are keyed by the (p,q,r,s) irrep
+// quadruple and created lazily — only symmetry-allowed, non-empty blocks ever
+// materialize. materialize() is idempotent and zero-initializes on first call,
+// so block entries the functor never visits remain true zeros.
+class TiledSOERIFiller {
+    einsums::TiledRuntimeTensor<double> &T_;
+
+    void put(int hp, int p, int hq, int q, int hr, int r, int hs, int s, double v) {
+        auto &tile = T_.tile({hp, hq, hr, hs});
+        tile.materialize();
+        tile(std::vector<size_t>{static_cast<size_t>(p), static_cast<size_t>(q), static_cast<size_t>(r),
+                                 static_cast<size_t>(s)}) = v;
+    }
+
+  public:
+    explicit TiledSOERIFiller(einsums::TiledRuntimeTensor<double> &T) : T_(T) {}
+
+    // Argument order matches TwoBodySOInt's functor convention: four absolute SO
+    // indices (unused here), then (irrep, within-irrep) for each of p,q,r,s, then
+    // the value. (pq|rs)=(qp|rs)=(pq|sr)=(qp|sr)=(rs|pq)=(sr|pq)=(rs|qp)=(sr|qp).
+    void operator()(int, int, int, int, int hp, int p, int hq, int q, int hr, int r, int hs, int s, double v) {
+        put(hp, p, hq, q, hr, r, hs, s, v);
+        put(hq, q, hp, p, hr, r, hs, s, v);
+        put(hp, p, hq, q, hs, s, hr, r, v);
+        put(hq, q, hp, p, hs, s, hr, r, v);
+        put(hr, r, hs, s, hp, p, hq, q, v);
+        put(hs, s, hr, r, hp, p, hq, q, v);
+        put(hr, r, hs, s, hq, q, hp, p, v);
+        put(hs, s, hr, r, hq, q, hp, p, v);
+    }
+};
+} // namespace
+
+einsums::TiledRuntimeTensor<double> MintsHelper::tiled_from_matrix(SharedMatrix mat, const std::string &name) {
+    const int        nirrep = mat->nirrep();
+    const Dimension &rowspi = mat->rowspi();
+    const Dimension &colspi = mat->colspi();
+    const int        sym    = mat->symmetry();
+
+    // One tile partition per axis, from the per-irrep row/column dimensions.
+    std::vector<int> rows(nirrep), cols(nirrep);
+    for (int h = 0; h < nirrep; ++h) {
+        rows[h] = rowspi[h];
+        cols[h] = colspi[h];
+    }
+
+    einsums::TiledRuntimeTensor<double> T(name, {rows, cols}, /*row_major=*/true);
+
+    // Block h has rowspi[h] rows and colspi[h ^ sym] columns; it lives at tile
+    // (h, h ^ sym). For a totally-symmetric operator (sym == 0) this is the
+    // block-diagonal (h, h).
+    for (int h = 0; h < nirrep; ++h) {
+        const int hc = h ^ sym;
+        if (rowspi[h] == 0 || colspi[hc] == 0) continue;
+        auto &tile = T.tile({h, hc});
+        tile.materialize();
+        for (int r = 0; r < rowspi[h]; ++r) {
+            for (int c = 0; c < colspi[hc]; ++c) {
+                tile(std::vector<size_t>{static_cast<size_t>(r), static_cast<size_t>(c)}) = mat->get(h, r, c);
+            }
+        }
+    }
+    return T;
+}
+
+einsums::TiledRuntimeTensor<double> MintsHelper::so_overlap_tiled() { return tiled_from_matrix(so_overlap(), "SO Overlap"); }
+
+einsums::TiledRuntimeTensor<double> MintsHelper::so_kinetic_tiled() { return tiled_from_matrix(so_kinetic(), "SO Kinetic"); }
+
+einsums::TiledRuntimeTensor<double> MintsHelper::so_potential_tiled() { return tiled_from_matrix(so_potential(), "SO Potential"); }
+
+einsums::TiledRuntimeTensor<double> MintsHelper::so_eri_tiled() {
+    const int       nirrep   = sobasis_->nirrep();
+    const Dimension sopi_dim = sobasis_->dimension();
+    std::vector<int> sopi(nirrep);
+    for (int h = 0; h < nirrep; ++h) sopi[h] = sopi_dim[h];
+
+    // Rank-4 tensor tiled by SO-per-irrep on every axis. A tile (the irrep
+    // quadruple p,q,r,s) is created only when an integral lands in it, i.e. for
+    // symmetry-allowed blocks whose direct product is totally symmetric.
+    einsums::TiledRuntimeTensor<double> T("SO ERI", {sopi, sopi, sopi, sopi}, /*row_major=*/true);
+
+    std::vector<std::shared_ptr<TwoBodyAOInt>> tb(1);
+    tb[0]      = std::shared_ptr<TwoBodyAOInt>(integral_->eri());
+    auto soeri = std::make_shared<TwoBodySOInt>(tb, integral_);
+
+    TiledSOERIFiller filler(T);
+    soeri->compute_integrals(filler);
+    return T;
+}
+
+einsums::RuntimeTensor<double> MintsHelper::ao_eri_einsums() {
+    auto                      ints = std::shared_ptr<TwoBodyAOInt>(integral_->eri());
+    std::shared_ptr<BasisSet> bs1  = ints->basis1();
+    std::shared_ptr<BasisSet> bs2  = ints->basis2();
+    std::shared_ptr<BasisSet> bs3  = ints->basis3();
+    std::shared_ptr<BasisSet> bs4  = ints->basis4();
+    const size_t              nbf1 = bs1->nbf();
+    const size_t              nbf2 = bs2->nbf();
+    const size_t              nbf3 = bs3->nbf();
+    const size_t              nbf4 = bs4->nbf();
+
+    // Dense, row-major, zero-initialized rank-4 tensor; write straight into its
+    // backing buffer at the row-major flat index for speed.
+    einsums::RuntimeTensor<double> T("AO ERI", std::vector<size_t>{nbf1, nbf2, nbf3, nbf4}, /*row_major=*/true);
+    double                        *data = T.data();
+
+    // Shell-batched fill: compute one shell quartet at a time and scatter its
+    // contiguous buffer into the tensor (same loop structure as ao_helper).
+    for (int M = 0; M < bs1->nshell(); ++M) {
+        for (int N = 0; N < bs2->nshell(); ++N) {
+            for (int P = 0; P < bs3->nshell(); ++P) {
+                for (int Q = 0; Q < bs4->nshell(); ++Q) {
+                    ints->compute_shell(M, N, P, Q);
+                    const double *buffer = ints->buffer();
+                    const size_t  om     = bs1->shell(M).function_index();
+                    const size_t  on     = bs2->shell(N).function_index();
+                    const size_t  op     = bs3->shell(P).function_index();
+                    const size_t  oq     = bs4->shell(Q).function_index();
+                    size_t        index  = 0;
+                    for (int m = 0; m < bs1->shell(M).nfunction(); ++m) {
+                        for (int n = 0; n < bs2->shell(N).nfunction(); ++n) {
+                            for (int p = 0; p < bs3->shell(P).nfunction(); ++p) {
+                                for (int q = 0; q < bs4->shell(Q).nfunction(); ++q, ++index) {
+                                    data[(((om + m) * nbf2 + (on + n)) * nbf3 + (op + p)) * nbf4 + (oq + q)] =
+                                        buffer[index];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return T;
+}
+
+einsums::RuntimeTensor<double> MintsHelper::mo_bra_half_transform_einsums(SharedMatrix C1, SharedMatrix C2) {
+    // (pq|ls) = sum_{mn} C1[m,p] C2[n,q] (mn|ls)  — chemists' notation.
+    //
+    // Integral-direct first-half (bra) transform. Each significant ket shell-pair
+    // (P,Q) gathers the AO bra block (mn|ls) over all (Schwarz-significant) bra
+    // shells into an nbf^2 * dP * dQ scratch, then collapses the bra with two
+    // GEMMs. The full N^4 AO tensor is never formed, so memory scales as the
+    // output (n1 * n2 * nbf^2).
+    //
+    // Tier-1 optimizations: Schwarz screening (skip negligible bra/ket pairs and
+    // quartets via the engine sieve) and OpenMP over ket shell-pairs (each pair
+    // writes a disjoint (l,s) slab of H, so threads never collide; each thread
+    // owns a cloned integral engine, the pattern used elsewhere in this file).
+    // Permutational symmetry (bra m<->n, ket l<->s) and shell-pair batching are
+    // the deferred Tier-2/3 wins.
+    auto                      ints = std::shared_ptr<TwoBodyAOInt>(integral_->eri());
+    std::shared_ptr<BasisSet> bs1  = ints->basis1(); // mu  (bra 1)
+    std::shared_ptr<BasisSet> bs2  = ints->basis2(); // nu  (bra 2)
+    std::shared_ptr<BasisSet> bs3  = ints->basis3(); // lambda (ket 1)
+    std::shared_ptr<BasisSet> bs4  = ints->basis4(); // sigma  (ket 2)
+    const size_t              nbf1 = bs1->nbf();
+    const size_t              nbf2 = bs2->nbf();
+    const size_t              nbf3 = bs3->nbf();
+    const size_t              nbf4 = bs4->nbf();
+
+    const size_t n1 = static_cast<size_t>(C1->colspi()[0]);
+    const size_t n2 = static_cast<size_t>(C2->colspi()[0]);
+    if (static_cast<size_t>(C1->rowspi()[0]) != nbf1 || static_cast<size_t>(C2->rowspi()[0]) != nbf2) {
+        throw PSIEXCEPTION("mo_bra_half_transform_einsums: C1/C2 row dimensions must match the bra AO basis (C1 single-irrep)");
+    }
+    double **C1p = C1->pointer();
+    double **C2p = C2->pointer();
+
+    // Dense, row-major output (n1, n2, nbf3, nbf4); write straight into the buffer.
+    einsums::RuntimeTensor<double> H("MO bra half-transform", std::vector<size_t>{n1, n2, nbf3, nbf4}, /*row_major=*/true);
+    double                        *Hdata = H.data();
+
+    // Per-thread integral engines (clone pattern, as elsewhere in this file).
+    std::vector<std::shared_ptr<TwoBodyAOInt>> tb(nthread_);
+    tb[0] = ints;
+    for (int t = 1; t < nthread_; ++t) tb[t] = std::shared_ptr<TwoBodyAOInt>(tb.front()->clone());
+
+    // Permutational symmetry of the AO ERI lets us touch each unique pair once:
+    //   bra:  (mn|ls) = (nm|ls)             -> loop N<=M, scatter into [m,n] and [n,m]
+    //   ket:  (pq|ls) = (pq|sl) (inherited)  -> loop Q<=P, write the (l,s) and (s,l) slabs
+    // ~4x fewer compute_shell calls. Requires the bra (resp. ket) AO bases to
+    // match, which they do for the primary-basis ERI used here.
+    if (bs1 != bs2 || bs3 != bs4) {
+        throw PSIEXCEPTION("mo_bra_half_transform_einsums: permutational symmetry assumes matching bra/ket bases");
+    }
+
+    // Significant, unique (P>=Q) ket shell-pairs are the unit of parallel work;
+    // each writes a disjoint set of (l,s) slabs, so threads never collide. An
+    // insignificant pair contributes nothing (its H slabs stay zero-initialized).
+    std::vector<std::pair<int, int>> ketpairs;
+    for (int P = 0; P < bs3->nshell(); ++P) {
+        for (int Q = 0; Q <= P; ++Q) {
+            if (ints->shell_pair_significant(P, Q)) ketpairs.emplace_back(P, Q);
+        }
+    }
+    const long npairs = static_cast<long>(ketpairs.size());
+
+#pragma omp parallel for schedule(dynamic) num_threads(nthread_)
+    for (long kp = 0; kp < npairs; ++kp) {
+        const int     tid = omp_get_thread_num();
+        TwoBodyAOInt *eng = tb[tid].get();
+        const int     P   = ketpairs[kp].first;
+        const int     Q   = ketpairs[kp].second;
+        const size_t  dP  = bs3->shell(P).nfunction();
+        const size_t  oP  = bs3->shell(P).function_index();
+        const size_t  dQ  = bs4->shell(Q).nfunction();
+        const size_t  oQ  = bs4->shell(Q).function_index();
+        const size_t  npq = dP * dQ;
+
+        // AO bra block for this ket pair: [mu, nu, p_, q_], row-major (thread-local).
+        // Bra pairs are looped triangularly (N<=M); each is scattered into both
+        // [mu,nu] and (off-diagonal) [nu,mu] via (mn|ls) = (nm|ls).
+        std::vector<double> aobra(nbf1 * nbf2 * npq, 0.0);
+        for (int M = 0; M < bs1->nshell(); ++M) {
+            const size_t dM = bs1->shell(M).nfunction();
+            const size_t oM = bs1->shell(M).function_index();
+            for (int N = 0; N <= M; ++N) {
+                if (!eng->shell_significant(M, N, P, Q)) continue; // Schwarz quartet screen
+                const size_t dN = bs2->shell(N).nfunction();
+                const size_t oN = bs2->shell(N).function_index();
+                eng->compute_shell(M, N, P, Q);
+                const double *buf  = eng->buffer();
+                const bool    offd = (M != N);
+                size_t        idx  = 0;
+                for (size_t m = 0; m < dM; ++m) {
+                    for (size_t n = 0; n < dN; ++n) {
+                        for (size_t p_ = 0; p_ < dP; ++p_) {
+                            for (size_t q_ = 0; q_ < dQ; ++q_, ++idx) {
+                                const double v  = buf[idx];
+                                const size_t pq = p_ * dQ + q_;
+                                aobra[((oM + m) * nbf2 + (oN + n)) * npq + pq] = v;             // (mu,nu)
+                                if (offd) aobra[((oN + n) * nbf2 + (oM + m)) * npq + pq] = v;   // (nu,mu)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Quarter 1: half1[p, nu, p_q_] = sum_mu C1[mu,p] aobra[mu, nu, p_q_].
+        // C1 is (nbf1 x n1) row-major (lda n1); 'T' uses C1^T (n1 x nbf1).
+        std::vector<double> half1(n1 * nbf2 * npq, 0.0);
+        C_DGEMM('T', 'N', n1, nbf2 * npq, nbf1, 1.0, C1p[0], n1, aobra.data(), nbf2 * npq, 0.0, half1.data(),
+                nbf2 * npq);
+
+        // Quarter 2 (per surviving bra-1 index p): out[q, p_q_] = sum_nu C2[nu,q] half1[p, nu, p_q_].
+        const bool          offd_ket = (P != Q);
+        std::vector<double> outp(n2 * npq, 0.0);
+        for (size_t p = 0; p < n1; ++p) {
+            C_DGEMM('T', 'N', n2, npq, nbf2, 1.0, C2p[0], n2, half1.data() + p * nbf2 * npq, npq, 0.0, outp.data(), npq);
+            // Scatter into the (l,s) slab and, for off-diagonal ket pairs, its
+            // (s,l) partner via (pq|ls) = (pq|sl). Disjoint across ket pairs.
+            for (size_t q = 0; q < n2; ++q) {
+                for (size_t p_ = 0; p_ < dP; ++p_) {
+                    for (size_t q_ = 0; q_ < dQ; ++q_) {
+                        const double v = outp[q * npq + (p_ * dQ + q_)];
+                        Hdata[((p * n2 + q) * nbf3 + (oP + p_)) * nbf4 + (oQ + q_)] = v;              // (l in P, s in Q)
+                        if (offd_ket) Hdata[((p * n2 + q) * nbf3 + (oQ + q_)) * nbf4 + (oP + p_)] = v; // (l in Q, s in P)
+                    }
+                }
+            }
+        }
+    }
+    return H;
+}
+#endif
 
 void MintsHelper::add_dipole_perturbation(SharedMatrix potential_mat) {
     std::string perturb_with = options_.get_str("PERTURB_WITH");

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -34,9 +34,6 @@
 #include "psi4/libmints/molecule.h"
 
 #include "psi4/libmints/matrix.h"
-#ifdef USING_Einsums
-#include <Einsums/Tensor/TiledRuntimeTensor.hpp>
-#endif
 #include "psi4/psifiles.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libiwl/iwl.hpp"
@@ -62,6 +59,7 @@
 #include <cmath>
 #include <iostream>
 #include <list>
+#include <array>
 #include <map>
 #include <memory>
 #include <set>
@@ -1404,28 +1402,28 @@ SharedMatrix MintsHelper::so_potential(bool include_perturbations) {
     return cached_oe_ints_[p];
 }
 
-#ifdef USING_Einsums
 namespace {
-// Fills a rank-4 einsums::TiledRuntimeTensor with SO two-electron integrals
-// (pq|rs), Mulliken/chemists' notation. TwoBodySOInt emits each integral once
-// in canonical (8-fold-reduced) form; we scatter it into all eight
-// permutation-equivalent positions so the resulting tensor is fully dense
-// within each symmetry-allowed block. Tiles are keyed by the (p,q,r,s) irrep
-// quadruple and created lazily — only symmetry-allowed, non-empty blocks ever
-// materialize. materialize() is idempotent and zero-initializes on first call,
-// so block entries the functor never visits remain true zeros.
-class TiledSOERIFiller {
-    einsums::TiledRuntimeTensor<double> &T_;
+// Fills the symmetry-allowed irrep-quadruple blocks of the SO two-electron
+// integrals (pq|rs), Mulliken/chemists' notation. TwoBodySOInt emits each
+// integral once in canonical (8-fold-reduced) form; we scatter it into all
+// eight permutation-equivalent positions so each block is fully dense. Blocks
+// are keyed by the (p,q,r,s) irrep quadruple and created lazily -- only
+// symmetry-allowed, non-empty blocks ever materialize. Each block is a
+// zero-initialized (d1*d2, d3*d4) row-major Matrix over the within-irrep
+// compound indices (p*d2+q, r*d4+s).
+class BlockedSOERIFiller {
+    std::map<std::array<int, 4>, SharedMatrix> &blocks_;
+    const Dimension &sopi_;
 
     void put(int hp, int p, int hq, int q, int hr, int r, int hs, int s, double v) {
-        auto &tile = T_.tile({hp, hq, hr, hs});
-        tile.materialize();
-        tile(std::vector<size_t>{static_cast<size_t>(p), static_cast<size_t>(q), static_cast<size_t>(r),
-                                 static_cast<size_t>(s)}) = v;
+        auto &blk = blocks_[{hp, hq, hr, hs}];
+        if (!blk) blk = std::make_shared<Matrix>("SO ERI block", sopi_[hp] * sopi_[hq], sopi_[hr] * sopi_[hs]);
+        blk->set(p * sopi_[hq] + q, r * sopi_[hs] + s, v);
     }
 
   public:
-    explicit TiledSOERIFiller(einsums::TiledRuntimeTensor<double> &T) : T_(T) {}
+    BlockedSOERIFiller(std::map<std::array<int, 4>, SharedMatrix> &blocks, const Dimension &sopi)
+        : blocks_(blocks), sopi_(sopi) {}
 
     // Argument order matches TwoBodySOInt's functor convention: four absolute SO
     // indices (unused here), then (irrep, within-irrep) for each of p,q,r,s, then
@@ -1443,111 +1441,27 @@ class TiledSOERIFiller {
 };
 } // namespace
 
-einsums::TiledRuntimeTensor<double> MintsHelper::tiled_from_matrix(SharedMatrix mat, const std::string &name) {
-    const int        nirrep = mat->nirrep();
-    const Dimension &rowspi = mat->rowspi();
-    const Dimension &colspi = mat->colspi();
-    const int        sym    = mat->symmetry();
-
-    // One tile partition per axis, from the per-irrep row/column dimensions.
-    std::vector<int> rows(nirrep), cols(nirrep);
-    for (int h = 0; h < nirrep; ++h) {
-        rows[h] = rowspi[h];
-        cols[h] = colspi[h];
-    }
-
-    einsums::TiledRuntimeTensor<double> T(name, {rows, cols}, /*row_major=*/true);
-
-    // Block h has rowspi[h] rows and colspi[h ^ sym] columns; it lives at tile
-    // (h, h ^ sym). For a totally-symmetric operator (sym == 0) this is the
-    // block-diagonal (h, h).
-    for (int h = 0; h < nirrep; ++h) {
-        const int hc = h ^ sym;
-        if (rowspi[h] == 0 || colspi[hc] == 0) continue;
-        auto &tile = T.tile({h, hc});
-        tile.materialize();
-        for (int r = 0; r < rowspi[h]; ++r) {
-            for (int c = 0; c < colspi[hc]; ++c) {
-                tile(std::vector<size_t>{static_cast<size_t>(r), static_cast<size_t>(c)}) = mat->get(h, r, c);
-            }
-        }
-    }
-    return T;
-}
-
-einsums::TiledRuntimeTensor<double> MintsHelper::so_overlap_tiled() { return tiled_from_matrix(so_overlap(), "SO Overlap"); }
-
-einsums::TiledRuntimeTensor<double> MintsHelper::so_kinetic_tiled() { return tiled_from_matrix(so_kinetic(), "SO Kinetic"); }
-
-einsums::TiledRuntimeTensor<double> MintsHelper::so_potential_tiled() { return tiled_from_matrix(so_potential(), "SO Potential"); }
-
-einsums::TiledRuntimeTensor<double> MintsHelper::so_eri_tiled() {
-    const int       nirrep   = sobasis_->nirrep();
-    const Dimension sopi_dim = sobasis_->dimension();
-    std::vector<int> sopi(nirrep);
-    for (int h = 0; h < nirrep; ++h) sopi[h] = sopi_dim[h];
-
-    // Rank-4 tensor tiled by SO-per-irrep on every axis. A tile (the irrep
-    // quadruple p,q,r,s) is created only when an integral lands in it, i.e. for
-    // symmetry-allowed blocks whose direct product is totally symmetric.
-    einsums::TiledRuntimeTensor<double> T("SO ERI", {sopi, sopi, sopi, sopi}, /*row_major=*/true);
-
+std::vector<std::pair<std::vector<int>, SharedMatrix>> MintsHelper::so_eri_blocked() {
     std::vector<std::shared_ptr<TwoBodyAOInt>> tb(1);
     tb[0]      = std::shared_ptr<TwoBodyAOInt>(integral_->eri());
     auto soeri = std::make_shared<TwoBodySOInt>(tb, integral_);
 
-    TiledSOERIFiller filler(T);
+    const Dimension sopi = sobasis_->dimension();
+    std::map<std::array<int, 4>, SharedMatrix> blocks;
+    BlockedSOERIFiller filler(blocks, sopi);
     soeri->compute_integrals(filler);
-    return T;
-}
 
-einsums::RuntimeTensor<double> MintsHelper::ao_eri_einsums() {
-    auto                      ints = std::shared_ptr<TwoBodyAOInt>(integral_->eri());
-    std::shared_ptr<BasisSet> bs1  = ints->basis1();
-    std::shared_ptr<BasisSet> bs2  = ints->basis2();
-    std::shared_ptr<BasisSet> bs3  = ints->basis3();
-    std::shared_ptr<BasisSet> bs4  = ints->basis4();
-    const size_t              nbf1 = bs1->nbf();
-    const size_t              nbf2 = bs2->nbf();
-    const size_t              nbf3 = bs3->nbf();
-    const size_t              nbf4 = bs4->nbf();
-
-    // Dense, row-major, zero-initialized rank-4 tensor; write straight into its
-    // backing buffer at the row-major flat index for speed.
-    einsums::RuntimeTensor<double> T("AO ERI", std::vector<size_t>{nbf1, nbf2, nbf3, nbf4}, /*row_major=*/true);
-    double                        *data = T.data();
-
-    // Shell-batched fill: compute one shell quartet at a time and scatter its
-    // contiguous buffer into the tensor (same loop structure as ao_helper).
-    for (int M = 0; M < bs1->nshell(); ++M) {
-        for (int N = 0; N < bs2->nshell(); ++N) {
-            for (int P = 0; P < bs3->nshell(); ++P) {
-                for (int Q = 0; Q < bs4->nshell(); ++Q) {
-                    ints->compute_shell(M, N, P, Q);
-                    const double *buffer = ints->buffer();
-                    const size_t  om     = bs1->shell(M).function_index();
-                    const size_t  on     = bs2->shell(N).function_index();
-                    const size_t  op     = bs3->shell(P).function_index();
-                    const size_t  oq     = bs4->shell(Q).function_index();
-                    size_t        index  = 0;
-                    for (int m = 0; m < bs1->shell(M).nfunction(); ++m) {
-                        for (int n = 0; n < bs2->shell(N).nfunction(); ++n) {
-                            for (int p = 0; p < bs3->shell(P).nfunction(); ++p) {
-                                for (int q = 0; q < bs4->shell(Q).nfunction(); ++q, ++index) {
-                                    data[(((om + m) * nbf2 + (on + n)) * nbf3 + (op + p)) * nbf4 + (oq + q)] =
-                                        buffer[index];
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    // Deterministic (lexicographic) order; the quadruple crosses to Python as a
+    // plain list, so callers see a list of ([hp, hq, hr, hs], Matrix) pairs.
+    std::vector<std::pair<std::vector<int>, SharedMatrix>> out;
+    out.reserve(blocks.size());
+    for (auto &entry : blocks) {
+        out.emplace_back(std::vector<int>(entry.first.begin(), entry.first.end()), entry.second);
     }
-    return T;
+    return out;
 }
 
-einsums::RuntimeTensor<double> MintsHelper::mo_bra_half_transform_einsums(SharedMatrix C1, SharedMatrix C2) {
+SharedMatrix MintsHelper::mo_bra_half_transform(SharedMatrix C1, SharedMatrix C2) {
     // (pq|ls) = sum_{mn} C1[m,p] C2[n,q] (mn|ls)  — chemists' notation.
     //
     // Integral-direct first-half (bra) transform. Each significant ket shell-pair
@@ -1575,14 +1489,15 @@ einsums::RuntimeTensor<double> MintsHelper::mo_bra_half_transform_einsums(Shared
     const size_t n1 = static_cast<size_t>(C1->colspi()[0]);
     const size_t n2 = static_cast<size_t>(C2->colspi()[0]);
     if (static_cast<size_t>(C1->rowspi()[0]) != nbf1 || static_cast<size_t>(C2->rowspi()[0]) != nbf2) {
-        throw PSIEXCEPTION("mo_bra_half_transform_einsums: C1/C2 row dimensions must match the bra AO basis (C1 single-irrep)");
+        throw PSIEXCEPTION("mo_bra_half_transform: C1/C2 row dimensions must match the bra AO basis (C1 single-irrep)");
     }
     double **C1p = C1->pointer();
     double **C2p = C2->pointer();
 
-    // Dense, row-major output (n1, n2, nbf3, nbf4); write straight into the buffer.
-    einsums::RuntimeTensor<double> H("MO bra half-transform", std::vector<size_t>{n1, n2, nbf3, nbf4}, /*row_major=*/true);
-    double                        *Hdata = H.data();
+    // Dense output: the rank-4 (n1, n2, nbf3, nbf4) row-major array flattened to a
+    // (n1*n2, nbf3*nbf4) Matrix; write straight into its contiguous buffer.
+    auto H = std::make_shared<Matrix>("MO bra half-transform", static_cast<int>(n1 * n2), static_cast<int>(nbf3 * nbf4));
+    double *Hdata = H->pointer()[0];
 
     // Per-thread integral engines (clone pattern, as elsewhere in this file).
     std::vector<std::shared_ptr<TwoBodyAOInt>> tb(nthread_);
@@ -1595,7 +1510,7 @@ einsums::RuntimeTensor<double> MintsHelper::mo_bra_half_transform_einsums(Shared
     // ~4x fewer compute_shell calls. Requires the bra (resp. ket) AO bases to
     // match, which they do for the primary-basis ERI used here.
     if (bs1 != bs2 || bs3 != bs4) {
-        throw PSIEXCEPTION("mo_bra_half_transform_einsums: permutational symmetry assumes matching bra/ket bases");
+        throw PSIEXCEPTION("mo_bra_half_transform: permutational symmetry assumes matching bra/ket bases");
     }
 
     // Significant, unique (P>=Q) ket shell-pairs are the unit of parallel work;
@@ -1677,7 +1592,6 @@ einsums::RuntimeTensor<double> MintsHelper::mo_bra_half_transform_einsums(Shared
     }
     return H;
 }
-#endif
 
 void MintsHelper::add_dipole_perturbation(SharedMatrix potential_mat) {
     std::string perturb_with = options_.get_str("PERTURB_WITH");

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -35,6 +35,22 @@
 
 #include <vector>
 
+#ifdef USING_Einsums
+#include <memory>  // std::allocator, for the RuntimeTensor alias below
+// Forward declarations only — keeps Einsums headers out of mintshelper.h (and the
+// shared PCH). Callers of these accessors include the relevant Einsums tensor
+// headers themselves (<Einsums/Tensor/TiledRuntimeTensor.hpp>, which also pulls
+// in RuntimeTensor).
+namespace einsums {
+template <typename T>
+struct TiledRuntimeTensor;
+template <typename T, typename Alloc>
+struct GeneralRuntimeTensor;
+template <typename T>
+using RuntimeTensor = GeneralRuntimeTensor<T, std::allocator<T>>;
+}
+#endif
+
 namespace psi {
 
 class CdSalcList;
@@ -340,6 +356,38 @@ class PSI_API MintsHelper {
 #endif
     /// SO Potential Integrals
     SharedMatrix so_potential(bool include_perturbations = true);
+#ifdef USING_Einsums
+    /// Copy a symmetry-blocked Matrix into a rank-2 einsums::TiledRuntimeTensor.
+    /// Each irrep block h becomes tile (h, h^symmetry); the global shape is the
+    /// matrix's rowspi x colspi. Owning copy (independent of the source Matrix).
+    einsums::TiledRuntimeTensor<double> tiled_from_matrix(SharedMatrix mat, const std::string &name);
+    /// SO overlap integrals as a (block-diagonal) tiled tensor.
+    einsums::TiledRuntimeTensor<double> so_overlap_tiled();
+    /// SO kinetic integrals as a tiled tensor.
+    einsums::TiledRuntimeTensor<double> so_kinetic_tiled();
+    /// SO potential (nuclear attraction) integrals as a tiled tensor.
+    einsums::TiledRuntimeTensor<double> so_potential_tiled();
+    /// SO two-electron integrals (pq|rs), chemists' notation, as a rank-4 tiled
+    /// tensor. Tiles are the symmetry-allowed irrep quadruples; each axis is
+    /// tiled by the SO-per-irrep dimension.
+    einsums::TiledRuntimeTensor<double> so_eri_tiled();
+    /// AO two-electron integrals (pq|rs), chemists' notation, as a dense rank-4
+    /// einsums::RuntimeTensor. AO integrals carry no point-group symmetry, so a
+    /// dense tensor (not a tiled one) is the natural representation. Built with
+    /// the performant shell-batched primitive (TwoBodyAOInt::compute_shell). N^4
+    /// storage — not recommended for large systems.
+    einsums::RuntimeTensor<double> ao_eri_einsums();
+    /// First-half (bra) MO transform of the AO two-electron integrals, integral-
+    /// direct: returns (pq|ls) = sum_{mn} C1[m,p] C2[n,q] (mn|ls) as a dense
+    /// rank-4 einsums::RuntimeTensor of shape (n1, n2, nbf, nbf), chemists'
+    /// notation. The bra is collapsed against C1/C2 one ket shell-pair at a
+    /// time, so the N^4 AO tensor is never materialized — memory scales as the
+    /// output (n1*n2*nbf^2), not N^4. The remaining ket (3rd/4th) quarter-
+    /// transforms are left to the caller (e.g. an einsums ComputeGraph). Assumes
+    /// C1/C2 carry no point-group symmetry (single irrep), matching the dense AO
+    /// representation. Schwarz screening / shell-pair batching are deferred.
+    einsums::RuntimeTensor<double> mo_bra_half_transform_einsums(SharedMatrix C1, SharedMatrix C2);
+#endif
     /// Vector SO Dipole Integrals
     std::vector<SharedMatrix> so_dipole() const;
     /// Vector SO Nabla Integrals

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -33,23 +33,9 @@
 #include "psi4/libmints/multipolesymmetry.h"
 #include "psi4/libpsi4util/process.h"
 
+#include <utility>
 #include <vector>
 
-#ifdef USING_Einsums
-#include <memory>  // std::allocator, for the RuntimeTensor alias below
-// Forward declarations only — keeps Einsums headers out of mintshelper.h (and the
-// shared PCH). Callers of these accessors include the relevant Einsums tensor
-// headers themselves (<Einsums/Tensor/TiledRuntimeTensor.hpp>, which also pulls
-// in RuntimeTensor).
-namespace einsums {
-template <typename T>
-struct TiledRuntimeTensor;
-template <typename T, typename Alloc>
-struct GeneralRuntimeTensor;
-template <typename T>
-using RuntimeTensor = GeneralRuntimeTensor<T, std::allocator<T>>;
-}
-#endif
 
 namespace psi {
 
@@ -356,38 +342,19 @@ class PSI_API MintsHelper {
 #endif
     /// SO Potential Integrals
     SharedMatrix so_potential(bool include_perturbations = true);
-#ifdef USING_Einsums
-    /// Copy a symmetry-blocked Matrix into a rank-2 einsums::TiledRuntimeTensor.
-    /// Each irrep block h becomes tile (h, h^symmetry); the global shape is the
-    /// matrix's rowspi x colspi. Owning copy (independent of the source Matrix).
-    einsums::TiledRuntimeTensor<double> tiled_from_matrix(SharedMatrix mat, const std::string &name);
-    /// SO overlap integrals as a (block-diagonal) tiled tensor.
-    einsums::TiledRuntimeTensor<double> so_overlap_tiled();
-    /// SO kinetic integrals as a tiled tensor.
-    einsums::TiledRuntimeTensor<double> so_kinetic_tiled();
-    /// SO potential (nuclear attraction) integrals as a tiled tensor.
-    einsums::TiledRuntimeTensor<double> so_potential_tiled();
-    /// SO two-electron integrals (pq|rs), chemists' notation, as a rank-4 tiled
-    /// tensor. Tiles are the symmetry-allowed irrep quadruples; each axis is
-    /// tiled by the SO-per-irrep dimension.
-    einsums::TiledRuntimeTensor<double> so_eri_tiled();
-    /// AO two-electron integrals (pq|rs), chemists' notation, as a dense rank-4
-    /// einsums::RuntimeTensor. AO integrals carry no point-group symmetry, so a
-    /// dense tensor (not a tiled one) is the natural representation. Built with
-    /// the performant shell-batched primitive (TwoBodyAOInt::compute_shell). N^4
-    /// storage — not recommended for large systems.
-    einsums::RuntimeTensor<double> ao_eri_einsums();
-    /// First-half (bra) MO transform of the AO two-electron integrals, integral-
-    /// direct: returns (pq|ls) = sum_{mn} C1[m,p] C2[n,q] (mn|ls) as a dense
-    /// rank-4 einsums::RuntimeTensor of shape (n1, n2, nbf, nbf), chemists'
-    /// notation. The bra is collapsed against C1/C2 one ket shell-pair at a
-    /// time, so the N^4 AO tensor is never materialized — memory scales as the
-    /// output (n1*n2*nbf^2), not N^4. The remaining ket (3rd/4th) quarter-
-    /// transforms are left to the caller (e.g. an einsums ComputeGraph). Assumes
-    /// C1/C2 carry no point-group symmetry (single irrep), matching the dense AO
-    /// representation. Schwarz screening / shell-pair batching are deferred.
-    einsums::RuntimeTensor<double> mo_bra_half_transform_einsums(SharedMatrix C1, SharedMatrix C2);
-#endif
+    /// SO two-electron integrals (pq|rs), chemists' notation, as symmetry-allowed
+    /// irrep-quadruple blocks: ([hp, hq, hr, hs], block) pairs in lexicographic
+    /// order. Each block is a dense row-major (d1*d2, d3*d4) Matrix over the
+    /// within-irrep compound indices (all eight permutations scattered). Neutral
+    /// psi4 types by design: assemble into the tensor library of your choice on
+    /// the Python side.
+    std::vector<std::pair<std::vector<int>, SharedMatrix>> so_eri_blocked();
+    /// Integral-direct first-half (bra) MO transform, chemists' notation:
+    /// (pq|ls) = sum_{mn} C1[m,p] C2[n,q] (mn|ls). Returns the rank-4
+    /// (n1, n2, nbf, nbf) row-major array flattened to a (n1*n2, nbf*nbf)
+    /// Matrix. Schwarz-screened and OpenMP-parallel; the N^4 AO tensor is never
+    /// materialized. Assumes C1/C2 are single-irrep (C1 symmetry).
+    SharedMatrix mo_bra_half_transform(SharedMatrix C1, SharedMatrix C2);
     /// Vector SO Dipole Integrals
     std::vector<SharedMatrix> so_dipole() const;
     /// Vector SO Nabla Integrals


### PR DESCRIPTION
Updates Psi4 to use an in-progress version of Einsums 2. Adds interfaces to MintsHelper and DFTensor to return Einsums RuntimeTensor objects.

## Status
- [ ] Ready for review
- [ ] Ready for merge
