### PR TITLE
libiwl: add standalone round-trip test

### DIFF
--- a/psi4/src/psi4/libiwl/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/CMakeLists.txt
@@ -11,3 +11,19 @@ list(APPEND sources
   wrtone.cc
   )
 psi4_add_module(lib iwl sources)
+
+# test/ contains a standalone round-trip exerciser (iwl_roundtrip_test.cc).
+# It links against the libiwl/libpsio/libpsi4util/liboptions/libciomr static
+# archives plus a tiny stubs TU (test/stubs.cc) that supplies the runtime
+# globals normally provided by core.cc / libdpd. That curated link resolves with
+# GNU/Clang on Linux/macOS but not with clang-cl/lld-link, which emits inline and
+# implicit functions that GCC discards as unused, so the Windows objects carry
+# undefined references the link line does not provide: psio.lib wants
+# DPDMOSpace::~DPDMOSpace (instantiated by std::vector<DPDMOSpace> in dpd.h), and
+# psi4util.lib wants Molecule::Molecule(const Molecule&) (from inline
+# Molecule::clone) and ExternalPotential::print (from inline py_print). Not a
+# unity or PCH artifact -- Linux is unity-built too, and Azure Windows builds with
+# PCH off. Restrict the test to non-Windows rather than drag in the full closure.
+if(NOT WIN32)
+    add_subdirectory(test)
+endif()

--- a/psi4/src/psi4/libiwl/test/CMakeLists.txt
+++ b/psi4/src/psi4/libiwl/test/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Standalone round-trip exerciser for libiwl. Links the libiwl/libpsio/
+# libpsi4util/liboptions/libciomr static archives plus a tiny stubs TU
+# (test/stubs.cc) that supplies the runtime globals normally provided by
+# core.cc / libdpd, and one no-op leaf (C_DSYEV) that libciomr's unity object
+# references but the test never exercises. This keeps the test self-contained
+# without pulling the full libmints/Libint closure.
+#
+# Only the executable is defined here. See ctest registration in `tests/libiwl/`
+# (an add_test() in this scope would not register at all: psi4-core is a separate
+# ExternalProject that never calls enable_testing()).
+add_executable(iwl_roundtrip_test.x iwl_roundtrip_test.cc stubs.cc)
+target_link_libraries(iwl_roundtrip_test.x PRIVATE iwl psio psi4util options ciomr)

--- a/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
+++ b/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
@@ -28,7 +28,15 @@
 
 // Standalone round-trip test for libiwl. Exercises every bucket-boundary case
 // the 1995 README warned about: empty, single, exactly one bucket, just over
-// one bucket, mid-bucket termination, and all-zeros sweeps.
+// one bucket, and mid-bucket termination.
+//
+// Also covers cutoff filtering. write_value() keeps an integral only when
+// |value| > cutoff, so sub-cutoff entries are *dropped*, not stored as zeros --
+// nothing is read back for them at all. That makes filtering a repacking
+// operation: survivors slide forward into earlier bucket slots, so which
+// bucket the dropped run falls in changes the packing downstream of it. The
+// positional cases below (first/second/second-to-last/last bucket fully
+// filtered, plus all-filtered and interleaved) pin that behavior down.
 
 #include <cmath>
 #include <cstdio>
@@ -73,6 +81,21 @@ std::vector<Quartet> make_test_data(std::size_t n) {
     return out;
 }
 
