### PR TITLE
XYG3 functional

### DIFF
--- a/psi4/driver/driver_nbody.py
+++ b/psi4/driver/driver_nbody.py
@@ -427,6 +427,7 @@ class ManyBodyComputer(ManyBodyComputerQCNG):
                 "specification": specification,
                 "keywords": mbkwargs,
                 "driver": driver,
+                "protocols": {"component_results": "all"},
             },
             molecule=molecule.to_schema(dtype=2),
         )
@@ -677,6 +678,8 @@ class ManyBodyComputer(ManyBodyComputerQCNG):
             grad = core.Matrix.from_array(nbody_model.properties.return_gradient)
             wfn.set_hessian(ret)
             wfn.set_gradient(grad)
+
+        wfn.qcschema = nbody_model
 
         if return_wfn:
             return (ret, wfn)

--- a/psi4/driver/procrouting/dft/dh_functionals.py
+++ b/psi4/driver/procrouting/dft/dh_functionals.py
@@ -90,6 +90,35 @@ funcs.append({
 })
 
 funcs.append({
+    "name": "XYG3",
+    "x_functionals": {
+        "LDA_X": {
+            "alpha": -0.0140  # 1 - aX - a0
+        },
+        "GGA_X_B88": {
+            "alpha": 0.2107  # a0
+        }
+    },
+    "x_hf": {
+        "alpha": 0.8033  # aX
+    },
+    "c_functionals": {
+        "GGA_C_LYP": {
+            "alpha": 0.6789  # 1 - aC
+        }
+    },
+    "c_mp2": {
+        "alpha": 0.3211  # aC
+    },
+    "xdh": {
+        "orbital_functional": "B3LYP",
+    },
+    "citation": '    Y. Zhang, X. Xu, W. A. Goddard III, Proc. Natl. Acad. Sci. U.S.A. 106, 4963-4968, 2009\n',
+    "description": '    XYG3 xDH Double Hybrid Exchange-Correlation Functional\n',
+    # composition from Eq. 7 of https://pubs.acs.org/doi/10.1021/ct100466k
+})
+
+funcs.append({
     "name": "DSD-BLYP",
     "x_functionals": {
         "GGA_X_B88": {

--- a/psi4/driver/procrouting/dft/libxc_functionals.py
+++ b/psi4/driver/procrouting/dft/libxc_functionals.py
@@ -120,6 +120,7 @@ funcs.append({"name": "LC-VV10"        , "xc_functionals": {"HYB_GGA_XC_LC_VV10"
 funcs.append({"name": "HPBEINT"        , "xc_functionals": {"HYB_GGA_XC_HPBEINT"        : {}}})
 funcs.append({"name": "LRC-WPBE"       , "xc_functionals": {"HYB_GGA_XC_LRC_WPBE"       : {}}})
 funcs.append({"name": "B3LYP5"         , "xc_functionals": {"HYB_GGA_XC_B3LYP5"         : {}}})
+funcs.append({"name": "B3LYP3"         , "xc_functionals": {"HYB_GGA_XC_B3LYP3"         : {}}})
 funcs.append({"name": "EDF2"           , "xc_functionals": {"HYB_GGA_XC_EDF2"           : {}}})
 funcs.append({"name": "CAP0"           , "xc_functionals": {"HYB_GGA_XC_CAP0"           : {}}})
 funcs.append({"name": "B88B95"         , "xc_functionals": {"HYB_MGGA_XC_B88B95"        : {}}, "alias": ["B1B95"]})

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -2589,10 +2589,126 @@ def run_scf(name, **kwargs):
     if not core.has_global_option_changed('SCF_TYPE'):
         core.set_global_option('SCF_TYPE', 'DF')
 
+    requested_func = kwargs.get("dft_functional", name)
+    xdh_def = None
+    xdh_name = requested_func
+    if isinstance(requested_func, dict):
+        if "xdh" in requested_func:
+            xdh_def = requested_func["xdh"]
+            xdh_name = requested_func
+    elif isinstance(requested_func, str) and requested_func.lower() in dft.functionals:
+        xdh_name = dft.functionals[requested_func.lower()]["name"]
+        if "xdh" in dft.functionals[requested_func.lower()]:
+            xdh_def = dft.functionals[requested_func.lower()]["xdh"]
+
+    print(f"{requested_func=} {xdh_name=} {xdh_def=}")
+    if xdh_def is not None:
+        if core.get_option("SCF", "REFERENCE") != "RKS":
+            raise ValidationError("xDH functionals are currently implemented for RKS references only.")
+
+        if (mp2_type := core.get_global_option("MP2_TYPE")) != "DF":
+            raise ValidationError(f"Invalid MP2 type {mp2_type} for xDH energy. See capabilities Table.")
+
+        xdh_orbital_functional = xdh_def["orbital_functional"]
+        scf_kwargs = dict(kwargs)
+        scf_kwargs.pop("dft_functional", None)
+        core.set_local_option("SCF", "SAVE_JK", True)
+        scf_wfn = scf_helper(xdh_orbital_functional, post_scf=False, **scf_kwargs)
+        orbital_ref = scf_wfn.energy()
+
+        xdh_super, _ = dft.build_superfunctional(xdh_name, True)
+        dmat = scf_wfn.Da()
+        jk_obj = scf_wfn.jk()
+        if jk_obj is None:
+            raise ValidationError("xDH energy requires SCF JK matrices, but no JK object is available.")
+        jmat = jk_obj.J()[0]
+        kmat = jk_obj.K()[0]
+
+        vxc = core.VBase.build(scf_wfn.get_basisset("ORBITAL"), xdh_super, "RV")
+        vxc.initialize()
+        vxc.set_D([dmat])
+        vtmp = dmat.clone()
+        vtmp.zero()
+        vxc.compute_V([vtmp])
+        quad = vxc.quadrature_values()
+        xdh_xc = quad["FUNCTIONAL"] if "FUNCTIONAL" in quad else 0.0
+        xdh_vv10 = quad["VV10"] if "VV10" in quad else 0.0
+        vxc.finalize()
+
+        nuc = scf_wfn.get_energies("Nuclear")
+        one_e = scf_wfn.get_energies("One-Electron")
+        dashd_e = scf_wfn.get_energies("-D")
+        coulomb_e = 2.0 * dmat.vector_dot(jmat)
+        exchange_e = -xdh_super.x_alpha() * dmat.vector_dot(kmat)
+        if xdh_super.is_x_lrc():
+            wK = jk_obj.wK()[0]
+            if jk_obj.get_do_wK() and jk_obj.get_wcombine():
+                exchange_e -= dmat.vector_dot(wK)
+            else:
+                exchange_e -= xdh_super.x_beta() * dmat.vector_dot(wK)
+
+        xdh_ref = nuc + one_e + coulomb_e + exchange_e + xdh_xc + xdh_vv10 + dashd_e
+
+        core.tstart()
+        aux_basis = core.BasisSet.build(scf_wfn.molecule(), "DF_BASIS_MP2",
+                                        core.get_option("DFMP2", "DF_BASIS_MP2"),
+                                        "RIFIT", core.get_global_option('BASIS'),
+                                        puream=-1)
+        scf_wfn.set_basisset("DF_BASIS_MP2", aux_basis)
+        if xdh_super.is_c_scs_hybrid():
+            core.set_local_option('DFMP2', 'MP2_OS_SCALE', xdh_super.c_os_alpha())
+            core.set_local_option('DFMP2', 'MP2_SS_SCALE', xdh_super.c_ss_alpha())
+            dfmp2_wfn = core.dfmp2(scf_wfn)
+            dfmp2_wfn.compute_energy()
+            vdh = dfmp2_wfn.variable("CUSTOM SCS-MP2 CORRELATION ENERGY")
+        else:
+            dfmp2_wfn = core.dfmp2(scf_wfn)
+            dfmp2_wfn.compute_energy()
+            totvdh = dfmp2_wfn.variable("MP2 CORRELATION ENERGY")
+            vdh = xdh_super.c_alpha() * dfmp2_wfn.variable("MP2 CORRELATION ENERGY")
+
+        for var in dfmp2_wfn.variables():
+            if var.startswith('MP2 '):
+                scf_wfn.del_variable(var)
+
+        returnvalue = xdh_ref + vdh
+        scf_wfn.set_variable("DFT XC ENERGY", xdh_xc)
+        scf_wfn.set_variable("DFT VV10 ENERGY", xdh_vv10)
+        scf_wfn.set_variable("DFT FUNCTIONAL TOTAL ENERGY", nuc + one_e + coulomb_e + exchange_e + xdh_xc + xdh_vv10)
+        scf_wfn.set_variable("SCF TOTAL ENERGY", xdh_ref)
+        scf_wfn.set_variable("DFT ORBITAL TOTAL ENERGY", orbital_ref)
+        scf_wfn.set_variable(f"{xdh_super.name()} ORBITAL REFERENCE ENERGY", orbital_ref)
+        scf_wfn.set_variable(f"{xdh_super.name()} DFT REFERENCE ENERGY", xdh_ref)
+        scf_wfn.set_variable("DOUBLE-HYBRID CORRECTION ENERGY", vdh)
+        scf_wfn.set_variable(f"{xdh_super.name()} DOUBLE-HYBRID CORRECTION ENERGY", vdh)
+        scf_wfn.set_variable("DFT TOTAL ENERGY", returnvalue)
+        scf_wfn.set_variable(f"{xdh_super.name()} TOTAL ENERGY", returnvalue)
+        scf_wfn.set_variable("CURRENT ENERGY", returnvalue)
+        scf_wfn.set_variable("CURRENT REFERENCE ENERGY", xdh_ref)
+        scf_wfn.set_energy(returnvalue)
+
+        core.print_out('\n\n')
+        core.print_out(f'    {xdh_super.name()} Energy Summary\n')
+        core.print_out('    ' + '-' * (15 + len(xdh_super.name())) + '\n')
+        core.print_out(f'    Orbital Functional ({xdh_orbital_functional})    = {orbital_ref:18.12f}\n')
+        core.print_out('    xDH DFT Reference Energy               = %18.12lf\n' % (xdh_ref))
+        core.print_out('    MP2 Correlation                        = %18.12lf\n' % (totvdh))
+        core.print_out('    Scaled MP2 Correlation                 = %18.12lf\n' % (vdh))
+        core.print_out('    @Final xDH DFT total energy            = %18.12lf\n\n' % (returnvalue))
+        core.tstop()
+
+        for k, v in scf_wfn.variables().items():
+            core.set_variable(k, v)
+
+        optstash_scf.restore()
+        optstash_mp2.restore()
+        return scf_wfn
+
     scf_wfn = scf_helper(name, post_scf=False, **kwargs)
     returnvalue = scf_wfn.energy()
 
     ssuper = scf_wfn.functional()
+
 
     if ssuper.is_c_hybrid():
 
@@ -2617,6 +2733,7 @@ def run_scf(name, **kwargs):
         else:
             dfmp2_wfn = core.dfmp2(scf_wfn)
             dfmp2_wfn.compute_energy()
+            totvdh = dfmp2_wfn.variable('MP2 CORRELATION ENERGY')
             vdh = ssuper.c_alpha() * dfmp2_wfn.variable('MP2 CORRELATION ENERGY')
 
         # remove misleading MP2 psivars computed with DFT, not HF, reference
@@ -2642,6 +2759,7 @@ def run_scf(name, **kwargs):
         core.print_out('    %s Energy Summary\n' % (name.upper()))
         core.print_out('    ' + '-' * (15 + len(name)) + '\n')
         core.print_out('    DFT Reference Energy                  = %22.16lf\n' % (returnvalue - vdh))
+        core.print_out('    MP2 Correlation                       = %22.16lf\n' % (totvdh))
         core.print_out('    Scaled MP2 Correlation                = %22.16lf\n' % (vdh))
         core.print_out('    @Final double-hybrid DFT total energy = %22.16lf\n\n' % (returnvalue))
         core.tstop()

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -2601,7 +2601,6 @@ def run_scf(name, **kwargs):
         if "xdh" in dft.functionals[requested_func.lower()]:
             xdh_def = dft.functionals[requested_func.lower()]["xdh"]
 
-    print(f"{requested_func=} {xdh_name=} {xdh_def=}")
     if xdh_def is not None:
         if core.get_option("SCF", "REFERENCE") != "RKS":
             raise ValidationError("xDH functionals are currently implemented for RKS references only.")
@@ -2617,37 +2616,14 @@ def run_scf(name, **kwargs):
         orbital_ref = scf_wfn.energy()
 
         xdh_super, _ = dft.build_superfunctional(xdh_name, True)
-        dmat = scf_wfn.Da()
-        jk_obj = scf_wfn.jk()
-        if jk_obj is None:
-            raise ValidationError("xDH energy requires SCF JK matrices, but no JK object is available.")
-        jmat = jk_obj.J()[0]
-        kmat = jk_obj.K()[0]
-
-        vxc = core.VBase.build(scf_wfn.get_basisset("ORBITAL"), xdh_super, "RV")
-        vxc.initialize()
-        vxc.set_D([dmat])
-        vtmp = dmat.clone()
-        vtmp.zero()
-        vxc.compute_V([vtmp])
-        quad = vxc.quadrature_values()
-        xdh_xc = quad["FUNCTIONAL"] if "FUNCTIONAL" in quad else 0.0
-        xdh_vv10 = quad["VV10"] if "VV10" in quad else 0.0
-        vxc.finalize()
-
-        nuc = scf_wfn.get_energies("Nuclear")
-        one_e = scf_wfn.get_energies("One-Electron")
-        dashd_e = scf_wfn.get_energies("-D")
-        coulomb_e = 2.0 * dmat.vector_dot(jmat)
-        exchange_e = -xdh_super.x_alpha() * dmat.vector_dot(kmat)
-        if xdh_super.is_x_lrc():
-            wK = jk_obj.wK()[0]
-            if jk_obj.get_do_wK() and jk_obj.get_wcombine():
-                exchange_e -= dmat.vector_dot(wK)
-            else:
-                exchange_e -= xdh_super.x_beta() * dmat.vector_dot(wK)
-
-        xdh_ref = nuc + one_e + coulomb_e + exchange_e + xdh_xc + xdh_vv10 + dashd_e
+        xdh_components = scf_wfn.evaluate_fixed_density_dft_energy(xdh_super)
+        nuc = xdh_components["Nuclear"]
+        one_e = xdh_components["One-Electron"]
+        coulomb_e = xdh_components["Coulomb"]
+        exchange_e = xdh_components["Exchange"]
+        xdh_xc = xdh_components["XC"]
+        xdh_vv10 = xdh_components["VV10"]
+        xdh_ref = xdh_components["Total"]
 
         core.tstart()
         aux_basis = core.BasisSet.build(scf_wfn.molecule(), "DF_BASIS_MP2",
@@ -2660,6 +2636,7 @@ def run_scf(name, **kwargs):
             core.set_local_option('DFMP2', 'MP2_SS_SCALE', xdh_super.c_ss_alpha())
             dfmp2_wfn = core.dfmp2(scf_wfn)
             dfmp2_wfn.compute_energy()
+            totvdh = dfmp2_wfn.variable("MP2 CORRELATION ENERGY")
             vdh = dfmp2_wfn.variable("CUSTOM SCS-MP2 CORRELATION ENERGY")
         else:
             dfmp2_wfn = core.dfmp2(scf_wfn)
@@ -2727,6 +2704,7 @@ def run_scf(name, **kwargs):
             core.set_local_option('DFMP2', 'MP2_SS_SCALE', ssuper.c_ss_alpha())
             dfmp2_wfn = core.dfmp2(scf_wfn)
             dfmp2_wfn.compute_energy()
+            totvdh = dfmp2_wfn.variable('MP2 CORRELATION ENERGY')
 
             vdh = dfmp2_wfn.variable('CUSTOM SCS-MP2 CORRELATION ENERGY')
 

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -361,6 +361,8 @@ void export_wavefunction(py::module& m) {
         .def("occupation_b", &scf::HF::occupation_b, "Returns the Beta occupation numbers.")
         .def("reset_occupation", &scf::HF::reset_occupation, "docstring")
         .def("compute_E", &scf::HF::compute_E, "docstring")
+        .def("evaluate_fixed_density_dft_energy", &scf::HF::evaluate_fixed_density_dft_energy,
+             "Evaluate DFT energy components on the current density for a target SuperFunctional.")
         .def("compute_initial_E", &scf::HF::compute_initial_E, "docstring")
         .def("rotate_orbitals", &scf::HF::rotate_orbitals, "docstring")
         .def("save_density_and_energy", &scf::HF::save_density_and_energy, "docstring")

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -321,6 +321,9 @@ void HF::save_density_and_energy() {
 void HF::form_G() { throw PSIEXCEPTION("Sorry, the base HF wavefunction does not understand."); }
 void HF::form_F() { throw PSIEXCEPTION("Sorry, the base HF wavefunction does not understand Roothan."); }
 double HF::compute_E() { throw PSIEXCEPTION("Sorry, the base HF wavefunction does not understand Hall."); }
+std::map<std::string, double> HF::evaluate_fixed_density_dft_energy(std::shared_ptr<SuperFunctional> functional) {
+    throw PSIEXCEPTION("Sorry, fixed-density DFT energy evaluation is not implemented for this SCF wavefunction type.");
+}
 void HF::rotate_orbitals(SharedMatrix C, const SharedMatrix x) {
     // => Rotate orbitals <= //
     auto U = std::make_shared<Matrix>("Ck", nmopi_, nmopi_);

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -324,6 +324,9 @@ class HF : public Wavefunction {
 
     /// Compute energy for the iteration.
     virtual double compute_E();
+    /// Evaluate DFT energy components on the current density for a target functional.
+    virtual std::map<std::string, double> evaluate_fixed_density_dft_energy(
+        std::shared_ptr<SuperFunctional> functional);
 
     /** Applies second-order convergence acceleration */
     virtual int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, bool soscf_print);

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -365,6 +365,86 @@ double RHF::compute_E() {
 
     return Etotal;
 }
+
+std::map<std::string, double> RHF::evaluate_fixed_density_dft_energy(std::shared_ptr<SuperFunctional> functional) {
+    if (!functional) {
+        throw PSIEXCEPTION("RHF::evaluate_fixed_density_dft_energy: Target functional is null.");
+    }
+    if (!jk_) {
+        throw PSIEXCEPTION("RHF::evaluate_fixed_density_dft_energy: JK object is not available.");
+    }
+
+    const std::vector<SharedMatrix>& J = jk_->J();
+    const std::vector<SharedMatrix>& K = jk_->K();
+    const std::vector<SharedMatrix>& wK = jk_->wK();
+
+    // In normal usage these are already present from the converged orbital-stage SCF.
+    if (J.empty() || !J[0]) {
+        std::vector<SharedMatrix>& C = jk_->C_left();
+        C.clear();
+        C.push_back(Ca_subset("SO", "OCC"));
+        jk_->compute();
+    }
+
+    if (J.empty() || !J[0]) {
+        throw PSIEXCEPTION("RHF::evaluate_fixed_density_dft_energy: JK object did not produce J.");
+    }
+    const auto& Jmat = J[0];
+
+    double XC_E = 0.0;
+    double VV10_E = 0.0;
+    if (functional->needs_xc()) {
+        auto potential = VBase::build_V(basisset_, functional, options_, "RV");
+        potential->initialize();
+        potential->set_D({Da_});
+        auto V = Da_->clone();
+        V->zero();
+        potential->compute_V({V});
+        auto quad = potential->quadrature_values();
+        if (quad.count("FUNCTIONAL")) XC_E = quad["FUNCTIONAL"];
+        if (quad.count("VV10")) VV10_E = quad["VV10"];
+        potential->finalize();
+    }
+
+    const double one_electron_E = 2.0 * Da_->vector_dot(H_);
+    const double coulomb_E = 2.0 * Da_->vector_dot(Jmat);
+
+    double exchange_E = 0.0;
+    const double alpha = functional->x_alpha();
+    const double beta = functional->x_beta();
+
+    if (functional->is_x_hybrid()) {
+        if (K.empty() || !K[0]) {
+            throw PSIEXCEPTION("RHF::evaluate_fixed_density_dft_energy: JK object did not produce K for hybrid functional.");
+        }
+        exchange_E -= alpha * Da_->vector_dot(K[0]);
+    }
+    if (functional->is_x_lrc()) {
+        if (wK.empty() || !wK[0]) {
+            throw PSIEXCEPTION("RHF::evaluate_fixed_density_dft_energy: JK object did not produce wK for LRC functional.");
+        }
+        if (jk_->get_do_wK() && jk_->get_wcombine()) {
+            exchange_E -= Da_->vector_dot(wK[0]);
+        } else {
+            exchange_E -= beta * Da_->vector_dot(wK[0]);
+        }
+    }
+
+    const double dashD_E = has_scalar_variable("-D Energy") ? scalar_variable("-D Energy") : 0.0;
+    const double total_E = nuclearrep_ + one_electron_E + coulomb_E + exchange_E + XC_E + VV10_E + dashD_E;
+
+    return {
+        {"Nuclear", nuclearrep_},
+        {"One-Electron", one_electron_E},
+        {"Coulomb", coulomb_E},
+        {"Exchange", exchange_E},
+        {"XC", XC_E},
+        {"VV10", VV10_E},
+        {"-D", dashD_E},
+        {"Total", total_E},
+    };
+}
+
 std::vector<SharedMatrix> RHF::onel_Hx(std::vector<SharedMatrix> x_vec) {
     // This is a bypass for C1 input
     std::vector<bool> c1_input_;

--- a/psi4/src/psi4/libscf_solver/rhf.h
+++ b/psi4/src/psi4/libscf_solver/rhf.h
@@ -71,6 +71,7 @@ class RHF : public HF {
     void form_G() override;
     void form_V() override;
     double compute_E() override;
+    std::map<std::string, double> evaluate_fixed_density_dft_energy(std::shared_ptr<SuperFunctional> functional) override;
     void finalize() override;
 
     void openorbital_scf() override;

--- a/tests/pytests/test_xyg3.py
+++ b/tests/pytests/test_xyg3.py
@@ -90,7 +90,7 @@ H   3.117061   0.013701   0.000000
     if db == 2:
         tottol, ietol = 0.0001, 0.001
     elif db == 4:
-        tottol, ietol = 0.0005, 0.008
+        tottol, ietol = 0.0005, 0.010
 
     import qcmanybody as qcmb
     cluster_qcvars = {qcmb.labeler(*qcmb.delabeler(k), opaque=False): v.extras["qcvars"] for k, v in wfn.qcschema.component_results.items()}

--- a/tests/pytests/test_xyg3.py
+++ b/tests/pytests/test_xyg3.py
@@ -1,0 +1,104 @@
+import pytest
+
+from psi4 import compare_values
+
+import psi4
+
+pytestmark = [pytest.mark.psi, pytest.mark.api, pytest.mark.dft, pytest.mark.scf]
+
+
+@pytest.mark.parametrize("db,refie", [
+    (2, -5.388),
+    (4, -16.352),
+])
+def test_xyg3_s22_ie(db, refie):
+    """S22 unCP interaction energy at XYG3/aug-cc-pVDZ."""
+
+    dh = 0.3211
+    labels = ["§(auto)_(1, 2)@(1, 2)", "§(auto)_(1)@(1)", "§(auto)_(2)@(2)"]
+    def ie(d, ma, mb):
+        return (d - ma - mb) * psi4.constants.hartree2kcalmol
+
+    ref = {
+        2: {
+            "DFT ORBITAL TOTAL ENERGY": [-152.896556997805, -76.444577153690, -76.444574136778],  # NWChem: Total DFT energy =
+            "DFT FUNCTIONAL TOTAL ENERGY": [-152.584365930251, -76.288376390838, -76.288510494955],  # NWChem: DFT energy
+            "DOUBLE-HYBRID CORRECTION ENERGY": [dh * -0.628008042867, dh * -0.312449744115, dh * -0.312114201506],  # NWChem: Unscaled MP2 energy
+            "DFT TOTAL ENERGY": [-152.786019312815, -76.388704003673, -76.388730365058]  # NWChem: Total DFT+MP2 energy
+        },
+        4: {
+            "DFT ORBITAL TOTAL ENERGY": [-339.872394738091, -169.924556335410, -169.924556335478],
+            "DFT FUNCTIONAL TOTAL ENERGY": [-339.125711995348, -169.550887686232, -169.550887686235],
+            "DOUBLE-HYBRID CORRECTION ENERGY": [dh * -1.542536206757, dh * -0.767970003064, dh * -0.767970003069],
+            "DFT TOTAL ENERGY": [-339.621020371338, -169.797482854216, -169.797482854220],
+        },
+    }
+    for item in list(ref.keys()):
+        for pv in list(ref[item].keys()):
+            ref[item][pv] = dict(zip(labels, ref[item][pv]))
+
+    sdimer = {
+        2: """
+O  -1.551007  -0.114520   0.000000
+H  -1.934259   0.762503   0.000000
+H  -0.599677   0.040712   0.000000
+--
+0 1
+O   1.350625   0.111469   0.000000
+H   1.680398  -0.373741  -0.758561
+H   1.680398  -0.373741   0.758561
+        """,
+        4: """
+0 1
+C  -2.018649   0.052883   0.000000
+O  -1.452200   1.143634   0.000000
+N  -1.407770  -1.142484   0.000000
+H  -1.964596  -1.977036   0.000000
+H  -0.387244  -1.207782   0.000000
+H  -3.117061  -0.013701   0.000000
+--
+0 1
+C   2.018649  -0.052883   0.000000
+O   1.452200  -1.143634   0.000000
+N   1.407770   1.142484   0.000000
+H   1.964596   1.977036   0.000000
+H   0.387244   1.207782   0.000000
+H   3.117061   0.013701   0.000000
+        """,
+    }[db]
+    dimer = psi4.geometry(sdimer)
+
+    psi4.set_options(
+        {
+            "basis": "aug-cc-pvdz",
+            #"puream": False,
+            #"scf_type": "pk",
+            "scf_type": "df",
+            "mp2_type": "df",
+            #"freeze_core": True,
+            "dft_radial_points": 99,
+            "dft_spherical_points": 590,
+            "e_convergence": 8,
+            "d_convergence": 8,
+        }
+    )
+
+    ie_au, wfn = psi4.energy("xyg3", molecule=dimer, bsse_type="nocp", return_wfn=True)
+
+    assert compare_values(refie, ie_au * psi4.constants.hartree2kcalmol, 2, f"S22-{db} IE")
+
+    import qcmanybody as qcmb
+    cluster_qcvars = {qcmb.labeler(*qcmb.delabeler(k), opaque=False): v.extras["qcvars"] for k, v in wfn.qcschema.component_results.items()}
+    for pv in ref[db].keys():
+        for cluster in ref[db][pv].keys():
+            assert compare_values(ref[db][pv][cluster], cluster_qcvars[cluster][pv], 3, f"{cluster}: {pv}")
+        assert compare_values(ie(ref[db][pv][labels[0]], ref[db][pv][labels[1]], ref[db][pv][labels[2]]),
+                              ie(cluster_qcvars[labels[0]][pv], cluster_qcvars[labels[1]][pv], cluster_qcvars[labels[2]][pv]), 2, "IE")
+
+
+if __name__ == "__main__":
+
+    test_xyg3_s22_ie(2, -5.388)
+    #test_xyg3_s22_ie(4, -16.352)
+
+    #test_xyg3_s22_ie(2, -5.48)  # -152.74379273     -76.36749396     -76.36756211"  IE= -5.48225  # paper with Alvaro

--- a/tests/pytests/test_xyg3.py
+++ b/tests/pytests/test_xyg3.py
@@ -87,13 +87,18 @@ H   3.117061   0.013701   0.000000
 
     assert compare_values(refie, ie_au * psi4.constants.hartree2kcalmol, 2, f"S22-{db} IE")
 
+    if db == 2:
+        tottol, ietol = 0.0001, 0.001
+    elif db == 4:
+        tottol, ietol = 0.0005, 0.008
+
     import qcmanybody as qcmb
     cluster_qcvars = {qcmb.labeler(*qcmb.delabeler(k), opaque=False): v.extras["qcvars"] for k, v in wfn.qcschema.component_results.items()}
     for pv in ref[db].keys():
         for cluster in ref[db][pv].keys():
-            assert compare_values(ref[db][pv][cluster], cluster_qcvars[cluster][pv], 3, f"{cluster}: {pv}")
+            assert compare_values(ref[db][pv][cluster], cluster_qcvars[cluster][pv], tottol, f"{cluster}: {pv}")
         assert compare_values(ie(ref[db][pv][labels[0]], ref[db][pv][labels[1]], ref[db][pv][labels[2]]),
-                              ie(cluster_qcvars[labels[0]][pv], cluster_qcvars[labels[1]][pv], cluster_qcvars[labels[2]][pv]), 2, "IE")
+                              ie(cluster_qcvars[labels[0]][pv], cluster_qcvars[labels[1]][pv], cluster_qcvars[labels[2]][pv]), ietol, "IE")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This is a WIP branch of implementing XYG3 functional to get it stashed publicly. I'm reasonably confident it's getting the right answer (checked against NWChem), but I'm not sure this is the right implementation to maximally re-use code. (I've tried driver-side and class-side.) They key quirk of this class of DH functional is that there's two functionals, one for DFT and one for MP2 and some are single-iteration. Implementation is Codex c. Feb 2026


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
<!-- Any questions or decision points on which you need clarification
     from the Psi4 team. -->
- [ ] Question1

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [ ] AI usage

## Checklist
- [ ] Tests added for any new features
- [ ] Docstring or narrative docs/sphinxman/source updated if needed
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
