### PR TITLE
libiwl: phase 1 modernization (collapse dup, overflow check, RAII)

### DIFF
--- a/psi4/src/psi4/libiwl/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/CMakeLists.txt
@@ -11,3 +11,12 @@ list(APPEND sources
   wrtone.cc
   )
 psi4_add_module(lib iwl sources)
+
+# test/ contains a standalone round-trip exerciser (iwl_roundtrip_test.cc)
+# that covers the bucket-boundary cases the 1995 README warned about. It is
+# not built by default because libpsio's static lib is not standalone --
+# PSIO::close references libdpd's `global_dpd_`, and libpsi4util's Options
+# system pulls in further hosting-context globals (`psi_file_prefix`,
+# `restart_id`) normally provided by the core python bindings TU. Re-enable
+# once a proper unit-test harness with stubs / gtest infra lands.
+# add_subdirectory(test)

--- a/psi4/src/psi4/libiwl/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/CMakeLists.txt
@@ -12,11 +12,8 @@ list(APPEND sources
   )
 psi4_add_module(lib iwl sources)
 
-# test/ contains a standalone round-trip exerciser (iwl_roundtrip_test.cc)
-# that covers the bucket-boundary cases the 1995 README warned about. It is
-# not built by default because libpsio's static lib is not standalone --
-# PSIO::close references libdpd's `global_dpd_`, and libpsi4util's Options
-# system pulls in further hosting-context globals (`psi_file_prefix`,
-# `restart_id`) normally provided by the core python bindings TU. Re-enable
-# once a proper unit-test harness with stubs / gtest infra lands.
-# add_subdirectory(test)
+# test/ contains a standalone round-trip exerciser (iwl_roundtrip_test.cc).
+# It links against the libiwl/libpsio/libpsi4util/liboptions/libciomr static
+# archives plus a tiny stubs TU (test/stubs.cc) that supplies the runtime
+# globals normally provided by core.cc / libdpd.
+add_subdirectory(test)

--- a/psi4/src/psi4/libiwl/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/CMakeLists.txt
@@ -15,10 +15,15 @@ psi4_add_module(lib iwl sources)
 # test/ contains a standalone round-trip exerciser (iwl_roundtrip_test.cc).
 # It links against the libiwl/libpsio/libpsi4util/liboptions/libciomr static
 # archives plus a tiny stubs TU (test/stubs.cc) that supplies the runtime
-# globals normally provided by core.cc / libdpd. That curated link resolves
-# with GNU/Clang on Linux/macOS but not with Windows lld-link (the unity/PCH
-# build pulls in extra symbol references the link line lacks), so restrict it
-# to non-Windows rather than drag in the full dependency closure.
+# globals normally provided by core.cc / libdpd. That curated link resolves with
+# GNU/Clang on Linux/macOS but not with clang-cl/lld-link, which emits inline and
+# implicit functions that GCC discards as unused, so the Windows objects carry
+# undefined references the link line does not provide: psio.lib wants
+# DPDMOSpace::~DPDMOSpace (instantiated by std::vector<DPDMOSpace> in dpd.h), and
+# psi4util.lib wants Molecule::Molecule(const Molecule&) (from inline
+# Molecule::clone) and ExternalPotential::print (from inline py_print). Not a
+# unity or PCH artifact -- Linux is unity-built too, and Azure Windows builds with
+# PCH off. Restrict the test to non-Windows rather than drag in the full closure.
 if(NOT WIN32)
     add_subdirectory(test)
 endif()

--- a/psi4/src/psi4/libiwl/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/CMakeLists.txt
@@ -15,5 +15,10 @@ psi4_add_module(lib iwl sources)
 # test/ contains a standalone round-trip exerciser (iwl_roundtrip_test.cc).
 # It links against the libiwl/libpsio/libpsi4util/liboptions/libciomr static
 # archives plus a tiny stubs TU (test/stubs.cc) that supplies the runtime
-# globals normally provided by core.cc / libdpd.
-add_subdirectory(test)
+# globals normally provided by core.cc / libdpd. That curated link resolves
+# with GNU/Clang on Linux/macOS but not with Windows lld-link (the unity/PCH
+# build pulls in extra symbol references the link line lacks), so restrict it
+# to non-Windows rather than drag in the full dependency closure.
+if(NOT WIN32)
+    add_subdirectory(test)
+endif()

--- a/psi4/src/psi4/libiwl/buf_close.cc
+++ b/psi4/src/psi4/libiwl/buf_close.cc
@@ -32,9 +32,8 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
-#include <cstdlib>
 #include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
 #include "iwl.h"
 #include "iwl.hpp"
 
@@ -44,8 +43,8 @@ IWL::~IWL() { close(); }
 
 void IWL::close() {
     if (psio_ != nullptr && psio_->open_check(itap_)) psio_->close(itap_, keep_);
-    if (labels_) delete[](labels_);
-    if (values_) delete[](values_);
+    delete[] labels_;
+    delete[] values_;
     labels_ = nullptr;
     values_ = nullptr;
 }
@@ -61,7 +60,9 @@ void IWL::close() {
 */
 void PSI_API iwl_buf_close(struct iwlbuf *Buf, int keep) {
     psio_close(Buf->itap, keep ? 1 : 0);
-    free(Buf->labels);
-    free(Buf->values);
+    delete[] Buf->labels;
+    delete[] Buf->values;
+    Buf->labels = nullptr;
+    Buf->values = nullptr;
 }
 }

