### PR TITLE
libpsio: modernize config.h constants + add round-trip test (#3429)

### DIFF
--- a/psi4/src/psi4/libpsio/CMakeLists.txt
+++ b/psi4/src/psi4/libpsio/CMakeLists.txt
@@ -34,6 +34,8 @@ list(APPEND sources
   )
 psi4_add_module(lib psio sources)
 
+add_subdirectory(test)
+
 if (psi4_ENABLE_PRECOMPILE_HEADERS)
     # Clearly from the paths, libpsio is a weird place to be defining the pch. However, if one sensibly
     #   puts it in mints, CMake creates a dependency of, say, fnocc on mints, and since mints is the

--- a/psi4/src/psi4/libpsio/CMakeLists.txt
+++ b/psi4/src/psi4/libpsio/CMakeLists.txt
@@ -34,11 +34,16 @@ list(APPEND sources
   )
 psi4_add_module(lib psio sources)
 
-# The standalone round-trip test links a curated subset of static archives
-# plus a small stubs TU. That works with GNU/Clang on Linux/macOS but not with
-# Windows lld-link, where the unity+PCH build pulls in extra symbol references
-# (Molecule, DPDMOSpace, ...) the curated link line doesn't provide. Restrict
-# it to non-Windows rather than drag in the full dependency closure.
+# The standalone round-trip test links a curated subset of static archives plus a
+# small stubs TU. That resolves with GNU/Clang on Linux/macOS but not with
+# clang-cl/lld-link, which emits inline and implicit functions that GCC discards
+# as unused, so the Windows objects carry undefined references the curated link
+# line does not provide: psio.lib wants DPDMOSpace::~DPDMOSpace (instantiated by
+# std::vector<DPDMOSpace> in dpd.h, reached via close.cc), and psi4util.lib wants
+# Molecule::Molecule(const Molecule&) (from inline Molecule::clone) and
+# ExternalPotential::print (from inline py_print). Not a unity or PCH artifact --
+# Linux is unity-built too, and Azure Windows builds with PCH off. Restrict the
+# test to non-Windows rather than drag in the full libmints/Libint closure.
 if(NOT WIN32)
     add_subdirectory(test)
 endif()

--- a/psi4/src/psi4/libpsio/CMakeLists.txt
+++ b/psi4/src/psi4/libpsio/CMakeLists.txt
@@ -34,7 +34,14 @@ list(APPEND sources
   )
 psi4_add_module(lib psio sources)
 
-add_subdirectory(test)
+# The standalone round-trip test links a curated subset of static archives
+# plus a small stubs TU. That works with GNU/Clang on Linux/macOS but not with
+# Windows lld-link, where the unity+PCH build pulls in extra symbol references
+# (Molecule, DPDMOSpace, ...) the curated link line doesn't provide. Restrict
+# it to non-Windows rather than drag in the full dependency closure.
+if(NOT WIN32)
+    add_subdirectory(test)
+endif()
 
 if (psi4_ENABLE_PRECOMPILE_HEADERS)
     # Clearly from the paths, libpsio is a weird place to be defining the pch. However, if one sensibly

--- a/psi4/src/psi4/libpsio/config.h
+++ b/psi4/src/psi4/libpsio/config.h
@@ -33,35 +33,38 @@
 
 namespace psi {
 
-#define PSIO_OPEN_NEW 0
-#define PSIO_OPEN_OLD 1
+// Names and values are unchanged from the historical macros (these are public
+// and consumed by downstream plugins); only the spelling is modernized so they
+// are typed, namespaced constants rather than preprocessor macros.
+inline constexpr int PSIO_OPEN_NEW = 0;
+inline constexpr int PSIO_OPEN_OLD = 1;
 
-#define PSIO_KEYLEN 80
-#define PSIO_MAXVOL 8
-#define PSIO_MAXUNIT 500
-#define PSIO_PAGELEN 65536
+inline constexpr int PSIO_KEYLEN = 80;
+inline constexpr int PSIO_MAXVOL = 8;
+inline constexpr int PSIO_MAXUNIT = 500;
+inline constexpr int PSIO_PAGELEN = 65536;
 
-#define PSIO_ERROR_INIT 1
-#define PSIO_ERROR_DONE 2
-#define PSIO_ERROR_MAXVOL 3
-#define PSIO_ERROR_NOVOLPATH 4
-#define PSIO_ERROR_OPEN 5
-#define PSIO_ERROR_REOPEN 6
-#define PSIO_ERROR_CLOSE 7
-#define PSIO_ERROR_RECLOSE 8
-#define PSIO_ERROR_OSTAT 9
-#define PSIO_ERROR_LSEEK 10
-#define PSIO_ERROR_READ 11
-#define PSIO_ERROR_WRITE 12
-#define PSIO_ERROR_NOTOCENT 13
-#define PSIO_ERROR_TOCENTSZ 14
-#define PSIO_ERROR_KEYLEN 15
-#define PSIO_ERROR_BLKSIZ 16
-#define PSIO_ERROR_BLKSTART 17
-#define PSIO_ERROR_BLKEND 18
-#define PSIO_ERROR_IDENTVOLPATH 19
-#define PSIO_ERROR_MAXUNIT 20
-#define PSIO_ERROR_UNOPENED 21
+inline constexpr int PSIO_ERROR_INIT = 1;
+inline constexpr int PSIO_ERROR_DONE = 2;
+inline constexpr int PSIO_ERROR_MAXVOL = 3;
+inline constexpr int PSIO_ERROR_NOVOLPATH = 4;
+inline constexpr int PSIO_ERROR_OPEN = 5;
+inline constexpr int PSIO_ERROR_REOPEN = 6;
+inline constexpr int PSIO_ERROR_CLOSE = 7;
+inline constexpr int PSIO_ERROR_RECLOSE = 8;
+inline constexpr int PSIO_ERROR_OSTAT = 9;
+inline constexpr int PSIO_ERROR_LSEEK = 10;
+inline constexpr int PSIO_ERROR_READ = 11;
+inline constexpr int PSIO_ERROR_WRITE = 12;
+inline constexpr int PSIO_ERROR_NOTOCENT = 13;
+inline constexpr int PSIO_ERROR_TOCENTSZ = 14;
+inline constexpr int PSIO_ERROR_KEYLEN = 15;
+inline constexpr int PSIO_ERROR_BLKSIZ = 16;
+inline constexpr int PSIO_ERROR_BLKSTART = 17;
+inline constexpr int PSIO_ERROR_BLKEND = 18;
+inline constexpr int PSIO_ERROR_IDENTVOLPATH = 19;
+inline constexpr int PSIO_ERROR_MAXUNIT = 20;
+inline constexpr int PSIO_ERROR_UNOPENED = 21;
 
 struct psio_address {
     /*! First page of entry */

--- a/psi4/src/psi4/libpsio/test/CMakeLists.txt
+++ b/psi4/src/psi4/libpsio/test/CMakeLists.txt
@@ -2,13 +2,15 @@
 # liboptions/libciomr static archives plus a tiny stubs TU (test/stubs.cc) for
 # the runtime globals normally provided by core.cc, so the test is
 # self-contained (no python, no libdpd).
+#
+# Only the executable is defined here. psi4-core is configured as a separate
+# ExternalProject with its own binary dir and never calls enable_testing(), so
+# an add_test() in this scope would generate no CTestTestfile.cmake and would
+# be invisible to the `ctest` that CI runs from the superbuild directory.
+# Registration therefore lives in the superbuild, in tests/libpsio/.
 add_executable(psio_roundtrip_test.x psio_roundtrip_test.cc stubs.cc)
 target_link_libraries(psio_roundtrip_test.x PRIVATE psio psi4util options ciomr)
 target_include_directories(psio_roundtrip_test.x PRIVATE
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src
 )
-add_test(NAME psio_roundtrip
-         COMMAND psio_roundtrip_test.x
-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-set_tests_properties(psio_roundtrip PROPERTIES LABELS "libpsio;quicktests")

--- a/psi4/src/psi4/libpsio/test/CMakeLists.txt
+++ b/psi4/src/psi4/libpsio/test/CMakeLists.txt
@@ -8,7 +8,3 @@
 # ExternalProject that never calls enable_testing()).
 add_executable(psio_roundtrip_test.x psio_roundtrip_test.cc stubs.cc)
 target_link_libraries(psio_roundtrip_test.x PRIVATE psio psi4util options ciomr)
-target_include_directories(psio_roundtrip_test.x PRIVATE
-    ${CMAKE_SOURCE_DIR}/src
-    ${CMAKE_BINARY_DIR}/src
-)

--- a/psi4/src/psi4/libpsio/test/CMakeLists.txt
+++ b/psi4/src/psi4/libpsio/test/CMakeLists.txt
@@ -3,11 +3,9 @@
 # the runtime globals normally provided by core.cc, so the test is
 # self-contained (no python, no libdpd).
 #
-# Only the executable is defined here. psi4-core is configured as a separate
-# ExternalProject with its own binary dir and never calls enable_testing(), so
-# an add_test() in this scope would generate no CTestTestfile.cmake and would
-# be invisible to the `ctest` that CI runs from the superbuild directory.
-# Registration therefore lives in the superbuild, in tests/libpsio/.
+# Only the executable is defined here. See ctest registration in `tests/libpsio/`
+# (an add_test() in this scope would not register at all: psi4-core is a separate
+# ExternalProject that never calls enable_testing()).
 add_executable(psio_roundtrip_test.x psio_roundtrip_test.cc stubs.cc)
 target_link_libraries(psio_roundtrip_test.x PRIVATE psio psi4util options ciomr)
 target_include_directories(psio_roundtrip_test.x PRIVATE

--- a/psi4/src/psi4/libpsio/test/CMakeLists.txt
+++ b/psi4/src/psi4/libpsio/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Standalone round-trip exerciser for libpsio. Links the libpsio/libpsi4util/
+# liboptions/libciomr static archives plus a tiny stubs TU (test/stubs.cc) for
+# the runtime globals normally provided by core.cc, so the test is
+# self-contained (no python, no libdpd).
+add_executable(psio_roundtrip_test.x psio_roundtrip_test.cc stubs.cc)
+target_link_libraries(psio_roundtrip_test.x PRIVATE psio psi4util options ciomr)
+target_include_directories(psio_roundtrip_test.x PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+add_test(NAME psio_roundtrip
+         COMMAND psio_roundtrip_test.x
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(psio_roundtrip PROPERTIES LABELS "libpsio;quicktests")

--- a/psi4/src/psi4/libpsio/test/psio_roundtrip_test.cc
+++ b/psi4/src/psi4/libpsio/test/psio_roundtrip_test.cc
@@ -1,0 +1,119 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+// Standalone round-trip test for libpsio. Writes several TOC entries to a new
+// unit (including a multi-page entry that exercises the paging path in
+// PSIO::rw), closes and reopens the file, reads everything back, and checks the
+// table-of-contents lookups. This is the behavior gate for any internal
+// refactor of the file/TOC/paging machinery.
+
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
+
+namespace {
+
+using namespace psi;
+
+bool g_failed = false;
+
+void check(bool cond, const std::string &what) {
+    if (!cond) {
+        std::cerr << "  FAIL: " << what << "\n";
+        g_failed = true;
+    }
+}
+
+// A TOC entry's worth of test data of a given byte size, deterministically
+// filled so we can verify it after a round trip.
+std::vector<char> make_payload(std::size_t nbytes, unsigned seed) {
+    std::vector<char> v(nbytes);
+    for (std::size_t i = 0; i < nbytes; ++i) v[i] = static_cast<char>((i * 31 + seed) & 0xff);
+    return v;
+}
+
+}  // namespace
+
+int main() {
+    psio_init();
+    auto psio = PSIO::shared_object();
+
+    const size_t unit = 84;
+
+    // Sizes chosen to span the single-partial-page, multi-full-page, and
+    // trailing-partial-page branches of PSIO::rw (PSIO_PAGELEN = 65536).
+    struct Entry {
+        std::string key;
+        std::size_t size;
+        unsigned seed;
+    };
+    std::vector<Entry> entries = {
+        {"Alpha small", 64, 1},
+        {"Beta one page", PSIO_PAGELEN, 2},
+        {"Gamma multi-page", 3 * PSIO_PAGELEN + 137, 3},
+        {"Delta empty-ish", 8, 4},
+    };
+
+    std::vector<std::vector<char>> payloads;
+    for (auto &e : entries) payloads.push_back(make_payload(e.size, e.seed));
+
+    // --- Write pass ---
+    psio->open(unit, PSIO_OPEN_NEW);
+    for (std::size_t i = 0; i < entries.size(); ++i) {
+        psio->write_entry(unit, entries[i].key.c_str(), payloads[i].data(), entries[i].size);
+    }
+    psio->close(unit, /*keep*/ 1);
+    check(!psio->open_check(unit), "unit closed after write pass");
+
+    // --- Read pass (reopen, verify each entry + TOC lookups) ---
+    psio->open(unit, PSIO_OPEN_OLD);
+    check(psio->open_check(unit) != 0, "unit open after reopen");
+
+    for (std::size_t i = 0; i < entries.size(); ++i) {
+        check(psio->tocentry_exists(unit, entries[i].key.c_str()), "tocentry_exists: " + entries[i].key);
+        std::vector<char> got(entries[i].size, 0);
+        psio->read_entry(unit, entries[i].key.c_str(), got.data(), entries[i].size);
+        check(got == payloads[i], "payload round-trips: " + entries[i].key);
+    }
+
+    check(!psio->tocentry_exists(unit, "No Such Key"), "absent key reported absent");
+
+    psio->close(unit, /*keep*/ 0);  // erase the scratch file
+
+    if (g_failed) {
+        std::cerr << "psio_roundtrip: FAILED\n";
+        return 1;
+    }
+    std::cout << "psio_roundtrip: all checks passed (" << entries.size() << " entries)\n";
+    return 0;
+}

--- a/psi4/src/psi4/libpsio/test/psio_roundtrip_test.cc
+++ b/psi4/src/psi4/libpsio/test/psio_roundtrip_test.cc
@@ -3,7 +3,7 @@
  *
  * Psi4: an open-source quantum chemistry software package
  *
- * Copyright (c) 2007-2025 The Psi4 Developers.
+ * Copyright (c) 2007-2026 The Psi4 Developers.
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/psi4/src/psi4/libpsio/test/stubs.cc
+++ b/psi4/src/psi4/libpsio/test/stubs.cc
@@ -3,7 +3,7 @@
  *
  * Psi4: an open-source quantum chemistry software package
  *
- * Copyright (c) 2007-2025 The Psi4 Developers.
+ * Copyright (c) 2007-2026 The Psi4 Developers.
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -46,8 +46,9 @@ std::shared_ptr<PsiOutStream> outfile;
 
 // libciomr's DSYEV_ascending lands in the same unity TU as helpers libpsio
 // pulls in; the standalone link references its LAPACK wrapper though the test
-// never diagonalizes. A no-op leaf keeps the test self-contained.
-void C_DSYEV(char, char, int, double *, int, double *, double *, int) {}
+// never diagonalizes. A no-op leaf keeps the test self-contained. The signature
+// matches the real declaration in libqt/qt.h (returns int).
+int C_DSYEV(char, char, int, double *, int, double *, double *, int) { return 0; }
 
 // PSIO::close calls global_dpd_->file4_cache_del_filenum on every file close.
 // In a non-DPD context the cache is empty, so a minimal DPD with a no-op method

--- a/psi4/src/psi4/libpsio/test/stubs.cc
+++ b/psi4/src/psi4/libpsio/test/stubs.cc
@@ -1,0 +1,66 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+// Minimal hosting globals for the standalone libpsio round-trip executable.
+// libpsio/libpsi4util/libciomr are not standalone archives -- they reference a
+// few runtime globals normally defined in core.cc. Supply just enough to link
+// without dragging in libdpd or the python bindings TU.
+
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "psi4/libpsi4util/PsiOutStream.h"
+
+namespace psi {
+
+std::string restart_id;
+char *psi_file_prefix = strdup("psio_test");
+std::shared_ptr<PsiOutStream> outfile;
+
+// libciomr's DSYEV_ascending lands in the same unity TU as helpers libpsio
+// pulls in; the standalone link references its LAPACK wrapper though the test
+// never diagonalizes. A no-op leaf keeps the test self-contained.
+void C_DSYEV(char, char, int, double *, int, double *, double *, int) {}
+
+// PSIO::close calls global_dpd_->file4_cache_del_filenum on every file close.
+// In a non-DPD context the cache is empty, so a minimal local DPD with a no-op
+// method and a non-null instance keeps the call well-defined. Linked without
+// libdpd, so no ODR clash with the real definition.
+class DPD {
+   public:
+    void file4_cache_del_filenum(unsigned long);
+};
+void DPD::file4_cache_del_filenum(unsigned long) {}
+
+namespace {
+DPD stub_dpd_instance;
+}
+DPD *global_dpd_ = &stub_dpd_instance;
+
+}  // namespace psi

--- a/psi4/src/psi4/libpsio/test/stubs.cc
+++ b/psi4/src/psi4/libpsio/test/stubs.cc
@@ -31,6 +31,7 @@
 // few runtime globals normally defined in core.cc. Supply just enough to link
 // without dragging in libdpd or the python bindings TU.
 
+#include <cstddef>
 #include <cstring>
 #include <memory>
 #include <string>
@@ -49,14 +50,21 @@ std::shared_ptr<PsiOutStream> outfile;
 void C_DSYEV(char, char, int, double *, int, double *, double *, int) {}
 
 // PSIO::close calls global_dpd_->file4_cache_del_filenum on every file close.
-// In a non-DPD context the cache is empty, so a minimal local DPD with a no-op
-// method and a non-null instance keeps the call well-defined. Linked without
-// libdpd, so no ODR clash with the real definition.
+// In a non-DPD context the cache is empty, so a minimal DPD with a no-op method
+// and a non-null instance keeps the call well-defined without linking libdpd.
+//
+// This is an ODR violation: close.cc is compiled against the real psi::DPD from
+// libdpd/dpd.h, while this TU defines a different psi::DPD. It is well-defined
+// enough in practice only because the call is non-virtual and the mangled name
+// matches. The parameter type must therefore be spelled exactly as in dpd.h --
+// `size_t`, not `unsigned long`. They coincide on LP64 but not on Windows x64
+// (where size_t is unsigned __int64 and unsigned long is 32-bit) nor on ILP32,
+// and a mismatch there is an undefined symbol at link time, not a diagnostic.
 class DPD {
    public:
-    void file4_cache_del_filenum(unsigned long);
+    void file4_cache_del_filenum(std::size_t);
 };
-void DPD::file4_cache_del_filenum(unsigned long) {}
+void DPD::file4_cache_del_filenum(std::size_t) {}
 
 namespace {
 DPD stub_dpd_instance;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,6 +118,14 @@ add_subdirectory(psi4numpy)
 add_subdirectory(cookbook)
 add_subdirectory(python)
 add_subdirectory(json)
+
+# C++ unit tests built inside the psi4-core ExternalProject. Skipped on Windows,
+# where their curated link lines do not resolve under lld-link (see
+# src/psi4/libpsio/CMakeLists.txt), so the executables are never built there.
+if(NOT WIN32)
+    add_subdirectory(libpsio)
+endif()
+
 if(ENABLE_pasture)
   add_subdirectory(pasture-ccsorttransqt2)
   message(STATUS "${Cyan}Found Pasture${ColourReset}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -121,7 +121,7 @@ add_subdirectory(json)
 
 # C++ unit tests built inside the psi4-core ExternalProject. Skipped on Windows,
 # where their curated link lines do not resolve under lld-link (see
-# src/psi4/libpsio/CMakeLists.txt), so the executables are never built there.
+# psi4/src/psi4/libpsio/CMakeLists.txt), so the executables are never built there.
 if(NOT WIN32)
     add_subdirectory(libpsio)
 endif()

--- a/tests/libpsio/CMakeLists.txt
+++ b/tests/libpsio/CMakeLists.txt
@@ -1,0 +1,12 @@
+# C++ unit tests for libpsio.
+#
+# The executables are built inside the psi4-core ExternalProject, which has its
+# own binary directory and does not call enable_testing(). Registration has to
+# happen here, in the superbuild, because that is where `enable_testing()` runs
+# (cmake/ConfigTesting.cmake) and where CI invokes `ctest`.
+ExternalProject_Get_Property(psi4-core BINARY_DIR)
+
+add_test(NAME libpsio-roundtrip
+         COMMAND ${BINARY_DIR}/src/psi4/libpsio/test/psio_roundtrip_test.x${CMAKE_EXECUTABLE_SUFFIX}
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(libpsio-roundtrip PROPERTIES LABELS "psi;quicktests;libpsio")

--- a/tests/libpsio/CMakeLists.txt
+++ b/tests/libpsio/CMakeLists.txt
@@ -6,7 +6,14 @@
 # (cmake/ConfigTesting.cmake) and where CI invokes `ctest`.
 ExternalProject_Get_Property(psi4-core BINARY_DIR)
 
+# "smoketests" is what actually gets this run: CI drives scarcely anything through
+# ctest because the regression tests are doubled by pytest, and a C++ unit test is
+# not eligible for pytest (it is not a `psi4 input.dat`). The smoke and plugin
+# labels *are* driven through ctest -- Azure Linux runs `ctest -L "plug|smoke"`
+# (devtools/scripts/ci_run_test.py), Azure Windows `--label-regex smoke`.
+# "quicktests" is kept alongside it, as 13 other tests do, so the GH macOS
+# `ctest -L quick` lane keeps running it too.
 add_test(NAME libpsio-roundtrip
          COMMAND ${BINARY_DIR}/src/psi4/libpsio/test/psio_roundtrip_test.x${CMAKE_EXECUTABLE_SUFFIX}
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-set_tests_properties(libpsio-roundtrip PROPERTIES LABELS "psi;quicktests;libpsio")
+set_tests_properties(libpsio-roundtrip PROPERTIES LABELS "psi;quicktests;smoketests;libpsio")


### PR DESCRIPTION
## Description

Non-breaking internal modernization of `libpsio`, plus the behavior gate the library never had. First slice of the plan in #3429.

Two things only: `config.h`'s preprocessor macros become `inline constexpr int`, and a standalone round-trip test is added and wired into `ctest`.

An earlier revision of this PR also removed the C `psio_*` free-function API. **That has been dropped.** As the analogous libiwl PR (#3428) showed, those free functions are public API that downstream plugins call directly (e.g. `v2rdm_casscf`), so removing them breaks the ecosystem build; and unlike libiwl's range-for `IWLReader`, they are no worse than the verbose `_default_psio_lib_->...`, so there was little upside to forcing the migration. Any future C-API change needs to be coordinated with downstream plugin updates rather than done unilaterally.

The deeper internal rewrites from #3429 — `AIOHandler` single job-queue, `psio_ud`/TOC/`char*`-path/fd-RAII — remain follow-ups that want this test as a safety net first. The multi-volume striping removal is #3452, stacked on this PR.

## User API & Changelog headlines
- [ ] No user-visible change. `psio_error()`'s public signature is unchanged (error codes stay `int` rather than becoming an `enum class`), so there is no downstream impact.

## Dev notes & details
- [ ] `config.h`: `#define` → `inline constexpr int` for `PSIO_KEYLEN`, `PSIO_MAXUNIT`, `PSIO_PAGELEN`, `PSIO_MAXVOL` and the `PSIO_ERROR_*` codes. Same names, same values. Gives the constants a type, a scope, and debugger visibility.
- [ ] New `psi4/src/psi4/libpsio/test/`: a standalone round-trip exerciser. Writes then reads back four entries whose sizes deliberately straddle the branches of `PSIO::rw` — 64 B (sub-page partial), exactly `PSIO_PAGELEN` (one full page, no remainder), `3 * PSIO_PAGELEN + 137` (multiple full pages plus a trailing partial), and 8 B.
- [ ] The test links a curated subset of static archives (`psio psi4util options ciomr`) plus a small `stubs.cc` supplying the runtime globals normally provided by `core.cc`. No Python, no libdpd, no libmints/Libint closure.
- [ ] Not built on Windows. The curated link line resolves under GNU/Clang but not clang-cl/lld-link, which emits inline and implicit functions that GCC discards as unused: `psio.lib` ends up referencing `DPDMOSpace::~DPDMOSpace` (via `std::vector<DPDMOSpace>` in `dpd.h`), and `psi4util.lib` references `Molecule::Molecule(const Molecule&)` (inline `Molecule::clone`, `molecule.h:200`) and `ExternalPotential::print` (inline `py_print`, `extern.h:131`). Not a unity or PCH artifact — Linux is unity-built too and its archives carry no such references, and Azure Windows builds with PCH off. (An earlier revision of this description blamed the unity build; that was wrong.)
- [ ] Labelled `"psi;quicktests;smoketests;libpsio"`. `quicktests` alone only reached the GH macOS lane; the Azure lanes drive ctest by `-L "plug|smoke"` (`devtools/scripts/ci_run_test.py`) and `--label-regex smoke`. Verified the test is selected by all three selectors.
- [ ] Fixed the `DPD` stub to declare `file4_cache_del_filenum(std::size_t)`, matching `dpd.h:483`. It previously said `unsigned long`, which mangles differently on Windows x64 — that accounted for one of the four undefined symbols above.
- [ ] Registration lives in the superbuild (`tests/libpsio/`), not next to the executable. `psi4-core` is configured as a separate `ExternalProject` with its own binary directory and never calls `enable_testing()`, so an `add_test()` under `psi4/src/` generates no `CTestTestfile.cmake` at all — and CI invokes `ctest` from the superbuild directory, which cannot descend into the core build tree in any case. Resolving the ExternalProject's `BINARY_DIR` from `tests/` makes `ctest -L quick` actually execute it.

## Questions
- [ ] `tests/CMakeLists.txt` gains an `add_subdirectory(libpsio)` under "Add internal projects". #3426 adds `add_subdirectory(libiwl)` at the same spot, so whichever of the two lands second will need a one-line conflict resolution. Happy to introduce a shared `add_core_unit_test()` macro in `cmake/TestingMacros.cmake` instead if you would rather have one entry point for C++ unit tests.
- [ ] Is skipping the unit tests on Windows acceptable, or would you prefer the executables link against the full closure so they run everywhere?

## AI
- [ ] Claude (Opus 4.8) assisted with the mechanical `#define` → `inline constexpr` conversion, drafting the round-trip test and its stubs, and diagnosing the ctest-registration and Windows-link problems. Reviewed and submitted by me; I am happy to answer questions about any of it.

## Checklist
- [x] Tests added for any new features — this PR *is* the test
- [x] Docstring or narrative docs/sphinxman/source updated if needed — n/a, internal only
- Verified locally: `ctest -R libpsio-roundtrip` passes, and reports failure when the binary is removed. Before the registration fix, `ctest -N -R psio_roundtrip` listed no tests at all.

## Status
- [x] Ready for review

---

Thanks @TiborGY — you were right on both counts. The description was stale, and the ctest never ran.

