### PR TITLE
check add-on running

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -436,11 +436,29 @@ jobs:
       # Win runs out of memory on the geometric mp2(conv) tests, so run them with less parallelism
     - name: Test Addons with Pytest (geomeTRIC)
       working-directory: ./objdir
-      run: PYTHONPATH=stage/lib pytest --cache-clear -v -rws --durations=50 --durations-min=40 --strict-markers --color yes -n 2 -m "geometric" stage/lib/psi4/tests/
+      run: PYTHONPATH=stage/lib pytest --addon-report=addon-report.json --cache-clear -v -rws --durations=50 --durations-min=40 --strict-markers --color yes -n 2 -m "geometric" stage/lib/psi4/tests/
 
     - name: Test Addons with Pytest
       working-directory: ./objdir
-      run: PYTHONPATH=stage/lib pytest --cache-clear -v -rws --durations=50 --durations-min=40 --strict-markers --color yes -n auto -m "${{ matrix.cfg.pytest-marker-expr }} and not geometric" -k "${{ matrix.cfg.pytest-name-expr }}" stage/lib/psi4/tests/
+      run: PYTHONPATH=stage/lib pytest --addon-report=addon-report.json --cache-clear -v -rws --durations=50 --durations-min=40 --strict-markers --color yes -n auto -m "${{ matrix.cfg.pytest-marker-expr }} and not geometric" -k "${{ matrix.cfg.pytest-name-expr }}" stage/lib/psi4/tests/
+
+    - name: Publish addon test report
+      if: always()
+      working-directory: ./objdir
+      run: |
+        cat addon-report.md >> "$GITHUB_STEP_SUMMARY"
+        # To require ECPInt to be green (some passed and none failed), uncomment:
+        python -c 'import json; r=json.load(open("addon-report.json"))["addons"]["ecpint"]; assert r["passed"] > 0 and r["failed"] == 0, r'
+
+    - name: Upload addon test report
+      # if: always()
+      if: false
+      uses: actions/upload-artifact@v4
+      with:
+        name: addon-report-${{ runner.os }}-py${{ matrix.cfg.python-version }}-${{ strategy.job-index }}
+        path: |
+          objdir/addon-report.json
+          objdir/addon-report.md
 
     - name: Write user Conda environment files
       run: |

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -446,9 +446,18 @@ jobs:
       if: always()
       working-directory: ./objdir
       run: |
-        cat addon-report.md >> "$GITHUB_STEP_SUMMARY"
-        # To require ECPInt to be green (some passed and none failed), uncomment:
-        python -c 'import json; r=json.load(open("addon-report.json"))["addons"]["ecpint"]; assert r["passed"] > 0 and r["failed"] == 0, r'
+        if [[ -f addon-report.md ]]; then
+          echo "::group::Addon test report (Markdown source)"
+          cat addon-report.md
+          echo "::endgroup::"
+          cat addon-report.md >> "$GITHUB_STEP_SUMMARY"
+          # Require ECPInt to be green (some passed and none failed):
+          python -c 'import json; r=json.load(open("addon-report.json"))["addons"]["ecpint"]; assert r["passed"] > 0 and r["failed"] == 0, r'
+        else
+          echo "::warning::addon-report.md was not produced"
+          echo "## Psi4 addon test report" >> "$GITHUB_STEP_SUMMARY"
+          echo "The addon report was not produced; pytest may have exited before session cleanup." >> "$GITHUB_STEP_SUMMARY"
+        fi
 
     - name: Upload addon test report
       # if: always()

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -436,11 +436,11 @@ jobs:
       # Win runs out of memory on the geometric mp2(conv) tests, so run them with less parallelism
     - name: Test Addons with Pytest (geomeTRIC)
       working-directory: ./objdir
-      run: PYTHONPATH=stage/lib pytest --addon-report=addon-report.json --cache-clear -v -rws --durations=50 --durations-min=40 --strict-markers --color yes -n 2 -m "geometric" stage/lib/psi4/tests/
+      run: PYTHONPATH=stage/lib pytest --addon-report=addon-report.json --addon-report-label="${{ runner.os }} / ${{ matrix.cfg.label }} / Python ${{ matrix.cfg.python-version }}" --cache-clear -v -rws --durations=50 --durations-min=40 --strict-markers --color yes -n 2 -m "geometric" stage/lib/psi4/tests/
 
     - name: Test Addons with Pytest
       working-directory: ./objdir
