### PR TITLE
Print Mem_DF memory even if Disk_DF selected

### DIFF
--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -210,14 +210,21 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
         // Build exact estimate via Schwarz metrics
         auto jk = build_JK(primary, auxiliary, options, "MEM_DF");
         jk->set_do_wK(do_wK);
-        if (jk->memory_estimate() < doubles) {
+        size_t memdfjk_memory = jk->memory_estimate();
+
+        if (memdfjk_memory < doubles) {
             return jk;
         }
         jk.reset();
 
+        outfile->Printf("  MemDFJK Memory: AOs need %.3f GiB; user supplied %.3f GiB.\n",
+                    memdfjk_memory * 8 / (1024 * 1024 * 1024.0),
+                    doubles * 8 / (1024 * 1024 * 1024.0));
+        outfile->Printf("  MemDFJK requires too much memory. DiskDFJK algorithm will be used.\n\n");
+       
         // Use Disk DFJK
         return build_JK(primary, auxiliary, options, "DISK_DF");
-
+        
     } else {  // otherwise it has already been set
         return build_JK(primary, auxiliary, options, options.get_str("SCF_TYPE"));
     }

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -224,7 +224,6 @@ std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_
        
         // Use Disk DFJK
         return build_JK(primary, auxiliary, options, "DISK_DF");
-        
     } else {  // otherwise it has already been set
         return build_JK(primary, auxiliary, options, options.get_str("SCF_TYPE"));
     }


### PR DESCRIPTION
When running HF/DFT computations with default settings, the MemDFJK algorithm memory estimate is now printed under the Integral Setup header even if the program eventually selects DiskDFJK. This way, users can easily see how much memory a computation would need to run fully in core. 

**if MemDFJK selected:**

```
==> Integral Setup <==

  DFHelper Memory: AOs need 21.009 GiB; user supplied 58.019 GiB. 
  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
  Using in-core AOs.

  ==> MemDFJK: Density-Fitted J/K Matrices <==

    J tasked:                   Yes
    K tasked:                   Yes
    wK tasked:                   No
    OpenMP threads:              10
    Memory [MiB]:             59411
    Algorithm:                 Core
    Schwarz Cutoff:           1E-12
    Mask sparsity (%):      56.9419
    Fitting Condition:        1E-10
```

**if DiskDFJK selected:**

```
==> Integral Setup <==

  MemDFJK Memory: AOs need 21.009 GiB; user supplied 11.256 GiB.
  MemDFJK requires too much memory. DiskDFJK algorithm will be used.

  ==> DiskDFJK: Density-Fitted J/K Matrices <==

    J tasked:                  Yes
    K tasked:                  Yes
    wK tasked:                  No
    OpenMP threads:             10
    Integrals threads:          10
    Memory [MiB]:            11526
    Algorithm:                Disk
    Integral Cache:           NONE
    Schwarz Cutoff:          1E-12
    Fitting Condition:       1E-10
```
