### PR TITLE
Remove unnecessary local copy of Dimension objects from cceom/diagSS

### DIFF
--- a/psi4/src/psi4/cc/cceom/diagSS.cc
+++ b/psi4/src/psi4/cc/cceom/diagSS.cc
@@ -70,7 +70,6 @@ void diagSS(int C_irr) {
     double norm, tval, *lambda, *lambda_old, zero = 0.0;
     double **G, *work, *evals_complex, **alpha, **evectors_left;
     int nirreps, range;
-    Dimension aoccpi, avirtpi, boccpi, bvirtpi;
     int *converged, num_converged, num_roots;
     int begin_occ, begin_virt, end_virt, dim_SS = 0;
     int pf, cnt, irr_occ, irr_virt;
@@ -79,13 +78,6 @@ void diagSS(int C_irr) {
     const auto& openpi = moinfo.openpi;
     const auto& occpi = moinfo.occpi;
     const auto& virtpi = moinfo.virtpi;
-
-    if (params.eom_ref == 2) { /* UHF */
-        aoccpi = moinfo.aoccpi;
-        boccpi = moinfo.boccpi;
-        avirtpi = moinfo.avirtpi;
-        bvirtpi = moinfo.bvirtpi;
-    }
 
     range = eom_params.excitation_range;
     pf = eom_params.print_singles;
@@ -206,6 +198,8 @@ void diagSS(int C_irr) {
                     }
             } else { /* UHF */
                 /* alpha excitations */
+                const Dimension& aoccpi = moinfo.aoccpi;
+                const Dimension& avirtpi = moinfo.avirtpi;
                 begin_occ = MAX(aoccpi[irr_occ] - range, 0);
                 end_virt = MIN(avirtpi[irr_virt], range);
                 for (i = begin_occ; i < aoccpi[irr_occ]; ++i)
@@ -222,6 +216,8 @@ void diagSS(int C_irr) {
                         global_dpd_->file2_mat_wrt(&Cme);
                         global_dpd_->file2_close(&Cme);
                     }
+                const Dimension& boccpi = moinfo.boccpi;
+                const Dimension& bvirtpi = moinfo.bvirtpi;
                 begin_occ = MAX(boccpi[irr_occ] - range, 0);
                 end_virt = MIN(bvirtpi[irr_virt], range);
                 for (i = begin_occ; i < boccpi[irr_occ]; ++i)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
PR #3356 introduced local mutable copies of the `moinfo.aoccpi`,  `moinfo.avirtpi` obejcts and their beta counterparts into cceom/diagSS
This PR provides a better solution via `const&`.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] No user-facing changes

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Replace declaring mutable dimension objects unconditionally and assigning them if needed, with `const&` in the smallest scope they are needed in. This restores the lack of copying before PR #3356.

## Checklist
- [x] No new features
- [x] CI tests are passing

## Status
- [x] Ready for review
- [x] Ready for merge