+// Sub-cutoff stand-ins. Exactly +0.0 is the common case in a real integrals
+// sweep, but a nonzero magnitude below the cutoff must be dropped just the
+// same, and |value| == cutoff must *also* drop because write_value() tests
+// strictly greater-than. Cycling all three keeps that boundary honest.
+double subcutoff_value(std::size_t i) {
+    switch (i % 3) {
+        case 0:
+            return 0.0;
+        case 1:
+            return (i % 6 == 1) ? 1.0e-20 : -1.0e-20;
+        default:
+            return 1.0e-14;  // == cutoff, so filtered by the strict >
+    }
+}
+
 // Drive an IWL write loop using the C++ API.
 void write_all(psi::IWL &buf, const std::vector<Quartet> &data) {
     for (const auto &q : data) {
@@ -108,9 +131,12 @@ std::vector<Quartet> read_all(int itap) {
     return out;
 }
 
+// Exact comparison, deliberately. IWL neither scales nor rounds: write_value()
+// casts to Value (= double, so a no-op) and put()/fetch() move the raw bytes
+// through libpsio. A surviving integral must therefore come back bit-identical,
+// and any tolerance here would only hide a real corruption.
 bool quartets_equal(const Quartet &a, const Quartet &b) {
-    return a.p == b.p && a.q == b.q && a.r == b.r && a.s == b.s &&
-           std::fabs(a.value - b.value) < 1.0e-12;
+    return a.p == b.p && a.q == b.q && a.r == b.r && a.s == b.s && a.value == b.value;
 }
 
 // Run one write/read round-trip for the given size and tape unit. Returns
@@ -160,6 +186,42 @@ bool round_trip_empty(int itap) {
     return true;
 }
 
+// Round-trip N integrals of which a contiguous run [lo, hi) is pushed below the
+// cutoff. Only the survivors should come back, in order and bit-exact; the
+// dropped run must leave no trace (no zero-valued placeholder, no gap).
+bool round_trip_filtered(std::size_t n, std::size_t lo, std::size_t hi, int itap, const std::string &what) {
+    auto data = make_test_data(n);
+    std::vector<Quartet> expected;
+    for (std::size_t i = 0; i < n; ++i) {
+        if (i >= lo && i < hi) {
+            data[i].value = subcutoff_value(i);
+        } else {
+            expected.push_back(data[i]);
+        }
+    }
+
+    {
+        psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
+                     /*oldfile*/ 0, /*readflag*/ 0);
+        write_all(buf, data);
+        buf.set_keep_flag(true);
+    }
+
+    auto got = read_all(itap);
+
+    if (got.size() != expected.size()) {
+        std::cerr << "  " << what << ": expected " << expected.size() << " survivors, read " << got.size() << "\n";
+        return false;
+    }
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        if (!quartets_equal(expected[i], got[i])) {
+            std::cerr << "  " << what << ": survivor " << i << " mismatch\n";
+            return false;
+        }
+    }
+    return true;
+}
+
 }  // namespace
 
 int main() {
@@ -182,6 +244,33 @@ int main() {
         std::cout << "[iwl_roundtrip] N = " << n << "\n";
         if (!round_trip(n, unit++)) ++failures;
     }
+
+    // Cutoff filtering, positioned bucket by bucket over a four-bucket write.
+    // Each case drops a full bucket's worth of input, so the survivors have to
+    // repack across the remaining buckets -- the first and last cases also
+    // exercise "the very first thing written is dropped" and "the file ends on
+    // a dropped run", where an off-by-one in flush/lastbuf would show up.
+    const std::size_t N4 = 4 * B;
+    struct FilterCase {
+        const char *what;
+        std::size_t lo, hi;
+    };
+    const std::vector<FilterCase> filtered = {
+        {"first bucket below cutoff", 0, B},
+        {"second bucket below cutoff", B, 2 * B},
+        {"second-to-last bucket below cutoff", 2 * B, 3 * B},
+        {"last bucket below cutoff", 3 * B, N4},
+        {"all below cutoff", 0, N4},
+    };
+    for (const auto &fc : filtered) {
+        std::cout << "[iwl_roundtrip] " << fc.what << "\n";
+        if (!round_trip_filtered(N4, fc.lo, fc.hi, unit++, fc.what)) ++failures;
+    }
+
+    // A sub-cutoff run that straddles a bucket boundary, so survivors on both
+    // sides of it repack into the same bucket.
+    std::cout << "[iwl_roundtrip] run straddling a bucket boundary\n";
+    if (!round_trip_filtered(3 * B, B - 7, B + 11, unit++, "straddling run")) ++failures;
 
     if (failures) {
         std::cerr << failures << " case(s) failed.\n";

--- a/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
+++ b/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
@@ -1,0 +1,192 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+// Standalone round-trip test for libiwl. Exercises every bucket-boundary case
+// the 1995 README warned about: empty, single, exactly one bucket, just over
+// one bucket, mid-bucket termination, and all-zeros sweeps.
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "psi4/libiwl/iwl.h"
+#include "psi4/libiwl/iwl.hpp"
+#include "psi4/libpsio/psio.h"
+#include "psi4/libpsio/psio.hpp"
+#include "psi4/libpsi4util/PsiOutStream.h"
+
+// Hosting globals (`outfile`, `restart_id`, `psi_file_prefix`, `global_dpd_`)
+// live in test/stubs.cc; the link line pulls that TU in.
+
+namespace {
+
+using namespace psi;
+
+struct Quartet {
+    int p, q, r, s;
+    double value;
+};
+
+// Deterministic pseudo-random test data with bounded indices.
+std::vector<Quartet> make_test_data(std::size_t n) {
+    std::vector<Quartet> out;
+    out.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        // Wraparound keeps indices in [0, 200) so they fit in 16 bits and we
+        // can compare without sorting.
+        const int p = static_cast<int>((i * 7 + 11) % 200);
+        const int q = static_cast<int>((i * 13 + 5) % 200);
+        const int r = static_cast<int>((i * 17 + 3) % 200);
+        const int s = static_cast<int>((i * 19 + 1) % 200);
+        // Values bounded away from cutoff (1e-14) so none get filtered.
+        const double v = 1.0 + 0.001 * static_cast<double>(i);
+        out.push_back({p, q, r, s, v});
+    }
+    return out;
+}
+
+// Drive an IWL write loop using the C++ API.
+void write_all(psi::IWL &buf, const std::vector<Quartet> &data) {
+    for (const auto &q : data) {
+        buf.write_value(q.p, q.q, q.r, q.s, q.value, /*printflag*/ 0,
+                        std::string("outfile"), /*dirac*/ 0);
+    }
+    buf.flush(/*lastbuf*/ 1);
+}
+
+// Drive an IWL read loop using the C-style API (the dominant in-tree pattern).
+std::vector<Quartet> read_all(int itap) {
+    std::vector<Quartet> out;
+    iwlbuf B;
+    iwl_buf_init(&B, itap, 1.0e-14, /*oldfile*/ 1, /*readflag*/ 1);
+
+    int lastbuf = B.lastbuf;
+    while (true) {
+        for (int i = B.idx; i < B.inbuf; ++i) {
+            const int j = 4 * i;
+            const int p = static_cast<int>(B.labels[j + 0]);
+            const int q = static_cast<int>(B.labels[j + 1]);
+            const int r = static_cast<int>(B.labels[j + 2]);
+            const int s = static_cast<int>(B.labels[j + 3]);
+            const double v = static_cast<double>(B.values[i]);
+            out.push_back({p, q, r, s, v});
+        }
+        B.idx = B.inbuf;
+        if (lastbuf) break;
+        iwl_buf_fetch(&B);
+        lastbuf = B.lastbuf;
+    }
+    iwl_buf_close(&B, /*keep*/ 0);
+    return out;
+}
+
+bool quartets_equal(const Quartet &a, const Quartet &b) {
+    return a.p == b.p && a.q == b.q && a.r == b.r && a.s == b.s &&
+           std::fabs(a.value - b.value) < 1.0e-12;
+}
+
+// Run one write/read round-trip for the given size and tape unit. Returns
+// true on success, false otherwise (with diagnostic to stderr).
+bool round_trip(std::size_t n, int itap) {
+    auto data = make_test_data(n);
+
+    {
+        psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
+                     /*oldfile*/ 0, /*readflag*/ 0);
+        write_all(buf, data);
+        buf.set_keep_flag(true);
+    }
+
+    auto got = read_all(itap);
+
+    if (got.size() != data.size()) {
+        std::cerr << "  size mismatch: wrote " << data.size() << " read "
+                  << got.size() << "\n";
+        return false;
+    }
+    for (std::size_t i = 0; i < data.size(); ++i) {
+        if (!quartets_equal(data[i], got[i])) {
+            std::cerr << "  entry " << i << " mismatch\n";
+            return false;
+        }
+    }
+    return true;
+}
+
+// Empty buffer: no integrals written, but flush(lastbuf=1) must still produce
+// a readable file that read_all() returns as zero entries. The 1995 README
+// specifically calls out this case.
+bool round_trip_empty(int itap) {
+    {
+        psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
+                     /*oldfile*/ 0, /*readflag*/ 0);
+        buf.flush(/*lastbuf*/ 1);
+        buf.set_keep_flag(true);
+    }
+    auto got = read_all(itap);
+    if (!got.empty()) {
+        std::cerr << "  empty round-trip returned " << got.size()
+                  << " entries\n";
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    // libpsio needs init before anything opens a unit.
+    psi::psio_init();
+
+    // Use tape unit numbers in a range unlikely to clash with the few entries
+    // libpsio's filecfg might preset.
+    const int base_unit = 80;
+    int unit = base_unit;
+    int failures = 0;
+
+    const std::size_t B = static_cast<std::size_t>(IWL_INTS_PER_BUF);
+    const std::vector<std::size_t> sizes = {1, B - 1, B, B + 1, 3 * B + B / 2};
+
+    std::cout << "[iwl_roundtrip] empty buffer\n";
+    if (!round_trip_empty(unit++)) ++failures;
+
+    for (auto n : sizes) {
+        std::cout << "[iwl_roundtrip] N = " << n << "\n";
+        if (!round_trip(n, unit++)) ++failures;
+    }
+
+    if (failures) {
+        std::cerr << failures << " case(s) failed.\n";
+        return 1;
+    }
+    std::cout << "All round-trip cases passed.\n";
+    return 0;
+}

--- a/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
+++ b/psi4/src/psi4/libiwl/test/iwl_roundtrip_test.cc
@@ -30,6 +30,11 @@
 // the 1995 README warned about: empty, single, exactly one bucket, just over
 // one bucket, and mid-bucket termination.
 //
+// Every case is run through all four write/read API combinations -- {C, C++}
+// write x {C, C++} read -- since libiwl exposes both a C-style (iwl_buf_*) and
+// a C++ (psi::IWL) interface and both are in use in-tree; a byte written by one
+// must read back identically through either.
+//
 // Also covers cutoff filtering. write_value() keeps an integral only when
 // |value| > cutoff, so sub-cutoff entries are *dropped*, not stored as zeros --
 // nothing is read back for them at all. That makes filtering a repacking
@@ -58,13 +63,17 @@ namespace {
 
 using namespace psi;
 
+// The IWL cutoff used throughout: write_value() keeps an integral only when
+// |value| is strictly greater than this.
+constexpr double CUTOFF = 1.0e-14;
+
 struct Quartet {
     int p, q, r, s;
     double value;
 };
 
 // Deterministic pseudo-random test data with bounded indices.
-std::vector<Quartet> make_test_data(std::size_t n) {
+std::vector<Quartet> make_test_data(const std::size_t n) {
     std::vector<Quartet> out;
     out.reserve(n);
     for (std::size_t i = 0; i < n; ++i) {
@@ -85,7 +94,7 @@ std::vector<Quartet> make_test_data(std::size_t n) {
 // sweep, but a nonzero magnitude below the cutoff must be dropped just the
 // same, and |value| == cutoff must *also* drop because write_value() tests
 // strictly greater-than. Cycling all three keeps that boundary honest.
-double subcutoff_value(std::size_t i) {
+double subcutoff_value(const std::size_t i) {
     switch (i % 3) {
         case 0:
             return 0.0;
@@ -96,20 +105,38 @@ double subcutoff_value(std::size_t i) {
     }
 }
 
-// Drive an IWL write loop using the C++ API.
-void write_all(psi::IWL &buf, const std::vector<Quartet> &data) {
-    for (const auto &q : data) {
-        buf.write_value(q.p, q.q, q.r, q.s, q.value, /*printflag*/ 0,
-                        std::string("outfile"), /*dirac*/ 0);
+// A writer emits `data` to tape `itap` and leaves the file on disk for the
+// reader; a reader pulls it back. The two write and two read functions below
+// are the C++ (psi::IWL) and C-style (iwl_buf_*) sides of the same operation.
+using Writer = void (*)(const int itap, const std::vector<Quartet>& data);
+using Reader = std::vector<Quartet> (*)(const int itap);
+
+// Write via the C++ API (psi::IWL).
+void write_all_cpp(const int itap, const std::vector<Quartet>& data) {
+    IWL buf(_default_psio_lib_.get(), itap, CUTOFF, /*oldfile*/ 0, /*readflag*/ 0);
+    for (const auto& q : data) {
+        buf.write_value(q.p, q.q, q.r, q.s, q.value, /*printflag*/ 0, std::string("outfile"), /*dirac*/ 0);
     }
     buf.flush(/*lastbuf*/ 1);
+    buf.set_keep_flag(true);  // keep the file on disk for the reader
 }
 
-// Drive an IWL read loop using the C-style API (the dominant in-tree pattern).
-std::vector<Quartet> read_all(int itap) {
+// Write via the C-style API (iwl_buf_*).
+void write_all_c(const int itap, const std::vector<Quartet>& data) {
+    iwlbuf B;
+    iwl_buf_init(&B, itap, CUTOFF, /*oldfile*/ 0, /*readflag*/ 0);
+    for (const auto& q : data) {
+        iwl_buf_wrt_val(&B, q.p, q.q, q.r, q.s, q.value, /*printflag*/ 0, std::string("outfile"), /*dirac*/ 0);
+    }
+    iwl_buf_flush(&B, /*lastbuf*/ 1);
+    iwl_buf_close(&B, /*keep*/ 1);  // keep the file on disk for the reader
+}
+
+// Read via the C-style API (the dominant in-tree pattern).
+std::vector<Quartet> read_all_c(const int itap) {
     std::vector<Quartet> out;
     iwlbuf B;
-    iwl_buf_init(&B, itap, 1.0e-14, /*oldfile*/ 1, /*readflag*/ 1);
+    iwl_buf_init(&B, itap, CUTOFF, /*oldfile*/ 1, /*readflag*/ 1);
 
     int lastbuf = B.lastbuf;
     while (true) {
@@ -127,7 +154,33 @@ std::vector<Quartet> read_all(int itap) {
         iwl_buf_fetch(&B);
         lastbuf = B.lastbuf;
     }
-    iwl_buf_close(&B, /*keep*/ 0);
+    iwl_buf_close(&B, /*keep*/ 0);  // done reading; delete the scratch file
+    return out;
+}
+
+// Read via the C++ API (psi::IWL). fetch() refills the buffer each pass; the
+// label/value pointers are stable across fetches.
+std::vector<Quartet> read_all_cpp(const int itap) {
+    std::vector<Quartet> out;
+    IWL buf(_default_psio_lib_.get(), itap, CUTOFF, /*oldfile*/ 1, /*readflag*/ 0);
+    const Label* labels = buf.labels();
+    const Value* values = buf.values();
+
+    int lastbuf;
+    do {
+        buf.fetch();
+        lastbuf = buf.last_buffer();
+        for (int i = 0; i < buf.buffer_count(); ++i) {
+            const int j = 4 * i;
+            const int p = static_cast<int>(labels[j + 0]);
+            const int q = static_cast<int>(labels[j + 1]);
+            const int r = static_cast<int>(labels[j + 2]);
+            const int s = static_cast<int>(labels[j + 3]);
+            const double v = static_cast<double>(values[i]);
+            out.push_back({p, q, r, s, v});
+        }
+    } while (!lastbuf);
+    buf.set_keep_flag(false);  // done reading; delete the scratch file
     return out;
 }
 
@@ -135,52 +188,39 @@ std::vector<Quartet> read_all(int itap) {
 // casts to Value (= double, so a no-op) and put()/fetch() move the raw bytes
 // through libpsio. A surviving integral must therefore come back bit-identical,
 // and any tolerance here would only hide a real corruption.
-bool quartets_equal(const Quartet &a, const Quartet &b) {
+bool quartets_equal(const Quartet& a, const Quartet& b) {
     return a.p == b.p && a.q == b.q && a.r == b.r && a.s == b.s && a.value == b.value;
 }
 
-// Run one write/read round-trip for the given size and tape unit. Returns
-// true on success, false otherwise (with diagnostic to stderr).
-bool round_trip(std::size_t n, int itap) {
-    auto data = make_test_data(n);
-
-    {
-        psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
-                     /*oldfile*/ 0, /*readflag*/ 0);
-        write_all(buf, data);
-        buf.set_keep_flag(true);
-    }
-
-    auto got = read_all(itap);
+// Run one write/read round-trip for the given size and tape unit through the
+// supplied write/read APIs. Returns true on success, false otherwise (with
+// diagnostic to stderr).
+bool round_trip(const std::size_t n, const int itap, const Writer write, const Reader read, const std::string& api) {
+    const auto data = make_test_data(n);
+    write(itap, data);
+    const auto got = read(itap);
 
     if (got.size() != data.size()) {
-        std::cerr << "  size mismatch: wrote " << data.size() << " read "
-                  << got.size() << "\n";
+        std::cerr << "  " << api << ": size mismatch: wrote " << data.size() << " read " << got.size() << "\n";
         return false;
     }
     for (std::size_t i = 0; i < data.size(); ++i) {
         if (!quartets_equal(data[i], got[i])) {
-            std::cerr << "  entry " << i << " mismatch\n";
+            std::cerr << "  " << api << ": entry " << i << " mismatch\n";
             return false;
         }
     }
     return true;
 }
 
-// Empty buffer: no integrals written, but flush(lastbuf=1) must still produce
-// a readable file that read_all() returns as zero entries. The 1995 README
+// Empty buffer: no integrals written, but flush(lastbuf=1) must still produce a
+// readable file that the reader returns as zero entries. The 1995 README
 // specifically calls out this case.
-bool round_trip_empty(int itap) {
-    {
-        psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
-                     /*oldfile*/ 0, /*readflag*/ 0);
-        buf.flush(/*lastbuf*/ 1);
-        buf.set_keep_flag(true);
-    }
-    auto got = read_all(itap);
+bool round_trip_empty(const int itap, const Writer write, const Reader read, const std::string& api) {
+    write(itap, {});
+    const auto got = read(itap);
     if (!got.empty()) {
-        std::cerr << "  empty round-trip returned " << got.size()
-                  << " entries\n";
+        std::cerr << "  " << api << ": empty round-trip returned " << got.size() << " entries\n";
         return false;
     }
     return true;
@@ -189,7 +229,8 @@ bool round_trip_empty(int itap) {
 // Round-trip N integrals of which a contiguous run [lo, hi) is pushed below the
 // cutoff. Only the survivors should come back, in order and bit-exact; the
 // dropped run must leave no trace (no zero-valued placeholder, no gap).
-bool round_trip_filtered(std::size_t n, std::size_t lo, std::size_t hi, int itap, const std::string &what) {
+bool round_trip_filtered(const std::size_t n, const std::size_t lo, const std::size_t hi, const int itap,
+                         const std::string& what, const Writer write, const Reader read, const std::string& api) {
     auto data = make_test_data(n);
     std::vector<Quartet> expected;
     for (std::size_t i = 0; i < n; ++i) {
@@ -200,22 +241,17 @@ bool round_trip_filtered(std::size_t n, std::size_t lo, std::size_t hi, int itap
         }
     }
 
-    {
-        psi::IWL buf(psi::_default_psio_lib_.get(), itap, 1.0e-14,
-                     /*oldfile*/ 0, /*readflag*/ 0);
-        write_all(buf, data);
-        buf.set_keep_flag(true);
-    }
-
-    auto got = read_all(itap);
+    write(itap, data);
+    const auto got = read(itap);
 
     if (got.size() != expected.size()) {
-        std::cerr << "  " << what << ": expected " << expected.size() << " survivors, read " << got.size() << "\n";
+        std::cerr << "  " << api << " " << what << ": expected " << expected.size() << " survivors, read " << got.size()
+                  << "\n";
         return false;
     }
     for (std::size_t i = 0; i < expected.size(); ++i) {
         if (!quartets_equal(expected[i], got[i])) {
-            std::cerr << "  " << what << ": survivor " << i << " mismatch\n";
+            std::cerr << "  " << api << " " << what << ": survivor " << i << " mismatch\n";
             return false;
         }
     }
@@ -231,30 +267,21 @@ int main() {
     // Use tape unit numbers in a range unlikely to clash with the few entries
     // libpsio's filecfg might preset.
     const int base_unit = 80;
-    int unit = base_unit;
     int failures = 0;
 
-    const std::size_t B = static_cast<std::size_t>(IWL_INTS_PER_BUF);
+    constexpr std::size_t B = IWL_INTS_PER_BUF;
     const std::vector<std::size_t> sizes = {1, B - 1, B, B + 1, 3 * B + B / 2};
 
-    std::cout << "[iwl_roundtrip] empty buffer\n";
-    if (!round_trip_empty(unit++)) ++failures;
-
-    for (auto n : sizes) {
-        std::cout << "[iwl_roundtrip] N = " << n << "\n";
-        if (!round_trip(n, unit++)) ++failures;
-    }
-
+    const std::size_t N4 = 4 * B;
+    struct FilterCase {
+        const char* what;
+        std::size_t lo, hi;
+    };
     // Cutoff filtering, positioned bucket by bucket over a four-bucket write.
     // Each case drops a full bucket's worth of input, so the survivors have to
     // repack across the remaining buckets -- the first and last cases also
     // exercise "the very first thing written is dropped" and "the file ends on
     // a dropped run", where an off-by-one in flush/lastbuf would show up.
-    const std::size_t N4 = 4 * B;
-    struct FilterCase {
-        const char *what;
-        std::size_t lo, hi;
-    };
     const std::vector<FilterCase> filtered = {
         {"first bucket below cutoff", 0, B},
         {"second bucket below cutoff", B, 2 * B},
@@ -262,15 +289,44 @@ int main() {
         {"last bucket below cutoff", 3 * B, N4},
         {"all below cutoff", 0, N4},
     };
-    for (const auto &fc : filtered) {
-        std::cout << "[iwl_roundtrip] " << fc.what << "\n";
-        if (!round_trip_filtered(N4, fc.lo, fc.hi, unit++, fc.what)) ++failures;
-    }
 
-    // A sub-cutoff run that straddles a bucket boundary, so survivors on both
-    // sides of it repack into the same bucket.
-    std::cout << "[iwl_roundtrip] run straddling a bucket boundary\n";
-    if (!round_trip_filtered(3 * B, B - 7, B + 11, unit++, "straddling run")) ++failures;
+    // Every case runs through all four write/read API combinations. Each reader
+    // deletes its file when done, so the unit range is free to reuse per pass.
+    struct Api {
+        const char* name;
+        Writer write;
+        Reader read;
+    };
+    const std::vector<Api> apis = {
+        {"C++w/Cr", write_all_cpp, read_all_c},
+        {"Cw/C++r", write_all_c, read_all_cpp},
+        {"C++w/C++r", write_all_cpp, read_all_cpp},
+        {"Cw/Cr", write_all_c, read_all_c},
+    };
+
+    for (const auto& api : apis) {
+        int unit = base_unit;
+        std::cout << "[iwl_roundtrip] ===== API: " << api.name << " =====\n";
+
+        std::cout << "[iwl_roundtrip] empty buffer\n";
+        if (!round_trip_empty(unit++, api.write, api.read, api.name)) ++failures;
+
+        for (const auto n : sizes) {
+            std::cout << "[iwl_roundtrip] N = " << n << "\n";
+            if (!round_trip(n, unit++, api.write, api.read, api.name)) ++failures;
+        }
+
+        for (const auto& fc : filtered) {
+            std::cout << "[iwl_roundtrip] " << fc.what << "\n";
+            if (!round_trip_filtered(N4, fc.lo, fc.hi, unit++, fc.what, api.write, api.read, api.name)) ++failures;
+        }
+
+        // A sub-cutoff run that straddles a bucket boundary, so survivors on
+        // both sides of it repack into the same bucket.
+        std::cout << "[iwl_roundtrip] run straddling a bucket boundary\n";
+        if (!round_trip_filtered(3 * B, B - 7, B + 11, unit++, "straddling run", api.write, api.read, api.name))
+            ++failures;
+    }
 
     if (failures) {
         std::cerr << failures << " case(s) failed.\n";

--- a/psi4/src/psi4/libiwl/test/stubs.cc
+++ b/psi4/src/psi4/libiwl/test/stubs.cc
@@ -1,0 +1,87 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+// Minimal hosting globals for the standalone IWL round-trip test executable.
+// libpsio and libpsi4util are not standalone static archives -- they reference
+// runtime globals normally defined in core.cc (the python bindings TU) and a
+// member function on libdpd's DPD class. This file supplies just enough to
+// satisfy the link without dragging in libdpd or core.cc.
+
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "psi4/libpsi4util/PsiOutStream.h"
+
+namespace psi {
+
+// libciomr / libpsio scratch-name globals; normally set by psi4 startup.
+std::string restart_id;
+char *psi_file_prefix = strdup("iwl_test");
+
+// libpsi4util's `outfile` is reached only from print paths the test never
+// triggers (printflag = 0 everywhere). The symbol still has to exist.
+std::shared_ptr<PsiOutStream> outfile;
+
+// libpsio's PSIO::close calls global_dpd_->file4_cache_del_filenum during
+// every file close. In a non-DPD context the cache walk is a no-op anyway,
+// but dereferencing a null global_dpd_ is UB. Provide a minimal DPD class
+// with the one referenced method as a no-op, plus a non-null instance to
+// dispatch through.
+//
+// This is an ODR violation: close.cc is compiled against the real psi::DPD from
+// libdpd/dpd.h, while this TU defines a different psi::DPD. It holds together
+// only because the call is non-virtual and the mangled name matches. The
+// parameter type must therefore be spelled exactly as in dpd.h -- `size_t`, not
+// `unsigned long`. They coincide on LP64 and nowhere else; on Windows x64
+// `size_t` is `unsigned __int64` while `unsigned long` is 32 bits, and the
+// mismatch is an undefined symbol at link time rather than a diagnostic.
+class DPD {
+ public:
+    void file4_cache_del_filenum(std::size_t);
+};
+
+void DPD::file4_cache_del_filenum(std::size_t) {}
+
+namespace {
+DPD stub_dpd_instance;
+}
+
+DPD *global_dpd_ = &stub_dpd_instance;
+
+// libciomr's DSYEV_ascending lands in the same unity translation unit as the
+// print helpers libpsio pulls in, so the linker drags its reference to libqt's
+// C_DSYEV LAPACK wrapper even though the test never diagonalizes anything.
+// Linking libqt to satisfy it cascades into libmints/Libint; a no-op leaf stub
+// is the bounded fix. Never called by the test. Signature matches the real
+// declaration in libqt/qt.h (returns int).
+int C_DSYEV(char, char, int, double *, int, double *, double *, int) { return 0; }
+
+}  // namespace psi

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,9 +119,11 @@ add_subdirectory(json)
 
 # C++ unit tests built inside the psi4-core ExternalProject. Skipped on Windows,
 # where their curated link lines do not resolve under lld-link (see
-# psi4/src/psi4/libpsio/CMakeLists.txt), so the executables are never built there.
+# psi4/src/psi4/libpsio/CMakeLists.txt and psi4/src/psi4/libiwl/CMakeLists.txt),
+# so the executables are never built there.
 if(NOT WIN32)
     add_subdirectory(libpsio)
+    add_subdirectory(libiwl)
 endif()
 
 if(ENABLE_pasture)

--- a/tests/libiwl/CMakeLists.txt
+++ b/tests/libiwl/CMakeLists.txt
@@ -1,0 +1,19 @@
+# C++ unit tests for libiwl.
+#
+# The executables are built inside the psi4-core ExternalProject, which has its
+# own binary directory and does not call enable_testing(). Registration has to
+# happen here, in the superbuild, because that is where `enable_testing()` runs
+# (cmake/ConfigTesting.cmake) and where CI invokes `ctest`.
+ExternalProject_Get_Property(psi4-core BINARY_DIR)
+
+# "smoketests" is what actually gets this run: CI drives scarcely anything through
+# ctest because the regression tests are doubled by pytest, and a C++ unit test is
+# not eligible for pytest (it is not a `psi4 input.dat`). The smoke and plugin
+# labels *are* driven through ctest -- Azure Linux runs `ctest -L "plug|smoke"`
+# (devtools/scripts/ci_run_test.py), Azure Windows `--label-regex smoke`.
+# "quicktests" is kept alongside it, as 13 other tests do, so the GH macOS
+# `ctest -L quick` lane keeps running it too.
+add_test(NAME libiwl-roundtrip
+         COMMAND ${BINARY_DIR}/src/psi4/libiwl/test/iwl_roundtrip_test.x${CMAKE_EXECUTABLE_SUFFIX}
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(libiwl-roundtrip PROPERTIES LABELS "psi;quicktests;smoketests;libiwl")


### PR DESCRIPTION
A standalone characterization test for the libiwl bucket I/O, landed on its own ahead of the phase-1 modernization so the refactor has a behavior-preserving guard to build on. **No library source changes** — this is purely a new test.

Split out of #3426 at TiborGY's request (tests first, modernization respun on top).

## Description
`test/iwl_roundtrip_test.cc` writes integrals through the C++ `IWL` API and reads them back through the C-style `iwl_buf_*` API (the dominant in-tree read pattern), checking every bucket-boundary case the 1995 README warned about: empty, `1`, `B-1`, `B`, `B+1`, and `3.5*B` integrals (`B = IWL_INTS_PER_BUF`). It links the libiwl/libpsio/libpsi4util/liboptions/libciomr archives plus a tiny stubs TU (`test/stubs.cc`) supplying the runtime globals normally provided by core.cc/libdpd (`global_dpd_`, `psi_file_prefix`, a no-op `C_DSYEV`), so it needs neither Python nor libdpd.

Built inside the psi4-core ExternalProject and registered as the `libiwl-roundtrip` ctest in the superbuild (`tests/libiwl/`, where `enable_testing()` runs), labeled `psi;quicktests;smoketests;libiwl`. Skipped on Windows, where the curated link line does not resolve under clang-cl/lld-link (see `psi4/src/psi4/libiwl/CMakeLists.txt`).

## User API & Changelog headlines
- [ ] None (test-only).

## Dev notes & details
- [x] new `libiwl-roundtrip` ctest; C++ write / C-API read round-trip over the bucket-boundary sizes
- [x] `test/stubs.cc` hosts the runtime globals so the exerciser links without Python/libdpd
- [x] non-Windows only (clang-cl/lld-link cannot resolve the curated link)

## Questions
- [ ] None outstanding.

## AI
- [x] AI usage: the test and its hosting stubs.

## Checklist
- [x] Tests added for any new features
- [ ] Docstring or narrative docs/sphinxman/source updated if needed (test-only)
- Test running is well covered by CI.

## Status
- [x] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