-      run: PYTHONPATH=stage/lib pytest --addon-report=addon-report.json --cache-clear -v -rws --durations=50 --durations-min=40 --strict-markers --color yes -n auto -m "${{ matrix.cfg.pytest-marker-expr }} and not geometric" -k "${{ matrix.cfg.pytest-name-expr }}" stage/lib/psi4/tests/
+      run: PYTHONPATH=stage/lib pytest --addon-report=addon-report.json --addon-report-label="${{ runner.os }} / ${{ matrix.cfg.label }} / Python ${{ matrix.cfg.python-version }}" --cache-clear -v -rws --durations=50 --durations-min=40 --strict-markers --color yes -n auto -m "${{ matrix.cfg.pytest-marker-expr }} and not geometric" -k "${{ matrix.cfg.pytest-name-expr }}" stage/lib/psi4/tests/
 
     - name: Publish addon test report
       if: always()
@@ -457,11 +457,11 @@ jobs:
           echo "::warning::addon-report.md was not produced"
           echo "## Psi4 addon test report" >> "$GITHUB_STEP_SUMMARY"
           echo "The addon report was not produced; pytest may have exited before session cleanup." >> "$GITHUB_STEP_SUMMARY"
+          ADDON_REPORT_LABEL="${{ runner.os }} / ${{ matrix.cfg.label }} / Python ${{ matrix.cfg.python-version }}" python -c 'import json, os; json.dump({"label": os.environ["ADDON_REPORT_LABEL"], "error": "report unavailable"}, open("addon-report.json", "w", encoding="utf-8"))'
         fi
 
     - name: Upload addon test report
-      # if: always()
-      if: false
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: addon-report-${{ runner.os }}-py${{ matrix.cfg.python-version }}-${{ strategy.job-index }}
@@ -502,6 +502,33 @@ jobs:
         export PYTHONPATH=stage/lib
         pytest --cache-clear -v -rws --color yes -n auto -m qcmanybody stage/lib/psi4/tests/
         pytest --cache-clear -v -rws --color yes -n auto -k missing stage/lib/psi4/tests/
+
+  addon-summary:
+    name: "Eco • Combined addon report"
+    if: always()
+    needs: ecosystem
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Psi4
+      uses: actions/checkout@v6
+
+    - name: Download addon reports
+      continue-on-error: true
+      uses: actions/download-artifact@v4
+      with:
+        pattern: addon-report-*
+        path: addon-reports
+
+    - name: Combine addon reports
+      run: python tests/pytests/addon_report.py --combine addon-reports --output addon-report-combined.md
+
+    - name: Publish combined addon report
+      run: |
+        echo "::group::Combined addon test report (Markdown source)"
+        cat addon-report-combined.md
+        echo "::endgroup::"
+        cat addon-report-combined.md >> "$GITHUB_STEP_SUMMARY"
 
 # Notes
 # -----

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,6 @@ pr:
       - 1.10.x
       - 1.11.x
 
-#jobs:
-#  - template: ./.azure-pipelines/azure-pipelines-windows.yml
-#  - template: ./.azure-pipelines/azure-pipelines-linux.yml
+jobs:
+  - template: ./.azure-pipelines/azure-pipelines-windows.yml
+  - template: ./.azure-pipelines/azure-pipelines-linux.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,6 @@ pr:
       - 1.10.x
       - 1.11.x
 
-jobs:
-  - template: ./.azure-pipelines/azure-pipelines-windows.yml
-  - template: ./.azure-pipelines/azure-pipelines-linux.yml
+#jobs:
+#  - template: ./.azure-pipelines/azure-pipelines-windows.yml
+#  - template: ./.azure-pipelines/azure-pipelines-linux.yml

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+"""Repository-level pytest configuration.
+
+Load command-line plugins here so their options are available before pytest
+descends into ``tests/pytests``.  The latter conftest is also installed as the
+root conftest of Psi4's packaged test suite.
+"""
+
+pytest_plugins = ["addon_report"]

--- a/doc/sphinxman/source/add_tests.rst
+++ b/doc/sphinxman/source/add_tests.rst
@@ -344,4 +344,3 @@ Extra QCA Functions
 .. autofunction:: psi4.compare
 
 .. autofunction:: psi4.compare_recursive
