### PR TITLE
Adapt for QCFractal v0.65

### DIFF
--- a/psi4/driver/endorsed_plugins.py
+++ b/psi4/driver/endorsed_plugins.py
@@ -63,6 +63,10 @@ try:
     import adcc
 except ImportError:
     pass
+except Exception:
+    # Some adcc versions evaluate sys.stdout at import time and can fail in
+    # redirected/headless worker contexts (e.g., QCFractal compute workers).
+    pass
 
 try:
     import psi4fockci

--- a/psi4/driver/endorsed_plugins.py
+++ b/psi4/driver/endorsed_plugins.py
@@ -63,10 +63,14 @@ try:
     import adcc
 except ImportError:
     pass
-except Exception:
-    # Some adcc versions evaluate sys.stdout at import time and can fail in
-    # redirected/headless worker contexts (e.g., QCFractal compute workers).
-    pass
+except AttributeError as e:
+    if "'NoneType' object has no attribute 'isatty'" in str(e):
+        # Some adcc versions evaluate sys.stdout at import time and can fail in
+        # redirected/headless worker contexts (e.g., QCFractal compute workers).
+        # (originates from adcc/timings.py default arg evaluation during import adcc)
+        pass
+    else:
+        raise
 
 try:
     import psi4fockci


### PR DESCRIPTION
## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Not sure the exact mechanism of difference between qcfractal 0.64 and 0.65 (since I can see this error with psi4 src fixed, adcc pkg fixed, and qcel/qcng fixed ~0.50), but importing adcc under certain circumstances (snowflake) fails, causing the qcengine records to return as errors and the psi4 logic to fail.
- AI suggested some better error handling but going to defer that to #3034 . For now, just want to get CI working again.

## Status
- [x] Ready for review
- [x] Ready for merge