--- a/psi4/src/psi4/libiwl/buf_fetch.cc
+++ b/psi4/src/psi4/libiwl/buf_fetch.cc
@@ -30,20 +30,29 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
 #include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
 #include "iwl.h"
 #include "iwl.hpp"
 
 namespace psi {
 
-void IWL::fetch() {
-    psio_->read(itap_, IWL_KEY_BUF, (char *)&(lastbuf_), sizeof(int), bufpos_, &bufpos_);
-    psio_->read(itap_, IWL_KEY_BUF, (char *)&(inbuf_), sizeof(int), bufpos_, &bufpos_);
-    psio_->read(itap_, IWL_KEY_BUF, (char *)labels_, ints_per_buf_ * 4 * sizeof(Label), bufpos_, &bufpos_);
-    psio_->read(itap_, IWL_KEY_BUF, (char *)values_, ints_per_buf_ * sizeof(Value), bufpos_, &bufpos_);
-    idx_ = 0;
+namespace {
+
+// Single source of truth for the bucket read sequence. Both the C-style and
+// C++ APIs go through here.
+void fetch_bucket(PSIO *psio, int itap, psio_address &bufpos, int &lastbuf, int &inbuf, Label *labels, Value *values,
+                  int ints_per_buf, int &idx) {
+    psio->read(itap, IWL_KEY_BUF, reinterpret_cast<char *>(&lastbuf), sizeof(int), bufpos, &bufpos);
+    psio->read(itap, IWL_KEY_BUF, reinterpret_cast<char *>(&inbuf), sizeof(int), bufpos, &bufpos);
+    psio->read(itap, IWL_KEY_BUF, reinterpret_cast<char *>(labels), ints_per_buf * 4 * sizeof(Label), bufpos, &bufpos);
+    psio->read(itap, IWL_KEY_BUF, reinterpret_cast<char *>(values), ints_per_buf * sizeof(Value), bufpos, &bufpos);
+    idx = 0;
 }
+
+}  // namespace
+
+void IWL::fetch() { fetch_bucket(psio_, itap_, bufpos_, lastbuf_, inbuf_, labels_, values_, ints_per_buf_, idx_); }
 
 /*!
 ** iwl_buf_fetch()
@@ -53,12 +62,7 @@ void IWL::fetch() {
 ** \ingroup IWL
 */
 void PSI_API iwl_buf_fetch(struct iwlbuf *Buf) {
-    psio_read(Buf->itap, IWL_KEY_BUF, (char *)&(Buf->lastbuf), sizeof(int), Buf->bufpos, &Buf->bufpos);
-    psio_read(Buf->itap, IWL_KEY_BUF, (char *)&(Buf->inbuf), sizeof(int), Buf->bufpos, &Buf->bufpos);
-    psio_read(Buf->itap, IWL_KEY_BUF, (char *)Buf->labels, Buf->ints_per_buf * 4 * sizeof(Label), Buf->bufpos,
-              &Buf->bufpos);
-    psio_read(Buf->itap, IWL_KEY_BUF, (char *)Buf->values, Buf->ints_per_buf * sizeof(Value), Buf->bufpos,
-              &Buf->bufpos);
-    Buf->idx = 0;
+    fetch_bucket(_default_psio_lib_.get(), Buf->itap, Buf->bufpos, Buf->lastbuf, Buf->inbuf, Buf->labels, Buf->values,
+                 Buf->ints_per_buf, Buf->idx);
 }
 }

--- a/psi4/src/psi4/libiwl/buf_flush.cc
+++ b/psi4/src/psi4/libiwl/buf_flush.cc
@@ -30,38 +30,33 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
-#include "psi4/libciomr/libciomr.h"
 #include "iwl.h"
 #include "iwl.hpp"
 
 namespace psi {
 
-void IWL::flush(int lastbuf) {
-    int idx;
-    Label *lblptr;
-    Value *valptr;
+namespace {
 
-    inbuf_ = idx_;
-    lblptr = labels_;
-    valptr = values_;
-
-    idx = 4 * idx_;
-
-    while (idx_ < ints_per_buf_) {
-        lblptr[idx++] = 0;
-        lblptr[idx++] = 0;
-        lblptr[idx++] = 0;
-        lblptr[idx++] = 0;
-        valptr[idx_] = 0.0;
-        idx_++;
+// Zero-fill the tail of a partially-filled bucket so that on-disk consumers
+// always read a well-defined bucket layout, then mark it written.
+void zero_fill_tail(Label *labels, Value *values, int &idx, int ints_per_buf, int lastbuf_flag,
+                    int &inbuf_out, int &lastbuf_out) {
+    inbuf_out = idx;
+    for (int i = idx; i < ints_per_buf; ++i) {
+        labels[4 * i + 0] = 0;
+        labels[4 * i + 1] = 0;
+        labels[4 * i + 2] = 0;
+        labels[4 * i + 3] = 0;
+        values[i] = 0.0;
     }
+    idx = ints_per_buf;
+    lastbuf_out = lastbuf_flag ? 1 : 0;
+}
 
-    if (lastbuf)
-        lastbuf_ = 1;
-    else
-        lastbuf_ = 0;
+}  // namespace
 
+void IWL::flush(int lastbuf) {
+    zero_fill_tail(labels_, values_, idx_, ints_per_buf_, lastbuf, inbuf_, lastbuf_);
     put();
     idx_ = 0;
 }
@@ -78,30 +73,7 @@ void IWL::flush(int lastbuf) {
 ** \ingroup IWL
 */
 void iwl_buf_flush(struct iwlbuf *Buf, int lastbuf) {
-    int idx;
-    Label *lblptr;
-    Value *valptr;
-
-    Buf->inbuf = Buf->idx;
-    lblptr = Buf->labels;
-    valptr = Buf->values;
-
-    idx = 4 * Buf->idx;
-
-    while (Buf->idx < Buf->ints_per_buf) {
-        lblptr[idx++] = 0;
-        lblptr[idx++] = 0;
-        lblptr[idx++] = 0;
-        lblptr[idx++] = 0;
-        valptr[Buf->idx] = 0.0;
-        Buf->idx++;
-    }
-
-    if (lastbuf)
-        Buf->lastbuf = 1;
-    else
-        Buf->lastbuf = 0;
-
+    zero_fill_tail(Buf->labels, Buf->values, Buf->idx, Buf->ints_per_buf, lastbuf, Buf->inbuf, Buf->lastbuf);
     iwl_buf_put(Buf);
     Buf->idx = 0;
 }

--- a/psi4/src/psi4/libiwl/buf_init.cc
+++ b/psi4/src/psi4/libiwl/buf_init.cc
@@ -33,59 +33,71 @@
 #include <cstdio>
 #include <cstdlib>
 #include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
 #include "iwl.h"
 #include "iwl.hpp"
-#include "psi4/psi4-dec.h"  //need outfile
+#include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
+#include "psi4/libpsi4util/exception.h"
 
 namespace psi {
 
-IWL::IWL() : psio_{nullptr}, labels_{nullptr}, values_{nullptr} {
-    /*! set up buffer info */
-    itap_ = -1;
-    bufpos_ = PSIO_ZERO;
-    ints_per_buf_ = IWL_INTS_PER_BUF;
-    cutoff_ = 1.e-14;
-    bufszc_ = 2 * sizeof(int) + ints_per_buf_ * 4 * sizeof(Label) + ints_per_buf_ * sizeof(Value);
-    lastbuf_ = 0;
-    inbuf_ = 0;
-    idx_ = 0;
+namespace {
+
+// Constant on-disk bucket size in bytes. Matches the layout written by
+// buf_put.cc / read by buf_fetch.cc.
+inline int bucket_bytes(int ints_per_buf) {
+    return 2 * static_cast<int>(sizeof(int)) + ints_per_buf * 4 * static_cast<int>(sizeof(Label)) +
+           ints_per_buf * static_cast<int>(sizeof(Value));
 }
 
-IWL::IWL(PSIO *psio, int it, double coff, int oldfile, int readflag) : keep_(true) {
-    init(psio, it, coff, oldfile, readflag);
+// Open the underlying psio file for an IWL buffer and verify it has the
+// expected TOC entry when reopening an existing file. Throws on failure
+// instead of leaving the buffer in a half-initialized state.
+void open_iwl_unit(PSIO *psio, int itap, bool oldfile) {
+    psio->open(itap, oldfile ? PSIO_OPEN_OLD : PSIO_OPEN_NEW);
+    if (oldfile && psio->tocscan(itap, IWL_KEY_BUF) == nullptr) {
+        psio->close(itap, 0);
+        throw PSIEXCEPTION("iwl_buf_init: file " + std::to_string(itap) +
+                           " does not contain an IWL buffer (TOC key '" + IWL_KEY_BUF + "' missing)");
+    }
 }
+
+}  // namespace
+
+IWL::IWL()
+    : itap_(-1),
+      bufpos_(PSIO_ZERO),
+      ints_per_buf_(IWL_INTS_PER_BUF),
+      bufszc_(bucket_bytes(IWL_INTS_PER_BUF)),
+      cutoff_(1.e-14),
+      lastbuf_(0),
+      inbuf_(0),
+      idx_(0),
+      labels_(nullptr),
+      values_(nullptr),
+      psio_(nullptr),
+      keep_(true) {}
+
+IWL::IWL(PSIO *psio, int it, double coff, int oldfile, int readflag) : IWL() { init(psio, it, coff, oldfile, readflag); }
 
 void IWL::init(PSIO *psio, int it, double coff, int oldfile, int readflag) {
     psio_ = psio;
-
-    /*! set up buffer info */
     itap_ = it;
     bufpos_ = PSIO_ZERO;
     ints_per_buf_ = IWL_INTS_PER_BUF;
     cutoff_ = coff;
-    bufszc_ = 2 * sizeof(int) + ints_per_buf_ * 4 * sizeof(Label) + ints_per_buf_ * sizeof(Value);
+    bufszc_ = bucket_bytes(ints_per_buf_);
     lastbuf_ = 0;
     inbuf_ = 0;
     idx_ = 0;
 
-    /*! make room in the buffer */
-    // labels_ = (Label *) malloc (4 * ints_per_buf_ * sizeof(Label));
-    // values_ = (Value *) malloc (ints_per_buf_ * sizeof(Value));
     labels_ = new Label[4 * ints_per_buf_];
     values_ = new Value[ints_per_buf_];
 
-    /*! open the output file */
-    /*! Note that we assume that if oldfile isn't set, we O_CREAT the file */
-    psio_->open(itap_, oldfile ? PSIO_OPEN_OLD : PSIO_OPEN_NEW);
-    if (oldfile && (psio_->tocscan(itap_, IWL_KEY_BUF) == nullptr)) {
-        outfile->Printf("iwl_buf_init: Can't open file %d\n", itap_);
-        psio_->close(itap_, 0);
-        return;
-    }
+    open_iwl_unit(psio_, itap_, oldfile != 0);
 
-    /*! go ahead and read a buffer */
     if (readflag) fetch();
 }
 
@@ -108,30 +120,20 @@ void IWL::init(PSIO *psio, int it, double coff, int oldfile, int readflag) {
 ** \ingroup IWL
 */
 void PSI_API iwl_buf_init(struct iwlbuf *Buf, int itape, double cutoff, int oldfile, int readflag) {
-    /*! set up buffer info */
     Buf->itap = itape;
     Buf->bufpos = PSIO_ZERO;
     Buf->ints_per_buf = IWL_INTS_PER_BUF;
     Buf->cutoff = cutoff;
-    Buf->bufszc = 2 * sizeof(int) + Buf->ints_per_buf * 4 * sizeof(Label) + Buf->ints_per_buf * sizeof(Value);
+    Buf->bufszc = bucket_bytes(Buf->ints_per_buf);
     Buf->lastbuf = 0;
     Buf->inbuf = 0;
     Buf->idx = 0;
 
-    /*! make room in the buffer */
-    Buf->labels = (Label *)malloc(4 * Buf->ints_per_buf * sizeof(Label));
-    Buf->values = (Value *)malloc(Buf->ints_per_buf * sizeof(Value));
+    Buf->labels = new Label[4 * Buf->ints_per_buf];
+    Buf->values = new Value[Buf->ints_per_buf];
 
-    /*! open the output file */
-    /*! Note that we assume that if oldfile isn't set, we O_CREAT the file */
-    psio_open(Buf->itap, oldfile ? PSIO_OPEN_OLD : PSIO_OPEN_NEW);
-    if (oldfile && (psio_tocscan(Buf->itap, IWL_KEY_BUF) == nullptr)) {
-        outfile->Printf("iwl_buf_init: Can't open file %d\n", Buf->itap);
-        psio_close(Buf->itap, 0);
-        return;
-    }
+    open_iwl_unit(_default_psio_lib_.get(), Buf->itap, oldfile != 0);
 
-    /*! go ahead and read a buffer */
     if (readflag) iwl_buf_fetch(Buf);
 }
 }

--- a/psi4/src/psi4/libiwl/buf_put.cc
+++ b/psi4/src/psi4/libiwl/buf_put.cc
@@ -30,18 +30,29 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
 #include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
 #include "iwl.h"
 #include "iwl.hpp"
 
 namespace psi {
 
+namespace {
+
+void put_bucket(PSIO *psio, int itap, psio_address &bufpos, int lastbuf, int inbuf, const Label *labels,
+                const Value *values, int ints_per_buf) {
+    psio->write(itap, IWL_KEY_BUF, reinterpret_cast<char *>(const_cast<int *>(&lastbuf)), sizeof(int), bufpos, &bufpos);
+    psio->write(itap, IWL_KEY_BUF, reinterpret_cast<char *>(const_cast<int *>(&inbuf)), sizeof(int), bufpos, &bufpos);
+    psio->write(itap, IWL_KEY_BUF, reinterpret_cast<char *>(const_cast<Label *>(labels)),
+                ints_per_buf * 4 * sizeof(Label), bufpos, &bufpos);
+    psio->write(itap, IWL_KEY_BUF, reinterpret_cast<char *>(const_cast<Value *>(values)), ints_per_buf * sizeof(Value),
+                bufpos, &bufpos);
+}
+
+}  // namespace
+
 void IWL::put() {
-    psio_->write(itap_, IWL_KEY_BUF, (char *)&(lastbuf_), sizeof(int), bufpos_, &(bufpos_));
-    psio_->write(itap_, IWL_KEY_BUF, (char *)&(inbuf_), sizeof(int), bufpos_, &(bufpos_));
-    psio_->write(itap_, IWL_KEY_BUF, (char *)labels_, ints_per_buf_ * 4 * sizeof(Label), bufpos_, &(bufpos_));
-    psio_->write(itap_, IWL_KEY_BUF, (char *)values_, ints_per_buf_ * sizeof(Value), bufpos_, &(bufpos_));
+    put_bucket(psio_, itap_, bufpos_, lastbuf_, inbuf_, labels_, values_, ints_per_buf_);
 }
 
 /*!
@@ -52,11 +63,7 @@ void IWL::put() {
 ** \ingroup IWL
 */
 void iwl_buf_put(struct iwlbuf *Buf) {
-    psio_write(Buf->itap, IWL_KEY_BUF, (char *)&(Buf->lastbuf), sizeof(int), Buf->bufpos, &(Buf->bufpos));
-    psio_write(Buf->itap, IWL_KEY_BUF, (char *)&(Buf->inbuf), sizeof(int), Buf->bufpos, &(Buf->bufpos));
-    psio_write(Buf->itap, IWL_KEY_BUF, (char *)Buf->labels, Buf->ints_per_buf * 4 * sizeof(Label), Buf->bufpos,
-               &(Buf->bufpos));
-    psio_write(Buf->itap, IWL_KEY_BUF, (char *)Buf->values, Buf->ints_per_buf * sizeof(Value), Buf->bufpos,
-               &(Buf->bufpos));
+    put_bucket(_default_psio_lib_.get(), Buf->itap, Buf->bufpos, Buf->lastbuf, Buf->inbuf, Buf->labels, Buf->values,
+               Buf->ints_per_buf);
 }
 }

--- a/psi4/src/psi4/libiwl/buf_wrt.cc
+++ b/psi4/src/psi4/libiwl/buf_wrt.cc
@@ -30,13 +30,15 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
 #include <cmath>
-#include "psi4/libciomr/libciomr.h"
+#include <memory>
 #include "iwl.h"
 #include "iwl.hpp"
-#include "psi4/libpsi4util/PsiOutStream.h"
+#include "iwl_impl.h"
+
 namespace psi {
+
+using iwl_impl::check_label_fits;
 
 /*!
 ** iwl_buf_wrt()
@@ -52,45 +54,39 @@ namespace psi {
 */
 void IWL::write(int p, int q, int pq, int pqsym, double *arr, int rmax, int *ioff, int *orbsym, int *firsti, int *lasti,
                 int printflag, std::string out) {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>((out)));
-    int r, s, rs, rsym, ssym, smax, idx;
-    double value;
-    Label *lblptr;
-    Value *valptr;
+    std::shared_ptr<PsiOutStream> printer = printflag ? ((out == "outfile") ? outfile : std::make_shared<PsiOutStream>(out))
+                                                      : nullptr;
 
-    lblptr = labels_;
-    valptr = values_;
+    for (int r = 0; r < rmax; r++) {
+        int rsym = orbsym[r];
+        int ssym = pqsym ^ rsym;
+        int smax = (rsym == ssym) ? r : lasti[ssym];
 
-    for (r = 0; r < rmax; r++) {
-        rsym = orbsym[r];
-        ssym = pqsym ^ rsym;
-        smax = (rsym == ssym) ? r : lasti[ssym];
+        for (int s = firsti[ssym]; s <= smax; s++) {
+            int rs = ioff[r] + s;
+            double value = arr[rs];
 
-        for (s = firsti[ssym]; s <= smax; s++) {
-            rs = ioff[r] + s;
-            value = arr[rs];
+            if (std::fabs(value) <= cutoff_) continue;
+            check_label_fits(p, q, r, s);
 
-            if (std::fabs(value) > cutoff_) {
-                idx = 4 * idx_;
-                lblptr[idx] = (Label)p;
-                lblptr[idx + 1] = (Label)q;
-                lblptr[idx + 2] = (Label)r;
-                lblptr[idx + 3] = (Label)s;
-                valptr[idx_] = (Value)value;
+            int idx = 4 * idx_;
+            labels_[idx + 0] = static_cast<Label>(p);
+            labels_[idx + 1] = static_cast<Label>(q);
+            labels_[idx + 2] = static_cast<Label>(r);
+            labels_[idx + 3] = static_cast<Label>(s);
+            values_[idx_] = static_cast<Value>(value);
 
-                idx_++;
+            idx_++;
 
-                if (idx_ == ints_per_buf_) {
-                    inbuf_ = idx_;
-                    lastbuf_ = 0;
-                    put();
-                    idx_ = 0;
-                }
+            if (idx_ == ints_per_buf_) {
+                inbuf_ = idx_;
+                lastbuf_ = 0;
+                put();
+                idx_ = 0;
+            }
 
-                if (printflag) printer->Printf("<%d %d %d %d [%d] [%d] = %20.10f\n", p, q, r, s, pq, rs, value);
-
-            } /* end if (fabs(value) > Buf->cutoff) ... */
-        }     /* end loop over s */
-    }         /* end loop over r */
+            if (printflag) printer->Printf("<%d %d %d %d [%d] [%d] = %20.10f\n", p, q, r, s, pq, rs, value);
+        }
+    }
 }
 }

--- a/psi4/src/psi4/libiwl/buf_wrt_mat.cc
+++ b/psi4/src/psi4/libiwl/buf_wrt_mat.cc
@@ -30,17 +30,24 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
 #include <cmath>
-#include "psi4/libciomr/libciomr.h"
+#include <memory>
+#include <algorithm>
 #include "iwl.h"
 #include "iwl.hpp"
-#include "psi4/libpsi4util/PsiOutStream.h"
+#include "iwl_impl.h"
+
 namespace psi {
 
-#define MAX0(a, b) (((a) > (b)) ? (a) : (b))
-#define MIN0(a, b) (((a) < (b)) ? (a) : (b))
-#define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
+using iwl_impl::check_label_fits;
+
+namespace {
+
+inline int packed_index(int i, int j, const int *ioff) {
+    return (i > j) ? (ioff[i] + j) : (ioff[j] + i);
+}
+
+}  // namespace
 
 /*!
 ** iwl_buf_wrt_mat()
@@ -72,49 +79,46 @@ namespace psi {
 */
 void IWL::write_matrix(int ptr, int qtr, double **mat, int rfirst, int rlast, int sfirst, int slast, int *reorder,
                        int reorder_offset, int printflag, int *ioff, std::string out) {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    int idx, r, s, R, S, rtr, str;
-    int ij, kl;
-    double value;
-    Label *lblptr;
-    Value *valptr;
+    std::shared_ptr<PsiOutStream> printer = printflag ? ((out == "outfile") ? outfile : std::make_shared<PsiOutStream>(out))
+                                                      : nullptr;
 
-    lblptr = labels_;
-    valptr = values_;
+    const int ij = packed_index(ptr, qtr, ioff);
 
-    ij = INDEX(ptr, qtr);
+    for (int r = rfirst, R = 0; r <= rlast; r++, R++) {
+        const int rtr = reorder[r] - reorder_offset;
 
-    for (r = rfirst, R = 0; r <= rlast; r++, R++) {
-        rtr = reorder[r] - reorder_offset;
+        for (int s = sfirst, S = 0; s <= slast && s <= r; s++, S++) {
+            const int str = reorder[s] - reorder_offset;
+            const int kl = packed_index(rtr, str, ioff);
+            const double value = mat[R][S];
 
-        for (s = sfirst, S = 0; s <= slast && s <= r; s++, S++) {
-            str = reorder[s] - reorder_offset;
+            if (ij < kl) continue;
+            if (std::fabs(value) <= cutoff_) continue;
 
-            kl = INDEX(rtr, str);
+            const int p_out = std::max(ptr, qtr);
+            const int q_out = std::min(ptr, qtr);
+            const int r_out = std::max(rtr, str);
+            const int s_out = std::min(rtr, str);
+            check_label_fits(p_out, q_out, r_out, s_out);
 
-            value = mat[R][S];
+            int idx = 4 * idx_;
+            labels_[idx + 0] = static_cast<Label>(p_out);
+            labels_[idx + 1] = static_cast<Label>(q_out);
+            labels_[idx + 2] = static_cast<Label>(r_out);
+            labels_[idx + 3] = static_cast<Label>(s_out);
+            values_[idx_] = static_cast<Value>(value);
 
-            if (ij >= kl && std::fabs(value) > cutoff_) {
-                idx = 4 * idx_;
-                lblptr[idx++] = (Label)MAX0(ptr, qtr);
-                lblptr[idx++] = (Label)MIN0(ptr, qtr);
-                lblptr[idx++] = (Label)MAX0(rtr, str);
-                lblptr[idx++] = (Label)MIN0(rtr, str);
-                valptr[idx_] = (Value)value;
+            idx_++;
 
-                idx_++;
+            if (idx_ == ints_per_buf_) {
+                lastbuf_ = 0;
+                inbuf_ = idx_;
+                put();
+                idx_ = 0;
+            }
 
-                if (idx_ == ints_per_buf_) {
-                    lastbuf_ = 0;
-                    inbuf_ = idx_;
-                    put();
-                    idx_ = 0;
-                }
-
-                if (printflag) printer->Printf(">%d %d %d %d [%d] [%d] = %20.10f\n", ptr, qtr, rtr, str, ij, kl, value);
-
-            } /* end if (std::fabs(value) > Buf->cutoff) ... */
-        }     /* end loop over s */
-    }         /* end loop over r */
+            if (printflag) printer->Printf(">%d %d %d %d [%d] [%d] = %20.10f\n", ptr, qtr, rtr, str, ij, kl, value);
+        }
+    }
 }
 }

--- a/psi4/src/psi4/libiwl/buf_wrt_val.cc
+++ b/psi4/src/psi4/libiwl/buf_wrt_val.cc
@@ -30,55 +30,48 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
 #include <cmath>
-#include "psi4/libciomr/libciomr.h"
 #include "iwl.h"
 #include "iwl.hpp"
-#include "psi4/libpsi4util/PsiOutStream.h"
+#include "iwl_impl.h"
+
 namespace psi {
 
+using iwl_impl::check_label_fits;
+using iwl_impl::make_printer;
+
 void IWL::write_value(int p, int q, int r, int s, double value, int printflag, std::string out, int dirac) {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
+    if (std::fabs(value) <= cutoff_) return;
+    check_label_fits(p, q, r, s);
 
-    int idx;
-    Label *lblptr;
-    Value *valptr;
+    int idx = 4 * idx_;
+    if (dirac) {
+        labels_[idx++] = static_cast<Label>(p);
+        labels_[idx++] = static_cast<Label>(r);
+        labels_[idx++] = static_cast<Label>(q);
+        labels_[idx++] = static_cast<Label>(s);
+    } else {
+        labels_[idx++] = static_cast<Label>(p);
+        labels_[idx++] = static_cast<Label>(q);
+        labels_[idx++] = static_cast<Label>(r);
+        labels_[idx++] = static_cast<Label>(s);
+    }
+    values_[idx_] = static_cast<Value>(value);
+    idx_++;
 
-    lblptr = labels_;
-    valptr = values_;
+    if (idx_ == ints_per_buf_) {
+        lastbuf_ = 0;
+        inbuf_ = idx_;
+        put();
+        idx_ = 0;
+    }
 
-    if (std::fabs(value) > cutoff_) {
-        idx = 4 * idx_;
-        if (dirac) {
-            lblptr[idx++] = (Label)p;
-            lblptr[idx++] = (Label)r;
-            lblptr[idx++] = (Label)q;
-            lblptr[idx++] = (Label)s;
-        } else {
-            lblptr[idx++] = (Label)p;
-            lblptr[idx++] = (Label)q;
-            lblptr[idx++] = (Label)r;
-            lblptr[idx++] = (Label)s;
-        }
-        valptr[idx_] = (Value)value;
-
-        idx_++;
-
-        if (idx_ == ints_per_buf_) {
-            lastbuf_ = 0;
-            inbuf_ = idx_;
-            put();
-            idx_ = 0;
-        }
-
-        if (printflag) {
-            if (dirac) {
-                printer->Printf(">%d %d %d %d = %20.10f\n", p, r, q, s, value);
-            } else {
-                printer->Printf(">%d %d %d %d = %20.10f\n", p, q, r, s, value);
-            }
-        }
+    if (printflag) {
+        auto printer = make_printer(out);
+        if (dirac)
+            printer->Printf(">%d %d %d %d = %20.10f\n", p, r, q, s, value);
+        else
+            printer->Printf(">%d %d %d %d = %20.10f\n", p, q, r, s, value);
     }
 }
 
@@ -100,45 +93,37 @@ void IWL::write_value(int p, int q, int r, int s, double value, int printflag, s
 */
 void iwl_buf_wrt_val(struct iwlbuf *Buf, int p, int q, int r, int s, double value, int printflag, std::string out,
                      int dirac) {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    int idx;
-    Label *lblptr;
-    Value *valptr;
+    if (std::fabs(value) <= Buf->cutoff) return;
+    check_label_fits(p, q, r, s);
 
-    lblptr = Buf->labels;
-    valptr = Buf->values;
+    int idx = 4 * Buf->idx;
+    if (dirac) {
+        Buf->labels[idx++] = static_cast<Label>(p);
+        Buf->labels[idx++] = static_cast<Label>(r);
+        Buf->labels[idx++] = static_cast<Label>(q);
+        Buf->labels[idx++] = static_cast<Label>(s);
+    } else {
+        Buf->labels[idx++] = static_cast<Label>(p);
+        Buf->labels[idx++] = static_cast<Label>(q);
+        Buf->labels[idx++] = static_cast<Label>(r);
+        Buf->labels[idx++] = static_cast<Label>(s);
+    }
+    Buf->values[Buf->idx] = static_cast<Value>(value);
+    Buf->idx++;
 
-    if (std::fabs(value) > Buf->cutoff) {
-        idx = 4 * Buf->idx;
-        if (dirac) {
-            lblptr[idx++] = (Label)p;
-            lblptr[idx++] = (Label)r;
-            lblptr[idx++] = (Label)q;
-            lblptr[idx++] = (Label)s;
-        } else {
-            lblptr[idx++] = (Label)p;
-            lblptr[idx++] = (Label)q;
-            lblptr[idx++] = (Label)r;
-            lblptr[idx++] = (Label)s;
-        }
-        valptr[Buf->idx] = (Value)value;
+    if (Buf->idx == Buf->ints_per_buf) {
+        Buf->lastbuf = 0;
+        Buf->inbuf = Buf->idx;
+        iwl_buf_put(Buf);
+        Buf->idx = 0;
+    }
 
-        Buf->idx++;
-
-        if (Buf->idx == Buf->ints_per_buf) {
-            Buf->lastbuf = 0;
-            Buf->inbuf = Buf->idx;
-            iwl_buf_put(Buf);
-            Buf->idx = 0;
-        }
-
-        if (printflag) {
-            if (dirac) {
-                printer->Printf(">%d %d %d %d = %20.10f\n", p, r, q, s, value);
-            } else {
-                printer->Printf(">%d %d %d %d = %20.10f\n", p, q, r, s, value);
-            }
-        }
+    if (printflag) {
+        auto printer = make_printer(out);
+        if (dirac)
+            printer->Printf(">%d %d %d %d = %20.10f\n", p, r, q, s, value);
+        else
+            printer->Printf(">%d %d %d %d = %20.10f\n", p, q, r, s, value);
     }
 }
 }

--- a/psi4/src/psi4/libiwl/config.h
+++ b/psi4/src/psi4/libiwl/config.h
@@ -31,13 +31,19 @@
 
 namespace psi {
 
-typedef short int Label;
-typedef double Value;
+// On-disk label width. The bucket format packs four labels per integral as
+// 16-bit signed integers, so any orbital index passed through IWL must fit in
+// [INT16_MIN, INT16_MAX]. The write paths check this and throw on overflow.
+using Label = short int;
+using Value = double;
 
-#define IWL_KEY_BUF "IWL Buffers"
-#define IWL_KEY_ONEL "IWL One-electron matrix elements"
+inline constexpr const char *IWL_KEY_BUF = "IWL Buffers";
+inline constexpr const char *IWL_KEY_ONEL = "IWL One-electron matrix elements";
 
-#define IWL_INTS_PER_BUF 2980
+// Number of integrals packed into a single on-disk bucket. Bucket size in
+// bytes is 2*sizeof(int) + 4*N*sizeof(Label) + N*sizeof(Value), i.e. ~28 kB at
+// N = 2980. Kept at the historical value for on-disk compatibility.
+inline constexpr int IWL_INTS_PER_BUF = 2980;
 }
 
 #endif

--- a/psi4/src/psi4/libiwl/iwl.hpp
+++ b/psi4/src/psi4/libiwl/iwl.hpp
@@ -30,33 +30,38 @@
 #define _psi_src_lib_libiwl_iwl_hpp_
 
 #include <cstdio>
+#include <string>
 #include "psi4/libpsio/psio.hpp"
 #include "config.h"
 
 namespace psi {
 
 class PSI_API IWL {
-    int itap_;            /* tape number for input file */
-    psio_address bufpos_; /* current page/offset */
-    int ints_per_buf_;    /* integrals per buffer */
-    int bufszc_;          /* buffer size in characters (bytes) */
-    double cutoff_;       /* cutoff value for writing */
-    int lastbuf_;         /* is this the last IWL buffer? 1=yes,0=no */
-    int inbuf_;           /* how many ints in current buffer? */
-    int idx_;             /* index of integral in current buffer */
-    Label *labels_;       /* pointer to where integral values begin */
-    Value *values_;       /* integral values */
-    /*! Instance of libpsio to use */
+    int itap_;
+    psio_address bufpos_;
+    int ints_per_buf_;
+    int bufszc_;
+    double cutoff_;
+    int lastbuf_;
+    int inbuf_;
+    int idx_;
+    Label *labels_;
+    Value *values_;
     PSIO *psio_;
-    /*! Flag indicating whether to keep the IWL file or not */
     bool keep_;
 
    public:
+    // Construct an empty buffer; you must call init() before use. The default
+    // constructor exists only for the deferred-init pattern used by
+    // libtrans/integraltransform_tei_2nd_half.cc and similar callers.
     IWL();
     IWL(PSIO *psio, int itap, double cutoff, int oldfile, int readflag);
     ~IWL();
 
-    // Accessor functions to data
+    // Disallow copy: the buffer owns a psio file handle and heap storage.
+    IWL(const IWL &) = delete;
+    IWL &operator=(const IWL &) = delete;
+
     int &itap() { return itap_; }
     psio_address &buffer_position() { return bufpos_; }
     int &ints_per_buffer() { return ints_per_buf_; }
@@ -81,8 +86,6 @@ class PSI_API IWL {
                          std::string OutFileRMR);
     static void write_one(PSIO *psio, int itap, const char *label, int ntri, double *onel_ints);
 
-    int read(int target_pq, double *ints, int *ioff_lt, int *ioff_rt, int mp2, int printflg, std::string OutFileRMR);
-
     void write(int p, int q, int pq, int pqsym, double *arr, int rmax, int *ioff, int *orbsym, int *firsti, int *lasti,
                int printflag, std::string OutFileRMR);
     void write_matrix(int ptr, int qtr, double **mat, int rfirst, int rlast, int sfirst, int slast, int *reorder,
@@ -90,7 +93,6 @@ class PSI_API IWL {
     void write_value(int p, int q, int r, int s, double value, int printflag, std::string OutFileRMR, int dirac);
 
     void flush(int lastbuf);
-    void to_end();
 };
 }
 

--- a/psi4/src/psi4/libiwl/iwl_impl.h
+++ b/psi4/src/psi4/libiwl/iwl_impl.h
@@ -1,0 +1,69 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+// Private implementation helpers shared between the C and C++ IWL APIs.
+// Not part of the installed public surface; do not include from outside
+// psi4/src/psi4/libiwl/.
+
+#ifndef _psi_src_lib_libiwl_iwl_impl_h_
+#define _psi_src_lib_libiwl_iwl_impl_h_
+
+#include <climits>
+#include <memory>
+#include <string>
+#include "config.h"
+#include "psi4/psi4-dec.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
+
+namespace psi {
+namespace iwl_impl {
+
+// Verify that all four orbital indices fit in the on-disk Label width. The
+// bucket format stores each label as int16, so any larger value would be
+// silently truncated and corrupt the file. Throws PSIEXCEPTION instead.
+inline void check_label_fits(int p, int q, int r, int s) {
+    if (p > SHRT_MAX || q > SHRT_MAX || r > SHRT_MAX || s > SHRT_MAX || p < SHRT_MIN || q < SHRT_MIN || r < SHRT_MIN ||
+        s < SHRT_MIN) {
+        throw PSIEXCEPTION(
+            "libiwl: orbital index does not fit in 16-bit Label (max " + std::to_string(SHRT_MAX) +
+            "). The on-disk IWL bucket format cannot store this case. p=" + std::to_string(p) +
+            " q=" + std::to_string(q) + " r=" + std::to_string(r) + " s=" + std::to_string(s));
+    }
+}
+
+// Construct a PsiOutStream once per call, lazily, only when printing is
+// actually requested. The pre-refactor code constructed one per integral.
+inline std::shared_ptr<PsiOutStream> make_printer(const std::string &out) {
+    return (out == "outfile") ? outfile : std::make_shared<PsiOutStream>(out);
+}
+
+}  // namespace iwl_impl
+}  // namespace psi
+
+#endif

--- a/psi4/src/psi4/libiwl/rdone.cc
+++ b/psi4/src/psi4/libiwl/rdone.cc
@@ -30,28 +30,34 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
 #include <cmath>
 #include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
 #include "psi4/libciomr/libciomr.h"
 #include "iwl.h"
 #include "iwl.hpp"
-#include "psi4/libpsi4util/PsiOutStream.h"
+
 namespace psi {
+
+namespace {
+
+void read_one_impl(PSIO *psio, int itap, const char *label, double *ints, int ntri, int erase, int printflg,
+                   const std::string &out) {
+    psio->open(itap, PSIO_OPEN_OLD);
+    psio->read_entry(itap, label, reinterpret_cast<char *>(ints), ntri * sizeof(double));
+    psio->close(itap, erase ? 0 : 1);
+
+    if (printflg) {
+        const int nmo = static_cast<int>(std::sqrt(static_cast<double>(1 + 8 * ntri)) - 1) / 2;
+        print_array(ints, nmo, out);
+    }
+}
+
+}  // namespace
 
 void IWL::read_one(PSIO *psio, int itap, const char *label, double *ints, int ntri, int erase, int printflg,
                    std::string out) {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    int nmo;
-
-    psio->open(itap, PSIO_OPEN_OLD);
-    psio->read_entry(itap, label, (char *)ints, ntri * sizeof(double));
-    psio->close(itap, !erase);
-
-    if (printflg) {
-        nmo = (int)(sqrt((double)(1 + 8 * ntri)) - 1) / 2;
-        print_array(ints, nmo, out);
-    }
+    read_one_impl(psio, itap, label, ints, ntri, erase, printflg, out);
 }
 
 /*!
@@ -78,18 +84,7 @@ void IWL::read_one(PSIO *psio, int itap, const char *label, double *ints, int nt
 ** \ingroup IWL
 */
 int iwl_rdone(int itap, const char *label, double *ints, int ntri, int erase, int printflg, std::string out) {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    int nmo;
-
-    psio_open(itap, PSIO_OPEN_OLD);
-    psio_read_entry(itap, label, (char *)ints, ntri * sizeof(double));
-    psio_close(itap, !erase);
-
-    if (printflg) {
-        nmo = (int)(sqrt((double)(1 + 8 * ntri)) - 1) / 2;
-        print_array(ints, nmo, out);
-    }
-
-    return (1);
+    read_one_impl(_default_psio_lib_.get(), itap, label, ints, ntri, erase, printflg, out);
+    return 1;
 }
 }

--- a/psi4/src/psi4/libiwl/test/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/test/CMakeLists.txt
@@ -4,11 +4,9 @@
 # core.cc / libdpd. This keeps the test self-contained without pulling the
 # full libmints/Libint closure.
 #
-# Only the executable is defined here. psi4-core is configured as a separate
-# ExternalProject with its own binary dir and never calls enable_testing(), so
-# an add_test() in this scope would generate no CTestTestfile.cmake and would
-# be invisible to the `ctest` that CI runs from the superbuild directory.
-# Registration therefore lives in the superbuild, in tests/libiwl/.
+# Only the executable is defined here. See ctest registration in `tests/libiwl/`
+# (an add_test() in this scope would not register at all: psi4-core is a separate
+# ExternalProject that never calls enable_testing()).
 add_executable(iwl_roundtrip_test.x iwl_roundtrip_test.cc stubs.cc)
 target_link_libraries(iwl_roundtrip_test.x PRIVATE iwl psio psi4util options ciomr)
 target_include_directories(iwl_roundtrip_test.x PRIVATE

--- a/psi4/src/psi4/libiwl/test/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(iwl_roundtrip_test.x iwl_roundtrip_test.cc)
+target_link_libraries(iwl_roundtrip_test.x PRIVATE iwl psio psi4util ciomr)
+target_include_directories(iwl_roundtrip_test.x PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+add_test(NAME iwl_roundtrip
+         COMMAND iwl_roundtrip_test.x
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(iwl_roundtrip PROPERTIES LABELS "libiwl;quicktests")

--- a/psi4/src/psi4/libiwl/test/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/test/CMakeLists.txt
@@ -1,10 +1,17 @@
+# Standalone round-trip exerciser for libiwl. Links the libiwl/libpsio/
+# libpsi4util/liboptions/libciomr static archives plus a tiny stubs TU
+# (test/stubs.cc) that supplies the runtime globals normally provided by
+# core.cc / libdpd. This keeps the test self-contained without pulling the
+# full libmints/Libint closure.
+#
+# Only the executable is defined here. psi4-core is configured as a separate
+# ExternalProject with its own binary dir and never calls enable_testing(), so
+# an add_test() in this scope would generate no CTestTestfile.cmake and would
+# be invisible to the `ctest` that CI runs from the superbuild directory.
+# Registration therefore lives in the superbuild, in tests/libiwl/.
 add_executable(iwl_roundtrip_test.x iwl_roundtrip_test.cc stubs.cc)
 target_link_libraries(iwl_roundtrip_test.x PRIVATE iwl psio psi4util options ciomr)
 target_include_directories(iwl_roundtrip_test.x PRIVATE
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
 )
-add_test(NAME iwl_roundtrip
-         COMMAND iwl_roundtrip_test.x
-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-set_tests_properties(iwl_roundtrip PROPERTIES LABELS "libiwl;quicktests")

--- a/psi4/src/psi4/libiwl/test/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/test/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_executable(iwl_roundtrip_test.x iwl_roundtrip_test.cc)
-target_link_libraries(iwl_roundtrip_test.x PRIVATE iwl psio psi4util ciomr)
+add_executable(iwl_roundtrip_test.x iwl_roundtrip_test.cc stubs.cc)
+target_link_libraries(iwl_roundtrip_test.x PRIVATE iwl psio psi4util options ciomr)
 target_include_directories(iwl_roundtrip_test.x PRIVATE
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src

--- a/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
+++ b/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
@@ -1,0 +1,223 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+// Standalone round-trip test for libiwl. Exercises every bucket-boundary case
+// the 1995 README warned about: empty, single, exactly one bucket, just over
+// one bucket, mid-bucket termination, and all-zeros sweeps. Also verifies
+// that the 16-bit Label overflow check fires instead of silently truncating.
+
+#include <cassert>
+#include <climits>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl.hpp"
+#include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsi4util/PsiOutStream.h"
+
+// The libiwl write paths reach into the global `outfile` only when the caller
+// passes `printflag != 0`. We never do, but the symbol must exist for the
+// link. Provide a minimal stub.
+namespace psi {
+std::shared_ptr<PsiOutStream> outfile;
+}
+
+namespace {
+
+using namespace psi;
+
+struct Quartet {
+    int p, q, r, s;
+    double value;
+};
+
+// Deterministic pseudo-random test data with bounded indices.
+std::vector<Quartet> make_test_data(std::size_t n) {
+    std::vector<Quartet> out;
+    out.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        // Wraparound keeps indices in [0, 200) so they fit in 16 bits and we
+        // can compare without sorting.
+        const int p = static_cast<int>((i * 7 + 11) % 200);
+        const int q = static_cast<int>((i * 13 + 5) % 200);
+        const int r = static_cast<int>((i * 17 + 3) % 200);
+        const int s = static_cast<int>((i * 19 + 1) % 200);
+        // Values bounded away from cutoff (1e-14) so none get filtered.
+        const double v = 1.0 + 0.001 * static_cast<double>(i);
+        out.push_back({p, q, r, s, v});
+    }
+    return out;
+}
+
+// Drive an IWL write loop using the C++ API.
+void write_all(psi::IWL &buf, const std::vector<Quartet> &data) {
+    for (const auto &q : data) {
+        buf.write_value(q.p, q.q, q.r, q.s, q.value, /*printflag*/ 0,
+                        std::string("outfile"), /*dirac*/ 0);
+    }
+    buf.flush(/*lastbuf*/ 1);
+}
+
+// Drive an IWL read loop using the C-style API (the dominant in-tree pattern).
+std::vector<Quartet> read_all(int itap) {
+    std::vector<Quartet> out;
+    iwlbuf B;
+    iwl_buf_init(&B, itap, 1.0e-14, /*oldfile*/ 1, /*readflag*/ 1);
+
+    int lastbuf = B.lastbuf;
+    while (true) {
+        for (int i = B.idx; i < B.inbuf; ++i) {
+            const int j = 4 * i;
+            const int p = static_cast<int>(B.labels[j + 0]);
+            const int q = static_cast<int>(B.labels[j + 1]);
+            const int r = static_cast<int>(B.labels[j + 2]);
+            const int s = static_cast<int>(B.labels[j + 3]);
+            const double v = static_cast<double>(B.values[i]);
+            out.push_back({p, q, r, s, v});
+        }
+        B.idx = B.inbuf;
+        if (lastbuf) break;
+        iwl_buf_fetch(&B);
+        lastbuf = B.lastbuf;
+    }
+    iwl_buf_close(&B, /*keep*/ 0);
+    return out;
+}
+
+bool quartets_equal(const Quartet &a, const Quartet &b) {
+    return a.p == b.p && a.q == b.q && a.r == b.r && a.s == b.s &&
+           std::fabs(a.value - b.value) < 1.0e-12;
+}
+
+// Run one write/read round-trip for the given size and tape unit. Returns
+// true on success, false otherwise (with diagnostic to stderr).
+bool round_trip(std::size_t n, int itap) {
+    auto data = make_test_data(n);
+
+    {
+        psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
+                     /*oldfile*/ 0, /*readflag*/ 0);
+        write_all(buf, data);
+        buf.set_keep_flag(true);
+    }
+
+    auto got = read_all(itap);
+
+    if (got.size() != data.size()) {
+        std::cerr << "  size mismatch: wrote " << data.size() << " read "
+                  << got.size() << "\n";
+        return false;
+    }
+    for (std::size_t i = 0; i < data.size(); ++i) {
+        if (!quartets_equal(data[i], got[i])) {
+            std::cerr << "  entry " << i << " mismatch\n";
+            return false;
+        }
+    }
+    return true;
+}
+
+// Empty buffer: no integrals written, but flush(lastbuf=1) must still produce
+// a readable file that read_all() returns as zero entries. The 1995 README
+// specifically calls out this case.
+bool round_trip_empty(int itap) {
+    {
+        psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
+                     /*oldfile*/ 0, /*readflag*/ 0);
+        buf.flush(/*lastbuf*/ 1);
+        buf.set_keep_flag(true);
+    }
+    auto got = read_all(itap);
+    if (!got.empty()) {
+        std::cerr << "  empty round-trip returned " << got.size()
+                  << " entries\n";
+        return false;
+    }
+    return true;
+}
+
+// Verify that writing an out-of-range orbital index throws rather than
+// silently truncating.
+bool overflow_check_fires(int itap) {
+    psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
+                 /*oldfile*/ 0, /*readflag*/ 0);
+    bool threw = false;
+    try {
+        buf.write_value(SHRT_MAX + 1, 0, 0, 0, 1.0, 0, std::string("outfile"), 0);
+    } catch (const std::exception &e) {
+        threw = true;
+    }
+    buf.flush(/*lastbuf*/ 1);
+    buf.set_keep_flag(false);
+    if (!threw) {
+        std::cerr << "  overflow check did not throw\n";
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    // libpsio needs init before anything opens a unit.
+    psi::psio_init();
+
+    // Use tape unit numbers in a range unlikely to clash with the few entries
+    // libpsio's filecfg might preset.
+    const int base_unit = 80;
+    int unit = base_unit;
+    int failures = 0;
+
+    const std::size_t B = static_cast<std::size_t>(psi::IWL_INTS_PER_BUF);
+    const std::vector<std::size_t> sizes = {1, B - 1, B, B + 1, 3 * B + B / 2};
+
+    std::cout << "[iwl_roundtrip] empty buffer\n";
+    if (!round_trip_empty(unit++)) ++failures;
+
+    for (auto n : sizes) {
+        std::cout << "[iwl_roundtrip] N = " << n << "\n";
+        if (!round_trip(n, unit++)) ++failures;
+    }
+
+    std::cout << "[iwl_roundtrip] Label overflow check\n";
+    if (!overflow_check_fires(unit++)) ++failures;
+
+    if (failures) {
+        std::cerr << failures << " case(s) failed.\n";
+        return 1;
+    }
+    std::cout << "All round-trip cases passed.\n";
+    return 0;
+}

--- a/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
+++ b/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
@@ -47,12 +47,8 @@
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
-// The libiwl write paths reach into the global `outfile` only when the caller
-// passes `printflag != 0`. We never do, but the symbol must exist for the
-// link. Provide a minimal stub.
-namespace psi {
-std::shared_ptr<PsiOutStream> outfile;
-}
+// Hosting globals (`outfile`, `restart_id`, `psi_file_prefix`, `global_dpd_`)
+// live in test/stubs.cc; the link line pulls that TU in.
 
 namespace {
 

--- a/psi4/src/psi4/libiwl/test/stubs.cc
+++ b/psi4/src/psi4/libiwl/test/stubs.cc
@@ -32,6 +32,7 @@
 // member function on libdpd's DPD class. This file supplies just enough to
 // satisfy the link without dragging in libdpd or core.cc.
 
+#include <cstddef>
 #include <cstdlib>
 #include <cstring>
 #include <memory>
@@ -51,16 +52,23 @@ std::shared_ptr<PsiOutStream> outfile;
 
 // libpsio's PSIO::close calls global_dpd_->file4_cache_del_filenum during
 // every file close. In a non-DPD context the cache walk is a no-op anyway,
-// but dereferencing a null global_dpd_ is UB. Provide a minimal local DPD
-// class with the same name and the one referenced method as a no-op, plus a
-// non-null instance to dispatch through. We link without libdpd so there is
-// no ODR clash with the real DPD definition.
+// but dereferencing a null global_dpd_ is UB. Provide a minimal DPD class
+// with the one referenced method as a no-op, plus a non-null instance to
+// dispatch through.
+//
+// This is an ODR violation: close.cc is compiled against the real psi::DPD from
+// libdpd/dpd.h, while this TU defines a different psi::DPD. It holds together
+// only because the call is non-virtual and the mangled name matches. The
+// parameter type must therefore be spelled exactly as in dpd.h -- `size_t`, not
+// `unsigned long`. They coincide on LP64 and nowhere else; on Windows x64
+// `size_t` is `unsigned __int64` while `unsigned long` is 32 bits, and the
+// mismatch is an undefined symbol at link time rather than a diagnostic.
 class DPD {
  public:
-    void file4_cache_del_filenum(unsigned long);
+    void file4_cache_del_filenum(std::size_t);
 };
 
-void DPD::file4_cache_del_filenum(unsigned long) {}
+void DPD::file4_cache_del_filenum(std::size_t) {}
 
 namespace {
 DPD stub_dpd_instance;

--- a/psi4/src/psi4/libiwl/test/stubs.cc
+++ b/psi4/src/psi4/libiwl/test/stubs.cc
@@ -1,0 +1,71 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+// Minimal hosting globals for the standalone IWL round-trip test executable.
+// libpsio and libpsi4util are not standalone static archives -- they reference
+// runtime globals normally defined in core.cc (the python bindings TU) and a
+// member function on libdpd's DPD class. This file supplies just enough to
+// satisfy the link without dragging in libdpd or core.cc.
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "psi4/libpsi4util/PsiOutStream.h"
+
+namespace psi {
+
+// libciomr / libpsio scratch-name globals; normally set by psi4 startup.
+std::string restart_id;
+char *psi_file_prefix = strdup("iwl_test");
+
+// libpsi4util's `outfile` is reached only from print paths the test never
+// triggers (printflag = 0 everywhere). The symbol still has to exist.
+std::shared_ptr<PsiOutStream> outfile;
+
+// libpsio's PSIO::close calls global_dpd_->file4_cache_del_filenum during
+// every file close. In a non-DPD context the cache walk is a no-op anyway,
+// but dereferencing a null global_dpd_ is UB. Provide a minimal local DPD
+// class with the same name and the one referenced method as a no-op, plus a
+// non-null instance to dispatch through. We link without libdpd so there is
+// no ODR clash with the real DPD definition.
+class DPD {
+ public:
+    void file4_cache_del_filenum(unsigned long);
+};
+
+void DPD::file4_cache_del_filenum(unsigned long) {}
+
+namespace {
+DPD stub_dpd_instance;
+}
+
+DPD *global_dpd_ = &stub_dpd_instance;
+
+}  // namespace psi

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,9 +119,11 @@ add_subdirectory(json)
 
 # C++ unit tests built inside the psi4-core ExternalProject. Skipped on Windows,
 # where their curated link lines do not resolve under lld-link (see
-# psi4/src/psi4/libpsio/CMakeLists.txt), so the executables are never built there.
+# psi4/src/psi4/libpsio/CMakeLists.txt and psi4/src/psi4/libiwl/CMakeLists.txt),
+# so the executables are never built there.
 if(NOT WIN32)
     add_subdirectory(libpsio)
+    add_subdirectory(libiwl)
 endif()
 
 if(ENABLE_pasture)

--- a/tests/libiwl/CMakeLists.txt
+++ b/tests/libiwl/CMakeLists.txt
@@ -6,7 +6,14 @@
 # (cmake/ConfigTesting.cmake) and where CI invokes `ctest`.
 ExternalProject_Get_Property(psi4-core BINARY_DIR)
 
+# "smoketests" is what actually gets this run: CI drives scarcely anything through
+# ctest because the regression tests are doubled by pytest, and a C++ unit test is
+# not eligible for pytest (it is not a `psi4 input.dat`). The smoke and plugin
+# labels *are* driven through ctest -- Azure Linux runs `ctest -L "plug|smoke"`
+# (devtools/scripts/ci_run_test.py), Azure Windows `--label-regex smoke`.
+# "quicktests" is kept alongside it, as 13 other tests do, so the GH macOS
+# `ctest -L quick` lane keeps running it too.
 add_test(NAME libiwl-roundtrip
          COMMAND ${BINARY_DIR}/src/psi4/libiwl/test/iwl_roundtrip_test.x${CMAKE_EXECUTABLE_SUFFIX}
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-set_tests_properties(libiwl-roundtrip PROPERTIES LABELS "psi;quicktests;libiwl")
+set_tests_properties(libiwl-roundtrip PROPERTIES LABELS "psi;quicktests;smoketests;libiwl")

--- a/tests/libiwl/CMakeLists.txt
+++ b/tests/libiwl/CMakeLists.txt
@@ -1,0 +1,12 @@
+# C++ unit tests for libiwl.
+#
+# The executables are built inside the psi4-core ExternalProject, which has its
+# own binary directory and does not call enable_testing(). Registration has to
+# happen here, in the superbuild, because that is where `enable_testing()` runs
+# (cmake/ConfigTesting.cmake) and where CI invokes `ctest`.
+ExternalProject_Get_Property(psi4-core BINARY_DIR)
+
+add_test(NAME libiwl-roundtrip
+         COMMAND ${BINARY_DIR}/src/psi4/libiwl/test/iwl_roundtrip_test.x${CMAKE_EXECUTABLE_SUFFIX}
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(libiwl-roundtrip PROPERTIES LABELS "psi;quicktests;libiwl")


### PR DESCRIPTION
Phase 1 of the libiwl modernization tracked in #3425. An internal refactor of `psi4/src/psi4/libiwl/` with **no caller-facing API change and no on-disk format change**, plus a standalone round-trip test for the bucket I/O. The ~30 in-tree consumers that poke `struct iwlbuf` fields directly all keep compiling unchanged.

## Description
The libiwl bucket reader/writer had two byte-identical bodies for every operation (a C `iwl_buf_*` free function and a C++ `IWL::` method), C-style macros, mixed `malloc`/`new[]` ownership, and silent 32-bit→16-bit narrowing at the `Label` cast that could corrupt a bucket file without warning. This PR consolidates the duplication, fixes the latent correctness/ownership issues, and adds a round-trip test — all without touching the public field layout or the on-disk format.

## User API & Changelog headlines
- [x] `Label` overflow (orbital index exceeding the 16-bit bucket field) now throws a `PSIEXCEPTION` naming the offending indices instead of silently narrowing and corrupting the IWL file.

## Dev notes & details
- `config.h`: replace `#define IWL_INTS_PER_BUF` / `IWL_KEY_*` with `inline constexpr`; document the bucket layout.
- `iwl.hpp`: remove dead declarations `IWL::read` / `IWL::to_end` (never defined); delete copy ctor / assign; document the deferred-init pattern used by `libtrans`.
- Collapse every duplicated C-function / C++-method body into a single shared static helper per operation (one implementation site instead of two byte-identical ones). New internal `iwl_impl.h` holds the shared `check_label_fits()` / `make_printer()` helpers.
- **Overflow check at every `(int) → Label` cast** in the three write paths (throws instead of silently narrowing).
- `buf_init`: throw on `tocscan` failure instead of `Printf`'ing and leaving a half-initialized buffer the caller then `fetch()`es from.
- Unify allocators on `new[]`/`delete[]` (removes the cross-API `malloc`/`free` vs `new[]`/`delete[]` ownership UB).
- Hoist per-integral `PsiOutStream` construction in the write paths to one per-call instance, only when `printflag` is set (previously one file open per nonzero integral).
- Default-construct all `IWL` members including `keep_`; drop `MAX0`/`MIN0`/`INDEX` macros in `buf_wrt_mat.cc` for `std::max`/`std::min` and an inline `packed_index()`.

**Test.** `test/iwl_roundtrip_test.cc` is a standalone round-trip exerciser covering the bucket-boundary cases the 1995 README warned about — empty, 1, `B-1`, `B`, `B+1`, `3.5*B` integrals — plus the `Label` overflow check. It is built and registered as the `libiwl-roundtrip` ctest (`tests/libiwl/`, in the superbuild where `enable_testing()` runs), labeled `psi;quicktests;smoketests;libiwl`. It links the libiwl/libpsio/libpsi4util/liboptions/libciomr archives plus a tiny stubs TU (`test/stubs.cc`) that supplies the runtime globals normally provided by `core.cc`/libdpd (`global_dpd_`, `psi_file_prefix`, a no-op `C_DSYEV`), so it needs neither Python nor libdpd. It is skipped on Windows, where the curated link line does not resolve under clang-cl/lld-link (see `psi4/src/psi4/libiwl/CMakeLists.txt`).

## What this PR does *not* do
- No change to `struct iwlbuf`'s field layout — direct field pokes keep compiling.
- No on-disk format change; the v1 bucket layout (`int lastbuf | int inbuf | Label[4*2980] | Value[2980]`) is preserved bit-for-bit.
- The hard 16-bit orbital-index cap is unchanged; only the failure mode changes (loud throw vs silent corruption). Bumping to 32-bit is phase 3.
- Phase 2 (iterator-based `IWLReader`/`IWLWriter` + caller migration, #3439–#3441) and phase 3 (versioned wire format, async default, optional compression) are follow-up PRs. See #3425.

## Questions
- [ ] None outstanding.

## AI
- [x] AI usage: refactor, the round-trip test and its hosting stubs, and bug-seeking (the `Label` overflow and allocator-mismatch issues).

## Checklist
- [x] Tests added for any new features
- [ ] Docstring or narrative docs/sphinxman/source updated if needed (internal refactor; none needed)
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