-

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -369,6 +369,7 @@ install(
     PATTERN "f12_libint1.json"
     PATTERN "tdscf_reference_data.json"
     PATTERN "utils.py"
+    PATTERN "addon_report.py"
   )
 install(
   DIRECTORY

--- a/tests/pytests/addon_report.py
+++ b/tests/pytests/addon_report.py
@@ -18,6 +18,16 @@ def _addons(item):
     return sorted(set(item.keywords).intersection(_using_cache))
 
 
+def _status_icon(counts):
+    if counts["failed"]:
+        return "🔴"
+    if counts["passed"]:
+        return "🟢"
+    if counts["skipped"]:
+        return "🟡"
+    return "⚪"
+
+
 def _cell_text(counts, *, diagonal=False):
     total = sum(counts.values())
     if not total:
@@ -25,7 +35,7 @@ def _cell_text(counts, *, diagonal=False):
     # A pass proves the addon is present and operational even if other tests in
     # the cell skip because a second addon is absent. Failures remain highest
     # priority; yellow is reserved for cells where every test skipped.
-    icon = "🔴" if counts["failed"] else "🟢" if counts["passed"] else "🟡"
+    icon = _status_icon(counts)
     details = " ".join(
         f"{counts[status]}{status[0].upper()}"
         for status in ("passed", "failed", "skipped")
@@ -47,11 +57,14 @@ def summarize(tests, known_addons=()):
     """Build per-addon and addon-pair result counts from test records."""
     addons = sorted(set(known_addons) | {addon for test in tests.values() for addon in test["addons"]})
     empty = lambda: {"registered": 0, "passed": 0, "failed": 0, "skipped": 0}
-    totals = {addon: empty() for addon in addons}
+    totals = {addon: empty() for addon in ["core", *addons]}
     matrix = {a: {b: empty() for b in addons} for a in addons}
 
     for test in tests.values():
         status = test["status"]
+        if not test["addons"]:
+            totals["core"]["registered"] += 1
+            totals["core"][status] += 1
         for addon in test["addons"]:
             totals[addon]["registered"] += 1
             totals[addon][status] += 1
@@ -67,15 +80,15 @@ def render_markdown(tests, known_addons=()):
     lines = [
         "# Psi4 addon test report",
         "",
-        "🟢 at least one passed · 🟡 all skipped · 🔴 at least one failed · **〔bold brackets〕** diagonal",
+        "🟢 at least one passed · 🟡 all skipped · 🔴 at least one failed · ⚪ no executed tests · **〔bold brackets〕** diagonal",
         "",
-        "| Addon | Registered | Passed | Failed | Skipped |",
-        "|---|---:|---:|---:|---:|",
+        "| Addon | Status | Registered | Passed | Failed | Skipped |",
+        "|---|:---:|---:|---:|---:|---:|",
     ]
-    for addon in addons:
+    for addon in ["core", *addons]:
         row = totals[addon]
         lines.append(
-            f"| {addon} | {row['registered']} | {row['passed']} | {row['failed']} | {row['skipped']} |"
+            f"| {addon} | {_status_icon(row)} | {row['registered']} | {row['passed']} | {row['failed']} | {row['skipped']} |"
         )
 
     lines.extend(["", "## Addon overlap matrix", ""])
@@ -104,16 +117,16 @@ class AddonReporter:
 
     def pytest_runtest_logreport(self, report):
         properties = dict(report.user_properties)
-        addons = properties.get("psi4_addons")
+        if "psi4_addons" not in properties:
+            return
+        addons = properties["psi4_addons"]
         self.known_addons.update(properties.get("psi4_known_addons", "").split(","))
         self.known_addons.discard("")
-        if not addons:
-            return
         current = self.tests.get(report.nodeid)
         status = "skipped" if report.skipped else "failed" if report.failed else "passed"
         # A passing setup must not mask a later skipped/failed call or teardown.
         if current is None or _STATUS_ORDER[status] > _STATUS_ORDER[current["status"]]:
-            self.tests[report.nodeid] = {"addons": addons.split(","), "status": status}
+            self.tests[report.nodeid] = {"addons": addons.split(",") if addons else [], "status": status}
 
     def pytest_sessionfinish(self):
         # Each invocation merges into the same report, which lets the ecosystem
@@ -122,7 +135,7 @@ class AddonReporter:
         known_addons = set(self.known_addons)
         if self.output.exists():
             try:
-                old_payload = json.loads(self.output.read_text())
+                old_payload = json.loads(self.output.read_text(encoding="utf-8"))
                 previous = old_payload.get("tests", {})
                 known_addons.update(old_payload.get("known_addons", ()))
             except (OSError, ValueError):
@@ -140,9 +153,9 @@ class AddonReporter:
         payload = {"known_addons": known_addons, "addons": totals, "matrix": matrix, "tests": previous}
         self.output.parent.mkdir(parents=True, exist_ok=True)
         temporary = self.output.with_suffix(self.output.suffix + ".tmp")
-        temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         temporary.replace(self.output)
-        self.output.with_suffix(".md").write_text(render_markdown(previous, known_addons))
+        self.output.with_suffix(".md").write_text(render_markdown(previous, known_addons), encoding="utf-8")
 
 
 def pytest_addoption(parser):
@@ -167,8 +180,7 @@ def pytest_collection_modifyitems(items):
     known_addons = ",".join(sorted(_using_cache))
     for item in items:
         addons = _addons(item)
-        if addons:
-            item.user_properties.append(("psi4_addons", ",".join(addons)))
-            # xdist's controller does not collect tests itself, so send the
-            # complete addon universe along with reports from each worker.
-            item.user_properties.append(("psi4_known_addons", known_addons))
+        item.user_properties.append(("psi4_addons", ",".join(addons)))
+        # xdist's controller does not collect tests itself, so send the
+        # complete addon universe along with reports from each worker.
+        item.user_properties.append(("psi4_known_addons", known_addons))

--- a/tests/pytests/addon_report.py
+++ b/tests/pytests/addon_report.py
@@ -1,0 +1,174 @@
+"""Pytest reporting for tests which depend on optional Psi4 addons."""
+
+import json
+from itertools import combinations_with_replacement
+from pathlib import Path
+
+
+_STATUS_ORDER = {"passed": 0, "skipped": 1, "failed": 2}
+
+
+def _addons(item):
+    """Return the addon names recorded by ``using``/``uusing`` markers."""
+    # Each using()/uusing() call populates this cache while test modules are
+    # imported. By collection completion it is the authoritative set of addon
+    # marker names, avoiding any change to the established marker scheme.
+    from addons import _using_cache
+
+    return sorted(set(item.keywords).intersection(_using_cache))
+
+
+def _cell_text(counts, *, diagonal=False):
+    total = sum(counts.values())
+    if not total:
+        return "**〔—〕**" if diagonal else ""
+    # A pass proves the addon is present and operational even if other tests in
+    # the cell skip because a second addon is absent. Failures remain highest
+    # priority; yellow is reserved for cells where every test skipped.
+    icon = "🔴" if counts["failed"] else "🟢" if counts["passed"] else "🟡"
+    details = " ".join(
+        f"{counts[status]}{status[0].upper()}"
+        for status in ("passed", "failed", "skipped")
+        if counts[status]
+    )
+    text = f"{icon} {details}"
+    return f"**〔{text}〕**" if diagonal else text
+
+
+def _column_codes(addons):
+    """Return stable one-character labels for a compact matrix."""
+    alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    if len(addons) > len(alphabet):
+        raise ValueError(f"Addon matrix supports at most {len(alphabet)} addons")
+    return dict(zip(addons, alphabet))
+
+
+def summarize(tests, known_addons=()):
+    """Build per-addon and addon-pair result counts from test records."""
+    addons = sorted(set(known_addons) | {addon for test in tests.values() for addon in test["addons"]})
+    empty = lambda: {"registered": 0, "passed": 0, "failed": 0, "skipped": 0}
+    totals = {addon: empty() for addon in addons}
+    matrix = {a: {b: empty() for b in addons} for a in addons}
+
+    for test in tests.values():
+        status = test["status"]
+        for addon in test["addons"]:
+            totals[addon]["registered"] += 1
+            totals[addon][status] += 1
+        for a, b in combinations_with_replacement(test["addons"], 2):
+            for row, col in {(a, b), (b, a)}:
+                matrix[row][col]["registered"] += 1
+                matrix[row][col][status] += 1
+    return addons, totals, matrix
+
+
+def render_markdown(tests, known_addons=()):
+    addons, totals, matrix = summarize(tests, known_addons)
+    lines = [
+        "# Psi4 addon test report",
+        "",
+        "🟢 at least one passed · 🟡 all skipped · 🔴 at least one failed · **〔bold brackets〕** diagonal",
+        "",
+        "| Addon | Registered | Passed | Failed | Skipped |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for addon in addons:
+        row = totals[addon]
+        lines.append(
+            f"| {addon} | {row['registered']} | {row['passed']} | {row['failed']} | {row['skipped']} |"
+        )
+
+    lines.extend(["", "## Addon overlap matrix", ""])
+    if addons:
+        codes = _column_codes(addons)
+        lines.append("| | " + " | ".join(codes[addon] for addon in addons) + " |")
+        lines.append("|---|" + "---:|" * len(addons))
+        for row_index, a in enumerate(addons):
+            cells = [
+                _cell_text(matrix[a][b], diagonal=col_index == row_index) if col_index <= row_index else ""
+                for col_index, b in enumerate(addons)
+            ]
+            lines.append(f"| **{codes[a]} · {a}** | " + " | ".join(cells) + " |")
+    else:
+        lines.append("No addon tests were selected.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+class AddonReporter:
+    def __init__(self, config, output):
+        self.config = config
+        self.output = Path(output)
+        self.tests = {}
+        self.known_addons = set()
+
+    def pytest_runtest_logreport(self, report):
+        properties = dict(report.user_properties)
+        addons = properties.get("psi4_addons")
+        self.known_addons.update(properties.get("psi4_known_addons", "").split(","))
+        self.known_addons.discard("")
+        if not addons:
+            return
+        current = self.tests.get(report.nodeid)
+        status = "skipped" if report.skipped else "failed" if report.failed else "passed"
+        # A passing setup must not mask a later skipped/failed call or teardown.
+        if current is None or _STATUS_ORDER[status] > _STATUS_ORDER[current["status"]]:
+            self.tests[report.nodeid] = {"addons": addons.split(","), "status": status}
+
+    def pytest_sessionfinish(self):
+        # Each invocation merges into the same report, which lets the ecosystem
+        # workflow run geomeTRIC separately without fragmenting the totals.
+        previous = {}
+        known_addons = set(self.known_addons)
+        if self.output.exists():
+            try:
+                old_payload = json.loads(self.output.read_text())
+                previous = old_payload.get("tests", {})
+                known_addons.update(old_payload.get("known_addons", ()))
+            except (OSError, ValueError):
+                pass
+        # Non-xdist runs share the collection process with this reporter.
+        try:
+            from addons import _using_cache
+
+            known_addons.update(_using_cache)
+        except ImportError:
+            pass
+        previous.update(self.tests)
+        known_addons = sorted(known_addons)
+        addons, totals, matrix = summarize(previous, known_addons)
+        payload = {"known_addons": known_addons, "addons": totals, "matrix": matrix, "tests": previous}
+        self.output.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.output.with_suffix(self.output.suffix + ".tmp")
+        temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        temporary.replace(self.output)
+        self.output.with_suffix(".md").write_text(render_markdown(previous, known_addons))
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("psi4 addon reporting")
+    group.addoption(
+        "--addon-report",
+        metavar="PATH",
+        help="write addon test counts to PATH (JSON) and a sibling Markdown file",
+    )
+
+
+def pytest_configure(config):
+    output = config.getoption("--addon-report")
+    # xdist workers attach metadata to reports, but only the controller writes.
+    if output and not hasattr(config, "workerinput"):
+        config.pluginmanager.register(AddonReporter(config, output), "psi4-addon-reporter")
+
+
+def pytest_collection_modifyitems(items):
+    from addons import _using_cache
+
+    known_addons = ",".join(sorted(_using_cache))
+    for item in items:
+        addons = _addons(item)
+        if addons:
+            item.user_properties.append(("psi4_addons", ",".join(addons)))
+            # xdist's controller does not collect tests itself, so send the
+            # complete addon universe along with reports from each worker.
+            item.user_properties.append(("psi4_known_addons", known_addons))

--- a/tests/pytests/addon_report.py
+++ b/tests/pytests/addon_report.py
@@ -1,11 +1,17 @@
 """Pytest reporting for tests which depend on optional Psi4 addons."""
 
+import argparse
 import json
 from itertools import combinations_with_replacement
 from pathlib import Path
 
 
 _STATUS_ORDER = {"passed": 0, "skipped": 1, "failed": 2}
+
+
+def _report_addons(addons):
+    """Normalize addon labels for reporting; Psi4 itself is implicit."""
+    return sorted(set(addons) - {"psi4"})
 
 
 def _addons(item):
@@ -15,26 +21,20 @@ def _addons(item):
     # marker names, avoiding any change to the established marker scheme.
     from addons import _using_cache
 
-    return sorted(set(item.keywords).intersection(_using_cache))
+    return _report_addons(set(item.keywords).intersection(_using_cache))
 
 
-def _status_icon(counts):
+def _summary_status_icon(counts):
+    """Status for the summary table."""
     if counts["failed"]:
         return "🔴"
+    if counts["registered"] and counts["passed"] == counts["registered"]:
+        return "🔵"
     if counts["passed"]:
         return "🟢"
     if counts["skipped"]:
         return "🟡"
     return "⚪"
-
-
-def _summary_status_icon(counts):
-    """Status for the summary table, including complete pass coverage."""
-    if counts["failed"]:
-        return "🔴"
-    if counts["registered"] and counts["passed"] == counts["registered"]:
-        return "🔵"
-    return _status_icon(counts)
 
 
 def _count_text(counts):
@@ -48,20 +48,23 @@ def _count_text(counts):
 
 def summarize(tests, known_addons=()):
     """Build per-addon and addon-pair result counts from test records."""
-    addons = sorted(set(known_addons) | {addon for test in tests.values() for addon in test["addons"]})
+    addons = _report_addons(set(known_addons) | {addon for test in tests.values() for addon in test["addons"]})
     empty = lambda: {"registered": 0, "passed": 0, "failed": 0, "skipped": 0}
-    totals = {addon: empty() for addon in ["core", *addons]}
+    totals = {addon: empty() for addon in ["core", *addons, "psi4"]}
     matrix = {a: {b: empty() for b in addons} for a in addons}
 
     for test in tests.values():
         status = test["status"]
-        if not test["addons"]:
+        test_addons = _report_addons(test["addons"])
+        totals["psi4"]["registered"] += 1
+        totals["psi4"][status] += 1
+        if not test_addons:
             totals["core"]["registered"] += 1
             totals["core"][status] += 1
-        for addon in test["addons"]:
+        for addon in test_addons:
             totals[addon]["registered"] += 1
             totals[addon][status] += 1
-        for a, b in combinations_with_replacement(test["addons"], 2):
+        for a, b in combinations_with_replacement(test_addons, 2):
             for row, col in {(a, b), (b, a)}:
                 matrix[row][col]["registered"] += 1
                 matrix[row][col][status] += 1
@@ -78,21 +81,73 @@ def render_markdown(tests, known_addons=()):
         "| Addon | Count | Also tested with |",
         "|---|:---|---|",
     ]
-    for addon in ["core", *addons]:
+    for addon in ["core", *addons, "psi4"]:
         row = totals[addon]
         partners = ""
-        if addon != "core":
+        if addon in matrix:
             partners = ", ".join(other for other in addons if other != addon and matrix[addon][other]["registered"])
-        lines.append(f"| {addon} | {_count_text(row)} | {partners} |")
+        lines.append(f"| *{addon}* | {_count_text(row)} | {partners} |")
 
     lines.append("")
     return "\n".join(lines)
 
 
+def render_combined_markdown(reports):
+    """Render addon counts from multiple CI lanes as one table."""
+    reports = sorted(reports, key=lambda report: report.get("label", ""))
+    addons = sorted(
+        {addon for report in reports for addon in report.get("addons", {}) if addon not in {"core", "psi4"}}
+    )
+    rows = ["core", *addons, "psi4"]
+    lines = [
+        "# Combined Psi4 addon test report",
+        "",
+        "🔵 all registered passed · 🟢 at least one passed · 🟡 all skipped · 🔴 at least one failed · ⚪ no executed tests · — report unavailable",
+        "",
+    ]
+    if not reports:
+        lines.extend(["No addon reports were available.", ""])
+        return "\n".join(lines)
+
+    partner_source = next(
+        (report for report in reports if "linux" in (report.get("label") or "").lower() and report.get("tests")),
+        next((report for report in reports if report.get("tests")), {}),
+    )
+    partners = {addon: set() for addon in addons}
+    for test in partner_source.get("tests", {}).values():
+        test_addons = _report_addons(test.get("addons", ()))
+        for addon in test_addons:
+            partners.setdefault(addon, set()).update(other for other in test_addons if other != addon)
+
+    labels = [report.get("label") or f"Lane {index}" for index, report in enumerate(reports, 1)]
+    lines.append("| Addon | Also tested with | " + " | ".join(labels) + " |")
+    lines.append("|---|---|" + ":---|" * len(reports))
+    for addon in rows:
+        cells = []
+        for report in reports:
+            counts = report.get("addons", {}).get(addon)
+            cells.append(_count_text(counts) if counts is not None else "—")
+        also_tested_with = ", ".join(sorted(partners.get(addon, ())))
+        lines.append(f"| *{addon}* | {also_tested_with} | " + " | ".join(cells) + " |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def combine_reports(input_dir, output):
+    reports = []
+    for path in sorted(Path(input_dir).rglob("addon-report.json")):
+        try:
+            reports.append(json.loads(path.read_text(encoding="utf-8")))
+        except (OSError, ValueError):
+            continue
+    Path(output).write_text(render_combined_markdown(reports), encoding="utf-8")
+
+
 class AddonReporter:
-    def __init__(self, config, output):
+    def __init__(self, config, output, label=None):
         self.config = config
         self.output = Path(output)
+        self.label = label
         self.tests = {}
         self.known_addons = set()
 
@@ -113,11 +168,13 @@ class AddonReporter:
         # Each invocation merges into the same report, which lets the ecosystem
         # workflow run geomeTRIC separately without fragmenting the totals.
         previous = {}
+        previous_label = None
         known_addons = set(self.known_addons)
         if self.output.exists():
             try:
                 old_payload = json.loads(self.output.read_text(encoding="utf-8"))
                 previous = old_payload.get("tests", {})
+                previous_label = old_payload.get("label")
                 known_addons.update(old_payload.get("known_addons", ()))
             except (OSError, ValueError):
                 pass
@@ -125,13 +182,18 @@ class AddonReporter:
         try:
             from addons import _using_cache
 
-            known_addons.update(_using_cache)
+            known_addons.update(_report_addons(_using_cache))
         except ImportError:
             pass
         previous.update(self.tests)
         known_addons = sorted(known_addons)
         _, totals, _ = summarize(previous, known_addons)
-        payload = {"known_addons": known_addons, "addons": totals, "tests": previous}
+        payload = {
+            "label": self.label or previous_label,
+            "known_addons": known_addons,
+            "addons": totals,
+            "tests": previous,
+        }
         self.output.parent.mkdir(parents=True, exist_ok=True)
         temporary = self.output.with_suffix(self.output.suffix + ".tmp")
         temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -146,22 +208,37 @@ def pytest_addoption(parser):
         metavar="PATH",
         help="write addon test counts to PATH (JSON) and a sibling Markdown file",
     )
+    group.addoption(
+        "--addon-report-label",
+        metavar="LABEL",
+        help="label this report when combining results from multiple CI lanes",
+    )
 
 
 def pytest_configure(config):
     output = config.getoption("--addon-report")
     # xdist workers attach metadata to reports, but only the controller writes.
     if output and not hasattr(config, "workerinput"):
-        config.pluginmanager.register(AddonReporter(config, output), "psi4-addon-reporter")
+        config.pluginmanager.register(
+            AddonReporter(config, output, config.getoption("--addon-report-label")), "psi4-addon-reporter"
+        )
 
 
 def pytest_collection_modifyitems(items):
     from addons import _using_cache
 
-    known_addons = ",".join(sorted(_using_cache))
+    known_addons = ",".join(_report_addons(_using_cache))
     for item in items:
         addons = _addons(item)
         item.user_properties.append(("psi4_addons", ",".join(addons)))
         # xdist's controller does not collect tests itself, so send the
         # complete addon universe along with reports from each worker.
         item.user_properties.append(("psi4_known_addons", known_addons))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Combine Psi4 addon reports from CI lanes")
+    parser.add_argument("--combine", metavar="DIRECTORY", required=True)
+    parser.add_argument("--output", metavar="PATH", required=True)
+    args = parser.parse_args()
+    combine_reports(args.combine, args.output)

--- a/tests/pytests/addon_report.py
+++ b/tests/pytests/addon_report.py
@@ -28,29 +28,22 @@ def _status_icon(counts):
     return "⚪"
 
 
-def _cell_text(counts, *, diagonal=False):
-    total = sum(counts.values())
-    if not total:
-        return "**〔—〕**" if diagonal else ""
-    # A pass proves the addon is present and operational even if other tests in
-    # the cell skip because a second addon is absent. Failures remain highest
-    # priority; yellow is reserved for cells where every test skipped.
-    icon = _status_icon(counts)
-    details = " ".join(
+def _summary_status_icon(counts):
+    """Status for the summary table, including complete pass coverage."""
+    if counts["failed"]:
+        return "🔴"
+    if counts["registered"] and counts["passed"] == counts["registered"]:
+        return "🔵"
+    return _status_icon(counts)
+
+
+def _count_text(counts):
+    details = "+".join(
         f"{counts[status]}{status[0].upper()}"
         for status in ("passed", "failed", "skipped")
         if counts[status]
     )
-    text = f"{icon} {details}"
-    return f"**〔{text}〕**" if diagonal else text
-
-
-def _column_codes(addons):
-    """Return stable one-character labels for a compact matrix."""
-    alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
-    if len(addons) > len(alphabet):
-        raise ValueError(f"Addon matrix supports at most {len(alphabet)} addons")
-    return dict(zip(addons, alphabet))
+    return f"{_summary_status_icon(counts)} {details or '0'}"
 
 
 def summarize(tests, known_addons=()):
@@ -80,30 +73,18 @@ def render_markdown(tests, known_addons=()):
     lines = [
         "# Psi4 addon test report",
         "",
-        "🟢 at least one passed · 🟡 all skipped · 🔴 at least one failed · ⚪ no executed tests · **〔bold brackets〕** diagonal",
+        "🔵 all registered passed · 🟢 at least one passed · 🟡 all skipped · 🔴 at least one failed · ⚪ no executed tests",
         "",
-        "| Addon | Status | Registered | Passed | Failed | Skipped |",
-        "|---|:---:|---:|---:|---:|---:|",
+        "| Addon | Count | Also tested with |",
+        "|---|:---|---|",
     ]
     for addon in ["core", *addons]:
         row = totals[addon]
-        lines.append(
-            f"| {addon} | {_status_icon(row)} | {row['registered']} | {row['passed']} | {row['failed']} | {row['skipped']} |"
-        )
+        partners = ""
+        if addon != "core":
+            partners = ", ".join(other for other in addons if other != addon and matrix[addon][other]["registered"])
+        lines.append(f"| {addon} | {_count_text(row)} | {partners} |")
 
-    lines.extend(["", "## Addon overlap matrix", ""])
-    if addons:
-        codes = _column_codes(addons)
-        lines.append("| | " + " | ".join(codes[addon] for addon in addons) + " |")
-        lines.append("|---|" + "---:|" * len(addons))
-        for row_index, a in enumerate(addons):
-            cells = [
-                _cell_text(matrix[a][b], diagonal=col_index == row_index) if col_index <= row_index else ""
-                for col_index, b in enumerate(addons)
-            ]
-            lines.append(f"| **{codes[a]} · {a}** | " + " | ".join(cells) + " |")
-    else:
-        lines.append("No addon tests were selected.")
     lines.append("")
     return "\n".join(lines)
 
@@ -149,8 +130,8 @@ class AddonReporter:
             pass
         previous.update(self.tests)
         known_addons = sorted(known_addons)
-        addons, totals, matrix = summarize(previous, known_addons)
-        payload = {"known_addons": known_addons, "addons": totals, "matrix": matrix, "tests": previous}
+        _, totals, _ = summarize(previous, known_addons)
+        payload = {"known_addons": known_addons, "addons": totals, "tests": previous}
         self.output.parent.mkdir(parents=True, exist_ok=True)
         temporary = self.output.with_suffix(self.output.suffix + ".tmp")
         temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -1,14 +1,29 @@
 import os
+from pathlib import Path
+
 import pytest
 
 
+# CMake installs this file one level higher, as ``psi4/tests/conftest.py``.
+# In the source tree the repository-level conftest loads the reporting plugin;
+# in the installed layout this file must expose its hooks directly.  A nested
+# ``pytest_plugins`` declaration is rejected by pytest 9.
+_installed_test_layout = Path(__file__).parent.name == "tests"
+if _installed_test_layout:
+    import addon_report
+
+
 def pytest_addoption(parser):
+    if _installed_test_layout:
+        addon_report.pytest_addoption(parser)
     parser.addoption(
         "--runnonroutine", action="store_true", default=False, help="run the nonroutine tests in stdsuite"
     )
 
 
 def pytest_collection_modifyitems(config, items):
+    if _installed_test_layout:
+        addon_report.pytest_collection_modifyitems(items)
     if config.getoption("--runnonroutine"):
         # --runnonroutine given in cli: do not skip nonroutine tests
         return
@@ -16,6 +31,11 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "nonroutine" in item.keywords:
             item.add_marker(skip_nonroutine)
+
+
+def pytest_configure(config):
+    if _installed_test_layout:
+        addon_report.pytest_configure(config)
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] When packages are changing and I can't count on a green checkmark on a lane is doing what I intend, it's annoying to go into the logs, remember a relevant test name, and grep it to check PASSED, not SKIPPED. Moreover, comparing what tests are active between CI lanes is difficult.
- [x] So I commissioned of codex a dashboard to show test coverage for the different addons. It shows up on the "Summary" page at the bottom, since there's a collection step to merge the tables.
- [x] These counts are based on `using()` and `uusing()` and doesn't know about `sed read_options.cc` strategems to broaden testing. 
- [x] My goal changed to pretty table, but this also shows how to fail a lane if an addon isn't running and passing tests (e.g., `python -c 'import json; r=json.load(open("addon-report.json"))["addons"]["ecpint"]; assert r["passed"] > 0 and r["failed"] == 0, r'`). Handy sometimes when you don't want psi4 testing to just fail gracefully.

<img width="1153" height="677" alt="Screenshot 2026-08-25 at 6 20 01 PM" src="https://github.com/user-attachments/assets/0dcdb6ff-7c56-4345-871f-1ddd556c2ea7" />

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [x] AI usage -- Codex Sol 5.6 almost entirely

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
