### PR TITLE
Improve CDJK object

### DIFF
--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -59,7 +59,7 @@ void export_fock(py::module &m) {
         .def("memory_estimate", &JK::memory_estimate)
         .def("initialize", &JK::initialize)
         .def("basisset", &JK::basisset)
-        .def("set_print_2", &JK::set_print)
+        .def("set_print", &JK::set_print)
         .def("set_cutoff", &JK::set_cutoff)
         .def("set_memory", &JK::set_memory)
         .def("set_omp_nthread", &JK::set_omp_nthread)

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -94,7 +94,7 @@ void export_fock(py::module &m) {
         .def("D", &JK::D, py::return_value_policy::reference_internal)
         .def("computed_shells_per_iter", py::overload_cast<>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
         .def("computed_shells_per_iter", py::overload_cast<const std::string&>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
-        .def("print_header_2", &JK::print_header, "docstring");
+        .def("print_header", &JK::print_header, "docstring");
 
     py::class_<LaplaceDenominator, std::shared_ptr<LaplaceDenominator>>(m, "LaplaceDenominator", "Computer class for a Laplace factorization of the four-index energy denominator in MP2 and coupled-cluster")
         .def(py::init<std::shared_ptr<Vector>, std::shared_ptr<Vector>, double>())

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -94,7 +94,7 @@ void export_fock(py::module &m) {
         .def("D", &JK::D, py::return_value_policy::reference_internal)
         .def("computed_shells_per_iter", py::overload_cast<>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
         .def("computed_shells_per_iter", py::overload_cast<const std::string&>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
-        .def("print_header", &JK::print_header, "docstring");
+        .def("print_header", &JK::print_header, "Prints information about the type and config of the JK object into the output file. Print verbosity may depend on the value of JK::print_.");
 
     py::class_<LaplaceDenominator, std::shared_ptr<LaplaceDenominator>>(m, "LaplaceDenominator", "Computer class for a Laplace factorization of the four-index energy denominator in MP2 and coupled-cluster")
         .def(py::init<std::shared_ptr<Vector>, std::shared_ptr<Vector>, double>())

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -94,7 +94,7 @@ void export_fock(py::module &m) {
         .def("D", &JK::D, py::return_value_policy::reference_internal)
         .def("computed_shells_per_iter", py::overload_cast<>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
         .def("computed_shells_per_iter", py::overload_cast<const std::string&>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
-        .def("print_header", &JK::print_header, "Prints information about the type and config of the JK object into the output file. Print verbosity may depend on the value of JK::print_.");
+        .def("print_header", &JK::print_header, "Prints information about the type and config of the JK object into the output file. Print verbosity may depend on the value of JK::print\_.");
 
     py::class_<LaplaceDenominator, std::shared_ptr<LaplaceDenominator>>(m, "LaplaceDenominator", "Computer class for a Laplace factorization of the four-index energy denominator in MP2 and coupled-cluster")
         .def(py::init<std::shared_ptr<Vector>, std::shared_ptr<Vector>, double>())

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -94,7 +94,7 @@ void export_fock(py::module &m) {
         .def("D", &JK::D, py::return_value_policy::reference_internal)
         .def("computed_shells_per_iter", py::overload_cast<>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
         .def("computed_shells_per_iter", py::overload_cast<const std::string&>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
-        .def("print_header", &JK::print_header, "docstring");
+        .def("print_header_2", &JK::print_header, "docstring");
 
     py::class_<LaplaceDenominator, std::shared_ptr<LaplaceDenominator>>(m, "LaplaceDenominator", "Computer class for a Laplace factorization of the four-index energy denominator in MP2 and coupled-cluster")
         .def(py::init<std::shared_ptr<Vector>, std::shared_ptr<Vector>, double>())

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -94,7 +94,7 @@ void export_fock(py::module &m) {
         .def("D", &JK::D, py::return_value_policy::reference_internal)
         .def("computed_shells_per_iter", py::overload_cast<>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
         .def("computed_shells_per_iter", py::overload_cast<const std::string&>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
-        .def("print_header", &JK::print_header, "Prints information about the type and config of the JK object into the output file. Print verbosity may depend on the value of JK::print\_.");
+        .def("print_header", &JK::print_header, "Prints information about the type and config of the JK object into the output file. Print verbosity may depend on the value of JK::print\\_.");
 
     py::class_<LaplaceDenominator, std::shared_ptr<LaplaceDenominator>>(m, "LaplaceDenominator", "Computer class for a Laplace factorization of the four-index energy denominator in MP2 and coupled-cluster")
         .def(py::init<std::shared_ptr<Vector>, std::shared_ptr<Vector>, double>())

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -59,7 +59,7 @@ void export_fock(py::module &m) {
         .def("memory_estimate", &JK::memory_estimate)
         .def("initialize", &JK::initialize)
         .def("basisset", &JK::basisset)
-        .def("set_print", &JK::set_print)
+        .def("set_print_2", &JK::set_print)
         .def("set_cutoff", &JK::set_cutoff)
         .def("set_memory", &JK::set_memory)
         .def("set_omp_nthread", &JK::set_omp_nthread)

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -53,8 +53,9 @@ namespace psi {
 
 CDJK::CDJK(std::shared_ptr<BasisSet> primary, Options& options, double cholesky_tolerance)
     : DiskDFJK(primary, primary, options), cholesky_tolerance_(cholesky_tolerance) {}
-CDJK::~CDJK() {}
+
 void CDJK::initialize_JK_disk() { throw PSIEXCEPTION("Disk algorithm for CD JK not implemented."); }
+
 size_t CDJK::memory_estimate() {
     // Size is unknown until actual evaluation
     size_t nbf = primary_->nbf();

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -54,7 +54,7 @@ namespace psi {
 CDJK::CDJK(std::shared_ptr<BasisSet> primary, Options& options, double cholesky_tolerance)
     : DiskDFJK(primary, primary, options), cholesky_tolerance_(cholesky_tolerance) {}
 CDJK::~CDJK() {}
-void CDJK::initialize_JK_disk() { throw PsiException("Disk algorithm for CD JK not implemented.", __FILE__, __LINE__); }
+void CDJK::initialize_JK_disk() { throw PSIEXCEPTION("Disk algorithm for CD JK not implemented."); }
 size_t CDJK::memory_estimate() {
     // Size is unknown until actual evaluation
     size_t nbf = primary_->nbf();
@@ -94,7 +94,7 @@ void CDJK::initialize_JK_core() {
     /// Kinda silly to check for memory after you perform CD.
     /// Most likely redundant as cholesky also checks for memory.
     if (memory_ < ((size_t)sizeof(double) * three_memory + (size_t)sizeof(double) * ncholesky_ * nbf * nbf))
-        throw PsiException("Not enough memory for CD.", __FILE__, __LINE__);
+        throw PSIEXCEPTION("Not enough memory for CD.");
 
     std::shared_ptr<Matrix> L = Ch->L();
     double** Lp = L->pointer();
@@ -157,6 +157,6 @@ void CDJK::print_header() const {
         outfile->Printf("    Cholesky tolerance:   %11.2E\n", cholesky_tolerance_);
         outfile->Printf("    No. Cholesky vectors: %11li\n\n", ncholesky_);
     }
-    if (do_wK_) throw PsiException("No wk for scf_type cd.", __FILE__, __LINE__);
+    if (do_wK_) throw PSIEXCEPTION("No wk for scf_type cd.");
 }
 }  // namespace psi

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -67,7 +67,9 @@ size_t CDJK::memory_estimate() {
 void CDJK::initialize_JK_core() {
     timer_on("CD: cholesky decomposition");
     auto integral = std::make_shared<IntegralFactory>(primary_, primary_, primary_, primary_);
-    cderi_ = std::shared_ptr<TwoBodyAOInt>(integral->eri());
+    // Integral engine for computing CD integrals. Note that this is a a "shallow const", only the shared_ptr is const,
+    // but the TwoBodyAOInt it is holding is still mutable
+    const auto cderi_ = std::shared_ptr<TwoBodyAOInt>(integral->eri());
     int ntri = cderi_->function_pairs().size();
     /// If user asks to read integrals from disk, just read them from disk.
     /// Qmn is only storing upper triangle.

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -76,7 +76,7 @@ void CDJK::initialize_JK_core() {
     //      const std::shared_ptr<TwoBodyAOInt> cderi = factory.eri();
     // in the future. A TwoBodyAOInt object keeps the factory as a raw non-owning back-pointer (const IntegralFactory
     // *integral_) and is therefore probably quite a dangerous thing if it ever outlives the IntegralFactory that was
-    // used for contructing the TwoBodyAOInt.
+    // used for constructing the TwoBodyAOInt.
     auto integral = std::make_shared<IntegralFactory>(primary_, primary_, primary_, primary_);
     cderi_ = std::shared_ptr<TwoBodyAOInt>(integral->eri());
     

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -79,6 +79,7 @@ void CDJK::initialize_JK_core() {
     // used for contructing the TwoBodyAOInt.
     auto integral = std::make_shared<IntegralFactory>(primary_, primary_, primary_, primary_);
     cderi_ = std::shared_ptr<TwoBodyAOInt>(integral->eri());
+    
     int ntri = cderi_->function_pairs().size();
     /// If user asks to read integrals from disk, just read them from disk.
     /// Qmn is only storing upper triangle.

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -66,6 +66,13 @@ size_t CDJK::memory_estimate() {
 
 void CDJK::initialize_JK_core() {
     timer_on("CD: cholesky decomposition");
+    // TODO: Fix after the cderi_ deprecation is out in v1.11
+    // this should probably be
+    //      IntegralFactory factory(primary_, primary_, primary_, primary_);
+    //      const std::shared_ptr<TwoBodyAOInt> cderi = factory.eri();
+    // in the future. A TwoBodyAOInt object keeps the factory as a raw non-owning back-pointer (const IntegralFactory
+    // *integral_) and is therefore probably quite a dangerous thing if it ever outlives the IntegralFactory that was
+    // used for contructing the TwoBodyAOInt.
     auto integral = std::make_shared<IntegralFactory>(primary_, primary_, primary_, primary_);
     cderi_ = std::shared_ptr<TwoBodyAOInt>(integral->eri());
     int ntri = cderi_->function_pairs().size();

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -54,6 +54,13 @@ CDJK::CDJK(std::shared_ptr<BasisSet> primary, Options& options, double cholesky_
 
 void CDJK::initialize_JK_disk() { throw PSIEXCEPTION("Disk algorithm for CD JK not implemented."); }
 
+void CDJK::set_do_wK(const bool do_wK) {
+    if (do_wK)
+        throw PSIEXCEPTION(
+            "CDJK (Coulomb and exchange via Cholesky decomposition) does not support range-separated (wK) exchange.");
+    DiskDFJK::set_do_wK(do_wK);
+}
+
 size_t CDJK::memory_estimate() {
     // Size is unknown until actual evaluation
     const size_t nbf = primary_->nbf();
@@ -162,6 +169,8 @@ void CDJK::print_header() const {
         outfile->Printf("    Cholesky tolerance:   %11.2E\n", cholesky_tolerance_);
         outfile->Printf("    No. Cholesky vectors: %11li\n\n", ncholesky_);
     }
-    if (do_wK_) throw PSIEXCEPTION("No wk for scf_type cd.");
+    if (do_wK_)
+        throw PSIEXCEPTION(
+            "CDJK (Coulomb and exchange via Cholesky decomposition) does not support range-separated (wK) exchange.");
 }
 }  // namespace psi

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -67,9 +67,7 @@ size_t CDJK::memory_estimate() {
 void CDJK::initialize_JK_core() {
     timer_on("CD: cholesky decomposition");
     auto integral = std::make_shared<IntegralFactory>(primary_, primary_, primary_, primary_);
-    // Integral engine for computing CD integrals. Note that this is a a "shallow const", only the shared_ptr is const,
-    // but the TwoBodyAOInt it is holding is still mutable
-    const auto cderi_ = std::shared_ptr<TwoBodyAOInt>(integral->eri());
+    cderi_ = std::shared_ptr<TwoBodyAOInt>(integral->eri());
     int ntri = cderi_->function_pairs().size();
     /// If user asks to read integrals from disk, just read them from disk.
     /// Qmn is only storing upper triangle.

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -56,8 +56,7 @@ void CDJK::initialize_JK_disk() { throw PSIEXCEPTION("Disk algorithm for CD JK n
 
 size_t CDJK::memory_estimate() {
     // Size is unknown until actual evaluation
-    size_t nbf = primary_->nbf();
-
+    const size_t nbf = primary_->nbf();
     // Assume cholesky index is ~4x of nbf.
     return nbf * nbf * nbf * 4;
 }

--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -47,8 +47,6 @@
 #include <omp.h>
 #endif
 
-using namespace psi;
-
 namespace psi {
 
 CDJK::CDJK(std::shared_ptr<BasisSet> primary, Options& options, double cholesky_tolerance)

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -195,9 +195,7 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
         return jk;
 
     } else {
-        std::stringstream message;
-        message << "JK::build_JK: Unkown SCF Type '" << jk_type << "'" << std::endl;
-        throw PSIEXCEPTION(message.str());
+        throw PSIEXCEPTION("JK::build_JK: Unkown SCF Type '" + jk_type + "'");
     }
 }
 std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary,

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -195,7 +195,7 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
         return jk;
 
     } else {
-        throw PSIEXCEPTION("JK::build_JK: Unkown SCF Type '" + jk_type + "'");
+        throw PSIEXCEPTION("JK::build_JK: Unknown SCF Type '" + jk_type + "'");
     }
 }
 std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary,

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1093,8 +1093,16 @@ class PSI_API CDJK : public DiskDFJK {
      */
     CDJK(std::shared_ptr<BasisSet> primary, Options& options, double cholesky_tolerance);
 
-    /// Destructor
-    ~CDJK() override;
+    /// Explicitly saying we want to override the inherited dtor with the default dtor for this object is not strictly
+    /// necessary, but it helps disarm a footgun.
+    /// Since this is an override, the corresponding base class function must be virtual. Hypotetically, someone
+    /// could try to change ~JK() to not be virtual, which would turn std::unique_ptr<JK> objects into UB hazards. For
+    /// example if std::unique_ptr<JK> is given a DirectJK* to hold onto, when unique_ptr destructs it would execute
+    /// delete JK*, which would only call ~JK(), leaking everything that ~DFJK() would have cleaned up. Currently since
+    /// ~JK() is virtual, delete JK* on a DirectJK* actually starts at ~DFJK(), which then eventually also calls ~JK().
+    /// Which this override below in place, changing ~JK() to not be virtual would give a compile error, hopefully
+    /// leading the developer to reconsider.
+    ~CDJK() override = default;
 };
 
 /**

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1051,6 +1051,9 @@ class PSI_API DiskDFJK : public JK {
  * cholesky decomposition technology
  */
 class PSI_API CDJK : public DiskDFJK {
+   private:
+    const double cholesky_tolerance_;
+
    protected:
     std::string name() override { return "CDJK"; }
     size_t memory_estimate() override;
@@ -1069,8 +1072,6 @@ class PSI_API CDJK : public DiskDFJK {
     void initialize_JK_core() override;
     void initialize_JK_disk() override;
     void manage_JK_core() override;
-
-    double cholesky_tolerance_;
 
     // => Accessors <= //
 

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1062,6 +1062,9 @@ class PSI_API CDJK : public DiskDFJK {
     size_t memory_estimate() override;
 
     /// integral engine for computing CD integrals
+    PSI_DEPRECATED(
+        "CDJK::cderi_ is planned to be moved inside CDJK::initialize_JK_core. Unless someone speaks up, 1.11 may be "
+        "the last release to have it.")
     std::shared_ptr<TwoBodyAOInt> cderi_;
 
     // => Required Algorithm-Specific Methods <= //

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -964,7 +964,7 @@ class PSI_API DiskDFJK : public JK {
     void initialize_w_temps();
     void free_w_temps();
 
-    // => J <= //
+    // => J and K <= //
     virtual void initialize_JK_core();
     virtual void initialize_JK_disk();
     virtual void manage_JK_core();
@@ -1072,7 +1072,7 @@ class PSI_API CDJK : public DiskDFJK {
 
     virtual bool is_core() { return true; }
 
-    // => J <= //
+    // => J and K <= //
     void initialize_JK_core() override;
     void initialize_JK_disk() override;
     void manage_JK_core() override;

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1053,9 +1053,9 @@ class PSI_API DiskDFJK : public JK {
  */
 class PSI_API CDJK : public DiskDFJK {
    private:
-    /// @brief Tolarence used in the Cholesky decomposition. Set by the ctor.
+    /// @brief Tolerance used in the Cholesky decomposition. Set by the ctor.
     const double cholesky_tolerance_;
-    /// @brief The number of cholesky vectors.
+    /// @brief The number of Cholesky vectors.
     long int ncholesky_;
 
    protected:
@@ -1100,11 +1100,11 @@ class PSI_API CDJK : public DiskDFJK {
     /// @brief Destructor for CDJK (Coulomb and exchange matrices via Cholesky decomposition) objects
     /// @note Explicitly saying we want to override the inherited dtor with the default dtor for this object is not
     /// strictly necessary, but it helps disarm a footgun. Since this is an override, the corresponding base class
-    /// function must be virtual. Hypotetically, someone could try to change ~JK() to not be virtual, which would turn
-    /// std::unique_ptr<JK> objects into UB hazards. For example if std::unique_ptr<JK> is given a DirectJK* to hold
+    /// function must be virtual. Hypothetically, someone could try to change ~JK() to not be virtual, which would turn
+    /// std::unique_ptr<JK> objects into UB hazards. For example if std::unique_ptr<JK> is given a DiskDFJK* to hold
     /// onto, when unique_ptr destructs it would execute delete JK*, which would only call ~JK(), leaking everything
-    /// that ~DFJK() would have cleaned up. Currently since ~JK() is virtual, delete JK* on a DirectJK* actually starts
-    /// at ~DFJK(), which then eventually also calls ~JK(). Which this override below in place, changing ~JK() to not be
+    /// that ~DiskDFJK() would have cleaned up. Currently since ~JK() is virtual, delete JK* on a DiskDFJK* actually starts
+    /// at ~DiskDFJK(), which then eventually also calls ~JK(). With this override below in place, changing ~JK() to not be
     /// virtual would give a compile error, hopefully leading the developer to reconsider.
     ~CDJK() override = default;
 

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1107,6 +1107,15 @@ class PSI_API CDJK : public DiskDFJK {
     /// at ~DFJK(), which then eventually also calls ~JK(). Which this override below in place, changing ~JK() to not be
     /// virtual would give a compile error, hopefully leading the developer to reconsider.
     ~CDJK() override = default;
+
+    // => Knobs <= //
+
+    /// @brief Configure range-separated exchange (wK) in CDJK.
+    /// @param do_wK Should CDJK compute range-separated exchange (wK)? Must always be false.
+    /// @note SCF_TYPE CD has no range-separated (wK) implementation yet. Therefore this function rejects attempts to
+    /// set_do_wK to true. If a linter complains: yes we do want both override and final. They are not exactly the same
+    /// thing, nor is final a strict superset of override.
+    void set_do_wK(bool do_wK) override final;
 };
 
 /**

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -393,6 +393,7 @@ class PSI_API JK {
     /// Do we need to backtransform to C1 under the hood?
     virtual bool C1() const = 0;
     virtual std::string name() = 0;
+    // TODO: investigate if JK::memory_estimate and all of its derived variants could be made const
     virtual size_t memory_estimate() = 0;
 
     // => Knobs <= //

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1059,9 +1059,13 @@ class PSI_API CDJK : public DiskDFJK {
 
    protected:
     std::string name() override { return "CDJK"; }
-    size_t memory_estimate() override;    
+    size_t memory_estimate() override;
+
+    /// integral engine for computing CD integrals
+    std::shared_ptr<TwoBodyAOInt> cderi_;
 
     // => Required Algorithm-Specific Methods <= //
+
     virtual bool is_core() { return true; }
 
     // => J <= //

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1052,7 +1052,10 @@ class PSI_API DiskDFJK : public JK {
  */
 class PSI_API CDJK : public DiskDFJK {
    private:
+    /// @brief Tolarence used in the Cholesky decomposition. Set by the ctor.
     const double cholesky_tolerance_;
+    /// @brief The number of cholesky vectors.
+    long int ncholesky_;
 
    protected:
     std::string name() override { return "CDJK"; }
@@ -1060,9 +1063,6 @@ class PSI_API CDJK : public DiskDFJK {
 
     /// integral engine for computing CD integrals
     std::shared_ptr<TwoBodyAOInt> cderi_;
-
-    // the number of cholesky vectors
-    long int ncholesky_;
 
     // => Required Algorithm-Specific Methods <= //
 
@@ -1082,7 +1082,7 @@ class PSI_API CDJK : public DiskDFJK {
     void print_header() const override;
 
    public:
-    // => Constructors < = //
+    // => Constructor and destructor < = //
 
     /// @brief Constructor for CDJK (Coulomb and exchange matrices via Cholesky decomposition) objects
     /// @param primary Primary basis set for this system. AO2USO transforms will be built with the molecule contained in

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1083,25 +1083,24 @@ class PSI_API CDJK : public DiskDFJK {
    public:
     // => Constructors < = //
 
-    /**
-     * @param primary primary basis set for this system.
-     *        AO2USO transforms will be built with the molecule
-     *        contained in this basis object, so the incoming
-     *        C matrices must have the same spatial symmetry
-     *        structure as this molecule
-     * @param cholesky_tolerance tolerance for cholesky decomposition.
-     */
+    /// @brief Constructor for CDJK (Coulomb and exchange matrices via Cholesky decomposition) objects
+    /// @param primary Primary basis set for this system. AO2USO transforms will be built with the molecule contained in
+    /// this basis object, so the incoming C matrices must have the same spatial symmetry structure as this molecule.
+    /// @param options
+    /// @param cholesky_tolerance Tolerance for the cholesky decomposition.
+    /// @note Cholesky needs no auxiliary basis, but the parent constructor demands one, so the primary basis is passed
+    /// into the auxiliary_ slot as a placeholder.
     CDJK(std::shared_ptr<BasisSet> primary, Options& options, double cholesky_tolerance);
 
-    /// Explicitly saying we want to override the inherited dtor with the default dtor for this object is not strictly
-    /// necessary, but it helps disarm a footgun.
-    /// Since this is an override, the corresponding base class function must be virtual. Hypotetically, someone
-    /// could try to change ~JK() to not be virtual, which would turn std::unique_ptr<JK> objects into UB hazards. For
-    /// example if std::unique_ptr<JK> is given a DirectJK* to hold onto, when unique_ptr destructs it would execute
-    /// delete JK*, which would only call ~JK(), leaking everything that ~DFJK() would have cleaned up. Currently since
-    /// ~JK() is virtual, delete JK* on a DirectJK* actually starts at ~DFJK(), which then eventually also calls ~JK().
-    /// Which this override below in place, changing ~JK() to not be virtual would give a compile error, hopefully
-    /// leading the developer to reconsider.
+    /// @brief Destructor for CDJK (Coulomb and exchange matrices via Cholesky decomposition) objects
+    /// @note Explicitly saying we want to override the inherited dtor with the default dtor for this object is not
+    /// strictly necessary, but it helps disarm a footgun. Since this is an override, the corresponding base class
+    /// function must be virtual. Hypotetically, someone could try to change ~JK() to not be virtual, which would turn
+    /// std::unique_ptr<JK> objects into UB hazards. For example if std::unique_ptr<JK> is given a DirectJK* to hold
+    /// onto, when unique_ptr destructs it would execute delete JK*, which would only call ~JK(), leaking everything
+    /// that ~DFJK() would have cleaned up. Currently since ~JK() is virtual, delete JK* on a DirectJK* actually starts
+    /// at ~DFJK(), which then eventually also calls ~JK(). Which this override below in place, changing ~JK() to not be
+    /// virtual would give a compile error, hopefully leading the developer to reconsider.
     ~CDJK() override = default;
 };
 

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1059,13 +1059,9 @@ class PSI_API CDJK : public DiskDFJK {
 
    protected:
     std::string name() override { return "CDJK"; }
-    size_t memory_estimate() override;
-
-    /// integral engine for computing CD integrals
-    std::shared_ptr<TwoBodyAOInt> cderi_;
+    size_t memory_estimate() override;    
 
     // => Required Algorithm-Specific Methods <= //
-
     virtual bool is_core() { return true; }
 
     // => J <= //


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR is a collection of modest improvements to the CDJK object, modernizing a few things, adding missing docstrings and improving the robustness of how the unimplemented range-separated (wK) exchange is refused.
The PR also reduces the exposure of `CDJK::cholesky_tolerance_` and `CDJK::ncholesky_` from protected to private, marks `CDJK::cholesky_tolerance_` as `const`, and deprecates `CDJK::cderi_` as a member variable.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] PSI_API changes: `CDJK::cholesky_tolerance_` and `CDJK::ncholesky_` are now private instead of protected, `cholesky_tolerance_` is now `const`.
- [x] PSI_API change: CDJK now overrides `set_do_wK` and throws in it if the unimplemented range-separated (wK) exchange is requested.
- [x] PSI_API deprecation notice: `CDJK::cderi_` is planned to be moved inside `CDJK::initialize_JK_core`. Unless someone speaks up, 1.11 will be the last release to have it.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Remove redundant `using namespace psi` from CDJK.cc
- [x] Instead of having an empty dtor definition, declare it to be the default dtor and add an explanation why deleting the dtor declaration would be undesirable.
- [x] Assert that `do_wK` must be false for CDJK in its setter, `set_do_wK`, instead of relying on users to call `print_header()`
- [x] Modernize uses of `PsiException("msg", __FILE__, __LINE__)` to the more concise `PSIEXCEPTION("msg")`. This should also make the eventual switch from ` __FILE__, __LINE__` to C++20's `std::source_location` easier, whenever that happens.
- [x] Simplify how the error is thrown for unknown SCF Type
- [x] Add proper Doxygen docstrings to `cholesky_tolerance_` and `ncholesky_`. Update and expand docstrings for the CDJK ctor and dtor, with explanations of why things are the way they are.

## Checklist
- [x] No new features
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
