### PR TITLE
Finish moving CDJK::cderi_ into initialize_JK_core

### DIFF
--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -70,17 +70,12 @@ size_t CDJK::memory_estimate() {
 
 void CDJK::initialize_JK_core() {
     timer_on("CD: cholesky decomposition");
-    // TODO: Fix after the cderi_ deprecation is out in v1.11
-    // this should probably be
-    //      IntegralFactory factory(primary_, primary_, primary_, primary_);
-    //      const std::shared_ptr<TwoBodyAOInt> cderi = factory.eri();
-    // in the future. A TwoBodyAOInt object keeps the factory as a raw non-owning back-pointer (const IntegralFactory
-    // *integral_) and is therefore probably quite a dangerous thing if it ever outlives the IntegralFactory that was
-    // used for constructing the TwoBodyAOInt.
-    auto integral = std::make_shared<IntegralFactory>(primary_, primary_, primary_, primary_);
-    cderi_ = std::shared_ptr<TwoBodyAOInt>(integral->eri());
+    IntegralFactory factory(primary_, primary_, primary_, primary_);
+    // Integral engine for computing CD integrals.
+    // Note that this is shallow-const, the engine itself is mutable, only the shared_ptr isn't.
+    const std::shared_ptr<TwoBodyAOInt> cderi = factory.eri();
     
-    int ntri = cderi_->function_pairs().size();
+    int ntri = cderi->function_pairs().size();
     /// If user asks to read integrals from disk, just read them from disk.
     /// Qmn is only storing upper triangle.
     /// Ugur needs ncholesky_ in NAUX (SCF), but it can also be read from disk
@@ -97,7 +92,7 @@ void CDJK::initialize_JK_core() {
     }
 
     /// If user does not want to read from disk, recompute the cholesky integrals
-    auto Ch = std::make_shared<CholeskyERI>(cderi_, 0.0, cholesky_tolerance_,
+    auto Ch = std::make_shared<CholeskyERI>(cderi, 0.0, cholesky_tolerance_,
                                             memory_);
     Ch->choleskify();
     ncholesky_ = Ch->Q();
@@ -117,7 +112,7 @@ void CDJK::initialize_JK_core() {
 
     double** Qmnp = Qmn_->pointer();
 
-    const std::vector<long int>& schwarz_fun_pairs = cderi_->function_pairs_to_dense();
+    const std::vector<long int>& schwarz_fun_pairs = cderi->function_pairs_to_dense();
 
     timer_on("CD: schwarz");
     for (size_t mu = 0; mu < nbf; mu++) {

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -195,7 +195,9 @@ size_t CompositeJK::num_computed_shells() {
 }
 
 size_t CompositeJK::memory_estimate() {
-    return 0;  // Memory is O(N^2), which psi4 counts as effectively 0
+    // Memory is O(N^2), which psi4 counts as effectively 0.
+    // TODO: return an accurate value.
+    return 0;  
 }
 
 void CompositeJK::print_header() const {

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -103,6 +103,7 @@ size_t DirectJK::num_computed_shells() {
 }
 
 size_t DirectJK::memory_estimate() {
+    // TODO: return an accurate value.
     return 0;  // Effectively
 }
 

--- a/psi4/src/psi4/libfock/DiskJK.cc
+++ b/psi4/src/psi4/libfock/DiskJK.cc
@@ -53,6 +53,7 @@ DiskJK::DiskJK(std::shared_ptr<BasisSet> primary, Options& options) : JK(primary
 DiskJK::~DiskJK() {}
 void DiskJK::common_init() {}
 size_t DiskJK::memory_estimate() {
+    // TODO: return an accurate value.
     return 0; // Effectively zero
 }
 void DiskJK::print_header() const {

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -1062,12 +1062,6 @@ class PSI_API CDJK : public DiskDFJK {
     std::string name() override { return "CDJK"; }
     size_t memory_estimate() override;
 
-    /// integral engine for computing CD integrals
-    PSI_DEPRECATED(
-        "CDJK::cderi_ is planned to be moved inside CDJK::initialize_JK_core. Unless someone speaks up, 1.11 may be "
-        "the last release to have it.")
-    std::shared_ptr<TwoBodyAOInt> cderi_;
-
     // => Required Algorithm-Specific Methods <= //
 
     virtual bool is_core() { return true; }

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -394,6 +394,7 @@ class PSI_API JK {
     virtual bool C1() const = 0;
     virtual std::string name() = 0;
     // TODO: investigate if JK::memory_estimate and all of its derived variants could be made const
+    // Probably requires refactoring DFHelper and MemDFJK first.
     virtual size_t memory_estimate() = 0;
 
     // => Knobs <= //


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR is a follow-up to #3432, moving `CDJK::cderi_` into `CDJK::initialize_JK_core`. This reduces the scope and lifetime of this implementation detail, narrows PSI_API, saving a little bit of memory, and making sure that we don't have an integral engine outliving the `IntegralFactory` it carries a pointer for.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] PSI_API change: `CDJK::cderi_` was deprecated in 1.11 and is now removed from the C++ API.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Finalize moving `CDJK::cderi_` from being a protected member of `CDJK` to a local in `CDJK::initialize_JK_core`
- [x] Adjust how `cderi` is initialized. The `IntegralFactory` does not need to be held by a `shared_ptr`, and `cderi` can be shallow-const.
- [x] Add/adjust comments/TODOs for `memory_estimate` functions in the JK hierarchy. Since we are moving towards linear-ish scaling correlation methods, "O(N^2) memory is negligible, return 0" type of approximations would be nice to tidy up.

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [x] LLMs were consulted regarding the new `cderi` init, and the comment about making `memory_estimate` `const` requiring `DFHelper` and `MemDFJK` refactoring is based on LLM output.

## Checklist
- [x] No new features.
- [x] No docs update needed
- [x] Tests run by the CI are passing.

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
