### PR TITLE
libiwl: migrate write-side consumers to IWLWriter (3/3, split from #3428)

### DIFF
--- a/psi4/src/psi4/cc/ccdensity/add_core_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/add_core_ROHF.cc
@@ -32,7 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
@@ -41,7 +41,7 @@
 namespace psi {
 namespace ccdensity {
 
-void add_core_ROHF(struct iwlbuf *OutBuf) {
+void add_core_ROHF(IWLWriter &OutBuf) {
     const auto actpi = moinfo.occpi + moinfo.virtpi - moinfo.openpi;
     int mo_offset = 0;
 
@@ -53,8 +53,8 @@ void add_core_ROHF(struct iwlbuf *OutBuf) {
                 double p_qt = moinfo.pitzer2qt[p + mo_offset];
                 double q_qt = moinfo.pitzer2qt[q + mo_offset];
                 for (int m = 0; m < moinfo.nfzc; m++) {
-                    iwl_buf_wrt_val(OutBuf, p_qt, q_qt, m, m, value, 0, "outfile", 0);
-                    iwl_buf_wrt_val(OutBuf, p_qt, m, m, q_qt, -0.5 * value, 0, "outfile", 0);
+                    OutBuf.write(p_qt, q_qt, m, m, value);
+                    OutBuf.write(p_qt, m, m, q_qt, -0.5 * value);
                 }
             }
         }

--- a/psi4/src/psi4/cc/ccdensity/add_core_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/add_core_UHF.cc
@@ -32,7 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
@@ -43,7 +43,7 @@ namespace ccdensity {
 
 /* doesn't work yet */
 
-void add_core_UHF(struct iwlbuf *OutBuf) {
+void add_core_UHF(IWLWriter &OutBuf) {
     int p, q, m, n;
     int nmo, nfzv, nfzc;
     double value;
@@ -58,8 +58,8 @@ void add_core_UHF(struct iwlbuf *OutBuf) {
         for (q = nfzc; q < (nmo - nfzv); q++) {
             value = moinfo.opdm_a[p][q];
             for (m = 0; m < nfzc; m++) {
-                iwl_buf_wrt_val(OutBuf, p, q, m, m, value, 0, "outfile", 0);
-                iwl_buf_wrt_val(OutBuf, p, m, m, q, -0.5 * value, 0, "outfile", 0);
+                OutBuf.write(p, q, m, m, value);
+                OutBuf.write(p, m, m, q, -0.5 * value);
             }
         }
     }

--- a/psi4/src/psi4/cc/ccdensity/add_ref_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/add_ref_RHF.cc
@@ -31,7 +31,7 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
@@ -40,7 +40,7 @@
 namespace psi {
 namespace ccdensity {
 
-void add_ref_RHF(struct iwlbuf *OutBuf) {
+void add_ref_RHF(IWLWriter &OutBuf) {
     int mo_offset = 0;
     for (int h = 0; h < moinfo.nirreps; h++) {
         auto clsd_h = moinfo.frdocc[h] + moinfo.clsdpi[h];
@@ -50,10 +50,10 @@ void add_ref_RHF(struct iwlbuf *OutBuf) {
             moinfo.opdm.add(h, i, i, 2);
             // Two electron closed-shell
             auto qt_i = moinfo.pitzer2qt[i + mo_offset];
-            iwl_buf_wrt_val(OutBuf, qt_i, qt_i, qt_i, qt_i, 1.0, 0, "outfile", 0);
+            OutBuf.write(qt_i, qt_i, qt_i, qt_i, 1.0);
             for (int qt_j = 0; qt_j < qt_i; qt_j++) {
-                iwl_buf_wrt_val(OutBuf, qt_i, qt_i, qt_j, qt_j, 2.0, 0, "outfile", 0);
-                iwl_buf_wrt_val(OutBuf, qt_i, qt_j, qt_j, qt_i, -1.0, 0, "outfile", 0);
+                OutBuf.write(qt_i, qt_i, qt_j, qt_j, 2.0);
+                OutBuf.write(qt_i, qt_j, qt_j, qt_i, -1.0);
             }
         }
         // One electron open-shell. Had better be zero.

--- a/psi4/src/psi4/cc/ccdensity/add_ref_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/add_ref_ROHF.cc
@@ -31,7 +31,7 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
@@ -40,7 +40,7 @@
 namespace psi {
 namespace ccdensity {
 
-void add_ref_ROHF(struct iwlbuf *OutBuf) {
+void add_ref_ROHF(IWLWriter &OutBuf) {
     int mo_offset = 0;
     for (int h = 0; h < moinfo.nirreps; h++) {
         auto clsd_h = moinfo.frdocc[h] + moinfo.clsdpi[h];
@@ -51,10 +51,10 @@ void add_ref_ROHF(struct iwlbuf *OutBuf) {
             moinfo.opdm_b.add(h, i, i, 1.0);
             // Two electron closed-shell
             auto qt_i = moinfo.pitzer2qt[i + mo_offset];
-            iwl_buf_wrt_val(OutBuf, qt_i, qt_i, qt_i, qt_i, 1.0, 0, "outfile", 0);
+            OutBuf.write(qt_i, qt_i, qt_i, qt_i, 1.0);
             for (int qt_j = 0; qt_j < qt_i; qt_j++) {
-                iwl_buf_wrt_val(OutBuf, qt_i, qt_i, qt_j, qt_j, 2.0, 0, "outfile", 0);
-                iwl_buf_wrt_val(OutBuf, qt_i, qt_j, qt_j, qt_i, -1.0, 0, "outfile", 0);
+                OutBuf.write(qt_i, qt_i, qt_j, qt_j, 2.0);
+                OutBuf.write(qt_i, qt_j, qt_j, qt_i, -1.0);
             }
         }
         for (int i = 0; i < moinfo.openpi[h]; i++) {
@@ -64,13 +64,13 @@ void add_ref_ROHF(struct iwlbuf *OutBuf) {
             auto qt_i = moinfo.pitzer2qt[i + mo_offset + clsd_h];
             // Two electron open x closed
             for (int qt_j = 0; qt_j < moinfo.nfzc + moinfo.nclsd; qt_j++) {
-                iwl_buf_wrt_val(OutBuf, qt_i, qt_i, qt_j, qt_j, 1.0, 0, "outfile", 0);
-                iwl_buf_wrt_val(OutBuf, qt_i, qt_j, qt_j, qt_i, -0.5, 0, "outfile", 0);
+                OutBuf.write(qt_i, qt_i, qt_j, qt_j, 1.0);
+                OutBuf.write(qt_i, qt_j, qt_j, qt_i, -0.5);
             }
             // Two electron open x open
             for (int qt_j = (moinfo.nfzc + moinfo.nclsd); qt_j < qt_i; qt_j++) {
-                iwl_buf_wrt_val(OutBuf, qt_i, qt_i, qt_j, qt_j, 0.5, 0, "outfile", 0);
-                iwl_buf_wrt_val(OutBuf, qt_i, qt_j, qt_j, qt_i, -0.5, 0, "outfile", 0);
+                OutBuf.write(qt_i, qt_i, qt_j, qt_j, 0.5);
+                OutBuf.write(qt_i, qt_j, qt_j, qt_i, -0.5);
             }
         }
         mo_offset += moinfo.orbspi[h];

--- a/psi4/src/psi4/cc/ccdensity/add_ref_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/add_ref_UHF.cc
@@ -31,7 +31,7 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"
@@ -57,7 +57,7 @@ namespace ccdensity {
 ** I use QT-standard ordering for the indices in these expressions.
 */
 
-void add_ref_UHF(struct iwlbuf *AA, struct iwlbuf *BB, struct iwlbuf *AB) {
+void add_ref_UHF(IWLWriter &AA, IWLWriter &BB, IWLWriter &AB) {
     int mo_offset = 0;
     for (int h = 0; h < moinfo.nirreps; h++) {
         auto clsd_h = moinfo.frdocc[h] + moinfo.clsdpi[h];
@@ -68,10 +68,10 @@ void add_ref_UHF(struct iwlbuf *AA, struct iwlbuf *BB, struct iwlbuf *AB) {
             // Two electron alpha-alpha
             auto qt_i = moinfo.pitzer2qt[i + mo_offset];
             for (int qt_j = 0; qt_j < qt_i; qt_j++) {
-                iwl_buf_wrt_val(AA, qt_i, qt_i, qt_j, qt_j, 0.5, 0, "outfile", 0);
-                iwl_buf_wrt_val(AA, qt_i, qt_j, qt_i, qt_j, -0.25, 0, "outfile", 0);
-                iwl_buf_wrt_val(AA, qt_j, qt_i, qt_j, qt_i, -0.25, 0, "outfile", 0);
-                iwl_buf_wrt_val(AA, qt_i, qt_j, qt_j, qt_i, -0.25, 0, "outfile", 0);
+                AA.write(qt_i, qt_i, qt_j, qt_j, 0.5);
+                AA.write(qt_i, qt_j, qt_i, qt_j, -0.25);
+                AA.write(qt_j, qt_i, qt_j, qt_i, -0.25);
+                AA.write(qt_i, qt_j, qt_j, qt_i, -0.25);
             }
         }
         // Beta
@@ -81,10 +81,10 @@ void add_ref_UHF(struct iwlbuf *AA, struct iwlbuf *BB, struct iwlbuf *AB) {
             // Two electron beta-beta
             auto qt_i = moinfo.pitzer2qt[i + mo_offset];
             for (int qt_j = 0; qt_j < qt_i; qt_j++) {
-                iwl_buf_wrt_val(BB, qt_i, qt_i, qt_j, qt_j, 0.5, 0, "outfile", 0);
-                iwl_buf_wrt_val(BB, qt_i, qt_j, qt_i, qt_j, -0.25, 0, "outfile", 0);
-                iwl_buf_wrt_val(BB, qt_j, qt_i, qt_j, qt_i, -0.25, 0, "outfile", 0);
-                iwl_buf_wrt_val(BB, qt_i, qt_j, qt_j, qt_i, -0.25, 0, "outfile", 0);
+                BB.write(qt_i, qt_i, qt_j, qt_j, 0.5);
+                BB.write(qt_i, qt_j, qt_i, qt_j, -0.25);
+                BB.write(qt_j, qt_i, qt_j, qt_i, -0.25);
+                BB.write(qt_i, qt_j, qt_j, qt_i, -0.25);
             }
         }
         mo_offset += moinfo.orbspi[h];
@@ -92,7 +92,7 @@ void add_ref_UHF(struct iwlbuf *AA, struct iwlbuf *BB, struct iwlbuf *AB) {
 
     // Two-electron alpha-beta
     for (int i = 0; i < (moinfo.nfzc + moinfo.nclsd + moinfo.nopen); i++)
-        for (int j = 0; j < (moinfo.nfzc + moinfo.nclsd); j++) iwl_buf_wrt_val(AB, i, i, j, j, 1.0, 0, "outfile", 0);
+        for (int j = 0; j < (moinfo.nfzc + moinfo.nclsd); j++) AB.write(i, i, j, j, 1.0);
 }
 }  // namespace ccdensity
 }  // namespace psi

--- a/psi4/src/psi4/cc/ccdensity/ccdensity.cc
+++ b/psi4/src/psi4/cc/ccdensity/ccdensity.cc
@@ -47,7 +47,8 @@
 #include "psi4/cc/ccwave.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libdpd/dpd.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
+#include "psi4/libpsio/psio.hpp"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libqt/qt.h"
@@ -83,14 +84,14 @@ void relax_D(const struct RHO_Params& rho_params);
 void sortI(Wavefunction& wfn);
 void fold(const struct RHO_Params& rho_params);
 void deanti(const struct RHO_Params& rho_params);
-void add_ref_RHF(struct iwlbuf *);
-void add_ref_ROHF(struct iwlbuf *);
-void add_ref_UHF(struct iwlbuf *, struct iwlbuf *, struct iwlbuf *);
-void add_core_ROHF(struct iwlbuf *);
-// void add_core_UHF(struct iwlbuf *, struct iwlbuf *, struct iwlbuf *);
-void dump_RHF(struct iwlbuf *, const struct RHO_Params& rho_params);
-void dump_ROHF(struct iwlbuf *, const struct RHO_Params& rho_params);
-void dump_UHF(struct iwlbuf *, struct iwlbuf *, struct iwlbuf *, const struct RHO_Params& rho_params);
+void add_ref_RHF(IWLWriter &);
+void add_ref_ROHF(IWLWriter &);
+void add_ref_UHF(IWLWriter &, IWLWriter &, IWLWriter &);
+void add_core_ROHF(IWLWriter &);
+// void add_core_UHF(IWLWriter &, IWLWriter &, IWLWriter &);
+void dump_RHF(IWLWriter &, const struct RHO_Params& rho_params);
+void dump_ROHF(IWLWriter &, const struct RHO_Params& rho_params);
+void dump_UHF(IWLWriter &, IWLWriter &, IWLWriter &, const struct RHO_Params& rho_params);
 void kinetic(std::shared_ptr<Wavefunction> wfn);
 void probable();
 int **cacheprep_rhf(int level, int *cachefiles);
@@ -140,8 +141,6 @@ void ex_td_print(std::vector<struct XTD_Params>);
 PsiReturnType ccdensity(std::shared_ptr<ccenergy::CCEnergyWavefunction> ref_wfn, Options &options) {
     int i;
     int **cachelist, *cachefiles;
-    struct iwlbuf OutBuf;
-    struct iwlbuf OutBuf_AA, OutBuf_BB, OutBuf_AB;
     dpdfile2 D;
     double tval;
 
@@ -284,43 +283,38 @@ PsiReturnType ccdensity(std::shared_ptr<ccenergy::CCEnergyWavefunction> ref_wfn,
 
         if (params.ref == 0) { /** RHF **/
 
-            iwl_buf_init(&OutBuf, PSIF_MO_TPDM, params.tolerance, 0, 0);
+            IWLWriter OutBuf(_default_psio_lib_, PSIF_MO_TPDM, params.tolerance);
 
-            add_core_ROHF(&OutBuf);
-            add_ref_RHF(&OutBuf);
+            add_core_ROHF(OutBuf);
+            add_ref_RHF(OutBuf);
 
-            dump_RHF(&OutBuf, rho_params[i]);
+            dump_RHF(OutBuf, rho_params[i]);
 
-            iwl_buf_flush(&OutBuf, 1);
-            iwl_buf_close(&OutBuf, 1);
+            OutBuf.close();
         } else if (params.ref == 1) { /** ROHF **/
 
-            iwl_buf_init(&OutBuf, PSIF_MO_TPDM, params.tolerance, 0, 0);
+            IWLWriter OutBuf(_default_psio_lib_, PSIF_MO_TPDM, params.tolerance);
 
-            add_core_ROHF(&OutBuf);
-            add_ref_ROHF(&OutBuf);
+            add_core_ROHF(OutBuf);
+            add_ref_ROHF(OutBuf);
 
-            dump_ROHF(&OutBuf, rho_params[i]);
+            dump_ROHF(OutBuf, rho_params[i]);
 
-            iwl_buf_flush(&OutBuf, 1);
-            iwl_buf_close(&OutBuf, 1);
+            OutBuf.close();
         } else if (params.ref == 2) { /** UHF **/
 
-            iwl_buf_init(&OutBuf_AA, PSIF_MO_AA_TPDM, params.tolerance, 0, 0);
-            iwl_buf_init(&OutBuf_BB, PSIF_MO_BB_TPDM, params.tolerance, 0, 0);
-            iwl_buf_init(&OutBuf_AB, PSIF_MO_AB_TPDM, params.tolerance, 0, 0);
+            IWLWriter OutBuf_AA(_default_psio_lib_, PSIF_MO_AA_TPDM, params.tolerance);
+            IWLWriter OutBuf_BB(_default_psio_lib_, PSIF_MO_BB_TPDM, params.tolerance);
+            IWLWriter OutBuf_AB(_default_psio_lib_, PSIF_MO_AB_TPDM, params.tolerance);
 
-            /*    add_core_UHF(&OutBuf_AA, &OutBuf_BB, &OutBuf_AB); */
-            add_ref_UHF(&OutBuf_AA, &OutBuf_BB, &OutBuf_AB);
+            /*    add_core_UHF(OutBuf_AA, OutBuf_BB, OutBuf_AB); */
+            add_ref_UHF(OutBuf_AA, OutBuf_BB, OutBuf_AB);
 
-            dump_UHF(&OutBuf_AA, &OutBuf_BB, &OutBuf_AB, rho_params[i]);
+            dump_UHF(OutBuf_AA, OutBuf_BB, OutBuf_AB, rho_params[i]);
 
-            iwl_buf_flush(&OutBuf_AA, 1);
-            iwl_buf_flush(&OutBuf_BB, 1);
-            iwl_buf_flush(&OutBuf_AB, 1);
-            iwl_buf_close(&OutBuf_AA, 1);
-            iwl_buf_close(&OutBuf_BB, 1);
-            iwl_buf_close(&OutBuf_AB, 1);
+            OutBuf_AA.close();
+            OutBuf_BB.close();
+            OutBuf_AB.close();
         }
         std::shared_ptr<Matrix> Ca = ref_wfn->Ca();
         std::shared_ptr<Matrix> Cb = ref_wfn->Cb();

--- a/psi4/src/psi4/cc/ccdensity/classify.cc
+++ b/psi4/src/psi4/cc/ccdensity/classify.cc
@@ -31,7 +31,7 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "psi4/libciomr/libciomr.h"
 #include "MOInfo.h"
 #include "Params.h"
@@ -41,8 +41,8 @@
 namespace psi {
 namespace ccdensity {
 
-void classify(int p, int q, int r, int s, double value, struct iwlbuf *ABuf, struct iwlbuf *BBuf, struct iwlbuf *CBuf,
-              struct iwlbuf *DBuf, struct iwlbuf *EBuf, struct iwlbuf *FBuf) {
+void classify(int p, int q, int r, int s, double value, IWLWriter &ABuf, IWLWriter &BBuf, IWLWriter &CBuf,
+              IWLWriter &DBuf, IWLWriter &EBuf, IWLWriter &FBuf) {
     int *occ, *vir, *socc;
     int *cc_occ, *cc_vir;
     int dirac = 1;
@@ -60,79 +60,79 @@ void classify(int p, int q, int r, int s, double value, struct iwlbuf *ABuf, str
 
     /* A (oo|oo) integrals */
     if ((occ[p] && occ[q] && occ[r] && occ[s]))
-        iwl_buf_wrt_val(ABuf, cc_occ[p], cc_occ[q], cc_occ[r], cc_occ[s], value, 0, "outfile", dirac);
+        ABuf.write(cc_occ[p], cc_occ[q], cc_occ[r], cc_occ[s], value, dirac);
 
     /* B (vv|vv) integrals */
     if ((vir[p] && vir[q] && vir[r] && vir[s]))
-        iwl_buf_wrt_val(BBuf, cc_vir[p], cc_vir[q], cc_vir[r], cc_vir[s], value, 0, "outfile", dirac);
+        BBuf.write(cc_vir[p], cc_vir[q], cc_vir[r], cc_vir[s], value, dirac);
 
     /* C (oo|vv) integrals */
     if (soccs > 1) {
         if ((occ[p] && occ[q] && vir[r] && vir[s]))
-            iwl_buf_wrt_val(CBuf, cc_occ[p], cc_occ[q], cc_vir[r], cc_vir[s], value, 0, "outfile", dirac);
+            CBuf.write(cc_occ[p], cc_occ[q], cc_vir[r], cc_vir[s], value, dirac);
         if ((occ[r] && occ[s] && vir[p] && vir[q]))
-            iwl_buf_wrt_val(CBuf, cc_occ[r], cc_occ[s], cc_vir[p], cc_vir[q], value, 0, "outfile", dirac);
+            CBuf.write(cc_occ[r], cc_occ[s], cc_vir[p], cc_vir[q], value, dirac);
     } else if ((occ[p] && occ[q] && vir[r] && vir[s]))
-        iwl_buf_wrt_val(CBuf, cc_occ[p], cc_occ[q], cc_vir[r], cc_vir[s], value, 0, "outfile", dirac);
+        CBuf.write(cc_occ[p], cc_occ[q], cc_vir[r], cc_vir[s], value, dirac);
     else if ((occ[r] && occ[s] && vir[p] && vir[q]))
-        iwl_buf_wrt_val(CBuf, cc_occ[r], cc_occ[s], cc_vir[p], cc_vir[q], value, 0, "outfile", dirac);
+        CBuf.write(cc_occ[r], cc_occ[s], cc_vir[p], cc_vir[q], value, dirac);
 
     /* D (ov|ov) integrals */
     if (soccs > 1) {
         if ((occ[p] && vir[q] && occ[r] && vir[s]))
-            iwl_buf_wrt_val(DBuf, cc_occ[p], cc_vir[q], cc_occ[r], cc_vir[s], value, 0, "outfile", dirac);
+            DBuf.write(cc_occ[p], cc_vir[q], cc_occ[r], cc_vir[s], value, dirac);
         if ((occ[q] && vir[p] && occ[r] && vir[s]))
-            iwl_buf_wrt_val(DBuf, cc_occ[q], cc_vir[p], cc_occ[r], cc_vir[s], value, 0, "outfile", dirac);
+            DBuf.write(cc_occ[q], cc_vir[p], cc_occ[r], cc_vir[s], value, dirac);
         if ((occ[p] && vir[q] && occ[s] && vir[r]))
-            iwl_buf_wrt_val(DBuf, cc_occ[p], cc_vir[q], cc_occ[s], cc_vir[r], value, 0, "outfile", dirac);
+            DBuf.write(cc_occ[p], cc_vir[q], cc_occ[s], cc_vir[r], value, dirac);
         if ((occ[q] && vir[p] && occ[s] && vir[r]))
-            iwl_buf_wrt_val(DBuf, cc_occ[q], cc_vir[p], cc_occ[s], cc_vir[r], value, 0, "outfile", dirac);
+            DBuf.write(cc_occ[q], cc_vir[p], cc_occ[s], cc_vir[r], value, dirac);
     } else if ((occ[p] && vir[q] && occ[r] && vir[s]))
-        iwl_buf_wrt_val(DBuf, cc_occ[p], cc_vir[q], cc_occ[r], cc_vir[s], value, 0, "outfile", dirac);
+        DBuf.write(cc_occ[p], cc_vir[q], cc_occ[r], cc_vir[s], value, dirac);
     else if ((occ[q] && vir[p] && occ[r] && vir[s]))
-        iwl_buf_wrt_val(DBuf, cc_occ[q], cc_vir[p], cc_occ[r], cc_vir[s], value, 0, "outfile", dirac);
+        DBuf.write(cc_occ[q], cc_vir[p], cc_occ[r], cc_vir[s], value, dirac);
     else if ((occ[p] && vir[q] && occ[s] && vir[r]))
-        iwl_buf_wrt_val(DBuf, cc_occ[p], cc_vir[q], cc_occ[s], cc_vir[r], value, 0, "outfile", dirac);
+        DBuf.write(cc_occ[p], cc_vir[q], cc_occ[s], cc_vir[r], value, dirac);
     else if ((occ[q] && vir[p] && occ[s] && vir[r]))
-        iwl_buf_wrt_val(DBuf, cc_occ[q], cc_vir[p], cc_occ[s], cc_vir[r], value, 0, "outfile", dirac);
+        DBuf.write(cc_occ[q], cc_vir[p], cc_occ[s], cc_vir[r], value, dirac);
 
     /* E (vo|oo) integrals */
     if (soccs > 1) {
         if ((vir[p] && occ[q] && occ[r] && occ[s]))
-            iwl_buf_wrt_val(EBuf, cc_vir[p], cc_occ[q], cc_occ[r], cc_occ[s], value, 0, "outfile", dirac);
+            EBuf.write(cc_vir[p], cc_occ[q], cc_occ[r], cc_occ[s], value, dirac);
         if ((vir[q] && occ[p] && occ[r] && occ[s]))
-            iwl_buf_wrt_val(EBuf, cc_vir[q], cc_occ[p], cc_occ[r], cc_occ[s], value, 0, "outfile", dirac);
+            EBuf.write(cc_vir[q], cc_occ[p], cc_occ[r], cc_occ[s], value, dirac);
         if ((vir[r] && occ[s] && occ[p] && occ[q]))
-            iwl_buf_wrt_val(EBuf, cc_vir[r], cc_occ[s], cc_occ[p], cc_occ[q], value, 0, "outfile", dirac);
+            EBuf.write(cc_vir[r], cc_occ[s], cc_occ[p], cc_occ[q], value, dirac);
         if ((vir[s] && occ[r] && occ[p] && occ[q]))
-            iwl_buf_wrt_val(EBuf, cc_vir[s], cc_occ[r], cc_occ[p], cc_occ[q], value, 0, "outfile", dirac);
+            EBuf.write(cc_vir[s], cc_occ[r], cc_occ[p], cc_occ[q], value, dirac);
     } else if ((vir[p] && occ[q] && occ[r] && occ[s]))
-        iwl_buf_wrt_val(EBuf, cc_vir[p], cc_occ[q], cc_occ[r], cc_occ[s], value, 0, "outfile", dirac);
+        EBuf.write(cc_vir[p], cc_occ[q], cc_occ[r], cc_occ[s], value, dirac);
     else if ((vir[p] && occ[q] && occ[s] && occ[r]))
-        iwl_buf_wrt_val(EBuf, cc_vir[q], cc_occ[p], cc_occ[r], cc_occ[s], value, 0, "outfile", dirac);
+        EBuf.write(cc_vir[q], cc_occ[p], cc_occ[r], cc_occ[s], value, dirac);
     else if ((vir[r] && occ[s] && occ[p] && occ[q]))
-        iwl_buf_wrt_val(EBuf, cc_vir[r], cc_occ[s], cc_occ[p], cc_occ[q], value, 0, "outfile", dirac);
+        EBuf.write(cc_vir[r], cc_occ[s], cc_occ[p], cc_occ[q], value, dirac);
     else if ((vir[r] && occ[s] && occ[q] && occ[p]))
-        iwl_buf_wrt_val(EBuf, cc_vir[s], cc_occ[r], cc_occ[p], cc_occ[q], value, 0, "outfile", dirac);
+        EBuf.write(cc_vir[s], cc_occ[r], cc_occ[p], cc_occ[q], value, dirac);
 
     /* F (ov|vv) integrals */
     if (soccs > 1) {
         if ((occ[p] && vir[q] && vir[r] && vir[s]))
-            iwl_buf_wrt_val(FBuf, cc_occ[p], cc_vir[q], cc_vir[r], cc_vir[s], value, 0, "outfile", dirac);
+            FBuf.write(cc_occ[p], cc_vir[q], cc_vir[r], cc_vir[s], value, dirac);
         if ((occ[q] && vir[p] && vir[r] && vir[s]))
-            iwl_buf_wrt_val(FBuf, cc_occ[q], cc_vir[p], cc_vir[r], cc_vir[s], value, 0, "outfile", dirac);
+            FBuf.write(cc_occ[q], cc_vir[p], cc_vir[r], cc_vir[s], value, dirac);
         if ((occ[r] && vir[s] && vir[p] && vir[q]))
-            iwl_buf_wrt_val(FBuf, cc_occ[r], cc_vir[s], cc_vir[p], cc_vir[q], value, 0, "outfile", dirac);
+            FBuf.write(cc_occ[r], cc_vir[s], cc_vir[p], cc_vir[q], value, dirac);
         if ((occ[s] && vir[r] && vir[p] && vir[q]))
-            iwl_buf_wrt_val(FBuf, cc_occ[s], cc_vir[r], cc_vir[p], cc_vir[q], value, 0, "outfile", dirac);
+            FBuf.write(cc_occ[s], cc_vir[r], cc_vir[p], cc_vir[q], value, dirac);
     } else if ((occ[p] && vir[q] && vir[r] && vir[s]))
-        iwl_buf_wrt_val(FBuf, cc_occ[p], cc_vir[q], cc_vir[r], cc_vir[s], value, 0, "outfile", dirac);
+        FBuf.write(cc_occ[p], cc_vir[q], cc_vir[r], cc_vir[s], value, dirac);
     else if ((occ[q] && vir[p] && vir[r] && vir[s]))
-        iwl_buf_wrt_val(FBuf, cc_occ[q], cc_vir[p], cc_vir[r], cc_vir[s], value, 0, "outfile", dirac);
+        FBuf.write(cc_occ[q], cc_vir[p], cc_vir[r], cc_vir[s], value, dirac);
     else if ((occ[r] && vir[s] && vir[p] && vir[q]))
-        iwl_buf_wrt_val(FBuf, cc_occ[r], cc_vir[s], cc_vir[p], cc_vir[q], value, 0, "outfile", dirac);
+        FBuf.write(cc_occ[r], cc_vir[s], cc_vir[p], cc_vir[q], value, dirac);
     else if ((occ[s] && vir[r] && vir[p] && vir[q]))
-        iwl_buf_wrt_val(FBuf, cc_occ[s], cc_vir[r], cc_vir[p], cc_vir[q], value, 0, "outfile", dirac);
+        FBuf.write(cc_occ[s], cc_vir[r], cc_vir[p], cc_vir[q], value, dirac);
 }
 
 }  // namespace ccdensity

--- a/psi4/src/psi4/cc/ccdensity/deanti_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/deanti_RHF.cc
@@ -30,7 +30,6 @@
     \ingroup CCDENSITY
     \brief Enter brief description of file here
 */
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psifiles.h"
 

--- a/psi4/src/psi4/cc/ccdensity/deanti_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/deanti_ROHF.cc
@@ -31,7 +31,6 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psifiles.h"
 

--- a/psi4/src/psi4/cc/ccdensity/deanti_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/deanti_UHF.cc
@@ -32,7 +32,6 @@
 */
 #include <cstdio>
 #include <cstring>
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psifiles.h"
 #include "MOInfo.h"

--- a/psi4/src/psi4/cc/ccdensity/distribute.cc
+++ b/psi4/src/psi4/cc/ccdensity/distribute.cc
@@ -31,7 +31,9 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_reader.h"
+#include "psi4/libiwl/iwl_writer.h"
+#include "psi4/libpsio/psio.hpp"
 #include "psi4/psifiles.h"
 #include "MOInfo.h"
 #include "Params.h"
@@ -41,83 +43,26 @@
 namespace psi {
 namespace ccdensity {
 
-void classify(int p, int q, int r, int s, double value, struct iwlbuf *ABuf, struct iwlbuf *BBuf, struct iwlbuf *CBuf,
-              struct iwlbuf *DBuf, struct iwlbuf *EBuf, struct iwlbuf *FBuf);
+void classify(int p, int q, int r, int s, double value, IWLWriter &ABuf, IWLWriter &BBuf, IWLWriter &CBuf,
+              IWLWriter &DBuf, IWLWriter &EBuf, IWLWriter &FBuf);
 
 void distribute() {
-    double tolerance;
-    struct iwlbuf InBuf;
-    struct iwlbuf ABuf, BBuf, CBuf, DBuf, EBuf, FBuf;
-    int lastbuf;
-    Value *valptr;
-    Label *lblptr;
-    int idx, p, q, r, s;
-    double value;
+    double tolerance = params.tolerance;
 
-    tolerance = params.tolerance;
+    IWLWriter ABuf(_default_psio_lib_, 90, tolerance);
+    IWLWriter BBuf(_default_psio_lib_, 91, tolerance);
+    IWLWriter CBuf(_default_psio_lib_, 92, tolerance);
+    IWLWriter DBuf(_default_psio_lib_, 93, tolerance);
+    IWLWriter EBuf(_default_psio_lib_, 94, tolerance);
+    IWLWriter FBuf(_default_psio_lib_, 95, tolerance);
 
-    iwl_buf_init(&InBuf, PSIF_MO_TEI, tolerance, 1, 1);
-    iwl_buf_init(&ABuf, 90, tolerance, 0, 0);
-    iwl_buf_init(&BBuf, 91, tolerance, 0, 0);
-    iwl_buf_init(&CBuf, 92, tolerance, 0, 0);
-    iwl_buf_init(&DBuf, 93, tolerance, 0, 0);
-    iwl_buf_init(&EBuf, 94, tolerance, 0, 0);
-    iwl_buf_init(&FBuf, 95, tolerance, 0, 0);
-
-    /* Run through the buffer that's already available */
-    lblptr = InBuf.labels;
-    valptr = InBuf.values;
-    lastbuf = InBuf.lastbuf;
-
-    for (idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
-        p = (int)lblptr[idx++];
-        q = (int)lblptr[idx++];
-        r = (int)lblptr[idx++];
-        s = (int)lblptr[idx++];
-
-        value = (double)valptr[InBuf.idx];
-
+    IWLReader eri(_default_psio_lib_, PSIF_MO_TEI);
+    for (const auto &integral : eri) {
         /* Check integral into each class */
-        classify(p, q, r, s, value, &ABuf, &BBuf, &CBuf, &DBuf, &EBuf, &FBuf);
-
-        /*    outfile->Printf( "(%d %d|%d %d) = %20.10lf\n", p, q, r, s, value);  */
-
-    } /* end loop through current buffer */
-
-    /* Now run through the rest of the buffers in the file */
-    while (!lastbuf) {
-        iwl_buf_fetch(&InBuf);
-        lastbuf = InBuf.lastbuf;
-
-        for (idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
-            p = (int)lblptr[idx++];
-            q = (int)lblptr[idx++];
-            r = (int)lblptr[idx++];
-            s = (int)lblptr[idx++];
-
-            value = (double)valptr[InBuf.idx];
-
-            /* Check integral into each class */
-            classify(p, q, r, s, value, &ABuf, &BBuf, &CBuf, &DBuf, &EBuf, &FBuf);
-
-            /*      outfile->Printf( "(%d %d|%d %d) = %20.10lf\n", p, q, r, s, value); */
-
-        } /* end loop through current buffer */
-    }     /* end loop over reading buffers */
-
-    iwl_buf_close(&InBuf, 1);
-    iwl_buf_flush(&ABuf, 1);
-    iwl_buf_flush(&BBuf, 1);
-    iwl_buf_flush(&CBuf, 1);
-    iwl_buf_flush(&DBuf, 1);
-    iwl_buf_flush(&EBuf, 1);
-    iwl_buf_flush(&FBuf, 1);
-    iwl_buf_close(&ABuf, 1);
-    iwl_buf_close(&BBuf, 1);
-    iwl_buf_close(&CBuf, 1);
-    iwl_buf_close(&DBuf, 1);
-    iwl_buf_close(&EBuf, 1);
-    iwl_buf_close(&FBuf, 1);
+        classify(integral.p, integral.q, integral.r, integral.s, integral.value, ABuf, BBuf, CBuf, DBuf, EBuf,
+                 FBuf);
+    }
+    // IWLReader/IWLWriter close (and the writers flush the last buffer) on scope exit.
 }
 
 }  // namespace ccdensity

--- a/psi4/src/psi4/cc/ccdensity/dump_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/dump_RHF.cc
@@ -32,7 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psifiles.h"
 #include "MOInfo.h"
@@ -75,7 +75,7 @@ namespace ccdensity {
 ** TDC, last updated 2/08
 */
 
-void dump_RHF(struct iwlbuf *OutBuf, const struct RHO_Params& rho_params) {
+void dump_RHF(IWLWriter &OutBuf, const struct RHO_Params& rho_params) {
     int nirreps, nmo, nfzv;
     int h, row, col, p, q, r, s;
     dpdbuf4 G;

--- a/psi4/src/psi4/cc/ccdensity/dump_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/dump_ROHF.cc
@@ -32,7 +32,7 @@
 */
 #include <cstdio>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psifiles.h"
 #include "MOInfo.h"
@@ -65,7 +65,7 @@ namespace ccdensity {
 ** I really need to give an example of this problem using specific
 ** elements of GIJKA so that the code below will be clearer.*/
 
-void dump_ROHF(struct iwlbuf *OutBuf, const struct RHO_Params& rho_params) {
+void dump_ROHF(IWLWriter &OutBuf, const struct RHO_Params& rho_params) {
     int nirreps, nmo, nfzv;
     int h, row, col, p, q, r, s;
     dpdbuf4 G;

--- a/psi4/src/psi4/cc/ccdensity/dump_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/dump_UHF.cc
@@ -33,7 +33,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psifiles.h"
 #include "MOInfo.h"
@@ -58,7 +58,7 @@ namespace ccdensity {
 
 #define INDEX(i, j) ((i) >= (j) ? EXPLICIT_IOFF(i) + (j) : EXPLICIT_IOFF(j) + (i))
 
-void dump_UHF(struct iwlbuf *AA, struct iwlbuf *BB, struct iwlbuf *AB, const struct RHO_Params& rho_params) {
+void dump_UHF(IWLWriter &AA, IWLWriter &BB, IWLWriter &AB, const struct RHO_Params& rho_params) {
     int nirreps, nmo, h, row, col;
     int p, q, r, s, P, Q, R, S, pr, qs;
     double value;
@@ -112,7 +112,7 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = 2.0 * G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(AB, P, R, Q, S, value, 0, "outfile", 0);
+                    AB.write(P, R, Q, S, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -136,7 +136,7 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(AA, P, R, Q, S, value, 0, "outfile", 0);
+                    AA.write(P, R, Q, S, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -160,7 +160,7 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(BB, P, R, Q, S, value, 0, "outfile", 0);
+                    BB.write(P, R, Q, S, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -184,8 +184,8 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(AB, P, R, Q, S, value, 0, "outfile", 0);
-                    iwl_buf_wrt_val(AB, P, R, S, Q, value, 0, "outfile", 0);
+                    AB.write(P, R, Q, S, value);
+                    AB.write(P, R, S, Q, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -209,8 +209,8 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(AB, Q, S, P, R, value, 0, "outfile", 0);
-                    iwl_buf_wrt_val(AB, S, Q, P, R, value, 0, "outfile", 0);
+                    AB.write(Q, S, P, R, value);
+                    AB.write(S, Q, P, R, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -250,7 +250,7 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = 2.0 * G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(AB, P, R, Q, S, value, 0, "outfile", 0);
+                    AB.write(P, R, Q, S, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -274,7 +274,7 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = 0.5 * G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(AA, P, R, Q, S, value, 0, "outfile", 0);
+                    AA.write(P, R, Q, S, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -298,7 +298,7 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = 0.5 * G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(BB, P, R, Q, S, value, 0, "outfile", 0);
+                    BB.write(P, R, Q, S, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -322,7 +322,7 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(AB, P, R, Q, S, value, 0, "outfile", 0);
+                    AB.write(P, R, Q, S, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -346,7 +346,7 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(AB, Q, S, P, R, value, 0, "outfile", 0);
+                    AB.write(Q, S, P, R, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -370,7 +370,7 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(AA, P, R, Q, S, value, 0, "outfile", 0);
+                    AA.write(P, R, Q, S, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -394,7 +394,7 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(BB, P, R, Q, S, value, 0, "outfile", 0);
+                    BB.write(P, R, Q, S, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -418,8 +418,8 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(AB, P, R, Q, S, value, 0, "outfile", 0);
-                    iwl_buf_wrt_val(AB, P, R, S, Q, value, 0, "outfile", 0);
+                    AB.write(P, R, Q, S, value);
+                    AB.write(P, R, S, Q, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -443,8 +443,8 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(AB, Q, S, P, R, value, 0, "outfile", 0);
-                    iwl_buf_wrt_val(AB, S, Q, P, R, value, 0, "outfile", 0);
+                    AB.write(Q, S, P, R, value);
+                    AB.write(S, Q, P, R, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -484,7 +484,7 @@ psio_write_entry(PSIF_MO_OPDM, "MO-basis Beta OPDM", (char *) moinfo.opdm_b[0],
 
                     value = 2.0 * G.matrix[h][row][col];
 
-                    iwl_buf_wrt_val(AB, P, R, Q, S, value, 0, "outfile", 0);
+                    AB.write(P, R, Q, S, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);

--- a/psi4/src/psi4/cc/ccdensity/ex_oscillator_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_oscillator_strength.cc
@@ -34,7 +34,6 @@
 #include <cstdlib>
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/cc/ccdensity/ex_rotational_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/ex_rotational_strength.cc
@@ -35,7 +35,6 @@
 #include <cstring>
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libmints/mintshelper.h"
 #include "psi4/libqt/qt.h"

--- a/psi4/src/psi4/cc/ccdensity/file_build.cc
+++ b/psi4/src/psi4/cc/ccdensity/file_build.cc
@@ -32,11 +32,15 @@
 */
 #include <cstdio>
 #include <cstdlib>
+#include <memory>
+#include <vector>
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libiwl/iwl_reader.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psi4-dec.h"
 #include "MOInfo.h"
@@ -47,20 +51,15 @@
 namespace psi {
 namespace ccdensity {
 
-void idx_permute(dpdfile4 *File, struct iwlbuf *OutBuf, int **bucket_map, int p, int q, int r, int s, int perm_pr,
-                 int perm_qs, int perm_prqs, double value, std::string out);
+void idx_permute(dpdfile4 *File, std::vector<std::unique_ptr<IWLWriter>> &OutBuf, int **bucket_map, int p, int q, int r,
+                 int s, int perm_pr, int perm_qs, int perm_prqs, double value, std::string out);
 
 int file_build(dpdfile4 *File, int inputfile, double tolerance, int perm_pr, int perm_qs, int perm_prqs, int keep) {
-    struct iwlbuf InBuf;
-    int lastbuf;
     long int memoryb, memoryd;
     int h, nirreps, n, row, col, nump, numq, row_length, core_left, nbuckets;
     int **bucket_map, **bucket_offset, **bucket_rowdim, **bucket_size, offset;
-    Value *valptr;
-    Label *lblptr;
-    int idx, p, q, r, s;
+    int p, q, r, s;
     double value;
-    struct iwlbuf *SortBuf, *OutBuf;
     psio_address next;
 
     nirreps = File->params->nirreps;
@@ -136,51 +135,21 @@ int file_build(dpdfile4 *File, int inputfile, double tolerance, int perm_pr, int
 
     outfile->Printf("\tSorting File: %s nbuckets = %d\n", File->label, nbuckets);
 
-    /* Set up IWL buffers for sorting */
-    SortBuf = (struct iwlbuf *)malloc(nbuckets * sizeof(struct iwlbuf));
-    for (n = 0; n < nbuckets; n++) iwl_buf_init(&SortBuf[n], PSIF_CC_MAX + 1 + n, tolerance, 0, 0);
+    /* Set up IWL buffers for sorting, one per bucket */
+    {
+        std::vector<std::unique_ptr<IWLWriter>> SortBuf;
+        SortBuf.reserve(nbuckets);
+        for (n = 0; n < nbuckets; n++)
+            SortBuf.push_back(std::make_unique<IWLWriter>(_default_psio_lib_, PSIF_CC_MAX + 1 + n, tolerance));
 
-    iwl_buf_init(&InBuf, inputfile, tolerance, 1, 1);
-
-    lblptr = InBuf.labels;
-    valptr = InBuf.values;
-    lastbuf = InBuf.lastbuf;
-
-    for (idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
-        p = (int)lblptr[idx++];
-        q = (int)lblptr[idx++];
-        r = (int)lblptr[idx++];
-        s = (int)lblptr[idx++];
-
-        value = (double)valptr[InBuf.idx];
-
-        idx_permute(File, SortBuf, bucket_map, p, q, r, s, perm_pr, perm_qs, perm_prqs, value, "outfile");
-
-    } /* end loop through current buffer */
-
-    /* Now run through the rest of the buffers in the file */
-    while (!lastbuf) {
-        iwl_buf_fetch(&InBuf);
-        lastbuf = InBuf.lastbuf;
-
-        for (idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
-            p = (int)lblptr[idx++];
-            q = (int)lblptr[idx++];
-            r = (int)lblptr[idx++];
-            s = (int)lblptr[idx++];
-
-            value = (double)valptr[InBuf.idx];
-
-            idx_permute(File, SortBuf, bucket_map, p, q, r, s, perm_pr, perm_qs, perm_prqs, value, "outfile");
-
-        } /* end loop through current buffer */
-    }     /* end loop over reading buffers */
-
-    iwl_buf_close(&InBuf, keep);
-
-    for (n = 0; n < nbuckets; n++) {
-        iwl_buf_flush(&SortBuf[n], 1);
-        iwl_buf_close(&SortBuf[n], 1);
+        IWLReader eri(_default_psio_lib_, inputfile);
+        eri.set_keep(keep != 0);
+        for (const auto &integral : eri) {
+            idx_permute(File, SortBuf, bucket_map, integral.p, integral.q, integral.r, integral.s, perm_pr, perm_qs,
+                        perm_prqs, integral.value, "outfile");
+        }
+        // SortBuf writers flush the last buffer and close (keeping the temp
+        // files) when this scope ends; the input reader closes honoring `keep`.
     }
 
     free_int_matrix(bucket_map);
@@ -188,24 +157,19 @@ int file_build(dpdfile4 *File, int inputfile, double tolerance, int perm_pr, int
     /* Now sort each buffer and send it to the final target */
     next = PSIO_ZERO;
     for (n = 0; n < nbuckets; n++) {
-        iwl_buf_init(&SortBuf[n], PSIF_CC_MAX + 1 + n, tolerance, 1, 0);
-        lastbuf = 0;
-
         for (h = 0; h < nirreps; h++) {
             File->matrix[h] = block_matrix(bucket_rowdim[n][h], File->params->coltot[h]);
         }
 
-        while (!lastbuf) {
-            iwl_buf_fetch(&SortBuf[n]);
-            lastbuf = SortBuf[n].lastbuf;
-
-            for (idx = 4 * SortBuf[n].idx; SortBuf[n].idx < SortBuf[n].inbuf; SortBuf[n].idx++) {
-                p = (int)SortBuf[n].labels[idx++];
-                q = (int)SortBuf[n].labels[idx++];
-                r = (int)SortBuf[n].labels[idx++];
-                s = (int)SortBuf[n].labels[idx++];
-
-                value = (double)SortBuf[n].values[SortBuf[n].idx];
+        {
+            IWLReader sortbuf(_default_psio_lib_, PSIF_CC_MAX + 1 + n);
+            sortbuf.set_keep(false);  // erase the temp bucket file once read
+            for (const auto &integral : sortbuf) {
+                p = integral.p;
+                q = integral.q;
+                r = integral.r;
+                s = integral.s;
+                value = integral.value;
 
                 h = File->params->psym[p] ^ File->params->qsym[q];
 
@@ -224,8 +188,6 @@ int file_build(dpdfile4 *File, int inputfile, double tolerance, int perm_pr, int
                            next, &next);
             free_block(File->matrix[h]);
         }
-
-        iwl_buf_close(&SortBuf[n], 0);
     }
 
     for (n = 0; n < nbuckets; n++) {
@@ -236,8 +198,6 @@ int file_build(dpdfile4 *File, int inputfile, double tolerance, int perm_pr, int
     free(bucket_offset);
     free(bucket_rowdim);
     free(bucket_size);
-
-    free(SortBuf);
 
     return 0;
 }

--- a/psi4/src/psi4/cc/ccdensity/idx_permute.cc
+++ b/psi4/src/psi4/cc/ccdensity/idx_permute.cc
@@ -31,7 +31,9 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include "psi4/libiwl/iwl.h"
+#include <memory>
+#include <vector>
+#include "psi4/libiwl/iwl_writer.h"
 #include "psi4/libdpd/dpd.h"
 
 namespace psi {
@@ -40,7 +42,7 @@ namespace ccdensity {
 void idx_error(const char *message, int p, int q, int r, int s, int pq, int rs, int pq_sym, int rs_sym,
                std::string out_fname);
 
-void idx_permute(dpdfile4 *File, struct iwlbuf *OutBuf, int **bucket_map, int p, int q, int r, int s, int perm_pr,
+void idx_permute(dpdfile4 *File, std::vector<std::unique_ptr<IWLWriter>> &OutBuf, int **bucket_map, int p, int q, int r, int s, int perm_pr,
                  int perm_qs, int perm_prqs, double value, std::string) {
     int p_sym, q_sym, r_sym, s_sym;
     int pq_sym, rs_sym, rq_sym, ps_sym, qp_sym, sp_sym, sr_sym, qr_sym;
@@ -72,7 +74,7 @@ void idx_permute(dpdfile4 *File, struct iwlbuf *OutBuf, int **bucket_map, int p,
         idx_error("Params_make: pq, rs", p, q, r, s, pq, rs, pq_sym, rs_sym, "outfile");
 
     this_bucket = bucket_map[p][q];
-    iwl_buf_wrt_val(&OutBuf[this_bucket], p, q, r, s, value, 0, "outfile", 0);
+    OutBuf[this_bucket]->write(p, q, r, s, value);
 
     if (perm_pr) {
         rq_sym = r_sym ^ q_sym;
@@ -83,7 +85,7 @@ void idx_permute(dpdfile4 *File, struct iwlbuf *OutBuf, int **bucket_map, int p,
             idx_error("Params_make: rq, ps", p, q, r, s, rq, ps, rq_sym, ps_sym, "outfile");
 
         this_bucket = bucket_map[r][q];
-        iwl_buf_wrt_val(&OutBuf[this_bucket], r, q, p, s, value, 0, "outfile", 0);
+        OutBuf[this_bucket]->write(r, q, p, s, value);
     }
 
     if (perm_qs) {
@@ -95,7 +97,7 @@ void idx_permute(dpdfile4 *File, struct iwlbuf *OutBuf, int **bucket_map, int p,
             idx_error("Params_make: ps, rq", p, q, r, s, ps, rq, ps_sym, rq_sym, "outfile");
 
         this_bucket = bucket_map[p][s];
-        iwl_buf_wrt_val(&OutBuf[this_bucket], p, s, r, q, value, 0, "outfile", 0);
+        OutBuf[this_bucket]->write(p, s, r, q, value);
     }
 
     if (perm_pr && perm_qs) {
@@ -107,7 +109,7 @@ void idx_permute(dpdfile4 *File, struct iwlbuf *OutBuf, int **bucket_map, int p,
             idx_error("Params_make: rs, pq", p, q, r, s, rs, pq, rs_sym, pq_sym, "outfile");
 
         this_bucket = bucket_map[r][s];
-        iwl_buf_wrt_val(&OutBuf[this_bucket], r, s, p, q, value, 0, "outfile", 0);
+        OutBuf[this_bucket]->write(r, s, p, q, value);
     }
 
     if (perm_prqs) {
@@ -119,7 +121,7 @@ void idx_permute(dpdfile4 *File, struct iwlbuf *OutBuf, int **bucket_map, int p,
             idx_error("Params_make: qp, sr", p, q, r, s, qp, sr, qp_sym, sr_sym, "outfile");
 
         this_bucket = bucket_map[q][p];
-        iwl_buf_wrt_val(&OutBuf[this_bucket], q, p, s, r, value, 0, "outfile", 0);
+        OutBuf[this_bucket]->write(q, p, s, r, value);
 
         if (perm_pr) {
             qr_sym = q_sym ^ r_sym;
@@ -130,7 +132,7 @@ void idx_permute(dpdfile4 *File, struct iwlbuf *OutBuf, int **bucket_map, int p,
                 idx_error("Params_make: qr, sp", p, q, r, s, qr, sp, qr_sym, sp_sym, "outfile");
 
             this_bucket = bucket_map[q][r];
-            iwl_buf_wrt_val(&OutBuf[this_bucket], q, r, s, p, value, 0, "outfile", 0);
+            OutBuf[this_bucket]->write(q, r, s, p, value);
         }
 
         if (perm_qs) {
@@ -142,7 +144,7 @@ void idx_permute(dpdfile4 *File, struct iwlbuf *OutBuf, int **bucket_map, int p,
                 idx_error("Params_make: sp, qr", p, q, r, s, sp, qr, sp_sym, qr_sym, "outfile");
 
             this_bucket = bucket_map[s][p];
-            iwl_buf_wrt_val(&OutBuf[this_bucket], s, p, q, r, value, 0, "outfile", 0);
+            OutBuf[this_bucket]->write(s, p, q, r, value);
         }
 
         if (perm_pr && perm_qs) {
@@ -154,7 +156,7 @@ void idx_permute(dpdfile4 *File, struct iwlbuf *OutBuf, int **bucket_map, int p,
                 idx_error("Params_make: sr, qp", p, q, r, s, sr, qp, sr_sym, qp_sym, "outfile");
 
             this_bucket = bucket_map[s][r];
-            iwl_buf_wrt_val(&OutBuf[this_bucket], s, r, q, p, value, 0, "outfile", 0);
+            OutBuf[this_bucket]->write(s, r, q, p, value);
         }
     }
 }

--- a/psi4/src/psi4/cc/ccdensity/kinetic.cc
+++ b/psi4/src/psi4/cc/ccdensity/kinetic.cc
@@ -33,7 +33,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/wavefunction.h"

--- a/psi4/src/psi4/cc/ccdensity/oscillator_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/oscillator_strength.cc
@@ -34,7 +34,6 @@
 #include <cstdlib>
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/cc/ccdensity/rotational_strength.cc
+++ b/psi4/src/psi4/cc/ccdensity/rotational_strength.cc
@@ -37,7 +37,6 @@
 #include "psi4/cc/ccwave.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libdpd/dpd.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libmints/mintshelper.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/cc/ccdensity/sortI_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_RHF.cc
@@ -35,7 +35,6 @@
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libmints/wavefunction.h"
-#include "psi4/libiwl/iwl.h"
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"

--- a/psi4/src/psi4/cc/ccdensity/sortI_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_ROHF.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libmints/wavefunction.h"
 #include "MOInfo.h"
 #include "Params.h"

--- a/psi4/src/psi4/cc/ccdensity/sortI_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortI_UHF.cc
@@ -34,7 +34,6 @@
 #include "psi4/libdpd/dpd.h"
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libmints/wavefunction.h"
 #include "MOInfo.h"
 #include "Params.h"

--- a/psi4/src/psi4/cc/ccdensity/sortone_RHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone_RHF.cc
@@ -35,7 +35,6 @@
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libiwl/iwl.h"
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"

--- a/psi4/src/psi4/cc/ccdensity/sortone_ROHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone_ROHF.cc
@@ -35,7 +35,6 @@
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libiwl/iwl.h"
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"

--- a/psi4/src/psi4/cc/ccdensity/sortone_UHF.cc
+++ b/psi4/src/psi4/cc/ccdensity/sortone_UHF.cc
@@ -35,7 +35,6 @@
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libiwl/iwl.h"
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"

--- a/psi4/src/psi4/cc/ccdensity/transL.cc
+++ b/psi4/src/psi4/cc/ccdensity/transL.cc
@@ -33,7 +33,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/cc/ccdensity/transdip.cc
+++ b/psi4/src/psi4/cc/ccdensity/transdip.cc
@@ -33,7 +33,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/cc/ccdensity/transp.cc
+++ b/psi4/src/psi4/cc/ccdensity/transp.cc
@@ -33,7 +33,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/cc/ccenergy/AO_contribute.cc
+++ b/psi4/src/psi4/cc/ccenergy/AO_contribute.cc
@@ -37,7 +37,7 @@
 #include <cstdlib>
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_reader.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/cc/ccwave.h"
@@ -45,23 +45,20 @@
 namespace psi {
 namespace ccenergy {
 
-int CCEnergyWavefunction::AO_contribute(struct iwlbuf *InBuf, dpdbuf4 *tau1_AO, dpdbuf4 *tau2_AO) {
+int CCEnergyWavefunction::AO_contribute(IWLReader &eri, dpdbuf4 *tau1_AO, dpdbuf4 *tau2_AO) {
     int p, q, r, s;
     double value = 0.0;
     int Gp, Gq, Gr, Gs, Gpr, Gps, Gqr, Gqs, Grp, Gsp, Grq, Gsq;
     int pr, ps, qr, qs, rp, rq, sp, sq, pq, rs;
     int count = 0;
 
-    auto lblptr = InBuf->labels;
-    auto valptr = InBuf->values;
+    for (const auto &integral : eri) {
+        p = std::abs(integral.p);
+        q = integral.q;
+        r = integral.r;
+        s = integral.s;
 
-    for (int idx = 4 * InBuf->idx; InBuf->idx < InBuf->inbuf; InBuf->idx++) {
-        p = std::abs((int)lblptr[idx++]);
-        q = (int)lblptr[idx++];
-        r = (int)lblptr[idx++];
-        s = (int)lblptr[idx++];
-
-        value = (double)valptr[InBuf->idx];
+        value = integral.value;
         count++;
 
         Gp = tau1_AO->params->psym[p];

--- a/psi4/src/psi4/cc/ccenergy/BT2_AO.cc
+++ b/psi4/src/psi4/cc/ccenergy/BT2_AO.cc
@@ -36,7 +36,7 @@
 
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_reader.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"
@@ -58,9 +58,6 @@ void CCEnergyWavefunction::BT2_AO() {
     int **T2_CD_row_start, **T2_Cd_row_start;
     dpdbuf4 tau, t2, tau1_AO, tau2_AO;
     dpdfile4 T;
-    struct iwlbuf InBuf;
-    int lastbuf;
-    double tolerance = 1e-14;
     int counter = 0, counterAA = 0, counterBB = 0, counterAB = 0;
 
     auto nirreps = moinfo_.nirreps;
@@ -158,20 +155,10 @@ void CCEnergyWavefunction::BT2_AO() {
                     global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
                 }
 
-                iwl_buf_init(&InBuf, PSIF_SO_TEI, tolerance, 1, 1);
-
-                lastbuf = InBuf.lastbuf;
-
-                counter += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
-
-                while (!lastbuf) {
-                    iwl_buf_fetch(&InBuf);
-                    lastbuf = InBuf.lastbuf;
-
-                    counter += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
+                {
+                    IWLReader eri(psio(), PSIF_SO_TEI);
+                    counter += AO_contribute(eri, &tau1_AO, &tau2_AO);
                 }
-
-                iwl_buf_close(&InBuf, 1);
 
                 if (params_.print & 2)
                     outfile->Printf("     *** Processed %d SO integrals for <ab||cd> --> T2\n", counter);
@@ -253,20 +240,10 @@ void CCEnergyWavefunction::BT2_AO() {
             global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
         }
 
-        iwl_buf_init(&InBuf, PSIF_SO_TEI, tolerance, 1, 1);
-
-        lastbuf = InBuf.lastbuf;
-
-        counterAA += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
-
-        while (!lastbuf) {
-            iwl_buf_fetch(&InBuf);
-            lastbuf = InBuf.lastbuf;
-
-            counterAA += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
+        {
+            IWLReader eri(psio(), PSIF_SO_TEI);
+            counterAA += AO_contribute(eri, &tau1_AO, &tau2_AO);
         }
-
-        iwl_buf_close(&InBuf, 1);
 
         if (params_.print & 2) outfile->Printf("     *** Processed %d SO integrals for <AB||CD> --> T2\n", counterAA);
 
@@ -326,20 +303,10 @@ void CCEnergyWavefunction::BT2_AO() {
             global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
         }
 
-        iwl_buf_init(&InBuf, PSIF_SO_TEI, tolerance, 1, 1);
-
-        lastbuf = InBuf.lastbuf;
-
-        counterBB += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
-
-        while (!lastbuf) {
-            iwl_buf_fetch(&InBuf);
-            lastbuf = InBuf.lastbuf;
-
-            counterBB += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
+        {
+            IWLReader eri(psio(), PSIF_SO_TEI);
+            counterBB += AO_contribute(eri, &tau1_AO, &tau2_AO);
         }
-
-        iwl_buf_close(&InBuf, 1);
 
         if (params_.print & 2) outfile->Printf("     *** Processed %d SO integrals for <ab||cd> --> T2\n", counterBB);
 
@@ -399,20 +366,10 @@ void CCEnergyWavefunction::BT2_AO() {
             global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
         }
 
-        iwl_buf_init(&InBuf, PSIF_SO_TEI, tolerance, 1, 1);
-
-        lastbuf = InBuf.lastbuf;
-
-        counterAB += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
-
-        while (!lastbuf) {
-            iwl_buf_fetch(&InBuf);
-            lastbuf = InBuf.lastbuf;
-
-            counterAB += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
+        {
+            IWLReader eri(psio(), PSIF_SO_TEI);
+            counterAB += AO_contribute(eri, &tau1_AO, &tau2_AO);
         }
-
-        iwl_buf_close(&InBuf, 1);
 
         if (params_.print & 2) outfile->Printf("     *** Processed %d SO integrals for <Ab|Cd> --> T2\n", counterAB);
 
@@ -475,20 +432,10 @@ void CCEnergyWavefunction::BT2_AO() {
             global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
         }
 
-        iwl_buf_init(&InBuf, PSIF_SO_TEI, tolerance, 1, 1);
-
-        lastbuf = InBuf.lastbuf;
-
-        counterAA += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
-
-        while (!lastbuf) {
-            iwl_buf_fetch(&InBuf);
-            lastbuf = InBuf.lastbuf;
-
-            counterAA += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
+        {
+            IWLReader eri(psio(), PSIF_SO_TEI);
+            counterAA += AO_contribute(eri, &tau1_AO, &tau2_AO);
         }
-
-        iwl_buf_close(&InBuf, 1);
 
         if (params_.print & 2) outfile->Printf("     *** Processed %d SO integrals for <AB||CD> --> T2\n", counterAA);
 
@@ -548,20 +495,10 @@ void CCEnergyWavefunction::BT2_AO() {
             global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
         }
 
-        iwl_buf_init(&InBuf, PSIF_SO_TEI, tolerance, 1, 1);
-
-        lastbuf = InBuf.lastbuf;
-
-        counterBB += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
-
-        while (!lastbuf) {
-            iwl_buf_fetch(&InBuf);
-            lastbuf = InBuf.lastbuf;
-
-            counterBB += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
+        {
+            IWLReader eri(psio(), PSIF_SO_TEI);
+            counterBB += AO_contribute(eri, &tau1_AO, &tau2_AO);
         }
-
-        iwl_buf_close(&InBuf, 1);
 
         if (params_.print & 2) outfile->Printf("     *** Processed %d SO integrals for <ab||cd> --> T2\n", counterBB);
 
@@ -621,20 +558,10 @@ void CCEnergyWavefunction::BT2_AO() {
             global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
         }
 
-        iwl_buf_init(&InBuf, PSIF_SO_TEI, tolerance, 1, 1);
-
-        lastbuf = InBuf.lastbuf;
-
-        counterAB += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
-
-        while (!lastbuf) {
-            iwl_buf_fetch(&InBuf);
-            lastbuf = InBuf.lastbuf;
-
-            counterAB += AO_contribute(&InBuf, &tau1_AO, &tau2_AO);
+        {
+            IWLReader eri(psio(), PSIF_SO_TEI);
+            counterAB += AO_contribute(eri, &tau1_AO, &tau2_AO);
         }
-
-        iwl_buf_close(&InBuf, 1);
 
         if (params_.print & 2) outfile->Printf("     *** Processed %d SO integrals for <Ab|Cd> --> T2\n", counterAB);
 

--- a/psi4/src/psi4/cc/ccenergy/fock_build.cc
+++ b/psi4/src/psi4/cc/ccenergy/fock_build.cc
@@ -34,7 +34,7 @@
 #include <cstdlib>
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_reader.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"
 #include "MOInfo.h"
@@ -50,11 +50,8 @@ namespace ccenergy {
 #define INDEX(i, j) ((i) >= (j) ? EXPLICIT_IOFF(i) + (j) : EXPLICIT_IOFF(j) + (i))
 
 void CCEnergyWavefunction::rhf_fock_build(double **fock, double **D) {
-    int lastbuf, p, q, r, s, pq, rs;
+    int p, q, r, s, pq, rs;
     double value;
-    Value *valptr;
-    Label *lblptr;
-    struct iwlbuf InBuf;
 
     auto nso = moinfo_.nso;
 
@@ -67,26 +64,18 @@ void CCEnergyWavefunction::rhf_fock_build(double **fock, double **D) {
     }
 
     /* two-electron contributions */
-    iwl_buf_init(&InBuf, PSIF_SO_TEI, 0.0, 1, 1);
-    do {
-        lastbuf = InBuf.lastbuf;
-        lblptr = InBuf.labels;
-        valptr = InBuf.values;
+    IWLReader eri(psio(), PSIF_SO_TEI);
+    for (const auto &integral : eri) {
+        p = std::abs(integral.p);  // sign of p is a writer sentinel; magnitude is the index
+        q = integral.q;
+        r = integral.r;
+        s = integral.s;
+        value = integral.value;
 
-        for (int idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
-            p = std::abs((int)lblptr[idx++]);
-            q = (int)lblptr[idx++];
-            r = (int)lblptr[idx++];
-            s = (int)lblptr[idx++];
-            value = (double)valptr[InBuf.idx];
+        pq = INDEX(p, q);
+        rs = INDEX(r, s);
 
-            pq = INDEX(p, q);
-            rs = INDEX(r, s);
-
-            /*
-            outfile->Printf( "%d %d %d %d [%d] [%d] %20.15f\n", p, q, r, s, pq, rs, value);
-            */
-
+        {  // permutational expansion of (pq|rs) into the Fock matrix (unchanged)
             /* (pq|rs) */
             fock[p][q] += 2.0 * D[r][s] * value;
             fock[p][r] -= D[q][s] * value;
@@ -164,19 +153,12 @@ void CCEnergyWavefunction::rhf_fock_build(double **fock, double **D) {
                 fock[r][p] -= D[s][q] * value;
             }
         }
-
-        if (!lastbuf) iwl_buf_fetch(&InBuf);
-
-    } while (!lastbuf);
-    iwl_buf_close(&InBuf, 1);
+    }
 }
 
 void CCEnergyWavefunction::uhf_fock_build(double **fock_a, double **fock_b, double **D_a, double **D_b) {
-    int lastbuf, p, q, r, s, pq, rs;
+    int p, q, r, s, pq, rs;
     double value;
-    Value *valptr;
-    Label *lblptr;
-    struct iwlbuf InBuf;
 
     auto nso = moinfo_.nso;
 
@@ -195,26 +177,18 @@ void CCEnergyWavefunction::uhf_fock_build(double **fock_a, double **fock_b, doub
         }
     }
 
-    iwl_buf_init(&InBuf, PSIF_SO_TEI, 0.0, 1, 1);
-    do {
-        lastbuf = InBuf.lastbuf;
-        lblptr = InBuf.labels;
-        valptr = InBuf.values;
+    IWLReader eri(psio(), PSIF_SO_TEI);
+    for (const auto &integral : eri) {
+        p = std::abs(integral.p);  // sign of p is a writer sentinel; magnitude is the index
+        q = integral.q;
+        r = integral.r;
+        s = integral.s;
+        value = integral.value;
 
-        for (int idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
-            p = std::abs((int)lblptr[idx++]);
-            q = (int)lblptr[idx++];
-            r = (int)lblptr[idx++];
-            s = (int)lblptr[idx++];
-            value = (double)valptr[InBuf.idx];
+        pq = INDEX(p, q);
+        rs = INDEX(r, s);
 
-            pq = INDEX(p, q);
-            rs = INDEX(r, s);
-
-            /*
-            outfile->Printf( "%d %d %d %d [%d] [%d] %20.15f\n", p, q, r, s, pq, rs, value);
-            */
-
+        {  // permutational expansion of (pq|rs) into the Fock matrices (unchanged)
             /* (pq|rs) */
             fock_a[p][q] += Dt[r][s] * value;
             fock_a[p][r] -= D_a[q][s] * value;
@@ -328,11 +302,7 @@ void CCEnergyWavefunction::uhf_fock_build(double **fock_a, double **fock_b, doub
                 fock_b[r][p] -= D_b[s][q] * value;
             }
         }
-
-        if (!lastbuf) iwl_buf_fetch(&InBuf);
-
-    } while (!lastbuf);
-    iwl_buf_close(&InBuf, 1);
+    }
 
     free_block(Dt);
 }

--- a/psi4/src/psi4/cc/ccenergy/local.cc
+++ b/psi4/src/psi4/cc/ccenergy/local.cc
@@ -39,7 +39,6 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/cc/ccenergy/rotate.cc
+++ b/psi4/src/psi4/cc/ccenergy/rotate.cc
@@ -38,7 +38,6 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libdpd/dpd.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/cc/cceom/local.cc
+++ b/psi4/src/psi4/cc/cceom/local.cc
@@ -39,7 +39,6 @@
 #include <sstream>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/cc/cclambda/BL2_AO.cc
+++ b/psi4/src/psi4/cc/cclambda/BL2_AO.cc
@@ -38,7 +38,8 @@
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libiwl/iwl_reader.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"
@@ -61,12 +62,7 @@ void BL2_AO(int L_irr) {
     int **T2_cd_row_start, **T2_pq_row_start, offset, cd, pq;
     dpdbuf4 tau, t2, tau1_AO, tau2_AO;
     psio_address next;
-    struct iwlbuf InBuf;
-    int idx, p, q, r, s, filenum;
-    int lastbuf;
-    double value, tolerance = 1e-14;
-    Value *valptr;
-    Label *lblptr;
+    int filenum;
 
     nirreps = moinfo.nirreps;
     orbspi = moinfo.orbspi;
@@ -116,42 +112,17 @@ void BL2_AO(int L_irr) {
         global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
     }
 
-    iwl_buf_init(&InBuf, PSIF_SO_TEI, tolerance, 1, 1);
-
-    lblptr = InBuf.labels;
-    valptr = InBuf.values;
-    lastbuf = InBuf.lastbuf;
-
-    for (idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
-        p = std::abs((int)lblptr[idx++]);
-        q = (int)lblptr[idx++];
-        r = (int)lblptr[idx++];
-        s = (int)lblptr[idx++];
-
-        value = (double)valptr[InBuf.idx];
-
-        /*    outfile->Printf( "<%d %d %d %d = %20.10lf\n", p, q, r, s, value); */
-
-        AO_contribute(p, q, r, s, value, &tau1_AO, &tau2_AO, 1);
-    }
-    while (!lastbuf) {
-        iwl_buf_fetch(&InBuf);
-        lastbuf = InBuf.lastbuf;
-        for (idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
-            p = std::abs((int)lblptr[idx++]);
-            q = (int)lblptr[idx++];
-            r = (int)lblptr[idx++];
-            s = (int)lblptr[idx++];
-
-            value = (double)valptr[InBuf.idx];
-
-            /*      outfile->Printf( "<%d %d %d %d = %20.10lf\n", p, q, r, s, value); */
-
+    {
+        IWLReader eri(_default_psio_lib_, PSIF_SO_TEI);
+        for (const auto &integral : eri) {
+            int p = std::abs(integral.p);
+            int q = integral.q;
+            int r = integral.r;
+            int s = integral.s;
+            double value = integral.value;
             AO_contribute(p, q, r, s, value, &tau1_AO, &tau2_AO, 1);
         }
     }
-
-    iwl_buf_close(&InBuf, 1);
 
     for (h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_wrt(&tau2_AO, h);
@@ -197,42 +168,17 @@ void BL2_AO(int L_irr) {
         global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
     }
 
-    iwl_buf_init(&InBuf, PSIF_SO_TEI, tolerance, 1, 1);
-
-    lblptr = InBuf.labels;
-    valptr = InBuf.values;
-    lastbuf = InBuf.lastbuf;
-
-    for (idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
-        p = std::abs((int)lblptr[idx++]);
-        q = (int)lblptr[idx++];
-        r = (int)lblptr[idx++];
-        s = (int)lblptr[idx++];
-
-        value = (double)valptr[InBuf.idx];
-
-        /*    outfile->Printf( "<%d %d %d %d = %20.10lf\n", p, q, r, s, value); */
-
-        AO_contribute(p, q, r, s, value, &tau1_AO, &tau2_AO, 1);
-    }
-    while (!lastbuf) {
-        iwl_buf_fetch(&InBuf);
-        lastbuf = InBuf.lastbuf;
-        for (idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
-            p = std::abs((int)lblptr[idx++]);
-            q = (int)lblptr[idx++];
-            r = (int)lblptr[idx++];
-            s = (int)lblptr[idx++];
-
-            value = (double)valptr[InBuf.idx];
-
-            /*      outfile->Printf( "<%d %d %d %d = %20.10lf\n", p, q, r, s, value); */
-
+    {
+        IWLReader eri(_default_psio_lib_, PSIF_SO_TEI);
+        for (const auto &integral : eri) {
+            int p = std::abs(integral.p);
+            int q = integral.q;
+            int r = integral.r;
+            int s = integral.s;
+            double value = integral.value;
             AO_contribute(p, q, r, s, value, &tau1_AO, &tau2_AO, 1);
         }
     }
-
-    iwl_buf_close(&InBuf, 1);
 
     for (h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_wrt(&tau2_AO, h);
@@ -278,42 +224,17 @@ void BL2_AO(int L_irr) {
         global_dpd_->buf4_mat_irrep_init(&tau2_AO, h);
     }
 
-    iwl_buf_init(&InBuf, PSIF_SO_TEI, tolerance, 1, 1);
-
-    lblptr = InBuf.labels;
-    valptr = InBuf.values;
-    lastbuf = InBuf.lastbuf;
-
-    for (idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
-        p = std::abs((int)lblptr[idx++]);
-        q = (int)lblptr[idx++];
-        r = (int)lblptr[idx++];
-        s = (int)lblptr[idx++];
-
-        value = (double)valptr[InBuf.idx];
-
-        /*    outfile->Printf( "<%d %d %d %d = %20.10lf\n", p, q, r, s, value); */
-
-        AO_contribute(p, q, r, s, value, &tau1_AO, &tau2_AO, 0);
-    }
-    while (!lastbuf) {
-        iwl_buf_fetch(&InBuf);
-        lastbuf = InBuf.lastbuf;
-        for (idx = 4 * InBuf.idx; InBuf.idx < InBuf.inbuf; InBuf.idx++) {
-            p = std::abs((int)lblptr[idx++]);
-            q = (int)lblptr[idx++];
-            r = (int)lblptr[idx++];
-            s = (int)lblptr[idx++];
-
-            value = (double)valptr[InBuf.idx];
-
-            /*      outfile->Printf( "<%d %d %d %d = %20.10lf\n", p, q, r, s, value); */
-
+    {
+        IWLReader eri(_default_psio_lib_, PSIF_SO_TEI);
+        for (const auto &integral : eri) {
+            int p = std::abs(integral.p);
+            int q = integral.q;
+            int r = integral.r;
+            int s = integral.s;
+            double value = integral.value;
             AO_contribute(p, q, r, s, value, &tau1_AO, &tau2_AO, 0);
         }
     }
-
-    iwl_buf_close(&InBuf, 1);
 
     for (h = 0; h < nirreps; h++) {
         global_dpd_->buf4_mat_irrep_wrt(&tau2_AO, h);

--- a/psi4/src/psi4/cc/cclambda/local.cc
+++ b/psi4/src/psi4/cc/cclambda/local.cc
@@ -37,7 +37,6 @@
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libpsi4util/exception.h"

--- a/psi4/src/psi4/cc/ccresponse/local.cc
+++ b/psi4/src/psi4/cc/ccresponse/local.cc
@@ -37,7 +37,6 @@
 #include <cmath>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libdpd/dpd.h"

--- a/psi4/src/psi4/cc/ccresponse/preppert.cc
+++ b/psi4/src/psi4/cc/ccresponse/preppert.cc
@@ -35,7 +35,6 @@
 #include <cstring>
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libqt/qt.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/psifiles.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/mintshelper.h"

--- a/psi4/src/psi4/cc/ccwave.h
+++ b/psi4/src/psi4/cc/ccwave.h
@@ -42,7 +42,7 @@ namespace psi {
 class Options;
 struct dpdfile2;
 struct dpdbuf4;
-struct iwlbuf;
+class IWLReader;
 }  // namespace psi
 
 namespace psi {
@@ -183,7 +183,7 @@ class CCEnergyWavefunction : public Wavefunction {
     void halftrans(dpdbuf4 *Buf1, int dpdnum1, dpdbuf4 *Buf2, int dpdnum2, double ***C1, double ***C2, int nirreps,
                    int **mo_row, int **so_row, Dimension const& mospi_left, Dimension const& mospi_right,
 		           Dimension const& sospi, int type, double alpha, double beta);
-    int AO_contribute(struct iwlbuf *InBuf, dpdbuf4 *tau1_AO, dpdbuf4 *tau2_AO);
+    int AO_contribute(IWLReader &eri, dpdbuf4 *tau1_AO, dpdbuf4 *tau2_AO);
 
     double rhf_energy();
     double uhf_energy();

--- a/psi4/src/psi4/cctransort/cctransort.cc
+++ b/psi4/src/psi4/cctransort/cctransort.cc
@@ -33,7 +33,7 @@
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl.hpp"
 #include "psi4/libqt/qt.h"
 #include "psi4/libtrans/integraltransform.h"
 #include "psi4/libdpd/dpd.h"
@@ -527,7 +527,7 @@ PsiReturnType cctransort(SharedWavefunction ref, Options &options) {
         int ntri_all = nmo * (nmo + 1) / 2;
         double *tmp_oei = init_array(ntri_all);
 
-        iwl_rdone(PSIF_OEI, PSIF_MO_A_FZC, tmp_oei, ntri_all, 0, 0, "outfile");
+        IWL::read_one(_default_psio_lib_.get(), PSIF_OEI, PSIF_MO_A_FZC, tmp_oei, ntri_all, 0, 0, "outfile");
 
         global_dpd_->file2_init(&H, PSIF_CC_OEI, 0, 0, 0, "h(I,J)");
         global_dpd_->file2_mat_init(&H);
@@ -574,7 +574,7 @@ PsiReturnType cctransort(SharedWavefunction ref, Options &options) {
         global_dpd_->file2_mat_close(&H);
         global_dpd_->file2_close(&H);
 
-        iwl_rdone(PSIF_OEI, PSIF_MO_B_FZC, tmp_oei, ntri_all, 0, 0, "outfile");
+        IWL::read_one(_default_psio_lib_.get(), PSIF_OEI, PSIF_MO_B_FZC, tmp_oei, ntri_all, 0, 0, "outfile");
 
         global_dpd_->file2_init(&H, PSIF_CC_OEI, 0, 2, 2, "h(i,j)");
         global_dpd_->file2_mat_init(&H);
@@ -625,7 +625,7 @@ PsiReturnType cctransort(SharedWavefunction ref, Options &options) {
         int ntri_all = nmo * (nmo + 1) / 2;
         double *tmp_oei = init_array(ntri_all);
 
-        iwl_rdone(PSIF_OEI, PSIF_MO_FZC, tmp_oei, ntri_all, 0, 0, "outfile");
+        IWL::read_one(_default_psio_lib_.get(), PSIF_OEI, PSIF_MO_FZC, tmp_oei, ntri_all, 0, 0, "outfile");
 
         global_dpd_->file2_init(&H, PSIF_CC_OEI, 0, 0, 0, "h(i,j)");
         global_dpd_->file2_mat_init(&H);

--- a/psi4/src/psi4/dct/dct_gradient.cc
+++ b/psi4/src/psi4/dct/dct_gradient.cc
@@ -34,7 +34,6 @@
 #include "psi4/libtrans/integraltransform.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libqt/qt.h"
-#include "psi4/libiwl/iwl.h"
 
 namespace psi {
 namespace dct {

--- a/psi4/src/psi4/dct/dct_gradient_RHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_RHF.cc
@@ -34,7 +34,7 @@
 #include "psi4/libtrans/integraltransform.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libqt/qt.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
 
 namespace psi {
 namespace dct {
@@ -485,12 +485,11 @@ void DCTSolver::compute_ewdm_odc_RHF() {
 
     dpdbuf4 G;
 
-    struct iwlbuf AA, AB;
 
     // Dump the density to IWL
 
     // Initialize IWL buffer for AB case
-    iwl_buf_init(&AB, PSIF_MO_TPDM, 1.0E-15, 0, 0);
+    IWLWriter AB(_default_psio_lib_, PSIF_MO_TPDM, 1.0E-15);
 
     psio_->open(PSIF_DCT_DENSITY, PSIO_OPEN_OLD);
     // VVVV
@@ -510,7 +509,7 @@ void DCTSolver::compute_ewdm_odc_RHF() {
                 int C = avir_qt[c];
                 int D = bvir_qt[d];
                 double value = 4.0 * G.matrix[h][ab][cd];
-                iwl_buf_wrt_val(&AB, A, C, B, D, value, 0, "outfile", 0);
+                AB.write(A, C, B, D, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -535,7 +534,7 @@ void DCTSolver::compute_ewdm_odc_RHF() {
                 int K = aocc_qt[k];
                 int L = bocc_qt[l];
                 double value = 4.0 * G.matrix[h][ij][kl];
-                iwl_buf_wrt_val(&AB, I, K, J, L, value, 0, "outfile", 0);
+                AB.write(I, K, J, L, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -559,7 +558,7 @@ void DCTSolver::compute_ewdm_odc_RHF() {
                 int A = avir_qt[a];
                 int B = bvir_qt[b];
                 double value = 4.0 * G.matrix[h][ij][ab];
-                iwl_buf_wrt_val(&AB, I, A, J, B, value, 0, "outfile", 0);
+                AB.write(I, A, J, B, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -572,7 +571,7 @@ void DCTSolver::compute_ewdm_odc_RHF() {
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,V]"), ID("[O,V]"), ID("[O,V]"), ID("[O,V]"), 0,
                            "Gamma SF <OV|OV>:<Ov|Ov>");
-    global_dpd_->buf4_dump(&G, &AB, aocc_qt, bvir_qt, aocc_qt, bvir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AB, aocc_qt, bvir_qt, aocc_qt, bvir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,V]"), ID("[O,V]"), ID("[O,V]"), ID("[O,V]"), 0,
@@ -591,7 +590,7 @@ void DCTSolver::compute_ewdm_odc_RHF() {
                 int J = bocc_qt[j];
                 int B = avir_qt[b];
                 double value = 1.0 * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&AB, A, B, I, J, value, 0, "outfile", 0);
+                AB.write(A, B, I, J, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -615,40 +614,39 @@ void DCTSolver::compute_ewdm_odc_RHF() {
                 int J = bocc_qt[j];
                 int B = avir_qt[b];
                 double value = (-2.0) * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&AB, I, B, J, A, value, 0, "outfile", 0);
+                AB.write(I, B, J, A, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
     }
     global_dpd_->buf4_close(&G);
 
-    iwl_buf_flush(&AB, 1);
-    iwl_buf_close(&AB, 1);
+    AB.close();
 
     // Presort TPDM (MO, AB case) for Deriv use
     presort_mo_tpdm_AB();
 
     // Initialize IWL buffer for AA case
-    iwl_buf_init(&AA, PSIF_MO_TPDM, 1.0E-16, 0, 0);
+    IWLWriter AA(_default_psio_lib_, PSIF_MO_TPDM, 1.0E-16);
     // VVVV
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[V,V]"), ID("[V,V]"), ID("[V,V]"), ID("[V,V]"), 0,
                            "Gamma <VV|VV>");
     global_dpd_->buf4_scm(&G, 2.0);  // Prefactor was 1.0. Use 2.0 because BB case = AA case
-    global_dpd_->buf4_dump(&G, &AA, avir_qt, avir_qt, avir_qt, avir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AA, avir_qt, avir_qt, avir_qt, avir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     // OOOO
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,O]"), ID("[O,O]"), ID("[O,O]"), ID("[O,O]"), 0,
                            "Gamma <OO|OO>");
     global_dpd_->buf4_scm(&G, 2.0);  // Prefactor was 1.0. Use 2.0 because BB case = AA case
-    global_dpd_->buf4_dump(&G, &AA, aocc_qt, aocc_qt, aocc_qt, aocc_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AA, aocc_qt, aocc_qt, aocc_qt, aocc_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     // OOVV
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                            "Gamma <OO|VV>");
     global_dpd_->buf4_scm(&G, 2.0);  // Prefactor was 1.0. Use 2.0 because BB case = AA case
-    global_dpd_->buf4_dump(&G, &AA, aocc_qt, aocc_qt, avir_qt, avir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AA, aocc_qt, aocc_qt, avir_qt, avir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     // OVOV
@@ -658,7 +656,7 @@ void DCTSolver::compute_ewdm_odc_RHF() {
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,V]"), ID("[O,V]"), ID("[O,V]"), ID("[O,V]"), 0,
                            "Gamma <OV|OV>");
     global_dpd_->buf4_scm(&G, 1.0);
-    global_dpd_->buf4_dump(&G, &AA, aocc_qt, avir_qt, aocc_qt, avir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AA, aocc_qt, avir_qt, aocc_qt, avir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     // -Г<ov|vo> contribution:
@@ -678,15 +676,14 @@ void DCTSolver::compute_ewdm_odc_RHF() {
                 int J = aocc_qt[j];
                 int B = avir_qt[b];
                 double value = -1.0 * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&AA, I, B, A, J, value, 0, "outfile", 0);
+                AA.write(I, B, A, J, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
     }
     global_dpd_->buf4_close(&G);
 
-    iwl_buf_flush(&AA, 1);
-    iwl_buf_close(&AA, 1);
+    AA.close();
 
     // Presort TPDM (MO) for Deriv use
     presort_mo_tpdm_AA();

--- a/psi4/src/psi4/dct/dct_gradient_UHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_UHF.cc
@@ -32,7 +32,7 @@
 #include "psi4/libtrans/integraltransform.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libqt/qt.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "psi4/libdiis/diismanager.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
@@ -3789,10 +3789,9 @@ void DCTSolver::compute_ewdm_dc() {
 
     dpdbuf4 G;
 
-    struct iwlbuf AA, AB, BB;
-    iwl_buf_init(&AA, PSIF_MO_AA_TPDM, 1.0E-15, 0, 0);
-    iwl_buf_init(&AB, PSIF_MO_AB_TPDM, 1.0E-15, 0, 0);
-    iwl_buf_init(&BB, PSIF_MO_BB_TPDM, 1.0E-15, 0, 0);
+    IWLWriter AA(_default_psio_lib_, PSIF_MO_AA_TPDM, 1.0E-15);
+    IWLWriter AB(_default_psio_lib_, PSIF_MO_AB_TPDM, 1.0E-15);
+    IWLWriter BB(_default_psio_lib_, PSIF_MO_BB_TPDM, 1.0E-15);
 
     psio_->open(PSIF_DCT_DENSITY, PSIO_OPEN_OLD);
 
@@ -4045,7 +4044,7 @@ void DCTSolver::compute_ewdm_dc() {
     // before calling dpd_buf4_dump - check that with swap23 = 0 (AYS)
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[V,V]"), ID("[V,V]"), ID("[V>V]-"), ID("[V>V]-"), 0,
                            "Gamma <VV|VV>");
-    global_dpd_->buf4_dump(&G, &AA, avir_qt, avir_qt, avir_qt, avir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AA, avir_qt, avir_qt, avir_qt, avir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[V,v]"), ID("[V,v]"), ID("[V,v]"), ID("[V,v]"), 0,
@@ -4064,7 +4063,7 @@ void DCTSolver::compute_ewdm_dc() {
                 int C = avir_qt[c];
                 int D = bvir_qt[d];
                 double value = 4.0 * G.matrix[h][ab][cd];
-                iwl_buf_wrt_val(&AB, A, C, B, D, value, 0, "outfile", 0);
+                AB.write(A, C, B, D, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4073,13 +4072,13 @@ void DCTSolver::compute_ewdm_dc() {
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[v,v]"), ID("[v,v]"), ID("[v>v]-"), ID("[v>v]-"), 0,
                            "Gamma <vv|vv>");
-    global_dpd_->buf4_dump(&G, &BB, bvir_qt, bvir_qt, bvir_qt, bvir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, BB, bvir_qt, bvir_qt, bvir_qt, bvir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     // OOOO
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,O]"), ID("[O,O]"), ID("[O>O]-"), ID("[O>O]-"), 0,
                            "Gamma <OO|OO>");
-    global_dpd_->buf4_dump(&G, &AA, aocc_qt, aocc_qt, aocc_qt, aocc_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AA, aocc_qt, aocc_qt, aocc_qt, aocc_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,o]"), ID("[O,o]"), ID("[O,o]"), ID("[O,o]"), 0,
@@ -4099,7 +4098,7 @@ void DCTSolver::compute_ewdm_dc() {
                 int K = aocc_qt[k];
                 int L = bocc_qt[l];
                 double value = 4.0 * G.matrix[h][ij][kl];
-                iwl_buf_wrt_val(&AB, I, K, J, L, value, 0, "outfile", 0);
+                AB.write(I, K, J, L, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4108,13 +4107,13 @@ void DCTSolver::compute_ewdm_dc() {
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[o,o]"), ID("[o,o]"), ID("[o>o]-"), ID("[o>o]-"), 0,
                            "Gamma <oo|oo>");
-    global_dpd_->buf4_dump(&G, &BB, bocc_qt, bocc_qt, bocc_qt, bocc_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, BB, bocc_qt, bocc_qt, bocc_qt, bocc_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     // OOVV
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Gamma <OO|VV>");
-    global_dpd_->buf4_dump(&G, &AA, aocc_qt, aocc_qt, avir_qt, avir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AA, aocc_qt, aocc_qt, avir_qt, avir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
@@ -4133,7 +4132,7 @@ void DCTSolver::compute_ewdm_dc() {
                 int A = avir_qt[a];
                 int B = bvir_qt[b];
                 double value = 4.0 * G.matrix[h][ij][ab];
-                iwl_buf_wrt_val(&AB, I, A, J, B, value, 0, "outfile", 0);
+                AB.write(I, A, J, B, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4142,7 +4141,7 @@ void DCTSolver::compute_ewdm_dc() {
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Gamma <oo|vv>");
-    global_dpd_->buf4_dump(&G, &BB, bocc_qt, bocc_qt, bvir_qt, bvir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, BB, bocc_qt, bocc_qt, bvir_qt, bvir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     // OVOV
@@ -4164,7 +4163,7 @@ void DCTSolver::compute_ewdm_dc() {
                 int J = aocc_qt[j];
                 int B = avir_qt[b];
                 double value = 0.5 * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&AA, I, J, A, B, value, 0, "outfile", 0);
+                AA.write(I, J, A, B, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4188,7 +4187,7 @@ void DCTSolver::compute_ewdm_dc() {
                 int J = aocc_qt[j];
                 int B = avir_qt[b];
                 double value = -0.5 * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&AA, I, B, A, J, value, 0, "outfile", 0);
+                AA.write(I, B, A, J, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4197,7 +4196,7 @@ void DCTSolver::compute_ewdm_dc() {
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,v]"), ID("[O,v]"), ID("[O,v]"), ID("[O,v]"), 0,
                            "Gamma <Ov|Ov>");
-    global_dpd_->buf4_dump(&G, &AB, aocc_qt, bvir_qt, aocc_qt, bvir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AB, aocc_qt, bvir_qt, aocc_qt, bvir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[o,V]"), ID("[o,V]"), ID("[o,V]"), ID("[o,V]"), 0,
@@ -4216,7 +4215,7 @@ void DCTSolver::compute_ewdm_dc() {
                 int J = bocc_qt[j];
                 int B = avir_qt[b];
                 double value = G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&AB, A, B, I, J, value, 0, "outfile", 0);
+                AB.write(A, B, I, J, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4240,7 +4239,7 @@ void DCTSolver::compute_ewdm_dc() {
                 int J = bocc_qt[j];
                 int B = avir_qt[b];
                 double value = (-2.0) * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&AB, I, B, J, A, value, 0, "outfile", 0);
+                AB.write(I, B, J, A, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4265,7 +4264,7 @@ void DCTSolver::compute_ewdm_dc() {
                 int J = bocc_qt[j];
                 int B = bvir_qt[b];
                 double value = 0.5 * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&BB, I, J, A, B, value, 0, "outfile", 0);
+                BB.write(I, J, A, B, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4289,7 +4288,7 @@ void DCTSolver::compute_ewdm_dc() {
                 int J = bocc_qt[j];
                 int B = bvir_qt[b];
                 double value = -0.5 * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&BB, I, B, A, J, value, 0, "outfile", 0);
+                BB.write(I, B, A, J, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4299,7 +4298,7 @@ void DCTSolver::compute_ewdm_dc() {
     // OOOV
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,O]"), ID("[O,V]"), ID("[O>O]-"), ID("[O,V]"), 0,
                            "Gamma <OO|OV>");
-    global_dpd_->buf4_dump(&G, &AA, aocc_qt, aocc_qt, aocc_qt, avir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AA, aocc_qt, aocc_qt, aocc_qt, avir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,o]"), ID("[O,v]"), ID("[O,o]"), ID("[O,v]"), 0,
@@ -4318,8 +4317,8 @@ void DCTSolver::compute_ewdm_dc() {
                 int K = aocc_qt[k];
                 int A = bvir_qt[a];
                 double value = G.matrix[h][ij][ka];
-                iwl_buf_wrt_val(&AB, I, K, J, A, value, 0, "outfile", 0);
-                iwl_buf_wrt_val(&AB, I, K, A, J, value, 0, "outfile", 0);
+                AB.write(I, K, J, A, value);
+                AB.write(I, K, A, J, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4342,8 +4341,8 @@ void DCTSolver::compute_ewdm_dc() {
                 int K = bocc_qt[k];
                 int A = avir_qt[a];
                 double value = G.matrix[h][ij][ka];
-                iwl_buf_wrt_val(&AB, A, J, K, I, value, 0, "outfile", 0);
-                iwl_buf_wrt_val(&AB, J, A, K, I, value, 0, "outfile", 0);
+                AB.write(A, J, K, I, value);
+                AB.write(J, A, K, I, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4352,13 +4351,13 @@ void DCTSolver::compute_ewdm_dc() {
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[o,o]"), ID("[o,v]"), ID("[o>o]-"), ID("[o,v]"), 0,
                            "Gamma <oo|ov>");
-    global_dpd_->buf4_dump(&G, &BB, bocc_qt, bocc_qt, bocc_qt, bvir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, BB, bocc_qt, bocc_qt, bocc_qt, bvir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     // OVVV
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,V]"), ID("[V,V]"), ID("[O,V]"), ID("[V>V]-"), 0,
                            "Gamma <OV|VV>");
-    global_dpd_->buf4_dump(&G, &AA, aocc_qt, avir_qt, avir_qt, avir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AA, aocc_qt, avir_qt, avir_qt, avir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,v]"), ID("[V,v]"), ID("[O,v]"), ID("[V,v]"), 0,
@@ -4377,8 +4376,8 @@ void DCTSolver::compute_ewdm_dc() {
                 int B = avir_qt[b];
                 int C = bvir_qt[c];
                 double value = G.matrix[h][ia][bc];
-                iwl_buf_wrt_val(&AB, I, B, A, C, value, 0, "outfile", 0);
-                iwl_buf_wrt_val(&AB, B, I, A, C, value, 0, "outfile", 0);
+                AB.write(I, B, A, C, value);
+                AB.write(B, I, A, C, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4401,8 +4400,8 @@ void DCTSolver::compute_ewdm_dc() {
                 int B = bvir_qt[b];
                 int C = avir_qt[c];
                 double value = G.matrix[h][ia][bc];
-                iwl_buf_wrt_val(&AB, C, A, B, I, value, 0, "outfile", 0);
-                iwl_buf_wrt_val(&AB, C, A, I, B, value, 0, "outfile", 0);
+                AB.write(C, A, B, I, value);
+                AB.write(C, A, I, B, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4411,17 +4410,14 @@ void DCTSolver::compute_ewdm_dc() {
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[o,v]"), ID("[v,v]"), ID("[o,v]"), ID("[v>v]-"), 0,
                            "Gamma <ov|vv>");
-    global_dpd_->buf4_dump(&G, &BB, bocc_qt, bvir_qt, bvir_qt, bvir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, BB, bocc_qt, bvir_qt, bvir_qt, bvir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     psio_->close(PSIF_DCT_DENSITY, 1);
 
-    iwl_buf_flush(&AA, 1);
-    iwl_buf_flush(&AB, 1);
-    iwl_buf_flush(&BB, 1);
-    iwl_buf_close(&AA, 1);
-    iwl_buf_close(&AB, 1);
-    iwl_buf_close(&BB, 1);
+    AA.close();
+    AB.close();
+    BB.close();
 
     delete[] alpha_pitzer_to_corr;
     delete[] beta_pitzer_to_corr;
@@ -4611,10 +4607,9 @@ void DCTSolver::compute_ewdm_odc() {
 
     dpdbuf4 G;
 
-    struct iwlbuf AA, AB, BB;
-    iwl_buf_init(&AA, PSIF_MO_AA_TPDM, 1.0E-15, 0, 0);
-    iwl_buf_init(&AB, PSIF_MO_AB_TPDM, 1.0E-15, 0, 0);
-    iwl_buf_init(&BB, PSIF_MO_BB_TPDM, 1.0E-15, 0, 0);
+    IWLWriter AA(_default_psio_lib_, PSIF_MO_AA_TPDM, 1.0E-15);
+    IWLWriter AB(_default_psio_lib_, PSIF_MO_AB_TPDM, 1.0E-15);
+    IWLWriter BB(_default_psio_lib_, PSIF_MO_BB_TPDM, 1.0E-15);
 
     psio_->open(PSIF_DCT_DENSITY, PSIO_OPEN_OLD);
 
@@ -4627,7 +4622,7 @@ void DCTSolver::compute_ewdm_odc() {
     // before calling dpd_buf4_dump - check that with swap23 = 0 (AYS)
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[V,V]"), ID("[V,V]"), ID("[V>V]-"), ID("[V>V]-"), 0,
                            "Gamma <VV|VV>");
-    global_dpd_->buf4_dump(&G, &AA, avir_qt, avir_qt, avir_qt, avir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AA, avir_qt, avir_qt, avir_qt, avir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[V,v]"), ID("[V,v]"), ID("[V,v]"), ID("[V,v]"), 0,
@@ -4646,7 +4641,7 @@ void DCTSolver::compute_ewdm_odc() {
                 int C = avir_qt[c];
                 int D = bvir_qt[d];
                 double value = 4.0 * G.matrix[h][ab][cd];
-                iwl_buf_wrt_val(&AB, A, C, B, D, value, 0, "outfile", 0);
+                AB.write(A, C, B, D, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4655,13 +4650,13 @@ void DCTSolver::compute_ewdm_odc() {
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[v,v]"), ID("[v,v]"), ID("[v>v]-"), ID("[v>v]-"), 0,
                            "Gamma <vv|vv>");
-    global_dpd_->buf4_dump(&G, &BB, bvir_qt, bvir_qt, bvir_qt, bvir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, BB, bvir_qt, bvir_qt, bvir_qt, bvir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     // OOOO
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,O]"), ID("[O,O]"), ID("[O>O]-"), ID("[O>O]-"), 0,
                            "Gamma <OO|OO>");
-    global_dpd_->buf4_dump(&G, &AA, aocc_qt, aocc_qt, aocc_qt, aocc_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AA, aocc_qt, aocc_qt, aocc_qt, aocc_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,o]"), ID("[O,o]"), ID("[O,o]"), ID("[O,o]"), 0,
@@ -4681,7 +4676,7 @@ void DCTSolver::compute_ewdm_odc() {
                 int K = aocc_qt[k];
                 int L = bocc_qt[l];
                 double value = 4.0 * G.matrix[h][ij][kl];
-                iwl_buf_wrt_val(&AB, I, K, J, L, value, 0, "outfile", 0);
+                AB.write(I, K, J, L, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4690,13 +4685,13 @@ void DCTSolver::compute_ewdm_odc() {
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[o,o]"), ID("[o,o]"), ID("[o>o]-"), ID("[o>o]-"), 0,
                            "Gamma <oo|oo>");
-    global_dpd_->buf4_dump(&G, &BB, bocc_qt, bocc_qt, bocc_qt, bocc_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, BB, bocc_qt, bocc_qt, bocc_qt, bocc_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     // OOVV
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,O]"), ID("[V,V]"), ID("[O>O]-"), ID("[V>V]-"), 0,
                            "Gamma <OO|VV>");
-    global_dpd_->buf4_dump(&G, &AA, aocc_qt, aocc_qt, avir_qt, avir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AA, aocc_qt, aocc_qt, avir_qt, avir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,o]"), ID("[V,v]"), ID("[O,o]"), ID("[V,v]"), 0,
@@ -4715,7 +4710,7 @@ void DCTSolver::compute_ewdm_odc() {
                 int A = avir_qt[a];
                 int B = bvir_qt[b];
                 double value = 4.0 * G.matrix[h][ij][ab];
-                iwl_buf_wrt_val(&AB, I, A, J, B, value, 0, "outfile", 0);
+                AB.write(I, A, J, B, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4724,7 +4719,7 @@ void DCTSolver::compute_ewdm_odc() {
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[o,o]"), ID("[v,v]"), ID("[o>o]-"), ID("[v>v]-"), 0,
                            "Gamma <oo|vv>");
-    global_dpd_->buf4_dump(&G, &BB, bocc_qt, bocc_qt, bvir_qt, bvir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, BB, bocc_qt, bocc_qt, bvir_qt, bvir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     // OVOV
@@ -4746,7 +4741,7 @@ void DCTSolver::compute_ewdm_odc() {
                 int J = aocc_qt[j];
                 int B = avir_qt[b];
                 double value = 0.5 * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&AA, I, J, A, B, value, 0, "outfile", 0);
+                AA.write(I, J, A, B, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4770,7 +4765,7 @@ void DCTSolver::compute_ewdm_odc() {
                 int J = aocc_qt[j];
                 int B = avir_qt[b];
                 double value = -0.5 * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&AA, I, B, A, J, value, 0, "outfile", 0);
+                AA.write(I, B, A, J, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4779,7 +4774,7 @@ void DCTSolver::compute_ewdm_odc() {
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[O,v]"), ID("[O,v]"), ID("[O,v]"), ID("[O,v]"), 0,
                            "Gamma <Ov|Ov>");
-    global_dpd_->buf4_dump(&G, &AB, aocc_qt, bvir_qt, aocc_qt, bvir_qt, 0, 1);
+    global_dpd_->buf4_dump(&G, AB, aocc_qt, bvir_qt, aocc_qt, bvir_qt, 0, 1);
     global_dpd_->buf4_close(&G);
 
     global_dpd_->buf4_init(&G, PSIF_DCT_DENSITY, 0, ID("[o,V]"), ID("[o,V]"), ID("[o,V]"), ID("[o,V]"), 0,
@@ -4798,7 +4793,7 @@ void DCTSolver::compute_ewdm_odc() {
                 int J = bocc_qt[j];
                 int B = avir_qt[b];
                 double value = G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&AB, A, B, I, J, value, 0, "outfile", 0);
+                AB.write(A, B, I, J, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4822,7 +4817,7 @@ void DCTSolver::compute_ewdm_odc() {
                 int J = bocc_qt[j];
                 int B = avir_qt[b];
                 double value = (-2.0) * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&AB, I, B, J, A, value, 0, "outfile", 0);
+                AB.write(I, B, J, A, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4847,7 +4842,7 @@ void DCTSolver::compute_ewdm_odc() {
                 int J = bocc_qt[j];
                 int B = bvir_qt[b];
                 double value = 0.5 * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&BB, I, J, A, B, value, 0, "outfile", 0);
+                BB.write(I, J, A, B, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4871,7 +4866,7 @@ void DCTSolver::compute_ewdm_odc() {
                 int J = bocc_qt[j];
                 int B = bvir_qt[b];
                 double value = -0.5 * G.matrix[h][ia][jb];
-                iwl_buf_wrt_val(&BB, I, B, A, J, value, 0, "outfile", 0);
+                BB.write(I, B, A, J, value);
             }
         }
         global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -4880,12 +4875,9 @@ void DCTSolver::compute_ewdm_odc() {
 
     psio_->close(PSIF_DCT_DENSITY, 1);
 
-    iwl_buf_flush(&AA, 1);
-    iwl_buf_flush(&AB, 1);
-    iwl_buf_flush(&BB, 1);
-    iwl_buf_close(&AA, 1);
-    iwl_buf_close(&AB, 1);
-    iwl_buf_close(&BB, 1);
+    AA.close();
+    AB.close();
+    BB.close();
 
     delete[] alpha_pitzer_to_corr;
     delete[] beta_pitzer_to_corr;

--- a/psi4/src/psi4/dct/dct_scf_RHF.cc
+++ b/psi4/src/psi4/dct/dct_scf_RHF.cc
@@ -30,6 +30,7 @@
 #include "psi4/psifiles.h"
 
 #include "psi4/libiwl/iwl.hpp"
+#include "psi4/libiwl/iwl_reader.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/matrix.h"
@@ -108,11 +109,6 @@ double DCTSolver::update_scf_density_RHF(bool damp) {
 void DCTSolver::process_so_ints_RHF() {
     dct_timer_on("DCTSolver::process_so_ints");
 
-    IWL *iwl = new IWL(psio_.get(), PSIF_SO_TEI, int_tolerance_, 1, 1);
-
-    Label *lblptr = iwl->labels();
-    Value *valptr = iwl->values();
-
     double *Da = init_array(ntriso_);
     double *Ga = init_array(ntriso_);
 
@@ -133,7 +129,7 @@ void DCTSolver::process_so_ints_RHF() {
     int Gc, Gd;
     int pqArr, qpArr, rsArr, srArr, qrArr, rqArr;
     int qsArr, sqArr, psArr, spArr, prArr, rpArr;
-    int offset, labelIndex, p, q, r, s, h, counter;
+    int offset, p, q, r, s, h, counter;
     int **pq_row_start, **CD_row_start, **Cd_row_start, **cd_row_start;
     dpdbuf4 tau_temp, lambda;
     dpdbuf4 tau1_AO_ab, tau2_AO_ab;
@@ -194,16 +190,14 @@ void DCTSolver::process_so_ints_RHF() {
         }
     }
 
-    bool lastBuffer;
-    do {
-        lastBuffer = iwl->last_buffer();
-        for (int index = 0; index < iwl->buffer_count(); ++index) {
-            labelIndex = 4 * index;
-            p = std::abs((int)lblptr[labelIndex++]);
-            q = (int)lblptr[labelIndex++];
-            r = (int)lblptr[labelIndex++];
-            s = (int)lblptr[labelIndex++];
-            value = (double)valptr[index];
+    IWLReader eri(psio_, PSIF_SO_TEI);
+    for (const auto &integral : eri) {
+        {
+            p = std::abs(integral.p);
+            q = integral.q;
+            r = integral.r;
+            s = integral.s;
+            value = integral.value;
             if (buildTensors) {
                 AO_contribute(&tau1_AO_ab, &tau2_AO_ab, p, q, r, s, value);
                 ++counter;
@@ -358,11 +352,8 @@ void DCTSolver::process_so_ints_RHF() {
                     Ga[spArr] -= Da[rqArr] * value;
                 }
             }
-        } /* end loop through current buffer */
-        if (!lastBuffer) iwl->fetch();
-    } while (!lastBuffer);
-    iwl->set_keep_flag(true);
-    delete iwl;
+        }
+    } /* end loop over SO integrals */
     if (buildTensors) {
         if (print_ > 1) {
             outfile->Printf("Processed %d SO integrals each for AB\n", counter);

--- a/psi4/src/psi4/dct/dct_scf_UHF.cc
+++ b/psi4/src/psi4/dct/dct_scf_UHF.cc
@@ -33,6 +33,7 @@
 #include <map>
 
 #include "psi4/libiwl/iwl.hpp"
+#include "psi4/libiwl/iwl_reader.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/matrix.h"
@@ -253,11 +254,6 @@ double DCTSolver::update_scf_density(bool damp) {
 void DCTSolver::process_so_ints() {
     dct_timer_on("DCTSolver::process_so_ints");
 
-    IWL *iwl = new IWL(psio_.get(), PSIF_SO_TEI, int_tolerance_, 1, 1);
-
-    Label *lblptr = iwl->labels();
-    Value *valptr = iwl->values();
-
     double *Da = init_array(ntriso_);
     double *Db = init_array(ntriso_);
     double *Ga = init_array(ntriso_);
@@ -283,7 +279,7 @@ void DCTSolver::process_so_ints() {
     int Gc, Gd;
     int pqArr, qpArr, rsArr, srArr, qrArr, rqArr;
     int qsArr, sqArr, psArr, spArr, prArr, rpArr;
-    int offset, labelIndex, p, q, r, s, h, counter;
+    int offset, p, q, r, s, h, counter;
     int **pq_row_start, **CD_row_start, **Cd_row_start, **cd_row_start;
     dpdbuf4 tau_temp, lambda;
     dpdbuf4 tau1_AO_aa, tau2_AO_aa;
@@ -414,16 +410,14 @@ void DCTSolver::process_so_ints() {
         }
     }
 
-    bool lastBuffer;
-    do {
-        lastBuffer = iwl->last_buffer();
-        for (int index = 0; index < iwl->buffer_count(); ++index) {
-            labelIndex = 4 * index;
-            p = std::abs((int)lblptr[labelIndex++]);
-            q = (int)lblptr[labelIndex++];
-            r = (int)lblptr[labelIndex++];
-            s = (int)lblptr[labelIndex++];
-            value = (double)valptr[index];
+    IWLReader eri(psio_, PSIF_SO_TEI);
+    for (const auto &integral : eri) {
+        {
+            p = std::abs(integral.p);
+            q = integral.q;
+            r = integral.r;
+            s = integral.s;
+            value = integral.value;
             if (buildTensors) {
                 AO_contribute(&tau1_AO_aa, &tau2_AO_aa, p, q, r, s, value);
                 AO_contribute(&tau1_AO_bb, &tau2_AO_bb, p, q, r, s, value);
@@ -616,11 +610,8 @@ void DCTSolver::process_so_ints() {
                     Gb[spArr] -= Db[rqArr] * value;
                 }
             }
-        } /* end loop through current buffer */
-        if (!lastBuffer) iwl->fetch();
-    } while (!lastBuffer);
-    iwl->set_keep_flag(true);
-    delete iwl;
+        }
+    } /* end loop over SO integrals */
     if (buildTensors) {
         if (print_ > 1) {
             outfile->Printf("Processed %d SO integrals each for AA, BB, and AB\n", counter);
@@ -780,14 +771,10 @@ void DCTSolver::update_fock() {
 void DCTSolver::build_AO_tensors() {
     dct_timer_on("DCTSolver::build_tensors");
 
-    IWL *iwl = new IWL(psio_.get(), PSIF_SO_TEI, int_tolerance_, 1, 1);
-
-    Label *lblptr = iwl->labels();
-    Value *valptr = iwl->values();
 
     double value;
     int Gc, Gd;
-    int offset, labelIndex, p, q, r, s, h, counter;
+    int offset, p, q, r, s, h, counter;
     int **pq_row_start, **CD_row_start, **Cd_row_start, **cd_row_start;
     dpdbuf4 tau_temp, lambda;
     dpdbuf4 tau1_AO_aa, tau2_AO_aa;
@@ -949,26 +936,18 @@ void DCTSolver::build_AO_tensors() {
         global_dpd_->buf4_mat_irrep_init(&tau2_AO_ab, h);
     }
 
-    bool lastBuffer;
-    do {
-        lastBuffer = iwl->last_buffer();
-        for (int index = 0; index < iwl->buffer_count(); ++index) {
-            labelIndex = 4 * index;
-            p = std::abs((int)lblptr[labelIndex++]);
-            q = (int)lblptr[labelIndex++];
-            r = (int)lblptr[labelIndex++];
-            s = (int)lblptr[labelIndex++];
-            value = (double)valptr[index];
-            AO_contribute(&tau1_AO_aa, &tau2_AO_aa, p, q, r, s, value, &s_aa_1, &s_bb_1, &s_aa_2);
-            AO_contribute(&tau1_AO_bb, &tau2_AO_bb, p, q, r, s, value, &s_bb_1, &s_aa_1, &s_bb_2);
-            AO_contribute(&tau1_AO_ab, &tau2_AO_ab, p, q, r, s, value);
-            ++counter;
-
-        } /* end loop through current buffer */
-        if (!lastBuffer) iwl->fetch();
-    } while (!lastBuffer);
-    iwl->set_keep_flag(true);
-    delete iwl;
+    IWLReader eri(psio_, PSIF_SO_TEI);
+    for (const auto &integral : eri) {
+        p = std::abs(integral.p);
+        q = integral.q;
+        r = integral.r;
+        s = integral.s;
+        value = integral.value;
+        AO_contribute(&tau1_AO_aa, &tau2_AO_aa, p, q, r, s, value, &s_aa_1, &s_bb_1, &s_aa_2);
+        AO_contribute(&tau1_AO_bb, &tau2_AO_bb, p, q, r, s, value, &s_bb_1, &s_aa_1, &s_bb_2);
+        AO_contribute(&tau1_AO_ab, &tau2_AO_ab, p, q, r, s, value);
+        ++counter;
+    } /* end loop over SO integrals */
     if (print_ > 1) {
         outfile->Printf("Processed %d SO integrals each for AA, BB, and AB\n", counter);
     }

--- a/psi4/src/psi4/dct/dct_sort_mo_tpdm.cc
+++ b/psi4/src/psi4/dct/dct_sort_mo_tpdm.cc
@@ -31,6 +31,7 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libiwl/iwl.hpp"
+#include "psi4/libiwl/iwl_reader.h"
 #include "psi4/libtrans/integraltransform_functors.h"
 #include "psi4/psifiles.h"
 #include "psi4/libtrans/mospace.h"
@@ -141,28 +142,17 @@ void DCTSolver::presort_mo_tpdm_AB() {
             I.matrix[h] = block_matrix(bucketRowDim[n][h], I.params->coltot[h]);
         }
 
-        IWL *iwl = new IWL(psio_.get(), PSIF_MO_TPDM, 1.0E-16, 1, 0);
         DPDFillerFunctor dpdFiller(&I, n, bucketMap, bucketOffset, true, false);
 
-        Label *lblptr = iwl->labels();
-        Value *valptr = iwl->values();
-        int lastbuf;
         /* Now run through the IWL buffers */
-        do {
-            iwl->fetch();
-            lastbuf = iwl->last_buffer();
-            for (int index = 0; index < iwl->buffer_count(); ++index) {
-                int labelIndex = 4 * index;
-                int p = _ints->alpha_corr_to_pitzer()[std::abs((int)lblptr[labelIndex++])];
-                int q = _ints->alpha_corr_to_pitzer()[(int)lblptr[labelIndex++]];
-                int r = _ints->alpha_corr_to_pitzer()[(int)lblptr[labelIndex++]];
-                int s = _ints->alpha_corr_to_pitzer()[(int)lblptr[labelIndex++]];
-                auto value = (double)valptr[index];
-                dpdFiller(p, q, r, s, value);
-            }               /* end loop through current buffer */
-        } while (!lastbuf); /* end loop over reading buffers */
-        iwl->set_keep_flag(true);
-        delete iwl;
+        IWLReader eri(psio_, PSIF_MO_TPDM);
+        for (const auto &integral : eri) {
+            int p = _ints->alpha_corr_to_pitzer()[std::abs(integral.p)];
+            int q = _ints->alpha_corr_to_pitzer()[integral.q];
+            int r = _ints->alpha_corr_to_pitzer()[integral.r];
+            int s = _ints->alpha_corr_to_pitzer()[integral.s];
+            dpdFiller(p, q, r, s, integral.value);
+        }
 
         for (int h = 0; h < nirrep_; ++h) {
             if (bucketSize[n][h])
@@ -294,29 +284,17 @@ void DCTSolver::presort_mo_tpdm_AA() {
             I.matrix[h] = block_matrix(bucketRowDim[n][h], I.params->coltot[h]);
         }
 
-        IWL *iwl = new IWL(psio_.get(), PSIF_MO_TPDM, 1.0E-16, 1, 0);
         DPDFillerFunctor dpdFiller(&I, n, bucketMap, bucketOffset, true, true);
 
-        Label *lblptr = iwl->labels();
-        Value *valptr = iwl->values();
-        int lastbuf;
         /* Now run through the IWL buffers */
-        do {
-            iwl->fetch();
-            lastbuf = iwl->last_buffer();
-            for (int index = 0; index < iwl->buffer_count(); ++index) {
-                int labelIndex = 4 * index;
-                int p = _ints->alpha_corr_to_pitzer()[std::abs((int)lblptr[labelIndex++])];
-                int q = _ints->alpha_corr_to_pitzer()[(int)lblptr[labelIndex++]];
-                int r = _ints->alpha_corr_to_pitzer()[(int)lblptr[labelIndex++]];
-                int s = _ints->alpha_corr_to_pitzer()[(int)lblptr[labelIndex++]];
-                auto value = (double)valptr[index];
-                dpdFiller(p, q, r, s, value);
-
-            }               /* end loop through current buffer */
-        } while (!lastbuf); /* end loop over reading buffers */
-        iwl->set_keep_flag(true);
-        delete iwl;
+        IWLReader eri(psio_, PSIF_MO_TPDM);
+        for (const auto &integral : eri) {
+            int p = _ints->alpha_corr_to_pitzer()[std::abs(integral.p)];
+            int q = _ints->alpha_corr_to_pitzer()[integral.q];
+            int r = _ints->alpha_corr_to_pitzer()[integral.r];
+            int s = _ints->alpha_corr_to_pitzer()[integral.s];
+            dpdFiller(p, q, r, s, integral.value);
+        }
 
         for (int h = 0; h < nirrep_; ++h) {
             if (bucketSize[n][h])

--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -50,7 +50,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl.hpp"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libqt/qt.h"
@@ -624,7 +624,7 @@ void CIWavefunction::read_dpd_ci_ints() {
     auto* tmp_onel_ints = new double[nmotri_full];
 
     // Read one electron integrals
-    iwl_rdone(PSIF_OEI, PSIF_MO_FZC, tmp_onel_ints, nmotri_full, 0, (print_ > 4), "outfile");
+    IWL::read_one(_default_psio_lib_.get(), PSIF_OEI, PSIF_MO_FZC, tmp_onel_ints, nmotri_full, 0, (print_ > 4), "outfile");
 
     // IntegralTransform does not properly order one electron integrals for
     // whatever reason

--- a/psi4/src/psi4/dfmp2/wrapper.cc
+++ b/psi4/src/psi4/dfmp2/wrapper.cc
@@ -36,7 +36,6 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/liboptions/liboptions.h"

--- a/psi4/src/psi4/fnocc/ccsd.h
+++ b/psi4/src/psi4/fnocc/ccsd.h
@@ -30,7 +30,6 @@
 #define CCSD_H
 
 #include "psi4/psi4-dec.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libmints/wavefunction.h"

--- a/psi4/src/psi4/fnocc/mp2.cc
+++ b/psi4/src/psi4/fnocc/mp2.cc
@@ -33,7 +33,8 @@
 #include "psi4/libqt/qt.h"
 #include "psi4/libtrans/mospace.h"
 #include "psi4/libtrans/integraltransform.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_reader.h"
+#include "psi4/libpsio/psio.hpp"
 #include "psi4/psifiles.h"
 #ifdef _OPENMP
 #include <omp.h>
@@ -47,7 +48,7 @@
 using namespace psi;
 namespace psi {
 namespace fnocc {
-void SortOVOV(struct iwlbuf *Buf, int nfzc, int nfzv, int norbs, int ndoccact, int nvirt);
+void SortOVOV(IWLReader &eri, int nfzc, int nfzv, int norbs, int ndoccact, int nvirt);
 }
 }
 
@@ -82,10 +83,8 @@ void CoupledCluster::MP2() {
     outfile->Printf("\n");
     outfile->Printf("        ==> Sort (OV|OV) integrals <==\n");
     outfile->Printf("\n");
-    struct iwlbuf Buf;
-    iwl_buf_init(&Buf, PSIF_MO_TEI, 0.0, 1, 1);
-    SortOVOV(&Buf, nfzc, nfzv, nfzc + nfzv + ndoccact + nvirt, ndoccact, nvirt);
-    iwl_buf_close(&Buf, 1);
+    IWLReader eri(_default_psio_lib_, PSIF_MO_TEI);
+    SortOVOV(eri, nfzc, nfzv, nfzc + nfzv + ndoccact + nvirt, ndoccact, nvirt);
 
     // energy
     double *v2 = (double *)malloc(o * o * v * v * sizeof(double));

--- a/psi4/src/psi4/fnocc/sortintegrals.cc
+++ b/psi4/src/psi4/fnocc/sortintegrals.cc
@@ -31,7 +31,7 @@
 
 #include "psi4/psi4-dec.h"
 #include "psi4/psifiles.h"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_reader.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsi4util/process.h"
@@ -43,7 +43,7 @@ struct integral {
     size_t ind;
     double val;
 };
-void SortAllIntegrals(iwlbuf *Buf, int nfzc, int nfzv, int norbs, int ndoccact, int nvirt, Options &options);
+void SortAllIntegrals(IWLReader &eri, int nfzc, int nfzv, int norbs, int ndoccact, int nvirt, Options &options);
 void klcd_terms_incore(double val, size_t pq, size_t rs, size_t p, size_t q, size_t r, size_t s, size_t o, size_t v,
                        double *klcd);
 void ijkl_terms(double val, size_t pq, size_t rs, size_t p, size_t q, size_t r, size_t s, size_t o, size_t &nijkl,
@@ -100,8 +100,7 @@ void SortBlockNewNew(size_t *nelem, size_t blockdim, struct integral *buffer, do
 namespace psi {
 namespace fnocc {
 void SortIntegrals(int nfzc, int nfzv, int norbs, int ndoccact, int nvirt, Options &options) {
-    struct iwlbuf Buf;
-    iwl_buf_init(&Buf, PSIF_MO_TEI, 0.0, 1, 1);
+    IWLReader eri(_default_psio_lib_, PSIF_MO_TEI);
 
     outfile->Printf("\n");
     outfile->Printf("        **********************************************************\n");
@@ -112,26 +111,18 @@ void SortIntegrals(int nfzc, int nfzv, int norbs, int ndoccact, int nvirt, Optio
     outfile->Printf("\n");
     outfile->Printf("\n");
 
-    SortAllIntegrals(&Buf, nfzc, nfzv, norbs, ndoccact, nvirt, options);
-
-    iwl_buf_close(&Buf, 1);
+    SortAllIntegrals(eri, nfzc, nfzv, norbs, ndoccact, nvirt, options);
 }
-void SortAllIntegrals(iwlbuf *Buf, int nfzc, int nfzv, int norbs, int ndoccact, int nvirt, Options &options) {
+void SortAllIntegrals(IWLReader &eri, int nfzc, int nfzv, int norbs, int ndoccact, int nvirt, Options &options) {
     double val;
     size_t o = ndoccact;
     size_t v = nvirt;
     size_t fstact = nfzc;
     size_t lstact = norbs - nfzv;
 
-    size_t lastbuf;
-    Label *lblptr;
-    Value *valptr;
-    size_t nocc, idx, p, q, r, s, pq, rs, pqrs;
+        size_t nocc, idx, p, q, r, s, pq, rs, pqrs;
 
-    lblptr = Buf->labels;
-    valptr = Buf->values;
 
-    lastbuf = Buf->lastbuf;
 
     // buckets for integrals:
     struct integral *ijkl, *klcd, *akjc, **abci1, **abci3;
@@ -331,11 +322,11 @@ void SortAllIntegrals(iwlbuf *Buf, int nfzc, int nfzv, int norbs, int ndoccact, 
     /**
       * first buffer (read in when Buf was initialized)
       */
-    for (idx = 4 * Buf->idx; Buf->idx < Buf->inbuf; Buf->idx++) {
-        p = (size_t)lblptr[idx++];
-        q = (size_t)lblptr[idx++];
-        r = (size_t)lblptr[idx++];
-        s = (size_t)lblptr[idx++];
+    for (const auto &integral : eri) {
+        p = (size_t)integral.p;
+        q = (size_t)integral.q;
+        r = (size_t)integral.r;
+        s = (size_t)integral.s;
 
         if (p < fstact || q < fstact || r < fstact || s < fstact) continue;
         if (p > lstact || q > lstact || r > lstact || s > lstact) continue;
@@ -357,7 +348,7 @@ void SortAllIntegrals(iwlbuf *Buf, int nfzc, int nfzv, int norbs, int ndoccact, 
         // which type of integral?
 
         if (nocc == 4) {
-            val = (double)valptr[Buf->idx];
+            val = integral.value;
             ijkl_terms(val, pq, rs, p, q, r, s, o, nijkl, ijkl);
 
             if (nijkl >= nelem) {
@@ -369,7 +360,7 @@ void SortAllIntegrals(iwlbuf *Buf, int nfzc, int nfzv, int norbs, int ndoccact, 
                 nijkl = 0;
             }
         } else if (nocc == 3) {
-            val = (double)valptr[Buf->idx];
+            val = integral.value;
             ijak_terms(val, p, q, r, s, o, v, nijak, ijak);
             if (nijak >= nelem) {
                 psio->open(PSIF_DCC_IJAK, PSIO_OPEN_OLD);
@@ -389,7 +380,7 @@ void SortAllIntegrals(iwlbuf *Buf, int nfzc, int nfzv, int norbs, int ndoccact, 
                 nijak2 = 0;
             }
         } else if (nocc == 2) {
-            val = (double)valptr[Buf->idx];
+            val = integral.value;
 
             if ((p < o && q >= o) || (p >= o && q < o)) {
                 klcd_terms(val, pq, rs, p, q, r, s, o, v, nklcd, klcd);
@@ -414,7 +405,7 @@ void SortAllIntegrals(iwlbuf *Buf, int nfzc, int nfzv, int norbs, int ndoccact, 
                 }
             }
         } else if (nocc == 1) {
-            val = (double)valptr[Buf->idx];
+            val = integral.value;
             abci1_terms_new(val, p, q, r, s, o, v, nabci1, totalnabci1, abci1, ov3filesize, bucketsize, abci1_addr,
                             PSIF_DCC_SORT_START + 2 * nfiles, ov3nfiles);
             abci3_terms_new(val, p, q, r, s, o, v, nabci3, totalnabci3, abci3, ov3filesize, bucketsize, abci3_addr,
@@ -422,118 +413,11 @@ void SortAllIntegrals(iwlbuf *Buf, int nfzc, int nfzv, int norbs, int ndoccact, 
             abci5_terms_new(val, p, q, r, s, o, v, nabci5, totalnabci5, abci5, ov3filesize, bucketsize, abci5_addr,
                             PSIF_DCC_SORT_START + 2 * nfiles + 2 * ov3nfiles, ov3nfiles);
         } else if (nocc == 0) {
-            val = (double)valptr[Buf->idx];
+            val = integral.value;
             abcd1_terms_new(val, pq, rs, p, q, r, s, o, v, nabcd1, totalnabcd1, abcd1, filesize, bucketsize, abcd1_addr,
                             nfiles);
             abcd2_terms_new(val, pq, rs, p, q, r, s, o, v, nabcd2, totalnabcd2, abcd2, filesize, bucketsize, abcd2_addr,
                             nfiles);
-        }
-    }
-
-    /**
-      * now do the same for the rest of the buffers
-      */
-    while (!lastbuf) {
-        iwl_buf_fetch(Buf);
-        lastbuf = Buf->lastbuf;
-        for (idx = 4 * Buf->idx; Buf->idx < Buf->inbuf; Buf->idx++) {
-            p = (size_t)lblptr[idx++];
-            q = (size_t)lblptr[idx++];
-            r = (size_t)lblptr[idx++];
-            s = (size_t)lblptr[idx++];
-
-            if (p < fstact || q < fstact || r < fstact || s < fstact) continue;
-            if (p > lstact || q > lstact || r > lstact || s > lstact) continue;
-            p -= fstact;
-            q -= fstact;
-            r -= fstact;
-            s -= fstact;
-
-            pq = Position(p, q);
-            rs = Position(r, s);
-            pqrs = Position(pq, rs);
-
-            nocc = 0;
-            if (p < o) nocc++;
-            if (q < o) nocc++;
-            if (r < o) nocc++;
-            if (s < o) nocc++;
-
-            // which type of integral?
-
-            if (nocc == 4) {
-                val = (double)valptr[Buf->idx];
-                ijkl_terms(val, pq, rs, p, q, r, s, o, nijkl, ijkl);
-
-                if (nijkl >= nelem) {
-                    psio->open(PSIF_DCC_IJKL, PSIO_OPEN_OLD);
-                    psio->write(PSIF_DCC_IJKL, "E2ijkl", (char *)&ijkl[0], nijkl * sizeof(struct integral), ijkl_addr,
-                                &ijkl_addr);
-                    psio->close(PSIF_DCC_IJKL, 1);
-                    totalnijkl += nijkl;
-                    nijkl = 0;
-                }
-            } else if (nocc == 3) {
-                val = (double)valptr[Buf->idx];
-                ijak_terms(val, p, q, r, s, o, v, nijak, ijak);
-                if (nijak >= nelem) {
-                    psio->open(PSIF_DCC_IJAK, PSIO_OPEN_OLD);
-                    psio->write(PSIF_DCC_IJAK, "E2ijak", (char *)&ijak[0], nijak * sizeof(struct integral), ijak_addr,
-                                &ijak_addr);
-                    psio->close(PSIF_DCC_IJAK, 1);
-                    totalnijak += nijak;
-                    nijak = 0;
-                }
-                ijak2_terms(val, p, q, r, s, o, v, nijak2, ijak2);
-                if (nijak2 >= nelem) {
-                    psio->open(PSIF_DCC_IJAK2, PSIO_OPEN_OLD);
-                    psio->write(PSIF_DCC_IJAK2, "E2ijak2", (char *)&ijak2[0], nijak2 * sizeof(struct integral),
-                                ijak2_addr, &ijak2_addr);
-                    psio->close(PSIF_DCC_IJAK2, 1);
-                    totalnijak2 += nijak2;
-                    nijak2 = 0;
-                }
-            } else if (nocc == 2) {
-                val = (double)valptr[Buf->idx];
-
-                if ((p < o && q >= o) || (p >= o && q < o)) {
-                    klcd_terms(val, pq, rs, p, q, r, s, o, v, nklcd, klcd);
-
-                    if (nklcd >= nelem) {
-                        psio->open(PSIF_DCC_IAJB, PSIO_OPEN_OLD);
-                        psio->write(PSIF_DCC_IAJB, "E2iajb", (char *)&klcd[0], nklcd * sizeof(struct integral),
-                                    klcd_addr, &klcd_addr);
-                        psio->close(PSIF_DCC_IAJB, 1);
-                        totalnklcd += nklcd;
-                        nklcd = 0;
-                    }
-                } else {
-                    akjc_terms(val, p, q, r, s, o, v, nakjc, akjc);
-
-                    if (nakjc >= nelem) {
-                        psio->open(PSIF_DCC_IJAB, PSIO_OPEN_OLD);
-                        psio->write(PSIF_DCC_IJAB, "E2ijab", (char *)&akjc[0], nakjc * sizeof(struct integral),
-                                    akjc_addr, &akjc_addr);
-                        psio->close(PSIF_DCC_IJAB, 1);
-                        totalnakjc += nakjc;
-                        nakjc = 0;
-                    }
-                }
-            } else if (nocc == 1) {
-                val = (double)valptr[Buf->idx];
-                abci1_terms_new(val, p, q, r, s, o, v, nabci1, totalnabci1, abci1, ov3filesize, bucketsize, abci1_addr,
-                                PSIF_DCC_SORT_START + 2 * nfiles, ov3nfiles);
-                abci3_terms_new(val, p, q, r, s, o, v, nabci3, totalnabci3, abci3, ov3filesize, bucketsize, abci3_addr,
-                                PSIF_DCC_SORT_START + 2 * nfiles + ov3nfiles, ov3nfiles);
-                abci5_terms_new(val, p, q, r, s, o, v, nabci5, totalnabci5, abci5, ov3filesize, bucketsize, abci5_addr,
-                                PSIF_DCC_SORT_START + 2 * nfiles + 2 * ov3nfiles, ov3nfiles);
-            } else if (nocc == 0) {
-                val = (double)valptr[Buf->idx];
-                abcd1_terms_new(val, pq, rs, p, q, r, s, o, v, nabcd1, totalnabcd1, abcd1, filesize, bucketsize,
-                                abcd1_addr, nfiles);
-                abcd2_terms_new(val, pq, rs, p, q, r, s, o, v, nabcd2, totalnabcd2, abcd2, filesize, bucketsize,
-                                abcd2_addr, nfiles);
-            }
         }
     }
     outfile->Printf("done.\n\n");
@@ -2333,22 +2217,16 @@ void Sort_OV3_LowMemory(long int memory, long int o, long int v) {
 /**
   * OVOV in-core integral sort.  requires o^2v^2 doubles
   */
-void SortOVOV(struct iwlbuf *Buf, int nfzc, int nfzv, int norbs, int ndoccact, int nvirt) {
+void SortOVOV(IWLReader &eri, int nfzc, int nfzv, int norbs, int ndoccact, int nvirt) {
     double val;
     size_t o = ndoccact;
     size_t v = nvirt;
     size_t fstact = nfzc;
     size_t lstact = norbs - nfzv;
 
-    size_t lastbuf;
-    Label *lblptr;
-    Value *valptr;
-    size_t nocc, idx, p, q, r, s, pq, rs;
+        size_t nocc, idx, p, q, r, s, pq, rs;
 
-    lblptr = Buf->labels;
-    valptr = Buf->values;
 
-    lastbuf = Buf->lastbuf;
 
     // available memory:
     size_t memory = Process::environment.get_memory();
@@ -2369,11 +2247,11 @@ void SortOVOV(struct iwlbuf *Buf, int nfzc, int nfzv, int norbs, int ndoccact, i
     /**
       * first buffer (read in when Buf was initialized)
       */
-    for (idx = 4 * Buf->idx; Buf->idx < Buf->inbuf; Buf->idx++) {
-        p = (size_t)lblptr[idx++];
-        q = (size_t)lblptr[idx++];
-        r = (size_t)lblptr[idx++];
-        s = (size_t)lblptr[idx++];
+    for (const auto &integral : eri) {
+        p = (size_t)integral.p;
+        q = (size_t)integral.q;
+        r = (size_t)integral.r;
+        s = (size_t)integral.s;
 
         if (p < fstact || q < fstact || r < fstact || s < fstact) continue;
         if (p > lstact || q > lstact || r > lstact || s > lstact) continue;
@@ -2387,37 +2265,8 @@ void SortOVOV(struct iwlbuf *Buf, int nfzc, int nfzv, int norbs, int ndoccact, i
 
         if (pq > rs) continue;
 
-        val = (double)valptr[Buf->idx];
+        val = integral.value;
         klcd_terms_incore(val, pq, rs, p, q, r, s, o, v, klcd);
-    }
-
-    /**
-      * now do the same for the rest of the buffers
-      */
-    while (!lastbuf) {
-        iwl_buf_fetch(Buf);
-        lastbuf = Buf->lastbuf;
-        for (idx = 4 * Buf->idx; Buf->idx < Buf->inbuf; Buf->idx++) {
-            p = (size_t)lblptr[idx++];
-            q = (size_t)lblptr[idx++];
-            r = (size_t)lblptr[idx++];
-            s = (size_t)lblptr[idx++];
-
-            if (p < fstact || q < fstact || r < fstact || s < fstact) continue;
-            if (p > lstact || q > lstact || r > lstact || s > lstact) continue;
-            p -= fstact;
-            q -= fstact;
-            r -= fstact;
-            s -= fstact;
-
-            pq = Position(p, q);
-            rs = Position(r, s);
-
-            if (pq > rs) continue;
-
-            val = (double)valptr[Buf->idx];
-            klcd_terms_incore(val, pq, rs, p, q, r, s, o, v, klcd);
-        }
     }
 
     /**

--- a/psi4/src/psi4/lib3index/cholesky.cc
+++ b/psi4/src/psi4/lib3index/cholesky.cc
@@ -36,7 +36,6 @@
 #include "psi4/psifiles.h"
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsio/psio.hpp"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/vector.h"
 #include "psi4/libmints/basisset.h"

--- a/psi4/src/psi4/libdpd/buf4_dump.cc
+++ b/psi4/src/psi4/libdpd/buf4_dump.cc
@@ -31,12 +31,12 @@
     \brief Enter brief description of file here
 */
 #include <cstdio>
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "dpd.h"
 
 namespace psi {
 
-int DPD::buf4_dump(dpdbuf4 *DPDBuf, struct iwlbuf *IWLBuf, int *prel, int *qrel, int *rrel, int *srel, int bk_pack,
+int DPD::buf4_dump(dpdbuf4 *DPDBuf, IWLWriter &IWLBuf, int *prel, int *qrel, int *rrel, int *srel, int bk_pack,
                    int swap23) {
     int h, row, col, p, q, r, s, P, Q, R, S, my_irrep;
     double value;
@@ -61,9 +61,9 @@ int DPD::buf4_dump(dpdbuf4 *DPDBuf, struct iwlbuf *IWLBuf, int *prel, int *qrel,
                     value = DPDBuf->matrix[h][row][col];
 
                     if (swap23)
-                        iwl_buf_wrt_val(IWLBuf, P, R, Q, S, value, 0, "outfile", 0);
+                        IWLBuf.write(P, R, Q, S, value);
                     else
-                        iwl_buf_wrt_val(IWLBuf, P, Q, R, S, value, 0, "outfile", 0);
+                        IWLBuf.write(P, Q, R, S, value);
                 }
             } else {
                 for (col = 0; col < DPDBuf->params->coltot[h ^ my_irrep]; col++) {
@@ -75,9 +75,9 @@ int DPD::buf4_dump(dpdbuf4 *DPDBuf, struct iwlbuf *IWLBuf, int *prel, int *qrel,
                     value = DPDBuf->matrix[h][row][col];
 
                     if (swap23)
-                        iwl_buf_wrt_val(IWLBuf, P, R, Q, S, value, 0, "outfile", 0);
+                        IWLBuf.write(P, R, Q, S, value);
                     else
-                        iwl_buf_wrt_val(IWLBuf, P, Q, R, S, value, 0, "outfile", 0);
+                        IWLBuf.write(P, Q, R, S, value);
                 }
             }
         }

--- a/psi4/src/psi4/libdpd/dpd.h
+++ b/psi4/src/psi4/libdpd/dpd.h
@@ -48,6 +48,7 @@
 namespace psi {
 
 class Matrix;
+class IWLWriter;
 
 #define T3_TIMER_ON (0)
 
@@ -434,7 +435,7 @@ class PSI_API DPD {
     int buf4_mat_irrep_close_block(dpdbuf4 *Buf, int irrep, int num_pq);
     int buf4_mat_irrep_rd_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_pq);
     int buf4_mat_irrep_wrt_block(dpdbuf4 *Buf, int irrep, int start_pq, int num_pq);
-    int buf4_dump(dpdbuf4 *DPDBuf, struct iwlbuf *IWLBuf, int *prel, int *qrel, int *rrel, int *srel, int bk_pack,
+    int buf4_dump(dpdbuf4 *DPDBuf, IWLWriter &IWLBuf, int *prel, int *qrel, int *rrel, int *srel, int bk_pack,
                   int swap23);
     int trans4_init(dpdtrans4 *Trans, dpdbuf4 *Buf);
     int trans4_close(dpdtrans4 *Trans);

--- a/psi4/src/psi4/libfock/DiskJK.cc
+++ b/psi4/src/psi4/libfock/DiskJK.cc
@@ -33,6 +33,7 @@
 #include "psi4/psi4-dec.h"
 #include "psi4/psifiles.h"
 #include "psi4/libiwl/iwl.hpp"
+#include "psi4/libiwl/iwl_reader.h"
 #include "jk.h"
 
 #include "psi4/libmints/matrix.h"
@@ -94,21 +95,16 @@ void DiskJK::compute_JK() {
     zero();
 
     auto psio = std::make_shared<PSIO>();
-    IWL* iwl = new IWL(psio.get(), PSIF_SO_TEI, cutoff_, 1, 1);
-    Label* lblptr = iwl->labels();
-    Value* valptr = iwl->values();
-    int labelIndex, pabs, qabs, rabs, sabs, prel, qrel, rrel, srel, psym, qsym, rsym, ssym;
+    int pabs, qabs, rabs, sabs, prel, qrel, rrel, srel, psym, qsym, rsym, ssym;
     double value;
-    bool lastBuffer;
     if (J_.size() == K_.size()) {
-        do {
-            lastBuffer = iwl->last_buffer();
-            for (int index = 0; index < iwl->buffer_count(); ++index) {
-                labelIndex = 4 * index;
-                pabs = std::abs((int)lblptr[labelIndex++]);
-                qabs = (int)lblptr[labelIndex++];
-                rabs = (int)lblptr[labelIndex++];
-                sabs = (int)lblptr[labelIndex++];
+        IWLReader eri(psio, PSIF_SO_TEI);
+        for (const auto& integral : eri) {
+            {
+                pabs = std::abs(integral.p);
+                qabs = integral.q;
+                rabs = integral.r;
+                sabs = integral.s;
                 prel = so2index_[pabs];
                 qrel = so2index_[qabs];
                 rrel = so2index_[rabs];
@@ -117,7 +113,7 @@ void DiskJK::compute_JK() {
                 qsym = so2symblk_[qabs];
                 rsym = so2symblk_[rabs];
                 ssym = so2symblk_[sabs];
-                value = (double)valptr[index];
+                value = integral.value;
 
                 int pqsym = psym ^ qsym;
                 int rssym = rsym ^ ssym;
@@ -263,9 +259,8 @@ void DiskJK::compute_JK() {
                         }
                     }
                 }
-            } /* end loop through current buffer */
-            if (!lastBuffer) iwl->fetch();
-        } while (!lastBuffer);
+            }
+        } /* end loop over SO integrals */
 
         for (size_t N = 0; N < J_.size(); N++) {
             J_[N]->copy_lower_to_upper();
@@ -273,14 +268,13 @@ void DiskJK::compute_JK() {
         }
     } else {
         // J and K to be handled separately
-        do {
-            lastBuffer = iwl->last_buffer();
-            for (int index = 0; index < iwl->buffer_count(); ++index) {
-                labelIndex = 4 * index;
-                pabs = std::abs((int)lblptr[labelIndex++]);
-                qabs = (int)lblptr[labelIndex++];
-                rabs = (int)lblptr[labelIndex++];
-                sabs = (int)lblptr[labelIndex++];
+        IWLReader eri(psio, PSIF_SO_TEI);
+        for (const auto& integral : eri) {
+            {
+                pabs = std::abs(integral.p);
+                qabs = integral.q;
+                rabs = integral.r;
+                sabs = integral.s;
                 prel = so2index_[pabs];
                 qrel = so2index_[qabs];
                 rrel = so2index_[rabs];
@@ -289,7 +283,7 @@ void DiskJK::compute_JK() {
                 qsym = so2symblk_[qabs];
                 rsym = so2symblk_[rabs];
                 ssym = so2symblk_[sabs];
-                value = (double)valptr[index];
+                value = integral.value;
 
                 int pqsym = psym ^ qsym;
                 int rssym = rsym ^ ssym;
@@ -440,9 +434,8 @@ void DiskJK::compute_JK() {
                         }
                     }
                 }
-            } /* end loop through current buffer */
-            if (!lastBuffer) iwl->fetch();
-        } while (!lastBuffer);
+            }
+        } /* end loop over SO integrals */
 
         for (size_t N = 0; N < J_.size(); N++) {
             J_[N]->copy_lower_to_upper();
@@ -451,22 +444,15 @@ void DiskJK::compute_JK() {
             if (K_[N]->symmetry()) K_[N]->transpose_this();
         }
     }
-    iwl->set_keep_flag(true);
-    delete iwl;
 
     if (do_wK_) {
-        iwl = new IWL(psio.get(), PSIF_SO_ERF_TEI, cutoff_, 1, 1);
-        lblptr = iwl->labels();
-        valptr = iwl->values();
-
-        do {
-            lastBuffer = iwl->last_buffer();
-            for (int index = 0; index < iwl->buffer_count(); ++index) {
-                labelIndex = 4 * index;
-                pabs = std::abs((int)lblptr[labelIndex++]);
-                qabs = (int)lblptr[labelIndex++];
-                rabs = (int)lblptr[labelIndex++];
-                sabs = (int)lblptr[labelIndex++];
+        IWLReader eri(psio, PSIF_SO_ERF_TEI);
+        for (const auto& integral : eri) {
+            {
+                pabs = std::abs(integral.p);
+                qabs = integral.q;
+                rabs = integral.r;
+                sabs = integral.s;
                 prel = so2index_[pabs];
                 qrel = so2index_[qabs];
                 rrel = so2index_[rabs];
@@ -475,7 +461,7 @@ void DiskJK::compute_JK() {
                 qsym = so2symblk_[qabs];
                 rsym = so2symblk_[rabs];
                 ssym = so2symblk_[sabs];
-                value = (double)valptr[index];
+                value = integral.value;
 
                 int qrsym = qsym ^ rsym;
                 int pssym = psym ^ ssym;
@@ -569,15 +555,12 @@ void DiskJK::compute_JK() {
                         }
                     }
                 }
-            } /* end loop through current buffer */
-            if (!lastBuffer) iwl->fetch();
-        } while (!lastBuffer);
+            }
+        } /* end loop over SO integrals */
 
         for (size_t N = 0; N < wK_.size(); N++) {
             if (wK_[N]->symmetry()) wK_[N]->transpose_this();
         }
-        iwl->set_keep_flag(true);
-        delete iwl;
     }
 }
 void DiskJK::postiterations() {

--- a/psi4/src/psi4/libfock/DiskJK.cc
+++ b/psi4/src/psi4/libfock/DiskJK.cc
@@ -33,6 +33,7 @@
 #include "psi4/psi4-dec.h"
 #include "psi4/psifiles.h"
 #include "psi4/libiwl/iwl.hpp"
+#include "psi4/libiwl/iwl_reader.h"
 #include "jk.h"
 
 #include "psi4/libmints/matrix.h"
@@ -95,21 +96,16 @@ void DiskJK::compute_JK() {
     zero();
 
     auto psio = std::make_shared<PSIO>();
-    IWL* iwl = new IWL(psio.get(), PSIF_SO_TEI, cutoff_, 1, 1);
-    Label* lblptr = iwl->labels();
-    Value* valptr = iwl->values();
-    int labelIndex, pabs, qabs, rabs, sabs, prel, qrel, rrel, srel, psym, qsym, rsym, ssym;
+    int pabs, qabs, rabs, sabs, prel, qrel, rrel, srel, psym, qsym, rsym, ssym;
     double value;
-    bool lastBuffer;
     if (J_.size() == K_.size()) {
-        do {
-            lastBuffer = iwl->last_buffer();
-            for (int index = 0; index < iwl->buffer_count(); ++index) {
-                labelIndex = 4 * index;
-                pabs = std::abs((int)lblptr[labelIndex++]);
-                qabs = (int)lblptr[labelIndex++];
-                rabs = (int)lblptr[labelIndex++];
-                sabs = (int)lblptr[labelIndex++];
+        IWLReader eri(psio, PSIF_SO_TEI);
+        for (const auto& integral : eri) {
+            {
+                pabs = std::abs(integral.p);
+                qabs = integral.q;
+                rabs = integral.r;
+                sabs = integral.s;
                 prel = so2index_[pabs];
                 qrel = so2index_[qabs];
                 rrel = so2index_[rabs];
@@ -118,7 +114,7 @@ void DiskJK::compute_JK() {
                 qsym = so2symblk_[qabs];
                 rsym = so2symblk_[rabs];
                 ssym = so2symblk_[sabs];
-                value = (double)valptr[index];
+                value = integral.value;
 
                 int pqsym = psym ^ qsym;
                 int rssym = rsym ^ ssym;
@@ -264,9 +260,8 @@ void DiskJK::compute_JK() {
                         }
                     }
                 }
-            } /* end loop through current buffer */
-            if (!lastBuffer) iwl->fetch();
-        } while (!lastBuffer);
+            }
+        } /* end loop over SO integrals */
 
         for (size_t N = 0; N < J_.size(); N++) {
             J_[N]->copy_lower_to_upper();
@@ -274,14 +269,13 @@ void DiskJK::compute_JK() {
         }
     } else {
         // J and K to be handled separately
-        do {
-            lastBuffer = iwl->last_buffer();
-            for (int index = 0; index < iwl->buffer_count(); ++index) {
-                labelIndex = 4 * index;
-                pabs = std::abs((int)lblptr[labelIndex++]);
-                qabs = (int)lblptr[labelIndex++];
-                rabs = (int)lblptr[labelIndex++];
-                sabs = (int)lblptr[labelIndex++];
+        IWLReader eri(psio, PSIF_SO_TEI);
+        for (const auto& integral : eri) {
+            {
+                pabs = std::abs(integral.p);
+                qabs = integral.q;
+                rabs = integral.r;
+                sabs = integral.s;
                 prel = so2index_[pabs];
                 qrel = so2index_[qabs];
                 rrel = so2index_[rabs];
@@ -290,7 +284,7 @@ void DiskJK::compute_JK() {
                 qsym = so2symblk_[qabs];
                 rsym = so2symblk_[rabs];
                 ssym = so2symblk_[sabs];
-                value = (double)valptr[index];
+                value = integral.value;
 
                 int pqsym = psym ^ qsym;
                 int rssym = rsym ^ ssym;
@@ -441,9 +435,8 @@ void DiskJK::compute_JK() {
                         }
                     }
                 }
-            } /* end loop through current buffer */
-            if (!lastBuffer) iwl->fetch();
-        } while (!lastBuffer);
+            }
+        } /* end loop over SO integrals */
 
         for (size_t N = 0; N < J_.size(); N++) {
             J_[N]->copy_lower_to_upper();
@@ -452,22 +445,15 @@ void DiskJK::compute_JK() {
             if (K_[N]->symmetry()) K_[N]->transpose_this();
         }
     }
-    iwl->set_keep_flag(true);
-    delete iwl;
 
     if (do_wK_) {
-        iwl = new IWL(psio.get(), PSIF_SO_ERF_TEI, cutoff_, 1, 1);
-        lblptr = iwl->labels();
-        valptr = iwl->values();
-
-        do {
-            lastBuffer = iwl->last_buffer();
-            for (int index = 0; index < iwl->buffer_count(); ++index) {
-                labelIndex = 4 * index;
-                pabs = std::abs((int)lblptr[labelIndex++]);
-                qabs = (int)lblptr[labelIndex++];
-                rabs = (int)lblptr[labelIndex++];
-                sabs = (int)lblptr[labelIndex++];
+        IWLReader eri(psio, PSIF_SO_ERF_TEI);
+        for (const auto& integral : eri) {
+            {
+                pabs = std::abs(integral.p);
+                qabs = integral.q;
+                rabs = integral.r;
+                sabs = integral.s;
                 prel = so2index_[pabs];
                 qrel = so2index_[qabs];
                 rrel = so2index_[rabs];
@@ -476,7 +462,7 @@ void DiskJK::compute_JK() {
                 qsym = so2symblk_[qabs];
                 rsym = so2symblk_[rabs];
                 ssym = so2symblk_[sabs];
-                value = (double)valptr[index];
+                value = integral.value;
 
                 int qrsym = qsym ^ rsym;
                 int pssym = psym ^ ssym;
@@ -570,15 +556,12 @@ void DiskJK::compute_JK() {
                         }
                     }
                 }
-            } /* end loop through current buffer */
-            if (!lastBuffer) iwl->fetch();
-        } while (!lastBuffer);
+            }
+        } /* end loop over SO integrals */
 
         for (size_t N = 0; N < wK_.size(); N++) {
             if (wK_[N]->symmetry()) wK_[N]->transpose_this();
         }
-        iwl->set_keep_flag(true);
-        delete iwl;
     }
 }
 void DiskJK::postiterations() {

--- a/psi4/src/psi4/libfock/wrapper.cc
+++ b/psi4/src/psi4/libfock/wrapper.cc
@@ -32,7 +32,6 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libqt/qt.h"
 
 #include "psi4/psi4-dec.h"

--- a/psi4/src/psi4/libiwl/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/CMakeLists.txt
@@ -7,6 +7,7 @@ list(APPEND sources
   buf_wrt.cc
   buf_wrt_mat.cc
   buf_wrt_val.cc
+  iwl_reader.cc
   rdone.cc
   wrtone.cc
   )

--- a/psi4/src/psi4/libiwl/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/CMakeLists.txt
@@ -11,3 +11,19 @@ list(APPEND sources
   wrtone.cc
   )
 psi4_add_module(lib iwl sources)
+
+# test/ contains a standalone round-trip exerciser (iwl_roundtrip_test.cc).
+# It links against the libiwl/libpsio/libpsi4util/liboptions/libciomr static
+# archives plus a tiny stubs TU (test/stubs.cc) that supplies the runtime
+# globals normally provided by core.cc / libdpd. That curated link resolves with
+# GNU/Clang on Linux/macOS but not with clang-cl/lld-link, which emits inline and
+# implicit functions that GCC discards as unused, so the Windows objects carry
+# undefined references the link line does not provide: psio.lib wants
+# DPDMOSpace::~DPDMOSpace (instantiated by std::vector<DPDMOSpace> in dpd.h), and
+# psi4util.lib wants Molecule::Molecule(const Molecule&) (from inline
+# Molecule::clone) and ExternalPotential::print (from inline py_print). Not a
+# unity or PCH artifact -- Linux is unity-built too, and Azure Windows builds with
+# PCH off. Restrict the test to non-Windows rather than drag in the full closure.
+if(NOT WIN32)
+    add_subdirectory(test)
+endif()

--- a/psi4/src/psi4/libiwl/buf_close.cc
+++ b/psi4/src/psi4/libiwl/buf_close.cc
@@ -41,6 +41,49 @@ namespace psi {
 
 IWL::~IWL() { close(); }
 
+IWL::IWL(IWL &&o) noexcept
+    : itap_(o.itap_),
+      bufpos_(o.bufpos_),
+      ints_per_buf_(o.ints_per_buf_),
+      bufszc_(o.bufszc_),
+      cutoff_(o.cutoff_),
+      lastbuf_(o.lastbuf_),
+      inbuf_(o.inbuf_),
+      idx_(o.idx_),
+      labels_(o.labels_),
+      values_(o.values_),
+      psio_(o.psio_),
+      keep_(o.keep_) {
+    // Leave the moved-from object inert: no storage to free, no unit to close.
+    o.labels_ = nullptr;
+    o.values_ = nullptr;
+    o.psio_ = nullptr;
+    o.itap_ = -1;
+}
+
+IWL &IWL::operator=(IWL &&o) noexcept {
+    if (this != &o) {
+        close();
+        itap_ = o.itap_;
+        bufpos_ = o.bufpos_;
+        ints_per_buf_ = o.ints_per_buf_;
+        bufszc_ = o.bufszc_;
+        cutoff_ = o.cutoff_;
+        lastbuf_ = o.lastbuf_;
+        inbuf_ = o.inbuf_;
+        idx_ = o.idx_;
+        labels_ = o.labels_;
+        values_ = o.values_;
+        psio_ = o.psio_;
+        keep_ = o.keep_;
+        o.labels_ = nullptr;
+        o.values_ = nullptr;
+        o.psio_ = nullptr;
+        o.itap_ = -1;
+    }
+    return *this;
+}
+
 void IWL::close() {
     if (psio_ != nullptr && psio_->open_check(itap_)) psio_->close(itap_, keep_);
     delete[] labels_;

--- a/psi4/src/psi4/libiwl/buf_close.cc
+++ b/psi4/src/psi4/libiwl/buf_close.cc
@@ -32,9 +32,8 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
-#include <cstdlib>
 #include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
 #include "iwl.h"
 #include "iwl.hpp"
 
@@ -44,8 +43,8 @@ IWL::~IWL() { close(); }
 
 void IWL::close() {
     if (psio_ != nullptr && psio_->open_check(itap_)) psio_->close(itap_, keep_);
-    if (labels_) delete[](labels_);
-    if (values_) delete[](values_);
+    delete[] labels_;
+    delete[] values_;
     labels_ = nullptr;
     values_ = nullptr;
 }
@@ -61,7 +60,9 @@ void IWL::close() {
 */
 void PSI_API iwl_buf_close(struct iwlbuf *Buf, int keep) {
     psio_close(Buf->itap, keep ? 1 : 0);
-    free(Buf->labels);
-    free(Buf->values);
+    delete[] Buf->labels;
+    delete[] Buf->values;
+    Buf->labels = nullptr;
+    Buf->values = nullptr;
 }
 }

--- a/psi4/src/psi4/libiwl/buf_fetch.cc
+++ b/psi4/src/psi4/libiwl/buf_fetch.cc
@@ -30,20 +30,29 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
 #include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
 #include "iwl.h"
 #include "iwl.hpp"
 
 namespace psi {
 
-void IWL::fetch() {
-    psio_->read(itap_, IWL_KEY_BUF, (char *)&(lastbuf_), sizeof(int), bufpos_, &bufpos_);
-    psio_->read(itap_, IWL_KEY_BUF, (char *)&(inbuf_), sizeof(int), bufpos_, &bufpos_);
-    psio_->read(itap_, IWL_KEY_BUF, (char *)labels_, ints_per_buf_ * 4 * sizeof(Label), bufpos_, &bufpos_);
-    psio_->read(itap_, IWL_KEY_BUF, (char *)values_, ints_per_buf_ * sizeof(Value), bufpos_, &bufpos_);
-    idx_ = 0;
+namespace {
+
+// Single source of truth for the bucket read sequence. Both the C-style and
+// C++ APIs go through here.
+void fetch_bucket(PSIO *psio, int itap, psio_address &bufpos, int &lastbuf, int &inbuf, Label *labels, Value *values,
+                  int ints_per_buf, int &idx) {
+    psio->read(itap, IWL_KEY_BUF, reinterpret_cast<char *>(&lastbuf), sizeof(int), bufpos, &bufpos);
+    psio->read(itap, IWL_KEY_BUF, reinterpret_cast<char *>(&inbuf), sizeof(int), bufpos, &bufpos);
+    psio->read(itap, IWL_KEY_BUF, reinterpret_cast<char *>(labels), ints_per_buf * 4 * sizeof(Label), bufpos, &bufpos);
+    psio->read(itap, IWL_KEY_BUF, reinterpret_cast<char *>(values), ints_per_buf * sizeof(Value), bufpos, &bufpos);
+    idx = 0;
 }
+
+}  // namespace
+
+void IWL::fetch() { fetch_bucket(psio_, itap_, bufpos_, lastbuf_, inbuf_, labels_, values_, ints_per_buf_, idx_); }
 
 /*!
 ** iwl_buf_fetch()
@@ -53,12 +62,7 @@ void IWL::fetch() {
 ** \ingroup IWL
 */
 void PSI_API iwl_buf_fetch(struct iwlbuf *Buf) {
-    psio_read(Buf->itap, IWL_KEY_BUF, (char *)&(Buf->lastbuf), sizeof(int), Buf->bufpos, &Buf->bufpos);
-    psio_read(Buf->itap, IWL_KEY_BUF, (char *)&(Buf->inbuf), sizeof(int), Buf->bufpos, &Buf->bufpos);
-    psio_read(Buf->itap, IWL_KEY_BUF, (char *)Buf->labels, Buf->ints_per_buf * 4 * sizeof(Label), Buf->bufpos,
-              &Buf->bufpos);
-    psio_read(Buf->itap, IWL_KEY_BUF, (char *)Buf->values, Buf->ints_per_buf * sizeof(Value), Buf->bufpos,
-              &Buf->bufpos);
-    Buf->idx = 0;
+    fetch_bucket(_default_psio_lib_.get(), Buf->itap, Buf->bufpos, Buf->lastbuf, Buf->inbuf, Buf->labels, Buf->values,
+                 Buf->ints_per_buf, Buf->idx);
 }
 }

--- a/psi4/src/psi4/libiwl/buf_flush.cc
+++ b/psi4/src/psi4/libiwl/buf_flush.cc
@@ -30,38 +30,33 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
-#include "psi4/libciomr/libciomr.h"
 #include "iwl.h"
 #include "iwl.hpp"
 
 namespace psi {
 
-void IWL::flush(int lastbuf) {
-    int idx;
-    Label *lblptr;
-    Value *valptr;
+namespace {
 
-    inbuf_ = idx_;
-    lblptr = labels_;
-    valptr = values_;
-
-    idx = 4 * idx_;
-
-    while (idx_ < ints_per_buf_) {
-        lblptr[idx++] = 0;
-        lblptr[idx++] = 0;
-        lblptr[idx++] = 0;
-        lblptr[idx++] = 0;
-        valptr[idx_] = 0.0;
-        idx_++;
+// Zero-fill the tail of a partially-filled bucket so that on-disk consumers
+// always read a well-defined bucket layout, then mark it written.
+void zero_fill_tail(Label *labels, Value *values, int &idx, int ints_per_buf, int lastbuf_flag,
+                    int &inbuf_out, int &lastbuf_out) {
+    inbuf_out = idx;
+    for (int i = idx; i < ints_per_buf; ++i) {
+        labels[4 * i + 0] = 0;
+        labels[4 * i + 1] = 0;
+        labels[4 * i + 2] = 0;
+        labels[4 * i + 3] = 0;
+        values[i] = 0.0;
     }
+    idx = ints_per_buf;
+    lastbuf_out = lastbuf_flag ? 1 : 0;
+}
 
-    if (lastbuf)
-        lastbuf_ = 1;
-    else
-        lastbuf_ = 0;
+}  // namespace
 
+void IWL::flush(int lastbuf) {
+    zero_fill_tail(labels_, values_, idx_, ints_per_buf_, lastbuf, inbuf_, lastbuf_);
     put();
     idx_ = 0;
 }
@@ -78,30 +73,7 @@ void IWL::flush(int lastbuf) {
 ** \ingroup IWL
 */
 void iwl_buf_flush(struct iwlbuf *Buf, int lastbuf) {
-    int idx;
-    Label *lblptr;
-    Value *valptr;
-
-    Buf->inbuf = Buf->idx;
-    lblptr = Buf->labels;
-    valptr = Buf->values;
-
-    idx = 4 * Buf->idx;
-
-    while (Buf->idx < Buf->ints_per_buf) {
-        lblptr[idx++] = 0;
-        lblptr[idx++] = 0;
-        lblptr[idx++] = 0;
-        lblptr[idx++] = 0;
-        valptr[Buf->idx] = 0.0;
-        Buf->idx++;
-    }
-
-    if (lastbuf)
-        Buf->lastbuf = 1;
-    else
-        Buf->lastbuf = 0;
-
+    zero_fill_tail(Buf->labels, Buf->values, Buf->idx, Buf->ints_per_buf, lastbuf, Buf->inbuf, Buf->lastbuf);
     iwl_buf_put(Buf);
     Buf->idx = 0;
 }

--- a/psi4/src/psi4/libiwl/buf_init.cc
+++ b/psi4/src/psi4/libiwl/buf_init.cc
@@ -33,59 +33,71 @@
 #include <cstdio>
 #include <cstdlib>
 #include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
 #include "iwl.h"
 #include "iwl.hpp"
-#include "psi4/psi4-dec.h"  //need outfile
+#include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
+#include "psi4/libpsi4util/exception.h"
 
 namespace psi {
 
-IWL::IWL() : psio_{nullptr}, labels_{nullptr}, values_{nullptr} {
-    /*! set up buffer info */
-    itap_ = -1;
-    bufpos_ = PSIO_ZERO;
-    ints_per_buf_ = IWL_INTS_PER_BUF;
-    cutoff_ = 1.e-14;
-    bufszc_ = 2 * sizeof(int) + ints_per_buf_ * 4 * sizeof(Label) + ints_per_buf_ * sizeof(Value);
-    lastbuf_ = 0;
-    inbuf_ = 0;
-    idx_ = 0;
+namespace {
+
+// Constant on-disk bucket size in bytes. Matches the layout written by
+// buf_put.cc / read by buf_fetch.cc.
+inline int bucket_bytes(int ints_per_buf) {
+    return 2 * static_cast<int>(sizeof(int)) + ints_per_buf * 4 * static_cast<int>(sizeof(Label)) +
+           ints_per_buf * static_cast<int>(sizeof(Value));
 }
 
-IWL::IWL(PSIO *psio, int it, double coff, int oldfile, int readflag) : keep_(true) {
-    init(psio, it, coff, oldfile, readflag);
+// Open the underlying psio file for an IWL buffer and verify it has the
+// expected TOC entry when reopening an existing file. Throws on failure
+// instead of leaving the buffer in a half-initialized state.
+void open_iwl_unit(PSIO *psio, int itap, bool oldfile) {
+    psio->open(itap, oldfile ? PSIO_OPEN_OLD : PSIO_OPEN_NEW);
+    if (oldfile && psio->tocscan(itap, IWL_KEY_BUF) == nullptr) {
+        psio->close(itap, 0);
+        throw PSIEXCEPTION("iwl_buf_init: file " + std::to_string(itap) +
+                           " does not contain an IWL buffer (TOC key '" + IWL_KEY_BUF + "' missing)");
+    }
 }
+
+}  // namespace
+
+IWL::IWL()
+    : itap_(-1),
+      bufpos_(PSIO_ZERO),
+      ints_per_buf_(IWL_INTS_PER_BUF),
+      bufszc_(bucket_bytes(IWL_INTS_PER_BUF)),
+      cutoff_(1.e-14),
+      lastbuf_(0),
+      inbuf_(0),
+      idx_(0),
+      labels_(nullptr),
+      values_(nullptr),
+      psio_(nullptr),
+      keep_(true) {}
+
+IWL::IWL(PSIO *psio, int it, double coff, int oldfile, int readflag) : IWL() { init(psio, it, coff, oldfile, readflag); }
 
 void IWL::init(PSIO *psio, int it, double coff, int oldfile, int readflag) {
     psio_ = psio;
-
-    /*! set up buffer info */
     itap_ = it;
     bufpos_ = PSIO_ZERO;
     ints_per_buf_ = IWL_INTS_PER_BUF;
     cutoff_ = coff;
-    bufszc_ = 2 * sizeof(int) + ints_per_buf_ * 4 * sizeof(Label) + ints_per_buf_ * sizeof(Value);
+    bufszc_ = bucket_bytes(ints_per_buf_);
     lastbuf_ = 0;
     inbuf_ = 0;
     idx_ = 0;
 
-    /*! make room in the buffer */
-    // labels_ = (Label *) malloc (4 * ints_per_buf_ * sizeof(Label));
-    // values_ = (Value *) malloc (ints_per_buf_ * sizeof(Value));
     labels_ = new Label[4 * ints_per_buf_];
     values_ = new Value[ints_per_buf_];
 
-    /*! open the output file */
-    /*! Note that we assume that if oldfile isn't set, we O_CREAT the file */
-    psio_->open(itap_, oldfile ? PSIO_OPEN_OLD : PSIO_OPEN_NEW);
-    if (oldfile && (psio_->tocscan(itap_, IWL_KEY_BUF) == nullptr)) {
-        outfile->Printf("iwl_buf_init: Can't open file %d\n", itap_);
-        psio_->close(itap_, 0);
-        return;
-    }
+    open_iwl_unit(psio_, itap_, oldfile != 0);
 
-    /*! go ahead and read a buffer */
     if (readflag) fetch();
 }
 
@@ -108,30 +120,20 @@ void IWL::init(PSIO *psio, int it, double coff, int oldfile, int readflag) {
 ** \ingroup IWL
 */
 void PSI_API iwl_buf_init(struct iwlbuf *Buf, int itape, double cutoff, int oldfile, int readflag) {
-    /*! set up buffer info */
     Buf->itap = itape;
     Buf->bufpos = PSIO_ZERO;
     Buf->ints_per_buf = IWL_INTS_PER_BUF;
     Buf->cutoff = cutoff;
-    Buf->bufszc = 2 * sizeof(int) + Buf->ints_per_buf * 4 * sizeof(Label) + Buf->ints_per_buf * sizeof(Value);
+    Buf->bufszc = bucket_bytes(Buf->ints_per_buf);
     Buf->lastbuf = 0;
     Buf->inbuf = 0;
     Buf->idx = 0;
 
-    /*! make room in the buffer */
-    Buf->labels = (Label *)malloc(4 * Buf->ints_per_buf * sizeof(Label));
-    Buf->values = (Value *)malloc(Buf->ints_per_buf * sizeof(Value));
+    Buf->labels = new Label[4 * Buf->ints_per_buf];
+    Buf->values = new Value[Buf->ints_per_buf];
 
-    /*! open the output file */
-    /*! Note that we assume that if oldfile isn't set, we O_CREAT the file */
-    psio_open(Buf->itap, oldfile ? PSIO_OPEN_OLD : PSIO_OPEN_NEW);
-    if (oldfile && (psio_tocscan(Buf->itap, IWL_KEY_BUF) == nullptr)) {
-        outfile->Printf("iwl_buf_init: Can't open file %d\n", Buf->itap);
-        psio_close(Buf->itap, 0);
-        return;
-    }
+    open_iwl_unit(_default_psio_lib_.get(), Buf->itap, oldfile != 0);
 
-    /*! go ahead and read a buffer */
     if (readflag) iwl_buf_fetch(Buf);
 }
 }

--- a/psi4/src/psi4/libiwl/buf_put.cc
+++ b/psi4/src/psi4/libiwl/buf_put.cc
@@ -30,18 +30,29 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
 #include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
 #include "iwl.h"
 #include "iwl.hpp"
 
 namespace psi {
 
+namespace {
+
+void put_bucket(PSIO *psio, int itap, psio_address &bufpos, int lastbuf, int inbuf, const Label *labels,
+                const Value *values, int ints_per_buf) {
+    psio->write(itap, IWL_KEY_BUF, reinterpret_cast<char *>(const_cast<int *>(&lastbuf)), sizeof(int), bufpos, &bufpos);
+    psio->write(itap, IWL_KEY_BUF, reinterpret_cast<char *>(const_cast<int *>(&inbuf)), sizeof(int), bufpos, &bufpos);
+    psio->write(itap, IWL_KEY_BUF, reinterpret_cast<char *>(const_cast<Label *>(labels)),
+                ints_per_buf * 4 * sizeof(Label), bufpos, &bufpos);
+    psio->write(itap, IWL_KEY_BUF, reinterpret_cast<char *>(const_cast<Value *>(values)), ints_per_buf * sizeof(Value),
+                bufpos, &bufpos);
+}
+
+}  // namespace
+
 void IWL::put() {
-    psio_->write(itap_, IWL_KEY_BUF, (char *)&(lastbuf_), sizeof(int), bufpos_, &(bufpos_));
-    psio_->write(itap_, IWL_KEY_BUF, (char *)&(inbuf_), sizeof(int), bufpos_, &(bufpos_));
-    psio_->write(itap_, IWL_KEY_BUF, (char *)labels_, ints_per_buf_ * 4 * sizeof(Label), bufpos_, &(bufpos_));
-    psio_->write(itap_, IWL_KEY_BUF, (char *)values_, ints_per_buf_ * sizeof(Value), bufpos_, &(bufpos_));
+    put_bucket(psio_, itap_, bufpos_, lastbuf_, inbuf_, labels_, values_, ints_per_buf_);
 }
 
 /*!
@@ -52,11 +63,7 @@ void IWL::put() {
 ** \ingroup IWL
 */
 void iwl_buf_put(struct iwlbuf *Buf) {
-    psio_write(Buf->itap, IWL_KEY_BUF, (char *)&(Buf->lastbuf), sizeof(int), Buf->bufpos, &(Buf->bufpos));
-    psio_write(Buf->itap, IWL_KEY_BUF, (char *)&(Buf->inbuf), sizeof(int), Buf->bufpos, &(Buf->bufpos));
-    psio_write(Buf->itap, IWL_KEY_BUF, (char *)Buf->labels, Buf->ints_per_buf * 4 * sizeof(Label), Buf->bufpos,
-               &(Buf->bufpos));
-    psio_write(Buf->itap, IWL_KEY_BUF, (char *)Buf->values, Buf->ints_per_buf * sizeof(Value), Buf->bufpos,
-               &(Buf->bufpos));
+    put_bucket(_default_psio_lib_.get(), Buf->itap, Buf->bufpos, Buf->lastbuf, Buf->inbuf, Buf->labels, Buf->values,
+               Buf->ints_per_buf);
 }
 }

--- a/psi4/src/psi4/libiwl/buf_wrt.cc
+++ b/psi4/src/psi4/libiwl/buf_wrt.cc
@@ -30,13 +30,15 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
 #include <cmath>
-#include "psi4/libciomr/libciomr.h"
+#include <memory>
 #include "iwl.h"
 #include "iwl.hpp"
-#include "psi4/libpsi4util/PsiOutStream.h"
+#include "iwl_impl.h"
+
 namespace psi {
+
+using iwl_impl::check_label_fits;
 
 /*!
 ** iwl_buf_wrt()
@@ -52,45 +54,39 @@ namespace psi {
 */
 void IWL::write(int p, int q, int pq, int pqsym, double *arr, int rmax, int *ioff, int *orbsym, int *firsti, int *lasti,
                 int printflag, std::string out) {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>((out)));
-    int r, s, rs, rsym, ssym, smax, idx;
-    double value;
-    Label *lblptr;
-    Value *valptr;
+    std::shared_ptr<PsiOutStream> printer = printflag ? ((out == "outfile") ? outfile : std::make_shared<PsiOutStream>(out))
+                                                      : nullptr;
 
-    lblptr = labels_;
-    valptr = values_;
+    for (int r = 0; r < rmax; r++) {
+        int rsym = orbsym[r];
+        int ssym = pqsym ^ rsym;
+        int smax = (rsym == ssym) ? r : lasti[ssym];
 
-    for (r = 0; r < rmax; r++) {
-        rsym = orbsym[r];
-        ssym = pqsym ^ rsym;
-        smax = (rsym == ssym) ? r : lasti[ssym];
+        for (int s = firsti[ssym]; s <= smax; s++) {
+            int rs = ioff[r] + s;
+            double value = arr[rs];
 
-        for (s = firsti[ssym]; s <= smax; s++) {
-            rs = ioff[r] + s;
-            value = arr[rs];
+            if (std::fabs(value) <= cutoff_) continue;
+            check_label_fits(p, q, r, s);
 
-            if (std::fabs(value) > cutoff_) {
-                idx = 4 * idx_;
-                lblptr[idx] = (Label)p;
-                lblptr[idx + 1] = (Label)q;
-                lblptr[idx + 2] = (Label)r;
-                lblptr[idx + 3] = (Label)s;
-                valptr[idx_] = (Value)value;
+            int idx = 4 * idx_;
+            labels_[idx + 0] = static_cast<Label>(p);
+            labels_[idx + 1] = static_cast<Label>(q);
+            labels_[idx + 2] = static_cast<Label>(r);
+            labels_[idx + 3] = static_cast<Label>(s);
+            values_[idx_] = static_cast<Value>(value);
 
-                idx_++;
+            idx_++;
 
-                if (idx_ == ints_per_buf_) {
-                    inbuf_ = idx_;
-                    lastbuf_ = 0;
-                    put();
-                    idx_ = 0;
-                }
+            if (idx_ == ints_per_buf_) {
+                inbuf_ = idx_;
+                lastbuf_ = 0;
+                put();
+                idx_ = 0;
+            }
 
-                if (printflag) printer->Printf("<%d %d %d %d [%d] [%d] = %20.10f\n", p, q, r, s, pq, rs, value);
-
-            } /* end if (fabs(value) > Buf->cutoff) ... */
-        }     /* end loop over s */
-    }         /* end loop over r */
+            if (printflag) printer->Printf("<%d %d %d %d [%d] [%d] = %20.10f\n", p, q, r, s, pq, rs, value);
+        }
+    }
 }
 }

--- a/psi4/src/psi4/libiwl/buf_wrt.cc
+++ b/psi4/src/psi4/libiwl/buf_wrt.cc
@@ -32,7 +32,6 @@
 */
 #include <cmath>
 #include <memory>
-#include "iwl.h"
 #include "iwl.hpp"
 #include "iwl_impl.h"
 

--- a/psi4/src/psi4/libiwl/buf_wrt_mat.cc
+++ b/psi4/src/psi4/libiwl/buf_wrt_mat.cc
@@ -33,7 +33,6 @@
 #include <cmath>
 #include <memory>
 #include <algorithm>
-#include "iwl.h"
 #include "iwl.hpp"
 #include "iwl_impl.h"
 

--- a/psi4/src/psi4/libiwl/buf_wrt_mat.cc
+++ b/psi4/src/psi4/libiwl/buf_wrt_mat.cc
@@ -30,17 +30,24 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
 #include <cmath>
-#include "psi4/libciomr/libciomr.h"
+#include <memory>
+#include <algorithm>
 #include "iwl.h"
 #include "iwl.hpp"
-#include "psi4/libpsi4util/PsiOutStream.h"
+#include "iwl_impl.h"
+
 namespace psi {
 
-#define MAX0(a, b) (((a) > (b)) ? (a) : (b))
-#define MIN0(a, b) (((a) < (b)) ? (a) : (b))
-#define INDEX(i, j) ((i > j) ? (ioff[(i)] + (j)) : (ioff[(j)] + (i)))
+using iwl_impl::check_label_fits;
+
+namespace {
+
+inline int packed_index(int i, int j, const int *ioff) {
+    return (i > j) ? (ioff[i] + j) : (ioff[j] + i);
+}
+
+}  // namespace
 
 /*!
 ** iwl_buf_wrt_mat()
@@ -72,49 +79,46 @@ namespace psi {
 */
 void IWL::write_matrix(int ptr, int qtr, double **mat, int rfirst, int rlast, int sfirst, int slast, int *reorder,
                        int reorder_offset, int printflag, int *ioff, std::string out) {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    int idx, r, s, R, S, rtr, str;
-    int ij, kl;
-    double value;
-    Label *lblptr;
-    Value *valptr;
+    std::shared_ptr<PsiOutStream> printer = printflag ? ((out == "outfile") ? outfile : std::make_shared<PsiOutStream>(out))
+                                                      : nullptr;
 
-    lblptr = labels_;
-    valptr = values_;
+    const int ij = packed_index(ptr, qtr, ioff);
 
-    ij = INDEX(ptr, qtr);
+    for (int r = rfirst, R = 0; r <= rlast; r++, R++) {
+        const int rtr = reorder[r] - reorder_offset;
 
-    for (r = rfirst, R = 0; r <= rlast; r++, R++) {
-        rtr = reorder[r] - reorder_offset;
+        for (int s = sfirst, S = 0; s <= slast && s <= r; s++, S++) {
+            const int str = reorder[s] - reorder_offset;
+            const int kl = packed_index(rtr, str, ioff);
+            const double value = mat[R][S];
 
-        for (s = sfirst, S = 0; s <= slast && s <= r; s++, S++) {
-            str = reorder[s] - reorder_offset;
+            if (ij < kl) continue;
+            if (std::fabs(value) <= cutoff_) continue;
 
-            kl = INDEX(rtr, str);
+            const int p_out = std::max(ptr, qtr);
+            const int q_out = std::min(ptr, qtr);
+            const int r_out = std::max(rtr, str);
+            const int s_out = std::min(rtr, str);
+            check_label_fits(p_out, q_out, r_out, s_out);
 
-            value = mat[R][S];
+            int idx = 4 * idx_;
+            labels_[idx + 0] = static_cast<Label>(p_out);
+            labels_[idx + 1] = static_cast<Label>(q_out);
+            labels_[idx + 2] = static_cast<Label>(r_out);
+            labels_[idx + 3] = static_cast<Label>(s_out);
+            values_[idx_] = static_cast<Value>(value);
 
-            if (ij >= kl && std::fabs(value) > cutoff_) {
-                idx = 4 * idx_;
-                lblptr[idx++] = (Label)MAX0(ptr, qtr);
-                lblptr[idx++] = (Label)MIN0(ptr, qtr);
-                lblptr[idx++] = (Label)MAX0(rtr, str);
-                lblptr[idx++] = (Label)MIN0(rtr, str);
-                valptr[idx_] = (Value)value;
+            idx_++;
 
-                idx_++;
+            if (idx_ == ints_per_buf_) {
+                lastbuf_ = 0;
+                inbuf_ = idx_;
+                put();
+                idx_ = 0;
+            }
 
-                if (idx_ == ints_per_buf_) {
-                    lastbuf_ = 0;
-                    inbuf_ = idx_;
-                    put();
-                    idx_ = 0;
-                }
-
-                if (printflag) printer->Printf(">%d %d %d %d [%d] [%d] = %20.10f\n", ptr, qtr, rtr, str, ij, kl, value);
-
-            } /* end if (std::fabs(value) > Buf->cutoff) ... */
-        }     /* end loop over s */
-    }         /* end loop over r */
+            if (printflag) printer->Printf(">%d %d %d %d [%d] [%d] = %20.10f\n", ptr, qtr, rtr, str, ij, kl, value);
+        }
+    }
 }
 }

--- a/psi4/src/psi4/libiwl/buf_wrt_val.cc
+++ b/psi4/src/psi4/libiwl/buf_wrt_val.cc
@@ -30,55 +30,48 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
 #include <cmath>
-#include "psi4/libciomr/libciomr.h"
 #include "iwl.h"
 #include "iwl.hpp"
-#include "psi4/libpsi4util/PsiOutStream.h"
+#include "iwl_impl.h"
+
 namespace psi {
 
+using iwl_impl::check_label_fits;
+using iwl_impl::make_printer;
+
 void IWL::write_value(int p, int q, int r, int s, double value, int printflag, std::string out, int dirac) {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
+    if (std::fabs(value) <= cutoff_) return;
+    check_label_fits(p, q, r, s);
 
-    int idx;
-    Label *lblptr;
-    Value *valptr;
+    int idx = 4 * idx_;
+    if (dirac) {
+        labels_[idx++] = static_cast<Label>(p);
+        labels_[idx++] = static_cast<Label>(r);
+        labels_[idx++] = static_cast<Label>(q);
+        labels_[idx++] = static_cast<Label>(s);
+    } else {
+        labels_[idx++] = static_cast<Label>(p);
+        labels_[idx++] = static_cast<Label>(q);
+        labels_[idx++] = static_cast<Label>(r);
+        labels_[idx++] = static_cast<Label>(s);
+    }
+    values_[idx_] = static_cast<Value>(value);
+    idx_++;
 
-    lblptr = labels_;
-    valptr = values_;
+    if (idx_ == ints_per_buf_) {
+        lastbuf_ = 0;
+        inbuf_ = idx_;
+        put();
+        idx_ = 0;
+    }
 
-    if (std::fabs(value) > cutoff_) {
-        idx = 4 * idx_;
-        if (dirac) {
-            lblptr[idx++] = (Label)p;
-            lblptr[idx++] = (Label)r;
-            lblptr[idx++] = (Label)q;
-            lblptr[idx++] = (Label)s;
-        } else {
-            lblptr[idx++] = (Label)p;
-            lblptr[idx++] = (Label)q;
-            lblptr[idx++] = (Label)r;
-            lblptr[idx++] = (Label)s;
-        }
-        valptr[idx_] = (Value)value;
-
-        idx_++;
-
-        if (idx_ == ints_per_buf_) {
-            lastbuf_ = 0;
-            inbuf_ = idx_;
-            put();
-            idx_ = 0;
-        }
-
-        if (printflag) {
-            if (dirac) {
-                printer->Printf(">%d %d %d %d = %20.10f\n", p, r, q, s, value);
-            } else {
-                printer->Printf(">%d %d %d %d = %20.10f\n", p, q, r, s, value);
-            }
-        }
+    if (printflag) {
+        auto printer = make_printer(out);
+        if (dirac)
+            printer->Printf(">%d %d %d %d = %20.10f\n", p, r, q, s, value);
+        else
+            printer->Printf(">%d %d %d %d = %20.10f\n", p, q, r, s, value);
     }
 }
 
@@ -100,45 +93,37 @@ void IWL::write_value(int p, int q, int r, int s, double value, int printflag, s
 */
 void iwl_buf_wrt_val(struct iwlbuf *Buf, int p, int q, int r, int s, double value, int printflag, std::string out,
                      int dirac) {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    int idx;
-    Label *lblptr;
-    Value *valptr;
+    if (std::fabs(value) <= Buf->cutoff) return;
+    check_label_fits(p, q, r, s);
 
-    lblptr = Buf->labels;
-    valptr = Buf->values;
+    int idx = 4 * Buf->idx;
+    if (dirac) {
+        Buf->labels[idx++] = static_cast<Label>(p);
+        Buf->labels[idx++] = static_cast<Label>(r);
+        Buf->labels[idx++] = static_cast<Label>(q);
+        Buf->labels[idx++] = static_cast<Label>(s);
+    } else {
+        Buf->labels[idx++] = static_cast<Label>(p);
+        Buf->labels[idx++] = static_cast<Label>(q);
+        Buf->labels[idx++] = static_cast<Label>(r);
+        Buf->labels[idx++] = static_cast<Label>(s);
+    }
+    Buf->values[Buf->idx] = static_cast<Value>(value);
+    Buf->idx++;
 
-    if (std::fabs(value) > Buf->cutoff) {
-        idx = 4 * Buf->idx;
-        if (dirac) {
-            lblptr[idx++] = (Label)p;
-            lblptr[idx++] = (Label)r;
-            lblptr[idx++] = (Label)q;
-            lblptr[idx++] = (Label)s;
-        } else {
-            lblptr[idx++] = (Label)p;
-            lblptr[idx++] = (Label)q;
-            lblptr[idx++] = (Label)r;
-            lblptr[idx++] = (Label)s;
-        }
-        valptr[Buf->idx] = (Value)value;
+    if (Buf->idx == Buf->ints_per_buf) {
+        Buf->lastbuf = 0;
+        Buf->inbuf = Buf->idx;
+        iwl_buf_put(Buf);
+        Buf->idx = 0;
+    }
 
-        Buf->idx++;
-
-        if (Buf->idx == Buf->ints_per_buf) {
-            Buf->lastbuf = 0;
-            Buf->inbuf = Buf->idx;
-            iwl_buf_put(Buf);
-            Buf->idx = 0;
-        }
-
-        if (printflag) {
-            if (dirac) {
-                printer->Printf(">%d %d %d %d = %20.10f\n", p, r, q, s, value);
-            } else {
-                printer->Printf(">%d %d %d %d = %20.10f\n", p, q, r, s, value);
-            }
-        }
+    if (printflag) {
+        auto printer = make_printer(out);
+        if (dirac)
+            printer->Printf(">%d %d %d %d = %20.10f\n", p, r, q, s, value);
+        else
+            printer->Printf(">%d %d %d %d = %20.10f\n", p, q, r, s, value);
     }
 }
 }

--- a/psi4/src/psi4/libiwl/config.h
+++ b/psi4/src/psi4/libiwl/config.h
@@ -31,13 +31,19 @@
 
 namespace psi {
 
-typedef short int Label;
-typedef double Value;
+// On-disk label width. The bucket format packs four labels per integral as
+// 16-bit signed integers, so any orbital index passed through IWL must fit in
+// [INT16_MIN, INT16_MAX]. The write paths check this and throw on overflow.
+using Label = short int;
+using Value = double;
 
-#define IWL_KEY_BUF "IWL Buffers"
-#define IWL_KEY_ONEL "IWL One-electron matrix elements"
+inline constexpr const char *IWL_KEY_BUF = "IWL Buffers";
+inline constexpr const char *IWL_KEY_ONEL = "IWL One-electron matrix elements";
 
-#define IWL_INTS_PER_BUF 2980
+// Number of integrals packed into a single on-disk bucket. Bucket size in
+// bytes is 2*sizeof(int) + 4*N*sizeof(Label) + N*sizeof(Value), i.e. ~28 kB at
+// N = 2980. Kept at the historical value for on-disk compatibility.
+inline constexpr int IWL_INTS_PER_BUF = 2980;
 }
 
 #endif

--- a/psi4/src/psi4/libiwl/iwl.hpp
+++ b/psi4/src/psi4/libiwl/iwl.hpp
@@ -64,6 +64,12 @@ class PSI_API IWL {
     IWL(const IWL &) = delete;
     IWL &operator=(const IWL &) = delete;
 
+    // Movable so IWL (and IWLWriter/IWLReader) can live in std::vector. The
+    // moved-from object is left empty (null storage, no open unit) so its
+    // destructor is a no-op.
+    IWL(IWL &&other) noexcept;
+    IWL &operator=(IWL &&other) noexcept;
+
     int &itap() { return itap_; }
     psio_address &buffer_position() { return bufpos_; }
     int &ints_per_buffer() { return ints_per_buf_; }

--- a/psi4/src/psi4/libiwl/iwl.hpp
+++ b/psi4/src/psi4/libiwl/iwl.hpp
@@ -30,6 +30,7 @@
 #define _psi_src_lib_libiwl_iwl_hpp_
 
 #include <cstdio>
+#include <string>
 #include "psi4/libpsio/psio.hpp"
 #include "config.h"
 
@@ -52,11 +53,17 @@ class PSI_API IWL {
     bool keep_;
 
    public:
+    // Construct an empty buffer; you must call init() before use. The default
+    // constructor exists only for the deferred-init pattern used by
+    // libtrans/integraltransform_tei_2nd_half.cc and similar callers.
     IWL();
     IWL(PSIO *psio, int itap, double cutoff, int oldfile, int readflag);
     ~IWL();
 
-    // Accessor functions to data
+    // Disallow copy: the buffer owns a psio file handle and heap storage.
+    IWL(const IWL &) = delete;
+    IWL &operator=(const IWL &) = delete;
+
     int &itap() { return itap_; }
     psio_address &buffer_position() { return bufpos_; }
     int &ints_per_buffer() { return ints_per_buf_; }
@@ -81,8 +88,6 @@ class PSI_API IWL {
                          std::string OutFileRMR);
     static void write_one(PSIO *psio, int itap, const char *label, int ntri, double *onel_ints);
 
-    int read(int target_pq, double *ints, int *ioff_lt, int *ioff_rt, int mp2, int printflg, std::string OutFileRMR);
-
     void write(int p, int q, int pq, int pqsym, double *arr, int rmax, int *ioff, int *orbsym, int *firsti, int *lasti,
                int printflag, std::string OutFileRMR);
     void write_matrix(int ptr, int qtr, double **mat, int rfirst, int rlast, int sfirst, int slast, int *reorder,
@@ -90,7 +95,6 @@ class PSI_API IWL {
     void write_value(int p, int q, int r, int s, double value, int printflag, std::string OutFileRMR, int dirac);
 
     void flush(int lastbuf);
-    void to_end();
 };
 }
 

--- a/psi4/src/psi4/libiwl/iwl_impl.h
+++ b/psi4/src/psi4/libiwl/iwl_impl.h
@@ -1,0 +1,69 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+// Private implementation helpers shared between the C and C++ IWL APIs.
+// Not part of the installed public surface; do not include from outside
+// psi4/src/psi4/libiwl/.
+
+#ifndef _psi_src_lib_libiwl_iwl_impl_h_
+#define _psi_src_lib_libiwl_iwl_impl_h_
+
+#include <climits>
+#include <memory>
+#include <string>
+#include "config.h"
+#include "psi4/psi4-dec.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
+
+namespace psi {
+namespace iwl_impl {
+
+// Verify that all four orbital indices fit in the on-disk Label width. The
+// bucket format stores each label as int16, so any larger value would be
+// silently truncated and corrupt the file. Throws PSIEXCEPTION instead.
+inline void check_label_fits(int p, int q, int r, int s) {
+    if (p > SHRT_MAX || q > SHRT_MAX || r > SHRT_MAX || s > SHRT_MAX || p < SHRT_MIN || q < SHRT_MIN || r < SHRT_MIN ||
+        s < SHRT_MIN) {
+        throw PSIEXCEPTION(
+            "libiwl: orbital index does not fit in 16-bit Label (max " + std::to_string(SHRT_MAX) +
+            "). The on-disk IWL bucket format cannot store this case. p=" + std::to_string(p) +
+            " q=" + std::to_string(q) + " r=" + std::to_string(r) + " s=" + std::to_string(s));
+    }
+}
+
+// Construct a PsiOutStream once per call, lazily, only when printing is
+// actually requested. The pre-refactor code constructed one per integral.
+inline std::shared_ptr<PsiOutStream> make_printer(const std::string &out) {
+    return (out == "outfile") ? outfile : std::make_shared<PsiOutStream>(out);
+}
+
+}  // namespace iwl_impl
+}  // namespace psi
+
+#endif

--- a/psi4/src/psi4/libiwl/iwl_reader.cc
+++ b/psi4/src/psi4/libiwl/iwl_reader.cc
@@ -1,0 +1,62 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+/*!
+  \file
+  \ingroup IWL
+*/
+#include "iwl_reader.h"
+#include "psi4/libpsio/psio.hpp"
+
+namespace psi {
+
+IWLReader::IWLReader(std::shared_ptr<PSIO> psio, int unit)
+    : buf_(psio.get(), unit, /*cutoff*/ 0.0, /*oldfile*/ 1, /*readflag*/ 1) {}
+
+bool IWLReader::next(Entry& e) {
+    // Skip past any exhausted (or empty) buckets, fetching the next one until
+    // we either find an entry or run out of buckets. The empty-bucket loop
+    // guards the corner case the 1995 README warned about.
+    while (cur_ >= buf_.buffer_count()) {
+        if (buf_.last_buffer()) return false;
+        buf_.fetch();
+        cur_ = 0;
+    }
+
+    const Label* labels = buf_.labels();
+    const int j = 4 * cur_;
+    e.p = static_cast<int>(labels[j + 0]);
+    e.q = static_cast<int>(labels[j + 1]);
+    e.r = static_cast<int>(labels[j + 2]);
+    e.s = static_cast<int>(labels[j + 3]);
+    e.value = static_cast<double>(buf_.values()[cur_]);
+    ++cur_;
+    return true;
+}
+
+}  // namespace psi

--- a/psi4/src/psi4/libiwl/iwl_reader.h
+++ b/psi4/src/psi4/libiwl/iwl_reader.h
@@ -1,0 +1,106 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#ifndef _psi_src_lib_libiwl_iwl_reader_h_
+#define _psi_src_lib_libiwl_iwl_reader_h_
+
+#include <memory>
+#include "iwl.hpp"  // brings in PSI_API (via psio.hpp) and class IWL
+
+namespace psi {
+
+class PSIO;
+
+/*!
+** IWLReader -- sequential, range-for-friendly reader over an IWL integral file.
+**
+** Replaces the hand-rolled fetch/lastbuf/idx/inbuf/labels/values loop that is
+** copy-pasted across ~15 call sites. Example:
+**
+**     IWLReader eri(psio(), PSIF_SO_TEI);
+**     for (const auto& I : eri) {
+**         // I.p, I.q, I.r, I.s, I.value
+**     }
+**
+** Notes:
+**  - The labels are returned exactly as stored on disk. In particular some
+**    writers (psimrcc) encode a sentinel in the sign of p; callers that relied
+**    on `std::abs((int)label[0])` must apply std::abs() to `I.p` themselves.
+**  - Construction opens the file (PSIO_OPEN_OLD) and primes the first bucket,
+**    matching the historical iwl_buf_init(..., readflag=1) behavior.
+**  - On destruction the file is kept by default (set_keep(false) to erase),
+**    matching the dominant iwl_buf_close(&Buf, 1) usage.
+*/
+class PSI_API IWLReader {
+   public:
+    struct Entry {
+        int p, q, r, s;
+        double value;
+    };
+
+    IWLReader(std::shared_ptr<PSIO> psio, int unit);
+
+    void set_keep(bool keep) { buf_.set_keep_flag(keep); }
+
+    //! Fetch the next integral. Returns false once the file is exhausted.
+    bool next(Entry& e);
+
+    //! Minimal input iterator so IWLReader works in a range-for.
+    class iterator {
+       public:
+        iterator() = default;  // end sentinel
+        explicit iterator(IWLReader* reader) : reader_(reader) { advance(); }
+
+        const Entry& operator*() const { return cur_; }
+        const Entry* operator->() const { return &cur_; }
+        iterator& operator++() {
+            advance();
+            return *this;
+        }
+        bool operator==(const iterator& o) const { return done_ == o.done_; }
+        bool operator!=(const iterator& o) const { return done_ != o.done_; }
+
+       private:
+        void advance() { done_ = !(reader_ && reader_->next(cur_)); }
+
+        IWLReader* reader_ = nullptr;
+        Entry cur_{};
+        bool done_ = true;
+    };
+
+    iterator begin() { return iterator(this); }
+    iterator end() { return iterator(); }
+
+   private:
+    IWL buf_;
+    int cur_ = 0;  // our cursor within the current bucket
+};
+
+}  // namespace psi
+
+#endif

--- a/psi4/src/psi4/libiwl/iwl_writer.h
+++ b/psi4/src/psi4/libiwl/iwl_writer.h
@@ -1,0 +1,98 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2025 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#ifndef _psi_src_lib_libiwl_iwl_writer_h_
+#define _psi_src_lib_libiwl_iwl_writer_h_
+
+#include <memory>
+#include "iwl.hpp"  // brings in PSI_API (via psio.hpp) and class IWL
+
+namespace psi {
+
+class PSIO;
+
+/*!
+** IWLWriter -- RAII writer over an IWL integral file.
+**
+** Replaces the iwl_buf_init / write_value... / iwl_buf_flush / iwl_buf_close
+** boilerplate scattered across the integral-sort and density-dump code. The
+** buffer is flushed (with the last-buffer marker) and closed automatically on
+** destruction. Example:
+**
+**     {
+**         IWLWriter out(psio(), PSIF_MO_TPDM, 1.0e-16);
+**         for (...) out.write(p, q, r, s, value);
+**     }   // flush(lastbuf) + close happen here
+**
+** Notes:
+**  - write() applies the file's cutoff and the 16-bit Label overflow check
+**    (it delegates to the shared write_value path), so behavior matches the
+**    legacy calls exactly.
+**  - `dirac` requests the Mulliken->Dirac index swap (q<->r) some callers used
+**    via iwl_buf_wrt_val(..., dirac=1).
+**  - The file is kept by default; pass keep=false (or call set_keep(false)) to
+**    erase it on close.
+*/
+class PSI_API IWLWriter {
+   public:
+    IWLWriter(std::shared_ptr<PSIO> psio, int unit, double cutoff, bool keep = true)
+        : buf_(psio.get(), unit, cutoff, /*oldfile*/ 0, /*readflag*/ 0) {
+        buf_.set_keep_flag(keep);
+    }
+
+    ~IWLWriter() { close(); }
+
+    // Flush the partial bucket (with the last-buffer marker) and close the
+    // underlying file now. Idempotent; the destructor calls it if you don't.
+    // Use this when the same psio unit must be reopened before the writer
+    // would otherwise go out of scope.
+    void close() {
+        if (!closed_) {
+            buf_.flush(/*lastbuf*/ 1);
+            buf_.close();
+            closed_ = true;
+        }
+    }
+
+    void set_keep(bool keep) { buf_.set_keep_flag(keep); }
+
+    void write(int p, int q, int r, int s, double value, bool dirac = false) {
+        buf_.write_value(p, q, r, s, value, /*printflag*/ 0, std::string("outfile"), dirac ? 1 : 0);
+    }
+
+    //! Direct access to the underlying buffer for the rare caller that needs it.
+    IWL& buffer() { return buf_; }
+
+   private:
+    IWL buf_;
+    bool closed_ = false;
+};
+
+}  // namespace psi
+
+#endif

--- a/psi4/src/psi4/libiwl/rdone.cc
+++ b/psi4/src/psi4/libiwl/rdone.cc
@@ -30,28 +30,34 @@
   \file
   \ingroup IWL
 */
-#include <cstdio>
 #include <cmath>
 #include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
 #include "psi4/libciomr/libciomr.h"
 #include "iwl.h"
 #include "iwl.hpp"
-#include "psi4/libpsi4util/PsiOutStream.h"
+
 namespace psi {
+
+namespace {
+
+void read_one_impl(PSIO *psio, int itap, const char *label, double *ints, int ntri, int erase, int printflg,
+                   const std::string &out) {
+    psio->open(itap, PSIO_OPEN_OLD);
+    psio->read_entry(itap, label, reinterpret_cast<char *>(ints), ntri * sizeof(double));
+    psio->close(itap, erase ? 0 : 1);
+
+    if (printflg) {
+        const int nmo = static_cast<int>(std::sqrt(static_cast<double>(1 + 8 * ntri)) - 1) / 2;
+        print_array(ints, nmo, out);
+    }
+}
+
+}  // namespace
 
 void IWL::read_one(PSIO *psio, int itap, const char *label, double *ints, int ntri, int erase, int printflg,
                    std::string out) {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    int nmo;
-
-    psio->open(itap, PSIO_OPEN_OLD);
-    psio->read_entry(itap, label, (char *)ints, ntri * sizeof(double));
-    psio->close(itap, !erase);
-
-    if (printflg) {
-        nmo = (int)(sqrt((double)(1 + 8 * ntri)) - 1) / 2;
-        print_array(ints, nmo, out);
-    }
+    read_one_impl(psio, itap, label, ints, ntri, erase, printflg, out);
 }
 
 /*!
@@ -78,18 +84,7 @@ void IWL::read_one(PSIO *psio, int itap, const char *label, double *ints, int nt
 ** \ingroup IWL
 */
 int iwl_rdone(int itap, const char *label, double *ints, int ntri, int erase, int printflg, std::string out) {
-    std::shared_ptr<psi::PsiOutStream> printer = (out == "outfile" ? outfile : std::make_shared<PsiOutStream>(out));
-    int nmo;
-
-    psio_open(itap, PSIO_OPEN_OLD);
-    psio_read_entry(itap, label, (char *)ints, ntri * sizeof(double));
-    psio_close(itap, !erase);
-
-    if (printflg) {
-        nmo = (int)(sqrt((double)(1 + 8 * ntri)) - 1) / 2;
-        print_array(ints, nmo, out);
-    }
-
-    return (1);
+    read_one_impl(_default_psio_lib_.get(), itap, label, ints, ntri, erase, printflg, out);
+    return 1;
 }
 }

--- a/psi4/src/psi4/libiwl/test/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/test/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Standalone round-trip exerciser for libiwl. Links the libiwl/libpsio/
+# libpsi4util/liboptions/libciomr static archives plus a tiny stubs TU
+# (test/stubs.cc) that supplies the runtime globals normally provided by
+# core.cc / libdpd, and one no-op leaf (C_DSYEV) that libciomr's unity object
+# references but the test never exercises. This keeps the test self-contained
+# without pulling the full libmints/Libint closure.
+#
+# Only the executable is defined here. See ctest registration in `tests/libiwl/`
+# (an add_test() in this scope would not register at all: psi4-core is a separate
+# ExternalProject that never calls enable_testing()).
+add_executable(iwl_roundtrip_test.x iwl_roundtrip_test.cc stubs.cc)
+target_link_libraries(iwl_roundtrip_test.x PRIVATE iwl psio psi4util options ciomr)

--- a/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
+++ b/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
@@ -28,7 +28,15 @@
 
 // Standalone round-trip test for libiwl. Exercises every bucket-boundary case
 // the 1995 README warned about: empty, single, exactly one bucket, just over
-// one bucket, mid-bucket termination, and all-zeros sweeps.
+// one bucket, and mid-bucket termination.
+//
+// Also covers cutoff filtering. write_value() keeps an integral only when
+// |value| > cutoff, so sub-cutoff entries are *dropped*, not stored as zeros --
+// nothing is read back for them at all. That makes filtering a repacking
+// operation: survivors slide forward into earlier bucket slots, so which
+// bucket the dropped run falls in changes the packing downstream of it. The
+// positional cases below (first/second/second-to-last/last bucket fully
+// filtered, plus all-filtered and interleaved) pin that behavior down.
 
 #include <cmath>
 #include <cstdio>
@@ -73,6 +81,21 @@ std::vector<Quartet> make_test_data(std::size_t n) {
     return out;
 }
 
+// Sub-cutoff stand-ins. Exactly +0.0 is the common case in a real integrals
+// sweep, but a nonzero magnitude below the cutoff must be dropped just the
+// same, and |value| == cutoff must *also* drop because write_value() tests
+// strictly greater-than. Cycling all three keeps that boundary honest.
+double subcutoff_value(std::size_t i) {
+    switch (i % 3) {
+        case 0:
+            return 0.0;
+        case 1:
+            return (i % 6 == 1) ? 1.0e-20 : -1.0e-20;
+        default:
+            return 1.0e-14;  // == cutoff, so filtered by the strict >
+    }
+}
+
 // Drive an IWL write loop using the C++ API.
 void write_all(psi::IWL &buf, const std::vector<Quartet> &data) {
     for (const auto &q : data) {
@@ -108,9 +131,12 @@ std::vector<Quartet> read_all(int itap) {
     return out;
 }
 
+// Exact comparison, deliberately. IWL neither scales nor rounds: write_value()
+// casts to Value (= double, so a no-op) and put()/fetch() move the raw bytes
+// through libpsio. A surviving integral must therefore come back bit-identical,
+// and any tolerance here would only hide a real corruption.
 bool quartets_equal(const Quartet &a, const Quartet &b) {
-    return a.p == b.p && a.q == b.q && a.r == b.r && a.s == b.s &&
-           std::fabs(a.value - b.value) < 1.0e-12;
+    return a.p == b.p && a.q == b.q && a.r == b.r && a.s == b.s && a.value == b.value;
 }
 
 // Run one write/read round-trip for the given size and tape unit. Returns
@@ -160,6 +186,42 @@ bool round_trip_empty(int itap) {
     return true;
 }
 
+// Round-trip N integrals of which a contiguous run [lo, hi) is pushed below the
+// cutoff. Only the survivors should come back, in order and bit-exact; the
+// dropped run must leave no trace (no zero-valued placeholder, no gap).
+bool round_trip_filtered(std::size_t n, std::size_t lo, std::size_t hi, int itap, const std::string &what) {
+    auto data = make_test_data(n);
+    std::vector<Quartet> expected;
+    for (std::size_t i = 0; i < n; ++i) {
+        if (i >= lo && i < hi) {
+            data[i].value = subcutoff_value(i);
+        } else {
+            expected.push_back(data[i]);
+        }
+    }
+
+    {
+        psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
+                     /*oldfile*/ 0, /*readflag*/ 0);
+        write_all(buf, data);
+        buf.set_keep_flag(true);
+    }
+
+    auto got = read_all(itap);
+
+    if (got.size() != expected.size()) {
+        std::cerr << "  " << what << ": expected " << expected.size() << " survivors, read " << got.size() << "\n";
+        return false;
+    }
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        if (!quartets_equal(expected[i], got[i])) {
+            std::cerr << "  " << what << ": survivor " << i << " mismatch\n";
+            return false;
+        }
+    }
+    return true;
+}
+
 }  // namespace
 
 int main() {
@@ -182,6 +244,33 @@ int main() {
         std::cout << "[iwl_roundtrip] N = " << n << "\n";
         if (!round_trip(n, unit++)) ++failures;
     }
+
+    // Cutoff filtering, positioned bucket by bucket over a four-bucket write.
+    // Each case drops a full bucket's worth of input, so the survivors have to
+    // repack across the remaining buckets -- the first and last cases also
+    // exercise "the very first thing written is dropped" and "the file ends on
+    // a dropped run", where an off-by-one in flush/lastbuf would show up.
+    const std::size_t N4 = 4 * B;
+    struct FilterCase {
+        const char *what;
+        std::size_t lo, hi;
+    };
+    const std::vector<FilterCase> filtered = {
+        {"first bucket below cutoff", 0, B},
+        {"second bucket below cutoff", B, 2 * B},
+        {"second-to-last bucket below cutoff", 2 * B, 3 * B},
+        {"last bucket below cutoff", 3 * B, N4},
+        {"all below cutoff", 0, N4},
+    };
+    for (const auto &fc : filtered) {
+        std::cout << "[iwl_roundtrip] " << fc.what << "\n";
+        if (!round_trip_filtered(N4, fc.lo, fc.hi, unit++, fc.what)) ++failures;
+    }
+
+    // A sub-cutoff run that straddles a bucket boundary, so survivors on both
+    // sides of it repack into the same bucket.
+    std::cout << "[iwl_roundtrip] run straddling a bucket boundary\n";
+    if (!round_trip_filtered(3 * B, B - 7, B + 11, unit++, "straddling run")) ++failures;
 
     if (failures) {
         std::cerr << failures << " case(s) failed.\n";

--- a/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
+++ b/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
@@ -28,7 +28,8 @@
 
 // Standalone round-trip test for libiwl. Exercises every bucket-boundary case
 // the 1995 README warned about: empty, single, exactly one bucket, just over
-// one bucket, and mid-bucket termination.
+// one bucket, and mid-bucket termination. Also verifies that the 16-bit Label
+// overflow check fires instead of silently truncating.
 //
 // Also covers cutoff filtering. write_value() keeps an integral only when
 // |value| > cutoff, so sub-cutoff entries are *dropped*, not stored as zeros --
@@ -38,10 +39,13 @@
 // positional cases below (first/second/second-to-last/last bucket fully
 // filtered, plus all-filtered and interleaved) pin that behavior down.
 
+#include <cassert>
+#include <climits>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -222,6 +226,26 @@ bool round_trip_filtered(std::size_t n, std::size_t lo, std::size_t hi, int itap
     return true;
 }
 
+// Verify that writing an out-of-range orbital index throws rather than
+// silently truncating.
+bool overflow_check_fires(int itap) {
+    psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
+                 /*oldfile*/ 0, /*readflag*/ 0);
+    bool threw = false;
+    try {
+        buf.write_value(SHRT_MAX + 1, 0, 0, 0, 1.0, 0, std::string("outfile"), 0);
+    } catch (const std::exception &e) {
+        threw = true;
+    }
+    buf.flush(/*lastbuf*/ 1);
+    buf.set_keep_flag(false);
+    if (!threw) {
+        std::cerr << "  overflow check did not throw\n";
+        return false;
+    }
+    return true;
+}
+
 }  // namespace
 
 int main() {
@@ -234,7 +258,7 @@ int main() {
     int unit = base_unit;
     int failures = 0;
 
-    const std::size_t B = static_cast<std::size_t>(IWL_INTS_PER_BUF);
+    const std::size_t B = static_cast<std::size_t>(psi::IWL_INTS_PER_BUF);
     const std::vector<std::size_t> sizes = {1, B - 1, B, B + 1, 3 * B + B / 2};
 
     std::cout << "[iwl_roundtrip] empty buffer\n";
@@ -271,6 +295,9 @@ int main() {
     // sides of it repack into the same bucket.
     std::cout << "[iwl_roundtrip] run straddling a bucket boundary\n";
     if (!round_trip_filtered(3 * B, B - 7, B + 11, unit++, "straddling run")) ++failures;
+
+    std::cout << "[iwl_roundtrip] Label overflow check\n";
+    if (!overflow_check_fires(unit++)) ++failures;
 
     if (failures) {
         std::cerr << failures << " case(s) failed.\n";

--- a/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
+++ b/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
@@ -1,0 +1,192 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+// Standalone round-trip test for libiwl. Exercises every bucket-boundary case
+// the 1995 README warned about: empty, single, exactly one bucket, just over
+// one bucket, mid-bucket termination, and all-zeros sweeps.
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl.hpp"
+#include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsi4util/PsiOutStream.h"
+
+// Hosting globals (`outfile`, `restart_id`, `psi_file_prefix`, `global_dpd_`)
+// live in test/stubs.cc; the link line pulls that TU in.
+
+namespace {
+
+using namespace psi;
+
+struct Quartet {
+    int p, q, r, s;
+    double value;
+};
+
+// Deterministic pseudo-random test data with bounded indices.
+std::vector<Quartet> make_test_data(std::size_t n) {
+    std::vector<Quartet> out;
+    out.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        // Wraparound keeps indices in [0, 200) so they fit in 16 bits and we
+        // can compare without sorting.
+        const int p = static_cast<int>((i * 7 + 11) % 200);
+        const int q = static_cast<int>((i * 13 + 5) % 200);
+        const int r = static_cast<int>((i * 17 + 3) % 200);
+        const int s = static_cast<int>((i * 19 + 1) % 200);
+        // Values bounded away from cutoff (1e-14) so none get filtered.
+        const double v = 1.0 + 0.001 * static_cast<double>(i);
+        out.push_back({p, q, r, s, v});
+    }
+    return out;
+}
+
+// Drive an IWL write loop using the C++ API.
+void write_all(psi::IWL &buf, const std::vector<Quartet> &data) {
+    for (const auto &q : data) {
+        buf.write_value(q.p, q.q, q.r, q.s, q.value, /*printflag*/ 0,
+                        std::string("outfile"), /*dirac*/ 0);
+    }
+    buf.flush(/*lastbuf*/ 1);
+}
+
+// Drive an IWL read loop using the C-style API (the dominant in-tree pattern).
+std::vector<Quartet> read_all(int itap) {
+    std::vector<Quartet> out;
+    iwlbuf B;
+    iwl_buf_init(&B, itap, 1.0e-14, /*oldfile*/ 1, /*readflag*/ 1);
+
+    int lastbuf = B.lastbuf;
+    while (true) {
+        for (int i = B.idx; i < B.inbuf; ++i) {
+            const int j = 4 * i;
+            const int p = static_cast<int>(B.labels[j + 0]);
+            const int q = static_cast<int>(B.labels[j + 1]);
+            const int r = static_cast<int>(B.labels[j + 2]);
+            const int s = static_cast<int>(B.labels[j + 3]);
+            const double v = static_cast<double>(B.values[i]);
+            out.push_back({p, q, r, s, v});
+        }
+        B.idx = B.inbuf;
+        if (lastbuf) break;
+        iwl_buf_fetch(&B);
+        lastbuf = B.lastbuf;
+    }
+    iwl_buf_close(&B, /*keep*/ 0);
+    return out;
+}
+
+bool quartets_equal(const Quartet &a, const Quartet &b) {
+    return a.p == b.p && a.q == b.q && a.r == b.r && a.s == b.s &&
+           std::fabs(a.value - b.value) < 1.0e-12;
+}
+
+// Run one write/read round-trip for the given size and tape unit. Returns
+// true on success, false otherwise (with diagnostic to stderr).
+bool round_trip(std::size_t n, int itap) {
+    auto data = make_test_data(n);
+
+    {
+        psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
+                     /*oldfile*/ 0, /*readflag*/ 0);
+        write_all(buf, data);
+        buf.set_keep_flag(true);
+    }
+
+    auto got = read_all(itap);
+
+    if (got.size() != data.size()) {
+        std::cerr << "  size mismatch: wrote " << data.size() << " read "
+                  << got.size() << "\n";
+        return false;
+    }
+    for (std::size_t i = 0; i < data.size(); ++i) {
+        if (!quartets_equal(data[i], got[i])) {
+            std::cerr << "  entry " << i << " mismatch\n";
+            return false;
+        }
+    }
+    return true;
+}
+
+// Empty buffer: no integrals written, but flush(lastbuf=1) must still produce
+// a readable file that read_all() returns as zero entries. The 1995 README
+// specifically calls out this case.
+bool round_trip_empty(int itap) {
+    {
+        psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
+                     /*oldfile*/ 0, /*readflag*/ 0);
+        buf.flush(/*lastbuf*/ 1);
+        buf.set_keep_flag(true);
+    }
+    auto got = read_all(itap);
+    if (!got.empty()) {
+        std::cerr << "  empty round-trip returned " << got.size()
+                  << " entries\n";
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    // libpsio needs init before anything opens a unit.
+    psi::psio_init();
+
+    // Use tape unit numbers in a range unlikely to clash with the few entries
+    // libpsio's filecfg might preset.
+    const int base_unit = 80;
+    int unit = base_unit;
+    int failures = 0;
+
+    const std::size_t B = static_cast<std::size_t>(IWL_INTS_PER_BUF);
+    const std::vector<std::size_t> sizes = {1, B - 1, B, B + 1, 3 * B + B / 2};
+
+    std::cout << "[iwl_roundtrip] empty buffer\n";
+    if (!round_trip_empty(unit++)) ++failures;
+
+    for (auto n : sizes) {
+        std::cout << "[iwl_roundtrip] N = " << n << "\n";
+        if (!round_trip(n, unit++)) ++failures;
+    }
+
+    if (failures) {
+        std::cerr << failures << " case(s) failed.\n";
+        return 1;
+    }
+    std::cout << "All round-trip cases passed.\n";
+    return 0;
+}

--- a/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
+++ b/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
@@ -49,8 +49,9 @@
 #include <string>
 #include <vector>
 
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libiwl/iwl.hpp"
+#include "psi4/libiwl/iwl_reader.h"
+#include "psi4/libiwl/iwl_writer.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libpsi4util/PsiOutStream.h"
@@ -109,29 +110,50 @@ void write_all(psi::IWL &buf, const std::vector<Quartet> &data) {
     buf.flush(/*lastbuf*/ 1);
 }
 
-// Drive an IWL read loop using the C-style API (the dominant in-tree pattern).
+// Write a file with the new RAII IWLWriter (the phase-2 write API). The flush
+// and close happen in the destructor when the writer goes out of scope.
+void write_all_writer(int itap, const std::vector<Quartet> &data) {
+    IWLWriter out(_default_psio_lib_, itap, 1.0e-14);
+    for (const auto &q : data) {
+        out.write(q.p, q.q, q.r, q.s, q.value);
+    }
+}
+
+// Drive an IWL read loop using the low-level IWL class accessors (the
+// fetch/last_buffer/buffer_count/labels/values pattern), distinct from the
+// IWLReader range-for path so the two can be cross-checked. Erases on close.
 std::vector<Quartet> read_all(int itap) {
     std::vector<Quartet> out;
-    iwlbuf B;
-    iwl_buf_init(&B, itap, 1.0e-14, /*oldfile*/ 1, /*readflag*/ 1);
+    IWL buf(_default_psio_lib_.get(), itap, 1.0e-14, /*oldfile*/ 1, /*readflag*/ 1);
+    buf.set_keep_flag(false);
 
-    int lastbuf = B.lastbuf;
+    int lastbuf = buf.last_buffer();
     while (true) {
-        for (int i = B.idx; i < B.inbuf; ++i) {
+        for (int i = 0; i < buf.buffer_count(); ++i) {
             const int j = 4 * i;
-            const int p = static_cast<int>(B.labels[j + 0]);
-            const int q = static_cast<int>(B.labels[j + 1]);
-            const int r = static_cast<int>(B.labels[j + 2]);
-            const int s = static_cast<int>(B.labels[j + 3]);
-            const double v = static_cast<double>(B.values[i]);
+            const int p = static_cast<int>(buf.labels()[j + 0]);
+            const int q = static_cast<int>(buf.labels()[j + 1]);
+            const int r = static_cast<int>(buf.labels()[j + 2]);
+            const int s = static_cast<int>(buf.labels()[j + 3]);
+            const double v = static_cast<double>(buf.values()[i]);
             out.push_back({p, q, r, s, v});
         }
-        B.idx = B.inbuf;
         if (lastbuf) break;
-        iwl_buf_fetch(&B);
-        lastbuf = B.lastbuf;
+        buf.fetch();
+        lastbuf = buf.last_buffer();
     }
-    iwl_buf_close(&B, /*keep*/ 0);
+    return out;
+}
+
+// Drive a read via the new range-for IWLReader (the phase-2 API). Reads the
+// same file the C-style read_all() does, so a per-entry comparison validates
+// the reader against the legacy loop.
+std::vector<Quartet> read_all_reader(int itap) {
+    std::vector<Quartet> out;
+    IWLReader reader(_default_psio_lib_, itap);
+    for (const auto &I : reader) {
+        out.push_back({I.p, I.q, I.r, I.s, I.value});
+    }
     return out;
 }
 
@@ -155,6 +177,9 @@ bool round_trip(std::size_t n, int itap) {
         buf.set_keep_flag(true);
     }
 
+    // Read once with the new range-for IWLReader (keep the file)...
+    auto got_reader = read_all_reader(itap);
+    // ...and once with the legacy C-style loop (which erases on close).
     auto got = read_all(itap);
 
     if (got.size() != data.size()) {
@@ -162,9 +187,34 @@ bool round_trip(std::size_t n, int itap) {
                   << got.size() << "\n";
         return false;
     }
+    if (got_reader.size() != data.size()) {
+        std::cerr << "  IWLReader size mismatch: wrote " << data.size()
+                  << " read " << got_reader.size() << "\n";
+        return false;
+    }
     for (std::size_t i = 0; i < data.size(); ++i) {
         if (!quartets_equal(data[i], got[i])) {
-            std::cerr << "  entry " << i << " mismatch\n";
+            std::cerr << "  entry " << i << " mismatch (C-API reader)\n";
+            return false;
+        }
+        if (!quartets_equal(data[i], got_reader[i])) {
+            std::cerr << "  entry " << i << " mismatch (IWLReader)\n";
+            return false;
+        }
+    }
+
+    // Independently round-trip through the RAII IWLWriter -> IWLReader on a
+    // separate unit, to exercise the phase-2 write path end to end.
+    write_all_writer(itap + 100, data);
+    auto got_writer = read_all_reader(itap + 100);
+    if (got_writer.size() != data.size()) {
+        std::cerr << "  IWLWriter size mismatch: wrote " << data.size()
+                  << " read " << got_writer.size() << "\n";
+        return false;
+    }
+    for (std::size_t i = 0; i < data.size(); ++i) {
+        if (!quartets_equal(data[i], got_writer[i])) {
+            std::cerr << "  entry " << i << " mismatch (IWLWriter)\n";
             return false;
         }
     }
@@ -180,6 +230,12 @@ bool round_trip_empty(int itap) {
                      /*oldfile*/ 0, /*readflag*/ 0);
         buf.flush(/*lastbuf*/ 1);
         buf.set_keep_flag(true);
+    }
+    auto got_reader = read_all_reader(itap);
+    if (!got_reader.empty()) {
+        std::cerr << "  empty IWLReader round-trip returned "
+                  << got_reader.size() << " entries\n";
+        return false;
     }
     auto got = read_all(itap);
     if (!got.empty()) {
@@ -249,8 +305,11 @@ bool overflow_check_fires(int itap) {
 }  // namespace
 
 int main() {
-    // libpsio needs init before anything opens a unit.
-    psi::psio_init();
+    // Initialize the default libpsio instance the way psio_init() would.
+    // (psio_init() itself is not exported from the core shared library, so we
+    // populate the exported globals directly.)
+    if (!psi::_default_psio_lib_) psi::_default_psio_lib_ = std::make_shared<psi::PSIO>();
+    if (!psi::_default_psio_manager_) psi::_default_psio_manager_ = std::make_shared<psi::PSIOManager>();
 
     // Use tape unit numbers in a range unlikely to clash with the few entries
     // libpsio's filecfg might preset.

--- a/psi4/src/psi4/libiwl/test/stubs.cc
+++ b/psi4/src/psi4/libiwl/test/stubs.cc
@@ -1,0 +1,87 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+// Minimal hosting globals for the standalone IWL round-trip test executable.
+// libpsio and libpsi4util are not standalone static archives -- they reference
+// runtime globals normally defined in core.cc (the python bindings TU) and a
+// member function on libdpd's DPD class. This file supplies just enough to
+// satisfy the link without dragging in libdpd or core.cc.
+
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "psi4/libpsi4util/PsiOutStream.h"
+
+namespace psi {
+
+// libciomr / libpsio scratch-name globals; normally set by psi4 startup.
+std::string restart_id;
+char *psi_file_prefix = strdup("iwl_test");
+
+// libpsi4util's `outfile` is reached only from print paths the test never
+// triggers (printflag = 0 everywhere). The symbol still has to exist.
+std::shared_ptr<PsiOutStream> outfile;
+
+// libpsio's PSIO::close calls global_dpd_->file4_cache_del_filenum during
+// every file close. In a non-DPD context the cache walk is a no-op anyway,
+// but dereferencing a null global_dpd_ is UB. Provide a minimal DPD class
+// with the one referenced method as a no-op, plus a non-null instance to
+// dispatch through.
+//
+// This is an ODR violation: close.cc is compiled against the real psi::DPD from
+// libdpd/dpd.h, while this TU defines a different psi::DPD. It holds together
+// only because the call is non-virtual and the mangled name matches. The
+// parameter type must therefore be spelled exactly as in dpd.h -- `size_t`, not
+// `unsigned long`. They coincide on LP64 and nowhere else; on Windows x64
+// `size_t` is `unsigned __int64` while `unsigned long` is 32 bits, and the
+// mismatch is an undefined symbol at link time rather than a diagnostic.
+class DPD {
+ public:
+    void file4_cache_del_filenum(std::size_t);
+};
+
+void DPD::file4_cache_del_filenum(std::size_t) {}
+
+namespace {
+DPD stub_dpd_instance;
+}
+
+DPD *global_dpd_ = &stub_dpd_instance;
+
+// libciomr's DSYEV_ascending lands in the same unity translation unit as the
+// print helpers libpsio pulls in, so the linker drags its reference to libqt's
+// C_DSYEV LAPACK wrapper even though the test never diagonalizes anything.
+// Linking libqt to satisfy it cascades into libmints/Libint; a no-op leaf stub
+// is the bounded fix. Never called by the test. Signature matches the real
+// declaration in libqt/qt.h (returns int).
+int C_DSYEV(char, char, int, double *, int, double *, double *, int) { return 0; }
+
+}  // namespace psi

--- a/psi4/src/psi4/libiwl/wrtone.cc
+++ b/psi4/src/psi4/libiwl/wrtone.cc
@@ -32,7 +32,6 @@
 */
 #include <cstdio>
 #include "psi4/libpsio/psio.h"
-#include "iwl.h"
 #include "iwl.hpp"
 
 namespace psi {

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -30,7 +30,6 @@
 #include "psi4/psifiles.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/orbitalspace.h"
 #include "psi4/libmints/molecule.h"

--- a/psi4/src/psi4/libqt/dx_write.cc
+++ b/psi4/src/psi4/libqt/dx_write.cc
@@ -32,7 +32,6 @@
 
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/libtrans/integraltransform_sort_mo_tpdm.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_sort_mo_tpdm.cc
@@ -34,6 +34,7 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libiwl/iwl.hpp"
+#include "psi4/libiwl/iwl_reader.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/exception.h"
 #include "psi4/psifiles.h"
@@ -148,30 +149,17 @@ void IntegralTransform::presort_mo_tpdm_restricted() {
             I.matrix[h] = block_matrix(bucketRowDim[n][h], I.params->coltot[h]);
         }
 
-        IWL *iwl = new IWL(psio_.get(), PSIF_MO_TPDM, tolerance_, 1, 0);
         DPDFillerFunctor dpdFiller(&I, n, bucketMap, bucketOffset, true, true);
 
-        Label *lblptr = iwl->labels();
-        Value *valptr = iwl->values();
-        int lastbuf;
         /* Now run through the IWL buffers */
-        do {
-            iwl->fetch();
-            lastbuf = iwl->last_buffer();
-            for (int index = 0; index < iwl->buffer_count(); ++index) {
-                int labelIndex = 4 * index;
-                int p = aCorrToPitzer_[std::abs((int)lblptr[labelIndex++])];
-                int q = aCorrToPitzer_[(int)lblptr[labelIndex++]];
-                int r = aCorrToPitzer_[(int)lblptr[labelIndex++]];
-                int s = aCorrToPitzer_[(int)lblptr[labelIndex++]];
-                auto value = (double)valptr[index];
-                // Check:
-                //                outfile->Printf("\t%4d %4d %4d %4d = %20.10f\n", p, q, r, s, value);
-                dpdFiller(p, q, r, s, value);
-            }               /* end loop through current buffer */
-        } while (!lastbuf); /* end loop over reading buffers */
-        iwl->set_keep_flag(true);
-        delete iwl;
+        IWLReader eri(psio_, PSIF_MO_TPDM);
+        for (const auto &integral : eri) {
+            int p = aCorrToPitzer_[std::abs(integral.p)];
+            int q = aCorrToPitzer_[integral.q];
+            int r = aCorrToPitzer_[integral.r];
+            int s = aCorrToPitzer_[integral.s];
+            dpdFiller(p, q, r, s, integral.value);
+        }
 
         for (int h = 0; h < nirreps_; ++h) {
             if (bucketSize[n][h])
@@ -300,28 +288,17 @@ void IntegralTransform::presort_mo_tpdm_unrestricted() {
         for (int h = 0; h < nirreps_; h++) {
             I.matrix[h] = block_matrix(bucketRowDim[n][h], I.params->coltot[h]);
         }
-        IWL *iwl = new IWL(psio_.get(), PSIF_MO_AA_TPDM, tolerance_, 1, 0);
         DPDFillerFunctor aaDpdFiller(&I, n, bucketMap, bucketOffset, true, true);
 
-        Label *lblptr = iwl->labels();
-        Value *valptr = iwl->values();
-        int lastbuf;
         /* Now run through the IWL buffers */
-        do {
-            iwl->fetch();
-            lastbuf = iwl->last_buffer();
-            for (int index = 0; index < iwl->buffer_count(); ++index) {
-                int labelIndex = 4 * index;
-                int p = aCorrToPitzer_[std::abs((int)lblptr[labelIndex++])];
-                int q = aCorrToPitzer_[(int)lblptr[labelIndex++]];
-                int r = aCorrToPitzer_[(int)lblptr[labelIndex++]];
-                int s = aCorrToPitzer_[(int)lblptr[labelIndex++]];
-                auto value = (double)valptr[index];
-                aaDpdFiller(p, q, r, s, value);
-            }               /* end loop through current buffer */
-        } while (!lastbuf); /* end loop over reading buffers */
-        iwl->set_keep_flag(true);
-        delete iwl;
+        IWLReader eri(psio_, PSIF_MO_AA_TPDM);
+        for (const auto &integral : eri) {
+            int p = aCorrToPitzer_[std::abs(integral.p)];
+            int q = aCorrToPitzer_[integral.q];
+            int r = aCorrToPitzer_[integral.r];
+            int s = aCorrToPitzer_[integral.s];
+            aaDpdFiller(p, q, r, s, integral.value);
+        }
 
         for (int h = 0; h < nirreps_; ++h) {
             if (bucketSize[n][h])
@@ -346,30 +323,17 @@ void IntegralTransform::presort_mo_tpdm_unrestricted() {
         for (int h = 0; h < nirreps_; h++) {
             I.matrix[h] = block_matrix(bucketRowDim[n][h], I.params->coltot[h]);
         }
-        IWL *iwl = new IWL(psio_.get(), PSIF_MO_AB_TPDM, tolerance_, 1, 0);
         DPDFillerFunctor abDpdFiller(&I, n, bucketMap, bucketOffset, true, false);
 
-        Label *lblptr = iwl->labels();
-        Value *valptr = iwl->values();
-        int lastbuf;
         /* Now run through the IWL buffers */
-        do {
-            iwl->fetch();
-            lastbuf = iwl->last_buffer();
-            for (int index = 0; index < iwl->buffer_count(); ++index) {
-                int labelIndex = 4 * index;
-                int p = aCorrToPitzer_[std::abs((int)lblptr[labelIndex++])];
-                int q = aCorrToPitzer_[(int)lblptr[labelIndex++]];
-                int r = bCorrToPitzer_[(int)lblptr[labelIndex++]];
-                int s = bCorrToPitzer_[(int)lblptr[labelIndex++]];
-                auto value = (double)valptr[index];
-                // Check:
-                //                outfile->Printf("\t%4d %4d %4d %4d = %20.10f\n", p, q, r, s, value);
-                abDpdFiller(p, q, r, s, value);
-            }               /* end loop through current buffer */
-        } while (!lastbuf); /* end loop over reading buffers */
-        iwl->set_keep_flag(true);
-        delete iwl;
+        IWLReader eri(psio_, PSIF_MO_AB_TPDM);
+        for (const auto &integral : eri) {
+            int p = aCorrToPitzer_[std::abs(integral.p)];
+            int q = aCorrToPitzer_[integral.q];
+            int r = bCorrToPitzer_[integral.r];
+            int s = bCorrToPitzer_[integral.s];
+            abDpdFiller(p, q, r, s, integral.value);
+        }
 
         for (int h = 0; h < nirreps_; ++h) {
             if (bucketSize[n][h])
@@ -394,28 +358,17 @@ void IntegralTransform::presort_mo_tpdm_unrestricted() {
         for (int h = 0; h < nirreps_; h++) {
             I.matrix[h] = block_matrix(bucketRowDim[n][h], I.params->coltot[h]);
         }
-        IWL *iwl = new IWL(psio_.get(), PSIF_MO_BB_TPDM, tolerance_, 1, 0);
         DPDFillerFunctor bbDpdFiller(&I, n, bucketMap, bucketOffset, true, true);
 
-        Label *lblptr = iwl->labels();
-        Value *valptr = iwl->values();
-        int lastbuf;
         /* Now run through the IWL buffers */
-        do {
-            iwl->fetch();
-            lastbuf = iwl->last_buffer();
-            for (int index = 0; index < iwl->buffer_count(); ++index) {
-                int labelIndex = 4 * index;
-                int p = bCorrToPitzer_[std::abs((int)lblptr[labelIndex++])];
-                int q = bCorrToPitzer_[(int)lblptr[labelIndex++]];
-                int r = bCorrToPitzer_[(int)lblptr[labelIndex++]];
-                int s = bCorrToPitzer_[(int)lblptr[labelIndex++]];
-                auto value = (double)valptr[index];
-                bbDpdFiller(p, q, r, s, value);
-            }               /* end loop through current buffer */
-        } while (!lastbuf); /* end loop over reading buffers */
-        iwl->set_keep_flag(true);
-        delete iwl;
+        IWLReader eri(psio_, PSIF_MO_BB_TPDM);
+        for (const auto &integral : eri) {
+            int p = bCorrToPitzer_[std::abs(integral.p)];
+            int q = bCorrToPitzer_[integral.q];
+            int r = bCorrToPitzer_[integral.r];
+            int s = bCorrToPitzer_[integral.s];
+            bbDpdFiller(p, q, r, s, integral.value);
+        }
 
         for (int h = 0; h < nirreps_; ++h) {
             if (bucketSize[n][h])

--- a/psi4/src/psi4/mcscf/scf_read_so_tei.cc
+++ b/psi4/src/psi4/mcscf/scf_read_so_tei.cc
@@ -31,6 +31,7 @@
 
 #include "psi4/psifiles.h"
 #include "psi4/libiwl/iwl.hpp"
+#include "psi4/libiwl/iwl_reader.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libmoinfo/libmoinfo.h"
 #include "psi4/libpsi4util/libpsi4util.h"
@@ -134,52 +135,42 @@ void SCF::read_so_tei_form_PK() {
 
         double value;
         size_t p, q, r, s, four_index;
-        int ilsti, nbuf, fi, index;
 
-        IWL ERIIN(psio_.get(), PSIF_SO_TEI, 0.0, 1, 1);
-        ERIIN.set_keep_flag(true);
-        do {
-            ilsti = ERIIN.last_buffer();
-            nbuf = ERIIN.buffer_count();
+        IWLReader eri(psio_, PSIF_SO_TEI);
+        for (const auto &integral : eri) {
+            p = std::abs(integral.p);
+            q = integral.q;
+            r = integral.r;
+            s = integral.s;
+            value = integral.value;
 
-            fi = 0;
-            for (index = 0; index < nbuf; ++index) {
-                p = (ERIIN.labels()[fi] >= 0 ? ERIIN.labels()[fi] : -ERIIN.labels()[fi]);
-                q = ERIIN.labels()[fi + 1];
-                r = ERIIN.labels()[fi + 2];
-                s = ERIIN.labels()[fi + 3];
-                value = ERIIN.values()[index];
-
-                if (pair_sym[p][q] == 0) {
-                    four_index = INDEX(pair[p][q], pair[r][s]);
-                    if ((four_index >= min_index) && (four_index < max_index)) {
-                        PK[four_index - min_index] += value;
-                    }
+            if (pair_sym[p][q] == 0) {
+                four_index = INDEX(pair[p][q], pair[r][s]);
+                if ((four_index >= min_index) && (four_index < max_index)) {
+                    PK[four_index - min_index] += value;
                 }
-                if (pair_sym[p][r] == 0) {
-                    four_index = INDEX(pair[p][r], pair[q][s]);
-                    if ((four_index >= min_index) && (four_index < max_index)) {
-                        if ((p == r) || (q == s))
+            }
+            if (pair_sym[p][r] == 0) {
+                four_index = INDEX(pair[p][r], pair[q][s]);
+                if ((four_index >= min_index) && (four_index < max_index)) {
+                    if ((p == r) || (q == s))
+                        PK[four_index - min_index] -= 0.5 * value;
+                    else
+                        PK[four_index - min_index] -= 0.25 * value;
+                }
+            }
+            if (pair_sym[p][s] == 0) {
+                four_index = INDEX(pair[p][s], pair[q][r]);
+                if ((four_index >= min_index) && (four_index < max_index)) {
+                    if ((p != q) && (r != s)) {
+                        if ((p == s) || (q == r))
                             PK[four_index - min_index] -= 0.5 * value;
                         else
                             PK[four_index - min_index] -= 0.25 * value;
                     }
                 }
-                if (pair_sym[p][s] == 0) {
-                    four_index = INDEX(pair[p][s], pair[q][r]);
-                    if ((four_index >= min_index) && (four_index < max_index)) {
-                        if ((p != q) && (r != s)) {
-                            if ((p == s) || (q == r))
-                                PK[four_index - min_index] -= 0.5 * value;
-                            else
-                                PK[four_index - min_index] -= 0.25 * value;
-                        }
-                    }
-                }
-                fi += 4;
             }
-            if (!ilsti) ERIIN.fetch();
-        } while (!ilsti);
+        }
 
         // Half the diagonal elements held in core
         for (size_t pq = batch_pq_min[batch]; pq < batch_pq_max[batch]; ++pq) {
@@ -212,33 +203,38 @@ void SCF::read_so_tei_form_PK_and_K() {
 
         double value;
         size_t p, q, r, s, four_index;
-        int ilsti, nbuf, fi, index;
 
-        IWL ERIIN(psio_.get(), PSIF_SO_TEI, 0.0, 1, 1);
-        ERIIN.set_keep_flag(true);
+        IWLReader eri(psio_, PSIF_SO_TEI);
+        for (const auto &integral : eri) {
+            p = std::abs(integral.p);
+            q = integral.q;
+            r = integral.r;
+            s = integral.s;
+            value = integral.value;
 
-        do {
-            ilsti = ERIIN.last_buffer();
-            nbuf = ERIIN.buffer_count();
-
-            fi = 0;
-            for (index = 0; index < nbuf; ++index) {
-                p = (ERIIN.labels()[fi] >= 0 ? ERIIN.labels()[fi] : -ERIIN.labels()[fi]);
-                q = ERIIN.labels()[fi + 1];
-                r = ERIIN.labels()[fi + 2];
-                s = ERIIN.labels()[fi + 3];
-                value = ERIIN.values()[index];
-
-                if (pair_sym[p][q] == 0) {
-                    four_index = INDEX(pair[p][q], pair[r][s]);
-                    if ((four_index >= min_index) && (four_index < max_index)) {
-                        PK[four_index - min_index] += value;
+            if (pair_sym[p][q] == 0) {
+                four_index = INDEX(pair[p][q], pair[r][s]);
+                if ((four_index >= min_index) && (four_index < max_index)) {
+                    PK[four_index - min_index] += value;
+                }
+            }
+            if (pair_sym[p][r] == 0) {
+                four_index = INDEX(pair[p][r], pair[q][s]);
+                if ((four_index >= min_index) && (four_index < max_index)) {
+                    if ((p == r) || (q == s)) {
+                        PK[four_index - min_index] -= 0.5 * value;
+                        K[four_index - min_index] -= 0.5 * value;
+                    } else {
+                        PK[four_index - min_index] -= 0.25 * value;
+                        K[four_index - min_index] -= 0.25 * value;
                     }
                 }
-                if (pair_sym[p][r] == 0) {
-                    four_index = INDEX(pair[p][r], pair[q][s]);
-                    if ((four_index >= min_index) && (four_index < max_index)) {
-                        if ((p == r) || (q == s)) {
+            }
+            if (pair_sym[p][s] == 0) {
+                four_index = INDEX(pair[p][s], pair[q][r]);
+                if ((four_index >= min_index) && (four_index < max_index)) {
+                    if ((p != q) && (r != s)) {
+                        if ((p == s) || (q == r)) {
                             PK[four_index - min_index] -= 0.5 * value;
                             K[four_index - min_index] -= 0.5 * value;
                         } else {
@@ -247,24 +243,8 @@ void SCF::read_so_tei_form_PK_and_K() {
                         }
                     }
                 }
-                if (pair_sym[p][s] == 0) {
-                    four_index = INDEX(pair[p][s], pair[q][r]);
-                    if ((four_index >= min_index) && (four_index < max_index)) {
-                        if ((p != q) && (r != s)) {
-                            if ((p == s) || (q == r)) {
-                                PK[four_index - min_index] -= 0.5 * value;
-                                K[four_index - min_index] -= 0.5 * value;
-                            } else {
-                                PK[four_index - min_index] -= 0.25 * value;
-                                K[four_index - min_index] -= 0.25 * value;
-                            }
-                        }
-                    }
-                }
-                fi += 4;
             }
-            if (!ilsti) ERIIN.fetch();
-        } while (!ilsti);
+        }
 
         // Half the diagonal elements held in core
         for (size_t pq = batch_pq_min[batch]; pq < batch_pq_max[batch]; ++pq) {

--- a/psi4/src/psi4/occ/arrays.h
+++ b/psi4/src/psi4/occ/arrays.h
@@ -30,7 +30,6 @@
 #define _psi_src_bin_occ_arrays_h_
 
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libiwl/iwl.h"
 
 using namespace psi;
 

--- a/psi4/src/psi4/occ/coord_grad.cc
+++ b/psi4/src/psi4/occ/coord_grad.cc
@@ -30,6 +30,7 @@
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/oeprop.h"
 #include "psi4/libpsio/psio.hpp"
+#include "psi4/libiwl/iwl_writer.h"
 #include "occwave.h"
 #include "defines.h"
 
@@ -117,8 +118,7 @@ void OCCWave::dump_pdms() {
         }
 
         // Write TPDMs to psi files
-        struct iwlbuf AA;
-        iwl_buf_init(&AA, PSIF_MO_TPDM, 1.0E-15, 0, 0);
+        IWLWriter AA(_default_psio_lib_, PSIF_MO_TPDM, 1.0E-15);
 
         // OOOO block
         global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[O,O]"), ID("[O,O]"), ID("[O,O]"), ID("[O,O]"), 0,
@@ -142,7 +142,7 @@ void OCCWave::dump_pdms() {
                         double value = 2.0 * G.matrix[h][ij][kl];
                         if (I > K) value *= 2.0;
                         if (J > L) value *= 2.0;
-                        iwl_buf_wrt_val(&AA, I, K, J, L, value, 0, "outfile", 0);
+                        AA.write(I, K, J, L, value);
                     }
                 }
             }
@@ -173,7 +173,7 @@ void OCCWave::dump_pdms() {
                             double value = 2.0 * G.matrix[h][ab][cd];
                             if (A > C) value *= 2.0;
                             if (B > D) value *= 2.0;
-                            iwl_buf_wrt_val(&AA, A, C, B, D, value, 0, "outfile", 0);
+                            AA.write(A, C, B, D, value);
                         }
                     }
                 }
@@ -202,7 +202,7 @@ void OCCWave::dump_pdms() {
                     int JB = ((B - nooA) * nooA) + J;
                     if (IA >= JB) {
                         double value = 8.0 * G.matrix[h][ij][ab];
-                        iwl_buf_wrt_val(&AA, A, I, B, J, value, 0, "outfile", 0);
+                        AA.write(A, I, B, J, value);
                     }
                 }
             }
@@ -215,7 +215,7 @@ void OCCWave::dump_pdms() {
         global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[O,V]"), ID("[O,V]"), ID("[O,V]"), ID("[O,V]"), 0,
                                "TPDM <OV|OV>");
         global_dpd_->buf4_scm(&G, 2.0);
-        global_dpd_->buf4_dump(&G, &AA, aocc_qt, avir_qt, aocc_qt, avir_qt, 0, 1);
+        global_dpd_->buf4_dump(&G, AA, aocc_qt, avir_qt, aocc_qt, avir_qt, 0, 1);
         global_dpd_->buf4_close(&G);
 
         // For the standard methods I need the following contribution
@@ -223,7 +223,7 @@ void OCCWave::dump_pdms() {
             global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[V,O]"), ID("[O,O]"), ID("[V,O]"), ID("[O,O]"), 0,
                                    "TPDM <VO|OO>");
             global_dpd_->buf4_scm(&G, 0.5);
-            global_dpd_->buf4_dump(&G, &AA, avir_qt, aocc_qt, aocc_qt, aocc_qt, 0, 1);
+            global_dpd_->buf4_dump(&G, AA, avir_qt, aocc_qt, aocc_qt, aocc_qt, 0, 1);
             global_dpd_->buf4_close(&G);
         }  // if (orb_opt_ == "FALSE")
 
@@ -233,8 +233,7 @@ void OCCWave::dump_pdms() {
 
         psio_->close(PSIF_OCC_DENSITY, 1);
 
-        iwl_buf_flush(&AA, 1);
-        iwl_buf_close(&AA, 1);
+        AA.close();
 
     }  // end if (reference_ == "RESTRICTED")
 
@@ -301,22 +300,21 @@ void OCCWave::dump_pdms() {
         }
 
         // Write TPDMs to psi files
-        struct iwlbuf AA, AB, BB;
-        iwl_buf_init(&AA, PSIF_MO_AA_TPDM, 1.0E-15, 0, 0);
-        iwl_buf_init(&AB, PSIF_MO_AB_TPDM, 1.0E-15, 0, 0);
-        iwl_buf_init(&BB, PSIF_MO_BB_TPDM, 1.0E-15, 0, 0);
+        IWLWriter AA(_default_psio_lib_, PSIF_MO_AA_TPDM, 1.0E-15);
+        IWLWriter AB(_default_psio_lib_, PSIF_MO_AB_TPDM, 1.0E-15);
+        IWLWriter BB(_default_psio_lib_, PSIF_MO_BB_TPDM, 1.0E-15);
 
         // OOOO: Alpha-Alpha spin-case
         global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[O,O]"), ID("[O,O]"), ID("[O,O]"), ID("[O,O]"), 0,
                                "TPDM <OO|OO>");
         // Dump tpdm in chemist notation, 0 means no pack, 1 means swap indices 23
-        global_dpd_->buf4_dump(&G, &AA, aocc_qt, aocc_qt, aocc_qt, aocc_qt, 0, 1);
+        global_dpd_->buf4_dump(&G, AA, aocc_qt, aocc_qt, aocc_qt, aocc_qt, 0, 1);
         global_dpd_->buf4_close(&G);
 
         // OOOO: Beta-Beta spin-case
         global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[o,o]"), ID("[o,o]"), ID("[o,o]"), ID("[o,o]"), 0,
                                "TPDM <oo|oo>");
-        global_dpd_->buf4_dump(&G, &BB, bocc_qt, bocc_qt, bocc_qt, bocc_qt, 0, 1);
+        global_dpd_->buf4_dump(&G, BB, bocc_qt, bocc_qt, bocc_qt, bocc_qt, 0, 1);
         global_dpd_->buf4_close(&G);
 
         // OOOO: Alpha-Beta spin-case
@@ -336,7 +334,7 @@ void OCCWave::dump_pdms() {
                     int K = aocc_qt[k];
                     int L = bocc_qt[l];
                     double value = 4.0 * G.matrix[h][ij][kl];
-                    iwl_buf_wrt_val(&AB, I, K, J, L, value, 0, "outfile", 0);
+                    AB.write(I, K, J, L, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -348,13 +346,13 @@ void OCCWave::dump_pdms() {
             // VVVV: Alpha-Alpha spin-case
             global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[V,V]"), ID("[V,V]"), ID("[V,V]"), ID("[V,V]"), 0,
                                    "TPDM <VV|VV>");
-            global_dpd_->buf4_dump(&G, &AA, avir_qt, avir_qt, avir_qt, avir_qt, 0, 1);
+            global_dpd_->buf4_dump(&G, AA, avir_qt, avir_qt, avir_qt, avir_qt, 0, 1);
             global_dpd_->buf4_close(&G);
 
             // VVVV: Beta-Beta spin-case
             global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[v,v]"), ID("[v,v]"), ID("[v,v]"), ID("[v,v]"), 0,
                                    "TPDM <vv|vv>");
-            global_dpd_->buf4_dump(&G, &BB, bvir_qt, bvir_qt, bvir_qt, bvir_qt, 0, 1);
+            global_dpd_->buf4_dump(&G, BB, bvir_qt, bvir_qt, bvir_qt, bvir_qt, 0, 1);
             global_dpd_->buf4_close(&G);
 
             // VVVV: Alpha-Beta spin-case
@@ -365,7 +363,7 @@ void OCCWave::dump_pdms() {
             global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[V,V]"), ID("[v,v]"), ID("[V,V]"), ID("[v,v]"), 0,
                                    "TPDM (VV|vv)");
             global_dpd_->buf4_scm(&G, 4.0);
-            global_dpd_->buf4_dump(&G, &AB, avir_qt, avir_qt, bvir_qt, bvir_qt, 0, 0);
+            global_dpd_->buf4_dump(&G, AB, avir_qt, avir_qt, bvir_qt, bvir_qt, 0, 0);
             global_dpd_->buf4_close(&G);
         }  // end if (wfn_type_ == "OMP3" || wfn_type_ == "OCEPA") {
 
@@ -373,14 +371,14 @@ void OCCWave::dump_pdms() {
         global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
                                "TPDM <OO|VV>");
         global_dpd_->buf4_scm(&G, 2.0);
-        global_dpd_->buf4_dump(&G, &AA, aocc_qt, aocc_qt, avir_qt, avir_qt, 0, 1);
+        global_dpd_->buf4_dump(&G, AA, aocc_qt, aocc_qt, avir_qt, avir_qt, 0, 1);
         global_dpd_->buf4_close(&G);
 
         // OOVV: Beta-Beta spin-case
         global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[o,o]"), ID("[v,v]"), ID("[o,o]"), ID("[v,v]"), 0,
                                "TPDM <oo|vv>");
         global_dpd_->buf4_scm(&G, 2.0);
-        global_dpd_->buf4_dump(&G, &BB, bocc_qt, bocc_qt, bvir_qt, bvir_qt, 0, 1);
+        global_dpd_->buf4_dump(&G, BB, bocc_qt, bocc_qt, bvir_qt, bvir_qt, 0, 1);
         global_dpd_->buf4_close(&G);
 
         // OOVV: Alpha-Beta spin-case
@@ -400,7 +398,7 @@ void OCCWave::dump_pdms() {
                     int A = avir_qt[a];
                     int B = bvir_qt[b];
                     double value = 8.0 * G.matrix[h][ij][ab];
-                    iwl_buf_wrt_val(&AB, I, A, J, B, value, 0, "outfile", 0);
+                    AB.write(I, A, J, B, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -424,7 +422,7 @@ void OCCWave::dump_pdms() {
                     int J = aocc_qt[j];
                     int B = avir_qt[b];
                     double value = 2.0 * G.matrix[h][ia][jb];
-                    iwl_buf_wrt_val(&AA, I, J, A, B, value, 0, "outfile", 0);
+                    AA.write(I, J, A, B, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -448,7 +446,7 @@ void OCCWave::dump_pdms() {
                     int J = bocc_qt[j];
                     int B = bvir_qt[b];
                     double value = 2.0 * G.matrix[h][ia][jb];
-                    iwl_buf_wrt_val(&BB, I, J, A, B, value, 0, "outfile", 0);
+                    BB.write(I, J, A, B, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -472,7 +470,7 @@ void OCCWave::dump_pdms() {
                     int J = aocc_qt[j];
                     int B = bvir_qt[b];
                     double value = 4.0 * G.matrix[h][ia][jb];
-                    iwl_buf_wrt_val(&AB, I, J, A, B, value, 0, "outfile", 0);
+                    AB.write(I, J, A, B, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -496,7 +494,7 @@ void OCCWave::dump_pdms() {
                     int J = aocc_qt[j];
                     int B = avir_qt[b];
                     double value = -2.0 * G.matrix[h][ia][jb];
-                    iwl_buf_wrt_val(&AA, I, B, A, J, value, 0, "outfile", 0);
+                    AA.write(I, B, A, J, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -520,7 +518,7 @@ void OCCWave::dump_pdms() {
                     int J = bocc_qt[j];
                     int B = bvir_qt[b];
                     double value = -2.0 * G.matrix[h][ia][jb];
-                    iwl_buf_wrt_val(&BB, I, B, A, J, value, 0, "outfile", 0);
+                    BB.write(I, B, A, J, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -546,7 +544,7 @@ void OCCWave::dump_pdms() {
                         int B = avir_qt[b];
                         int J = bocc_qt[j];
                         double value = 8.0 * G.matrix[h][ia][bj];
-                        iwl_buf_wrt_val(&AB, I, B, A, J, value, 0, "outfile", 0);
+                        AB.write(I, B, A, J, value);
                     }
                 }
                 global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -571,7 +569,7 @@ void OCCWave::dump_pdms() {
                     int B = avir_qt[b];
                     int J = bocc_qt[j];
                     double value = 4.0 * G.matrix[h][ai][bj];
-                    iwl_buf_wrt_val(&AB, A, B, I, J, value, 0, "outfile", 0);
+                    AB.write(A, B, I, J, value);
                 }
             }
             global_dpd_->buf4_mat_irrep_close(&G, h);
@@ -584,14 +582,14 @@ void OCCWave::dump_pdms() {
             global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[V,O]"), ID("[O,O]"), ID("[V,O]"), ID("[O,O]"), 0,
                                    "TPDM <VO|OO>");
             global_dpd_->buf4_scm(&G, 0.5);
-            global_dpd_->buf4_dump(&G, &AA, avir_qt, aocc_qt, aocc_qt, aocc_qt, 0, 1);
+            global_dpd_->buf4_dump(&G, AA, avir_qt, aocc_qt, aocc_qt, aocc_qt, 0, 1);
             global_dpd_->buf4_close(&G);
 
             // VOOO: Beta-Beta Spin-Case
             global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[v,o]"), ID("[o,o]"), ID("[v,o]"), ID("[o,o]"), 0,
                                    "TPDM <vo|oo>");
             global_dpd_->buf4_scm(&G, 0.5);
-            global_dpd_->buf4_dump(&G, &BB, bvir_qt, bocc_qt, bocc_qt, bocc_qt, 0, 1);
+            global_dpd_->buf4_dump(&G, BB, bvir_qt, bocc_qt, bocc_qt, bocc_qt, 0, 1);
             global_dpd_->buf4_close(&G);
 
             // VOOO: Alpha-Beta Spin-Case
@@ -611,7 +609,7 @@ void OCCWave::dump_pdms() {
                         int I = aocc_qt[i];
                         int N = bocc_qt[n];
                         double value = G.matrix[h][am][in];
-                        iwl_buf_wrt_val(&AB, A, I, M, N, value, 0, "outfile", 0);
+                        AB.write(A, I, M, N, value);
                     }
                 }
                 global_dpd_->buf4_mat_irrep_wrt(&G, h);
@@ -636,7 +634,7 @@ void OCCWave::dump_pdms() {
                         int N = aocc_qt[n];
                         int I = bocc_qt[i];
                         double value = G.matrix[h][ma][ni];
-                        iwl_buf_wrt_val(&AB, M, N, A, I, value, 0, "outfile", 0);
+                        AB.write(M, N, A, I, value);
                     }
                 }
                 global_dpd_->buf4_mat_irrep_wrt(&G, h);
@@ -654,12 +652,9 @@ void OCCWave::dump_pdms() {
 
         psio_->close(PSIF_OCC_DENSITY, 1);
 
-        iwl_buf_flush(&AA, 1);
-        iwl_buf_flush(&AB, 1);
-        iwl_buf_flush(&BB, 1);
-        iwl_buf_close(&AA, 1);
-        iwl_buf_close(&AB, 1);
-        iwl_buf_close(&BB, 1);
+        AA.close();
+        AB.close();
+        BB.close();
 
     }  // end if (reference_ == "UNRESTRICTED")
        // outfile->Printf("\n dump_pdms done. \n");

--- a/psi4/src/psi4/occ/gfock.cc
+++ b/psi4/src/psi4/occ/gfock.cc
@@ -27,6 +27,7 @@
  */
 
 #include "psi4/libiwl/iwl.hpp"
+#include "psi4/libiwl/iwl_reader.h"
 #include "psi4/libtrans/integraltransform.h"
 #include "psi4/libmints/matrix.h"
 #include "occwave.h"
@@ -145,47 +146,35 @@ void OCCWave::gfock() {
         }  // end if (wfn_type_ == "OMP2" && incore_iabc_ == 1)
 
         else if (wfn_type_ == "OMP2" && incore_iabc_ == 0) {
-            IWL ERIIN(psio_.get(), PSIF_OCC_IABC, 0.0, 1, 1);
-            int ilsti, nbuf, index, fi;
-            double value = 0.0;
             double summ = 0.0;
 
-            do {
-                ilsti = ERIIN.last_buffer();
-                nbuf = ERIIN.buffer_count();
+            IWLReader eri(psio_, PSIF_OCC_IABC);
+            for (const auto &integral : eri) {
+                int i = std::abs(integral.p);
+                int e = integral.q;
+                int a = integral.r;
+                int f = integral.s;
+                double value = integral.value;
 
-                fi = 0;
-                for (int idx = 0; idx < nbuf; idx++) {
-                    int i = ERIIN.labels()[fi];
-                    i = std::abs(i);
-                    int e = ERIIN.labels()[fi + 1];
-                    int a = ERIIN.labels()[fi + 2];
-                    int f = ERIIN.labels()[fi + 3];
-                    value = ERIIN.values()[idx];
-                    fi += 4;
+                int i_pitzer = qt2pitzerA[i];
+                int e_pitzer = qt2pitzerA[e];
+                int a_pitzer = qt2pitzerA[a];
+                int f_pitzer = qt2pitzerA[f];
 
-                    int i_pitzer = qt2pitzerA[i];
-                    int e_pitzer = qt2pitzerA[e];
-                    int a_pitzer = qt2pitzerA[a];
-                    int f_pitzer = qt2pitzerA[f];
+                int hi = mosym[i_pitzer];
+                int ha = mosym[a_pitzer];
+                int he = mosym[e_pitzer];
+                int hf = mosym[f_pitzer];
 
-                    int hi = mosym[i_pitzer];
-                    int ha = mosym[a_pitzer];
-                    int he = mosym[e_pitzer];
-                    int hf = mosym[f_pitzer];
-
-                    if (hi == ha && he == hf) {
-                        int ii = pitzer2symblk[i_pitzer];
-                        int ee = pitzer2symblk[e_pitzer];
-                        int aa = pitzer2symblk[a_pitzer];
-                        int ff = pitzer2symblk[f_pitzer];
-                        summ = 2.0 * value * gamma1corr->get(he, ee, ff);
-                        GFock->add(ha, aa, ii, summ);
-                    }
+                if (hi == ha && he == hf) {
+                    int ii = pitzer2symblk[i_pitzer];
+                    int ee = pitzer2symblk[e_pitzer];
+                    int aa = pitzer2symblk[a_pitzer];
+                    int ff = pitzer2symblk[f_pitzer];
+                    summ = 2.0 * value * gamma1corr->get(he, ee, ff);
+                    GFock->add(ha, aa, ii, summ);
                 }
-                if (!ilsti) ERIIN.fetch();
-
-            } while (!ilsti);
+            }
         }  // end else if (wfn_type_ == "OMP2" && incore_iabc_ == 0)
 
         else if (wfn_type_ != "OMP2") {
@@ -201,10 +190,6 @@ void OCCWave::gfock() {
 
         if (wfn_type_ == "OMP2" && incore_iabc_ == 0) {
             // Fai += 8 * \sum{e,m,f} <ma|ef> * G_mief
-            IWL ERIIN(psio_.get(), PSIF_OCC_IABC, 0.0, 1, 1);
-            int ilsti, nbuf, index, fi;
-            double value = 0;
-
             SymBlockMatrix *Goovv = new SymBlockMatrix("TPDM <OO|VV>", nirrep_, oo_pairpiAA, vv_pairpiAA);
             Goovv->zero();
             global_dpd_->buf4_init(&G, PSIF_OCC_DENSITY, 0, ID("[O,O]"), ID("[V,V]"), ID("[O,O]"), ID("[V,V]"), 0,
@@ -212,19 +197,14 @@ void OCCWave::gfock() {
             Goovv->set(G);
             global_dpd_->buf4_close(&G);
 
-            do {
-                ilsti = ERIIN.last_buffer();
-                nbuf = ERIIN.buffer_count();
-
-                fi = 0;
-                for (int idx = 0; idx < nbuf; idx++) {
-                    int m = ERIIN.labels()[fi];
-                    m = std::abs(m);
-                    int a = ERIIN.labels()[fi + 1];
-                    int e = ERIIN.labels()[fi + 2];
-                    int f = ERIIN.labels()[fi + 3];
-                    value = ERIIN.values()[idx];
-                    fi += 4;
+            IWLReader eri(psio_, PSIF_OCC_IABC);
+            for (const auto &integral : eri) {
+                {
+                    int m = std::abs(integral.p);
+                    int a = integral.q;
+                    int e = integral.r;
+                    int f = integral.s;
+                    double value = integral.value;
 
                     int m_pitzer = qt2pitzerA[m];
                     int a_pitzer = qt2pitzerA[a];
@@ -254,9 +234,7 @@ void OCCWave::gfock() {
                         }
                     }
                 }
-                if (!ilsti) ERIIN.fetch();
-
-            } while (!ilsti);
+            }
             delete Goovv;
 
         }  // end if (wfn_type_ == "OMP2" && incore_iabc_ == 0)

--- a/psi4/src/psi4/occ/omp2_ip_poles.cc
+++ b/psi4/src/psi4/occ/omp2_ip_poles.cc
@@ -42,7 +42,6 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libtrans/mospace.h"
 #include "psi4/libtrans/integraltransform.h"

--- a/psi4/src/psi4/occ/omp3_ip_poles.cc
+++ b/psi4/src/psi4/occ/omp3_ip_poles.cc
@@ -42,7 +42,6 @@
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libtrans/mospace.h"
 #include "psi4/libtrans/integraltransform.h"

--- a/psi4/src/psi4/occ/t2_2nd_general.cc
+++ b/psi4/src/psi4/occ/t2_2nd_general.cc
@@ -29,6 +29,7 @@
 #include "psi4/libqt/qt.h"
 #include "psi4/libtrans/integraltransform.h"
 #include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsio/psio.h"
 #include "defines.h"
 #include "occwave.h"
 

--- a/psi4/src/psi4/occ/tei_sort_iabc.cc
+++ b/psi4/src/psi4/occ/tei_sort_iabc.cc
@@ -27,6 +27,8 @@
  */
 
 #include "psi4/libiwl/iwl.hpp"
+#include "psi4/libiwl/iwl_reader.h"
+#include "psi4/libiwl/iwl_writer.h"
 
 #include "occwave.h"
 #include "defines.h"
@@ -41,40 +43,24 @@ void OCCWave::tei_sort_iabc() {
     /********************************************************************************************/
     /************************** sort chem -> phys ***********************************************/
     /********************************************************************************************/
-    struct iwlbuf AA;
-    iwl_buf_init(&AA, PSIF_OCC_IABC, cutoff, 0, 0);
-
-    IWL ERIIN(psio_.get(), PSIF_MO_TEI, 0.0, 1, 1);
-    int ilsti, nbuf, index, fi;
-    double value = 0;
+    IWLWriter out(psio_, PSIF_OCC_IABC, cutoff);
 
     if (print_ > 2) outfile->Printf("\n writing <ia|bc>... \n");
-    do {
-        ilsti = ERIIN.last_buffer();
-        nbuf = ERIIN.buffer_count();
+    IWLReader eri(psio_, PSIF_MO_TEI);
+    for (const auto &integral : eri) {
+        int i = std::abs(integral.p);
+        int j = integral.q;
+        int k = integral.r;
+        int l = integral.s;
+        double value = integral.value;
 
-        fi = 0;
-        for (int idx = 0; idx < nbuf; idx++) {
-            int i = ERIIN.labels()[fi];
-            i = std::abs(i);
-            int j = ERIIN.labels()[fi + 1];
-            int k = ERIIN.labels()[fi + 2];
-            int l = ERIIN.labels()[fi + 3];
-            value = ERIIN.values()[idx];
-            fi += 4;
-
-            // Make sure we are dealing with the (ia|bc) type integrals
-            if (i < nooA && j >= nooA && k >= nooA && l >= nooA) {
-                iwl_buf_wrt_val(&AA, i, k, j, l, value, 0, "outfile", 0);
-                if (k > l) iwl_buf_wrt_val(&AA, i, l, j, k, value, 0, "outfile", 0);
-            }
+        // Make sure we are dealing with the (ia|bc) type integrals
+        if (i < nooA && j >= nooA && k >= nooA && l >= nooA) {
+            out.write(i, k, j, l, value);
+            if (k > l) out.write(i, l, j, k, value);
         }
-        if (!ilsti) ERIIN.fetch();
-
-    } while (!ilsti);
-
-    iwl_buf_flush(&AA, 1);
-    iwl_buf_close(&AA, 1);
+    }
+    // `out` flushes the last buffer and closes (keeping the file) on scope exit.
 
     /*
             // Test reading

--- a/psi4/src/psi4/psimrcc/sort.cc
+++ b/psi4/src/psi4/psimrcc/sort.cc
@@ -38,7 +38,6 @@
 #include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.hpp"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"
 

--- a/psi4/src/psi4/psimrcc/transform.cc
+++ b/psi4/src/psi4/psimrcc/transform.cc
@@ -45,7 +45,7 @@
 
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.hpp"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl.hpp"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"
 
@@ -82,9 +82,9 @@ void CCTransform::read_oei_mo_integrals() {
 
     std::vector<double> H(INDEX(nmo - 1, nmo - 1) + 1, 0);
 
-    iwl_rdone(PSIF_OEI, const_cast<char*>(PSIF_MO_FZC), H.data(), nmo * (nmo + 1) / 2, 0, 0, "outfile");
+    IWL::read_one(_default_psio_lib_.get(), PSIF_OEI, const_cast<char*>(PSIF_MO_FZC), H.data(), nmo * (nmo + 1) / 2, 0, 0, "outfile");
     //   else
-    //     iwl_rdone(PSIF_OEI,PSIF_MO_FZC,H,norbs*(norbs+1)/2,0,1,outfile); //TODO fix it!
+    //     IWL::read_one(_default_psio_lib_.get(), PSIF_OEI,PSIF_MO_FZC,H,norbs*(norbs+1)/2,0,1,outfile); //TODO fix it!
 
     for (int i = 0; i < nmo; i++)
         for (int j = 0; j < nmo; j++) oei_mo[i][j] = H[INDEX(i, j)];

--- a/psi4/src/psi4/psimrcc/transform_mrpt2.cc
+++ b/psi4/src/psi4/psimrcc/transform_mrpt2.cc
@@ -49,7 +49,6 @@
 
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.hpp"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libtrans/integraltransform.h"
 #include "psi4/psifiles.h"

--- a/psi4/src/psi4/psimrcc/transform_presort.cc
+++ b/psi4/src/psi4/psimrcc/transform_presort.cc
@@ -37,7 +37,7 @@
 #include "psi4/pragma.h"
 #include <memory>
 #include "psi4/libpsio/psio.hpp"
-#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl_reader.h"
 #include "psi4/libmoinfo/libmoinfo.h"
 #include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/psifiles.h"
@@ -130,35 +130,25 @@ void CCTransform::presort_blocks(int first_irrep, int last_irrep) {
 
     // Read all the (frozen + non-frozen) TEI in Pitzer order
     // and store them in a in-core block-matrix
-    size_t lastbuf, inbuf, fi;
     size_t elements = 0;
-    struct iwlbuf ERIIN;
-    iwl_buf_init(&ERIIN, PSIF_MO_TEI, 0.0, 1, 1);
-    do {
-        lastbuf = ERIIN.lastbuf;
-        inbuf = ERIIN.inbuf;
-        fi = 0;
-        for (size_t index = 0; index < inbuf; index++) {
-            // Compute the [pq] index for this pqrs combination
-            size_t p = std::abs(ERIIN.labels[fi]);
-            size_t q = ERIIN.labels[fi + 1];
-            size_t r = ERIIN.labels[fi + 2];
-            size_t s = ERIIN.labels[fi + 3];
-            double value = ERIIN.values[index];
-            int irrep = pair_index->get_tuple_irrep(p, q);
-            // Fill in only the blocks that fit
-            if ((first_irrep <= irrep) && (irrep <= last_irrep)) {
-                size_t pq = pair_index->get_tuple_rel_index(p, q);
-                size_t rs = pair_index->get_tuple_rel_index(r, s);
-                size_t pqrs = INDEX(pq, rs);
-                tei_mo_temp[irrep][pqrs] = value;
-            }
-            fi += 4;
-            elements++;
+    IWLReader eri(_default_psio_lib_, PSIF_MO_TEI);
+    for (const auto& integral : eri) {
+        // Compute the [pq] index for this pqrs combination
+        size_t p = std::abs(integral.p);
+        size_t q = integral.q;
+        size_t r = integral.r;
+        size_t s = integral.s;
+        double value = integral.value;
+        int irrep = pair_index->get_tuple_irrep(p, q);
+        // Fill in only the blocks that fit
+        if ((first_irrep <= irrep) && (irrep <= last_irrep)) {
+            size_t pq = pair_index->get_tuple_rel_index(p, q);
+            size_t rs = pair_index->get_tuple_rel_index(r, s);
+            size_t pqrs = INDEX(pq, rs);
+            tei_mo_temp[irrep][pqrs] = value;
         }
-        if (!lastbuf) iwl_buf_fetch(&ERIIN);
-    } while (!lastbuf);
-    iwl_buf_close(&ERIIN, 1);
+        elements++;
+    }
 
     outfile->Printf(" (%lu non-zero integrals)", (size_t)elements);
 

--- a/psi4/src/psi4/psimrcc/transform_read_so.cc
+++ b/psi4/src/psi4/psimrcc/transform_read_so.cc
@@ -52,7 +52,6 @@
 
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsio/psio.hpp"
-#include "psi4/libiwl/iwl.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,9 +119,11 @@ add_subdirectory(json)
 
 # C++ unit tests built inside the psi4-core ExternalProject. Skipped on Windows,
 # where their curated link lines do not resolve under lld-link (see
-# psi4/src/psi4/libpsio/CMakeLists.txt), so the executables are never built there.
+# psi4/src/psi4/libpsio/CMakeLists.txt and psi4/src/psi4/libiwl/CMakeLists.txt),
+# so the executables are never built there.
 if(NOT WIN32)
     add_subdirectory(libpsio)
+    add_subdirectory(libiwl)
 endif()
 
 if(ENABLE_pasture)

--- a/tests/libiwl/CMakeLists.txt
+++ b/tests/libiwl/CMakeLists.txt
@@ -1,0 +1,19 @@
+# C++ unit tests for libiwl.
+#
+# The executables are built inside the psi4-core ExternalProject, which has its
+# own binary directory and does not call enable_testing(). Registration has to
+# happen here, in the superbuild, because that is where `enable_testing()` runs
+# (cmake/ConfigTesting.cmake) and where CI invokes `ctest`.
+ExternalProject_Get_Property(psi4-core BINARY_DIR)
+
+# "smoketests" is what actually gets this run: CI drives scarcely anything through
+# ctest because the regression tests are doubled by pytest, and a C++ unit test is
+# not eligible for pytest (it is not a `psi4 input.dat`). The smoke and plugin
+# labels *are* driven through ctest -- Azure Linux runs `ctest -L "plug|smoke"`
+# (devtools/scripts/ci_run_test.py), Azure Windows `--label-regex smoke`.
+# "quicktests" is kept alongside it, as 13 other tests do, so the GH macOS
+# `ctest -L quick` lane keeps running it too.
+add_test(NAME libiwl-roundtrip
+         COMMAND ${BINARY_DIR}/src/psi4/libiwl/test/iwl_roundtrip_test.x${CMAKE_EXECUTABLE_SUFFIX}
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(libiwl-roundtrip PROPERTIES LABELS "psi;quicktests;smoketests;libiwl")


### PR DESCRIPTION
## libiwl split 3/3 — migrate write-side consumers to IWLWriter

**Third of three PRs** splitting #3428. Stacked on #3440 (readers), on #3439 (API), on #3426.

Replaces manual `write_value` / flush bookkeeping with the RAII `IWLWriter` across the **write-side** callers, and drops the now-stale `psi4/libiwl/iwl.h` includes left in files that no longer touch the C API:

- `cc/ccdensity` dump pipeline — `classify`, `distribute`, `file_build`, `idx_permute`, `add_ref_*`, `add_core_*`, `dump_*`, `ccdensity`
- `dct` gradients (RHF/UHF)
- `occ` — `coord_grad`, `tei_sort_iabc`
- `buf4_dump` callers
- stale-`#include` cleanup across ~40 files that no longer reference the C API

All behavior-preserving. With this PR merged the full #3428 change is reconstituted as four reviewable PRs.

> **Reviewing:** the diff against `master` is cumulative over #3426 + #3439 + #3440. To see only this PR's change, compare `iwl-split/3-writers` against `iwl-split/2-readers`. Will be rebased to an incremental diff as the parents merge.

Completes the #3428 split: #3426 → #3439 (API) → #3440 (readers) → **this (writers)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
