### PR TITLE
Throw if Qmn_ is nullptr in DiskDFJK (in-core mode)

### DIFF
--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -1661,6 +1661,9 @@ void DiskDFJK::rebuild_wK_disk() {
     // No need to close
 }
 void DiskDFJK::manage_JK_core() {
+    if (!Qmn_ || Qmn_.use_count() == 0)
+        throw PSIEXCEPTION(
+            "DiskDFJK(in-core mode) tried to manage_JK_core with a Qmn_ that does not point to a Matrix object!");
     for (int Q = 0; Q < auxiliary_->nbf(); Q += max_rows_) {
         int naux = (auxiliary_->nbf() - Q <= max_rows_ ? auxiliary_->nbf() - Q : max_rows_);
         if (do_J_) {

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -504,6 +504,7 @@ void DiskDFJK::compute_JK() {
         }
     }
 }
+
 void DiskDFJK::postiterations() {
     Qmn_.reset();
     Qlmn_.reset();

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -469,20 +469,23 @@ void DiskDFJK::preiterations() {
 }
 
 void DiskDFJK::compute_JK() {
-
     // zero out J, K, and wK matrices
     zero();
-
     max_nocc_ = max_nocc();
     max_rows_ = max_rows();
 
     if (do_J_ || do_K_) {
-        if(!Qmn_) throw PSIEXCEPTION("DiskDFJK tried to compute J or K in compute_JK with a Qmn_ that does not point to a Matrix object!");
         initialize_temps();
-        if (is_core_)
+        if (is_core_) {
+            if (!Qmn_ || Qmn_.use_count() == 0) {
+                throw PSIEXCEPTION(
+                    "DiskDFJK(in-core mode) tried to compute J or K in compute_JK with a Qmn_ that does not point to a "
+                    "Matrix object!");
+            }
             manage_JK_core();
-        else
+        } else {
             manage_JK_disk();
+        }
         free_temps();
     }
 

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -477,6 +477,7 @@ void DiskDFJK::compute_JK() {
     max_rows_ = max_rows();
 
     if (do_J_ || do_K_) {
+        if(!Qmn_) throw PSIEXCEPTION("DiskDFJK tried to compute J or K in compute_JK with a Qmn_ that does not point to a Matrix object!");
         initialize_temps();
         if (is_core_)
             manage_JK_core();


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
DiskDFJK and its derived objects have some footguns, and currently improper usage results in segfaults instead of an informative exception. I ran into this with @andyj10224 while working on DLPNO.
This PR does not fix the underlying issue of these objects arguably being a bit unergonomic, but at least the error message will be a bit better than a segfault.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] None, I think?

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `manage_JK_core()` and `compute_JK()` in DiskDFJK now throw if called when the object is in a state where calling these functions would result in a nullptr dereference. (DiskDFJK is in in-core mode, and `Qmn_` is not a valid `shared_ptr` holding a ptr to a `Matrix`)
- [x] This PR also affects classes derived from DiskDFJK that do not override both of these functions, such as CDJK (only overrides  `manage_JK_core()` )

## Checklist
- [x] No new features
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
