### PR TITLE
Mark the Python exports of Options::set_read_globals and Options::set_read_globals as deprecated

### DIFF
--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -618,6 +618,15 @@ def set_module_options(module: str, options_dict: Dict[str, Any]) -> None:
     for k, v, in options_dict.items():
         core.set_local_option(module.upper(), k.upper(), v)
 
+_original_set_read_globals = core.Options.set_read_globals  # capture first
+def _deprecated_set_read_globals(self, b):
+    warnings.warn(
+        "Options.set_read_globals is deprecated due to disuse and because it is slightly hazardous. Unless someone speaks up, 1.12 will be the last release to have it.",
+        category=FutureWarning,
+        stacklevel=2,
+    )
+    return _original_set_read_globals(self, b)
+core.Options.set_read_globals = _deprecated_set_read_globals
 
 ## OEProp helpers
 

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -618,10 +618,20 @@ def set_module_options(module: str, options_dict: Dict[str, Any]) -> None:
     for k, v, in options_dict.items():
         core.set_local_option(module.upper(), k.upper(), v)
 
+_original_read_globals = core.Options.read_globals  # capture first
+def _deprecated_read_globals(self, b):
+    warnings.warn(
+        "The Python export of Options.read_globals is deprecated due to disuse and to better hide C++ implementation details. Unless someone speaks up, 1.12 will be the last release to have it.",
+        category=FutureWarning,
+        stacklevel=2,
+    )
+    return _original_read_globals(self, b)
+core.Options.read_globals = _deprecated_read_globals
+
 _original_set_read_globals = core.Options.set_read_globals  # capture first
 def _deprecated_set_read_globals(self, b):
     warnings.warn(
-        "Options.set_read_globals is deprecated due to disuse and because it is slightly hazardous. Unless someone speaks up, 1.12 will be the last release to have it.",
+        "The Python export of Options.set_read_globals is deprecated due to disuse and because it is slightly hazardous. Unless someone speaks up, 1.12 will be the last release to have it.",
         category=FutureWarning,
         stacklevel=2,
     )

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -55,6 +55,7 @@ import pathlib
 import re
 import uuid
 import warnings
+import functools
 from collections import Counter
 from itertools import product
 from tempfile import NamedTemporaryFile
@@ -68,6 +69,16 @@ from psi4 import core, extras
 from .. import qcdb
 from . import optproc
 from .exceptions import TestComparisonError, UpgradeHelper, ValidationError
+
+def _deprecate_method(cls, name, message):
+    original = getattr(cls, name)
+
+    @functools.wraps(original)
+    def wrapper(self, *args, **kwargs):
+        warnings.warn(message, category=FutureWarning, stacklevel=2)
+        return original(self, *args, **kwargs)
+
+    setattr(cls, name, wrapper)
 
 ## Python basis helps
 
@@ -618,25 +629,14 @@ def set_module_options(module: str, options_dict: Dict[str, Any]) -> None:
     for k, v, in options_dict.items():
         core.set_local_option(module.upper(), k.upper(), v)
 
-_original_read_globals = core.Options.read_globals  # capture first
-def _deprecated_read_globals(self, b):
-    warnings.warn(
-        "The Python export of Options.read_globals is deprecated due to disuse and to better hide C++ implementation details. Unless someone speaks up, 1.12 will be the last release to have it.",
-        category=FutureWarning,
-        stacklevel=2,
-    )
-    return _original_read_globals(self, b)
-core.Options.read_globals = _deprecated_read_globals
-
-_original_set_read_globals = core.Options.set_read_globals  # capture first
-def _deprecated_set_read_globals(self, b):
-    warnings.warn(
-        "The Python export of Options.set_read_globals is deprecated due to disuse and because it is slightly hazardous. Unless someone speaks up, 1.12 will be the last release to have it.",
-        category=FutureWarning,
-        stacklevel=2,
-    )
-    return _original_set_read_globals(self, b)
-core.Options.set_read_globals = _deprecated_set_read_globals
+_deprecate_method(
+    core.Options, "set_read_globals",
+    "The Python export of Options.set_read_globals is deprecated due to disuse and because it is slightly hazardous. Unless someone speaks up, 1.12 will be the last release to have it."
+)
+_deprecate_method(
+    core.Options, "read_globals",
+    "The Python export of Options.read_globals is deprecated due to disuse and to better hide C++ implementation details. Unless someone speaks up, 1.12 will be the last release to have it."
+)
 
 ## OEProp helpers
 

--- a/psi4/src/export_options.cc
+++ b/psi4/src/export_options.cc
@@ -30,8 +30,17 @@
 #include "psi4/pybind11.h"
 
 #include <string>
-
 using namespace psi;
