### PR TITLE
Remove unnecessary local copy of Dimension objects from cctriples/count_ijk

### DIFF
--- a/psi4/src/psi4/cc/cctriples/count_ijk.cc
+++ b/psi4/src/psi4/cc/cctriples/count_ijk.cc
@@ -47,8 +47,6 @@ void count_ijk() {
     int Ga, Gb, Gc;
     int a, b, c;
     int A, B, C;
-    Dimension occpi, aoccpi, boccpi;
-    Dimension virtpi, avirtpi, bvirtpi;
     const int *occ_off, *aocc_off, *bocc_off;
     const int *vir_off, *avir_off, *bvir_off;
     int nijk;
@@ -57,24 +55,25 @@ void count_ijk() {
     nirreps = moinfo.nirreps;
 
     if (params.ref == 0) { /** RHF **/
-        occpi = moinfo.occpi;
         occ_off = moinfo.occ_off;
-
         nijk = 0;
-        for (Gi = 0; Gi < nirreps; Gi++) {
-            for (Gj = 0; Gj < nirreps; Gj++) {
-                for (Gk = 0; Gk < nirreps; Gk++) {
-                    for (i = 0; i < occpi[Gi]; i++) {
-                        I = occ_off[Gi] + i;
-                        for (j = 0; j < occpi[Gj]; j++) {
-                            J = occ_off[Gj] + j;
-                            for (k = 0; k < occpi[Gk]; k++) {
-                                K = occ_off[Gk] + k;
+        {
+            const Dimension& occpi = moinfo.occpi;
+            for (Gi = 0; Gi < nirreps; Gi++) {
+                for (Gj = 0; Gj < nirreps; Gj++) {
+                    for (Gk = 0; Gk < nirreps; Gk++) {
+                        for (i = 0; i < occpi[Gi]; i++) {
+                            I = occ_off[Gi] + i;
+                            for (j = 0; j < occpi[Gj]; j++) {
+                                J = occ_off[Gj] + j;
+                                for (k = 0; k < occpi[Gk]; k++) {
+                                    K = occ_off[Gk] + k;
 
-                                if (params.dertype == 1)
-                                    nijk++;
-                                else if (I >= J && J >= K)
-                                    nijk++;
+                                    if (params.dertype == 1)
+                                        nijk++;
+                                    else if (I >= J && J >= K)
+                                        nijk++;
+                                }
                             }
                         }
                     }
@@ -85,7 +84,7 @@ void count_ijk() {
         outfile->Printf("\n    Number of ijk index combinations:   %14d\n", nijk);
 
         if (params.dertype == 1) {
-            virtpi = moinfo.virtpi;
+            const Dimension& virtpi = moinfo.virtpi;
             vir_off = moinfo.vir_off;
             nabc = 0;
             for (Ga = 0; Ga < nirreps; ++Ga) {
@@ -105,10 +104,9 @@ void count_ijk() {
         }  // dertype==1
 
     } else if (params.ref == 2) { /** UHF **/
-
-        aoccpi = moinfo.aoccpi;
+        const Dimension& aoccpi = moinfo.aoccpi;
         aocc_off = moinfo.aocc_off;
-        boccpi = moinfo.boccpi;
+        const Dimension& boccpi = moinfo.boccpi;
         bocc_off = moinfo.bocc_off;
 
         outfile->Printf("\n    Number of ijk index combinations:\n");
@@ -214,9 +212,9 @@ void count_ijk() {
         outfile->Printf("    Spin Case ABB:                      %14d\n", nijk);
 
         if (params.dertype == 1) {
-            avirtpi = moinfo.avirtpi;
+            const Dimension& avirtpi = moinfo.avirtpi;
             avir_off = moinfo.avir_off;
-            bvirtpi = moinfo.bvirtpi;
+            const Dimension& bvirtpi = moinfo.bvirtpi;
             bvir_off = moinfo.bvir_off;
 
             outfile->Printf("\n    Number of abc index combinations:\n");

--- a/psi4/src/psi4/cc/cctriples/count_ijk.cc
+++ b/psi4/src/psi4/cc/cctriples/count_ijk.cc
@@ -58,7 +58,7 @@ void count_ijk() {
         occ_off = moinfo.occ_off;
         nijk = 0;
         {
-            const Dimension& occpi = moinfo.occpi;
+            const auto& occpi = moinfo.occpi;
             for (Gi = 0; Gi < nirreps; Gi++) {
                 for (Gj = 0; Gj < nirreps; Gj++) {
                     for (Gk = 0; Gk < nirreps; Gk++) {
@@ -84,7 +84,7 @@ void count_ijk() {
         outfile->Printf("\n    Number of ijk index combinations:   %14d\n", nijk);
 
         if (params.dertype == 1) {
-            const Dimension& virtpi = moinfo.virtpi;
+            const auto& virtpi = moinfo.virtpi;
             vir_off = moinfo.vir_off;
             nabc = 0;
             for (Ga = 0; Ga < nirreps; ++Ga) {
@@ -104,9 +104,9 @@ void count_ijk() {
         }  // dertype==1
 
     } else if (params.ref == 2) { /** UHF **/
-        const Dimension& aoccpi = moinfo.aoccpi;
+        const auto& aoccpi = moinfo.aoccpi;
         aocc_off = moinfo.aocc_off;
-        const Dimension& boccpi = moinfo.boccpi;
+        const auto& boccpi = moinfo.boccpi;
         bocc_off = moinfo.bocc_off;
 
         outfile->Printf("\n    Number of ijk index combinations:\n");
@@ -212,9 +212,9 @@ void count_ijk() {
         outfile->Printf("    Spin Case ABB:                      %14d\n", nijk);
 
         if (params.dertype == 1) {
-            const Dimension& avirtpi = moinfo.avirtpi;
+            const auto& avirtpi = moinfo.avirtpi;
             avir_off = moinfo.avir_off;
-            const Dimension& bvirtpi = moinfo.bvirtpi;
+            const auto& bvirtpi = moinfo.bvirtpi;
             bvir_off = moinfo.bvir_off;
 
             outfile->Printf("\n    Number of abc index combinations:\n");


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
PR #3356 introduced local mutable copies of the `moinfo.occpi`,  `moinfo.virtpi` obejcts and their open-shell counterparts into cctriples/count_ijk
This PR provides a better solution via `const&`.
## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] No user-facing changes

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Replace declaring mutable dimension objects unconditionally and assigning them if needed, with `const&` in the smallest scope they are needed in. This restores the lack of copying before PR #3356.

## Checklist
- [x] No new features
- [x] CI tests are passing

## Status
- [x] Ready for review
- [x] Ready for merge
