### PR TITLE
Tidy up a test input after sqrt fix

### DIFF
--- a/tests/dfmp2-freq1/input.dat
+++ b/tests/dfmp2-freq1/input.dat
@@ -19,10 +19,8 @@ set {
   qc_module occ
 }
 
-if psi4.core.get_option("scf", "orbital_optimizer_package") == "INTERNAL":  # KP-TIGHT
-    tol = 1  # 0.1
-else:
-    tol = 1
+tol = 1  # 0.1
+if psi4.core.get_option("scf", "orbital_optimizer_package") != "INTERNAL":  # KP-TIGHT
     psi4.set_options({"d_convergence": 10})
 
 e, wfn = frequencies('mp2', dertype=0, return_wfn=True)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
After #3390 one of the tests was left with some redundant code. This PR tidies that up.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] None

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Tidy up now useless branch in the `dfmp2-freq1` test

## Checklist
- [x] No new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [ ] Ready for merge