+
+class pb11_deprecated_call_guard {
+    std::string msg;
+public:
+    pb11_deprecated_call_guard(const char* m) : msg(m) {}
+    bool operator()(py::detail::function_call&) const {
+        PyErr_WarnEx(PyExc_DeprecationWarning, msg.c_str(), 1);
+        return true;
+    }
+};
 
 void export_options(py::module& m) {
     py::class_<Options>(m, "Options", "docstring", py::dynamic_attr())
@@ -53,7 +62,7 @@ void export_options(py::module& m) {
         .def("set_str_i", &Options::set_str_i, "set string option")
         .def("set_array", &Options::set_array, "set array option")
         .def("read_globals", &Options::read_globals, "expert")
-        .def("set_read_globals", &Options::set_read_globals, "expert")
+        .def("set_read_globals", &Options::set_read_globals, py::call_guard<deprecated_call_guard>("Options.set_read_globals is deprecated"),"expert - Deprecated");
         .def("set_current_module", &Options::set_current_module, "sets *arg0* (all CAPS) as current module")
         .def("get_current_module", &Options::get_current_module, "gets current module")
         .def("validate_options", &Options::validate_options, "validate options for *arg0* module")

--- a/psi4/src/export_options.cc
+++ b/psi4/src/export_options.cc
@@ -30,17 +30,8 @@
 #include "psi4/pybind11.h"
 
 #include <string>
-using namespace psi;
 
-class pb11_deprecated_call_guard {
-    std::string msg;
-public:
-    pb11_deprecated_call_guard(const char* m) : msg(m) {}
-    bool operator()(py::detail::function_call&) const {
-        PyErr_WarnEx(PyExc_DeprecationWarning, msg.c_str(), 1);
-        return true;
-    }
-};
+using namespace psi;
 
 void export_options(py::module& m) {
     py::class_<Options>(m, "Options", "docstring", py::dynamic_attr())
@@ -62,7 +53,7 @@ void export_options(py::module& m) {
         .def("set_str_i", &Options::set_str_i, "set string option")
         .def("set_array", &Options::set_array, "set array option")
         .def("read_globals", &Options::read_globals, "expert")
-        .def("set_read_globals", &Options::set_read_globals, py::call_guard<deprecated_call_guard>("Options.set_read_globals is deprecated"),"expert - Deprecated");
+        .def("set_read_globals", &Options::set_read_globals, "expert")
         .def("set_current_module", &Options::set_current_module, "sets *arg0* (all CAPS) as current module")
         .def("get_current_module", &Options::get_current_module, "gets current module")
         .def("validate_options", &Options::validate_options, "validate options for *arg0* module")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
`edit_globals_` is a private `bool` mode flag in the `Options` class. The reason it exists it that `Options` objects keep options in two separate stores:

- globals_:  a single flat `map<string,Data>` the global keyword table.
- locals_: a map<string, `map<string,Data>>` keyed by module name, so each module (SCF, CCENERGY, DFMP2, …) has its own private option table

`edit_globals_` is the flag that decides which of those two stores the option machinery reads from and writes to. It is only ever turned on transiently, when Psi4 starts up, during `clean_options()` and if a plugin is being loaded. Its public face is the getter `read_globals()` and the setter `set_read_globals(bool)`. This is all fine, but these are also currently part of the Python API, which is probably not needed and in case of the setter, slightly dangerous.

To use `set_read_globals` correctly one has to call it to set it to `true`, do whatever has to be done on the globals, and then call it again with false to restore the `Options` object to its normal state. If a Python caller sets it true and never resets it (perhaps because an exception is thrown and handled before the reset) the options object is left silently corrupted, and mayhem ensues.

There is nothing in the Psi4 tree currently that is using these Pybind11 exports, so unless someone likes having these in for debugging or prototyping stuff, IMO it would be best to deprecate and remove them. A pure-Python plugin might conceivably want to inject options into the global space the same way the C++ plugin loader does, and that would need these exports, but I am not aware of anyone doing that.

Since these are not really acute problems, I am setting the deprecation time horizon to 1.12. Hopefully that will be enough time for any downstream users of the Python API to notice the deprecation messages.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Python API: The Python API export of `Options::set_read_globals(bool)` is now deprecated due to disuse and because it is slightly hazardous. Unless someone speaks up, 1.12 will be the last release to have it.
- [x] Python API: The Python API export of `Options::read_globals()` is deprecated due to disuse and to better hide C++ implementation details. Unless someone speaks up, 1.12 will be the last release to have it.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Add a universal deprecation helper to driver/p4util/python_helpers.py
- [x] Add deprecation notices for `Options.read_globals()` and `Options.set_read_globals(bool)`

## Checklist
- [x] No new features
- [x] Tests run by the CI are passing

## Status
- [x] Ready for review
- [x] Ready for merge
