### PR TITLE
Fix missing include in `timer.cc`

### DIFF
--- a/psi4/src/psi4/libqt/timer.cc
+++ b/psi4/src/psi4/libqt/timer.cc
@@ -118,6 +118,7 @@ typedef int omp_lock_t;
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/exception.h"
+#include "psi4/libqt/qt.h"
 
 /* guess for HZ, if missing */
 #ifndef HZ


### PR DESCRIPTION
## Description

Fixes missing include that doesn't appear for unity builds. I turn off unity builds because my nvim LSP likes the compile_commands.json when each entry is for a source file. #3443 introduced `get_timer_records()` and `TimerRecord` usage into `timer.cc`. Both are declared in `qt.h` but never included.

With unity builds on, `timer.cc` is bundled with other sources that do include `qt.h`, in particular `schmidt.cc`. I suspect newer CMake versions may change which sources are bundled together which could cause this bug to randomly appear later. Heisenbug averted?

## User API & Changelog headlines

none

## AI
- AI was used to find this bug and provide definitive proof for the cause.

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
