### PR TITLE
Dont predicate throw in CDJK on printlevel

### DIFF
--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -145,14 +145,9 @@ void CDJK::manage_JK_core() {
 void CDJK::print_header() const {
     if (print_) {
         outfile->Printf("  ==> CDJK: Cholesky-decomposed J/K Matrices <==\n\n");
-
         outfile->Printf("    J tasked:             %11s\n", (do_J_ ? "Yes" : "No"));
         outfile->Printf("    K tasked:             %11s\n", (do_K_ ? "Yes" : "No"));
         outfile->Printf("    wK tasked:            %11s\n", (do_wK_ ? "Yes" : "No"));
-        if (do_wK_) {
-            throw PsiException("no wk for scf_type cd.", __FILE__, __LINE__);
-            // outfile->Printf( "    Omega:                %11.3E\n", omega_);
-        }
         outfile->Printf("    OpenMP threads:       %11d\n", omp_nthread_);
         outfile->Printf("    Integrals threads:    %11d\n", df_ints_num_threads_);
         outfile->Printf("    Memory [MiB]:         %11ld\n", (memory_ * 8L) / (1024L * 1024L));
@@ -162,5 +157,6 @@ void CDJK::print_header() const {
         outfile->Printf("    Cholesky tolerance:   %11.2E\n", cholesky_tolerance_);
         outfile->Printf("    No. Cholesky vectors: %11li\n\n", ncholesky_);
     }
+    if (do_wK_) throw PsiException("no wk for scf_type cd.", __FILE__, __LINE__);
 }
 }  // namespace psi

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -157,6 +157,6 @@ void CDJK::print_header() const {
         outfile->Printf("    Cholesky tolerance:   %11.2E\n", cholesky_tolerance_);
         outfile->Printf("    No. Cholesky vectors: %11li\n\n", ncholesky_);
     }
-    if (do_wK_) throw PsiException("no wk for scf_type cd.", __FILE__, __LINE__);
+    if (do_wK_) throw PsiException("No wk for scf_type cd.", __FILE__, __LINE__);
 }
 }  // namespace psi


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
I noticed that currently the check that throws in CDJK if it is used with "wK tasked" (which is not supported in CDJK) is disarmed if the CDJK print level is zero. A sanity check like this should not be predicated on a print verbosity setting, this PR makes it unconditional.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Some improper usages of Cholesky decomposition methods in unimplemented ways now throw an error even if the output print verbosity is set to minimal

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Check if `do_wK_ == true` in `CDJK::print_header` and throw even if `CDJK::print_ == 0`

## Checklist
- [x] No new features
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge