### PR TITLE
Optional libcint two-electron integral backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ option(ENABLE_ecpint "Enables libecpint for effective core potentials (ECP)" OFF
 option(ENABLE_libefp "Enables LIBEFP and PylibEFP for fragments" OFF)
 option(ENABLE_Einsums "Enables the Einsums tensor library" OFF)
 option(ENABLE_simint "Enables use of SIMINT two-electron integral library" OFF)
+option(ENABLE_libcint "Enables use of the libcint two-electron integral library (experimental)" OFF)
 option(ENABLE_gauxc "Enables use of GauXC density functional library" OFF)
 option(ENABLE_gdma "Enables Stone's GDMA multipole code (requires Fortran; can also be added at runtime)" OFF)
 option(ENABLE_IntegratorXX "Enables use of IntegratorXX density functional grids library" OFF)
@@ -272,6 +273,7 @@ ExternalProject_Add(psi4-core
            openorbitaloptimizer_external
            optking_external
            simint_external
+           libcint_external
            libxc_external
            mdi_external
            brianqc_external
@@ -331,6 +333,7 @@ ExternalProject_Add(psi4-core
               -DENABLE_libefp=${ENABLE_libefp}
               -DENABLE_Einsums=${ENABLE_Einsums}
               -DENABLE_simint=${ENABLE_simint}
+              -DENABLE_libcint=${ENABLE_libcint}
               -DENABLE_gdma=${ENABLE_gdma}
               -DENABLE_PCMSolver=${ENABLE_PCMSolver}
               -DENABLE_mdi=${ENABLE_mdi}
@@ -357,6 +360,7 @@ ExternalProject_Add(psi4-core
               -Dgauxc_DIR=${gauxc_DIR}
               -Dpylibefp_DIR=${pylibefp_DIR}
               -Dsimint_DIR=${simint_DIR}
+              -Dlibcint_DIR=${libcint_DIR}
               -DLibxc_DIR=${Libxc_DIR}
               -DBrianQC_DIR=${BrianQC_DIR}
               -DFortran_ENABLED=${Fortran_ENABLED}

--- a/external/upstream/CMakeLists.txt
+++ b/external/upstream/CMakeLists.txt
@@ -21,6 +21,7 @@ foreach(dir
   openorbitaloptimizer
   optking
   simint
+  libcint
   libxc
   brianqc
   ddx

--- a/external/upstream/libcint/CMakeLists.txt
+++ b/external/upstream/libcint/CMakeLists.txt
@@ -1,0 +1,72 @@
+if(${ENABLE_libcint})
+    # libcint (Sun, J. Comput. Chem. 36, 1664, 2015) provides an optional
+    # alternative two-electron integral engine, selected at runtime with
+    # INTEGRAL_PACKAGE LIBCINT.
+    find_package(libcint CONFIG QUIET)
+
+    if(TARGET libcint::libcint)
+        get_property(_loc TARGET libcint::libcint PROPERTY LOCATION)
+        message(STATUS "${Cyan}Found libcint${ColourReset}: ${_loc} (found version ${libcint_VERSION})")
+        add_library(libcint_external INTERFACE)  # dummy
+
+        if(${CMAKE_INSIST_FIND_PACKAGE_libcint})
+            message(VERBOSE "Suitable libcint located externally as user insists")
+        endif()
+    else()
+        # No libcintConfig.cmake -- common for distro packages (e.g. Fedora).
+        # Locate the shared library and header and synthesize a config package
+        # so the core build's find_package(libcint CONFIG) succeeds.
+        find_library(LIBCINT_LIBRARY NAMES cint)
+        find_path(LIBCINT_INCLUDE_DIR NAMES cint.h)
+
+        if(LIBCINT_LIBRARY AND LIBCINT_INCLUDE_DIR)
+            message(STATUS "${Cyan}Found system libcint${ColourReset}: ${LIBCINT_LIBRARY}")
+            set(_gen ${CMAKE_CURRENT_BINARY_DIR}/libcint-config)
+            file(MAKE_DIRECTORY ${_gen})
+            file(WRITE ${_gen}/libcintConfig.cmake
+"if(NOT TARGET libcint::libcint)
+  add_library(libcint::libcint UNKNOWN IMPORTED)
+  set_target_properties(libcint::libcint PROPERTIES
+    IMPORTED_LOCATION \"${LIBCINT_LIBRARY}\"
+    INTERFACE_INCLUDE_DIRECTORIES \"${LIBCINT_INCLUDE_DIR}\")
+endif()
+set(libcint_VERSION \"system\")
+")
+            file(WRITE ${_gen}/libcintConfigVersion.cmake
+"set(PACKAGE_VERSION \"system\")
+set(PACKAGE_VERSION_COMPATIBLE TRUE)
+set(PACKAGE_VERSION_EXACT TRUE)
+")
+            set(libcint_DIR ${_gen} CACHE PATH "path to synthesized libcintConfig.cmake" FORCE)
+            add_library(libcint_external INTERFACE)  # dummy
+        else()
+            if(${CMAKE_INSIST_FIND_PACKAGE_libcint})
+                message(FATAL_ERROR "Suitable libcint could not be externally located as user insists")
+            endif()
+
+            include(ExternalProject)
+            message(STATUS "Suitable libcint could not be located, ${Magenta}Building libcint${ColourReset} instead.")
+            ExternalProject_Add(libcint_external
+                GIT_REPOSITORY https://github.com/sunqm/libcint
+                GIT_TAG v6.1.2
+                UPDATE_COMMAND ""
+                CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
+                           -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                           -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                           -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
+                           -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
+                           -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+                           -DWITH_RANGE_COULOMB=1
+                           -DWITH_FORTRAN=0
+                           -DENABLE_TEST=0
+                           -DENABLE_EXAMPLE=0
+                           -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_FPIC}
+                           -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+                CMAKE_CACHE_ARGS -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS})
+            set(libcint_DIR ${STAGED_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/libcint CACHE PATH "path to internally built libcintConfig.cmake" FORCE)
+        endif()
+    endif()
+else()
+    message(STATUS "Optional addon ${Blue}unsought: libcint${ColourReset}")
+    add_library(libcint_external INTERFACE)  # dummy
+endif()

--- a/psi4/CMakeLists.txt
+++ b/psi4/CMakeLists.txt
@@ -239,6 +239,15 @@ else()
     message(STATUS "Disabled simint ${simint_DIR}")
 endif()
 
+if(${ENABLE_libcint})
+    find_package(libcint CONFIG REQUIRED)
+    get_property(_loc TARGET libcint::libcint PROPERTY LOCATION)
+    list(APPEND _addons ${_loc})
+    message(STATUS "${Cyan}Using libcint${ColourReset}: ${_loc} (version ${libcint_VERSION})")
+else()
+    message(STATUS "Disabled libcint ${libcint_DIR}")
+endif()
+
 if(${ENABLE_BrianQC})
     find_package(BrianQC 1.1 CONFIG REQUIRED)  # edit in codedeps
     get_property(_loc TARGET BrianQC::static_wrapper PROPERTY LOCATION)

--- a/psi4/extras.py
+++ b/psi4/extras.py
@@ -155,6 +155,7 @@ _addons_ = {
     "cppe": which_import("cppe", return_bool=True),
     "ddx": which_import("pyddx", return_bool=True),
     "simint": _CMake_to_Py_boolean("@ENABLE_simint@"),
+    "libcint": _CMake_to_Py_boolean("@ENABLE_libcint@"),
     "dftd3": which_import("dftd3", return_bool=True),
     "cfour": psi4_which("xcfour", return_bool=True),
     "mrcc": psi4_which("dmrcc", return_bool=True),

--- a/psi4/src/psi4/CMakeLists.txt
+++ b/psi4/src/psi4/CMakeLists.txt
@@ -48,6 +48,11 @@ if(TARGET simint::simint)
   target_compile_definitions(psi4_optional_deps INTERFACE USING_simint)
 endif()
 
+if(TARGET libcint::libcint)
+  target_link_libraries(psi4_optional_deps INTERFACE libcint::libcint)
+  target_compile_definitions(psi4_optional_deps INTERFACE USING_libcint)
+endif()
+
 if(TARGET dkh::dkh)
   target_link_libraries(psi4_optional_deps INTERFACE dkh::dkh)
   # USING_dkh provided by dkh::dkh target itself

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -131,6 +131,13 @@ if(TARGET simint::simint)
     )
 endif()
 
+if(TARGET libcint::libcint)
+  target_sources(mints
+    PRIVATE
+      libcinteri.cc
+    )
+endif()
+
 # OpenOrbitalOptimizer needs to be PUBLIC so USING_OpenOrbitalOptimizer propagates
 # to modules that link to libmints (this enables armadillo support in matrix.h)
 # but doesn't pollute unrelated modules like libqt (which would get BLAS conflicts)

--- a/psi4/src/psi4/libmints/integral.cc
+++ b/psi4/src/psi4/libmints/integral.cc
@@ -56,6 +56,10 @@
 #include "psi4/libmints/siminteri.h"
 #endif
 
+#ifdef USING_libcint
+#include "psi4/libmints/libcinteri.h"
+#endif
+
 using namespace psi;
 
 IntegralFactory::IntegralFactory(std::shared_ptr<BasisSet> bs1, std::shared_ptr<BasisSet> bs2,
@@ -216,18 +220,28 @@ std::unique_ptr<TwoBodyAOInt> IntegralFactory::eri(int deriv, bool use_shell_pai
 #ifdef USING_simint
     if (deriv == 0 && integral_package == "SIMINT") return  std::make_unique<SimintERI>(this, deriv, use_shell_pairs, needs_exchange);
 #endif
+#ifdef USING_libcint
+    if (deriv == 0 && integral_package == "LIBCINT") return std::make_unique<LibcintERI>(this, deriv, use_shell_pairs, needs_exchange);
+#endif
     if (integral_package == "LIBINT2") return  std::make_unique<Libint2ERI>(this, threshold, deriv, use_shell_pairs, needs_exchange);
     if (deriv > 0 && integral_package != "LIBINT2")
         outfile->Printf("ERI derivative integrals only available using Libint");
     if (integral_package == "SIMINT")
         outfile->Printf("Chosen integral package " + integral_package +
                         " unavailable.\nRecompile with `-D ENABLE_simint=ON`.\nFalling back to Libint");
+    if (integral_package == "LIBCINT")
+        outfile->Printf("Chosen integral package " + integral_package +
+                        " unavailable.\nRecompile with `-D ENABLE_libcint=ON`.\nFalling back to Libint");
     throw PSIEXCEPTION("No ERI object to return.");
 }
 
 std::unique_ptr<TwoBodyAOInt> IntegralFactory::erf_eri(double omega, int deriv, bool use_shell_pairs, bool needs_exchange) {
     auto integral_package = Process::environment.options.get_str("INTEGRAL_PACKAGE");
     auto threshold = Process::environment.options.get_double("INTS_TOLERANCE");
+#ifdef USING_libcint
+    if (deriv == 0 && integral_package == "LIBCINT")
+        return std::make_unique<LibcintErfERI>(omega, this, deriv, use_shell_pairs, needs_exchange);
+#endif
     if (integral_package == "LIBINT2")
         return std::make_unique<Libint2ErfERI>(omega, this, threshold, deriv, use_shell_pairs, needs_exchange);
     throw PSIEXCEPTION("No ERI object to return.");
@@ -236,6 +250,10 @@ std::unique_ptr<TwoBodyAOInt> IntegralFactory::erf_eri(double omega, int deriv, 
 std::unique_ptr<TwoBodyAOInt> IntegralFactory::erf_complement_eri(double omega, int deriv, bool use_shell_pairs, bool needs_exchange) {
     auto integral_package = Process::environment.options.get_str("INTEGRAL_PACKAGE");
     auto threshold = Process::environment.options.get_double("INTS_TOLERANCE");
+#ifdef USING_libcint
+    if (deriv == 0 && integral_package == "LIBCINT")
+        return std::make_unique<LibcintErfComplementERI>(omega, this, deriv, use_shell_pairs, needs_exchange);
+#endif
     if (integral_package == "LIBINT2")
         return std::make_unique<Libint2ErfComplementERI>(omega, this, threshold, deriv, use_shell_pairs, needs_exchange);
     throw PSIEXCEPTION("No ERI object to return.");

--- a/psi4/src/psi4/libmints/libcinteri.cc
+++ b/psi4/src/psi4/libmints/libcinteri.cc
@@ -42,9 +42,13 @@ extern "C" {
 #include <cint.h>
 int int2e_sph(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env, CINTOpt *opt,
               double *cache);
+int int2e_cart(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env, CINTOpt *opt,
+               double *cache);
 void int2e_optimizer(CINTOpt **opt, int *atm, int natm, int *bas, int nbas, double *env);
 int int1e_ovlp_sph(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env,
                    CINTOpt *opt, double *cache);
+int int1e_ovlp_cart(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env,
+                    CINTOpt *opt, double *cache);
 double CINTgto_norm(int n, double a);
 }
 
@@ -71,6 +75,8 @@ inline int libcint_m(int i, int l) {
     return i - l;
 }
 
+inline int ncart(int l) { return (l + 1) * (l + 2) / 2; }
+
 }  // namespace
 
 LibcintTwoElectronInt::LibcintTwoElectronInt(const IntegralFactory *integral, int deriv, double omega,
@@ -79,17 +85,16 @@ LibcintTwoElectronInt::LibcintTwoElectronInt(const IntegralFactory *integral, in
     if (deriv_ != 0)
         throw PSIEXCEPTION("LIBCINT backend: integral derivatives are not implemented (use INTEGRAL_PACKAGE LIBINT2).");
 
-    // Spherical harmonics only for now; cartesian normalization differs from
-    // psi4's and would need a separate per-component rescale. Density fitting
-    // is supported by a simple jerry-rig: psi4 passes the "absent" center as a
-    // dummy s-shell (l=0, exp=0, coef=1) -- exactly libint2's unit shell, a
-    // constant function -- so the 4-center int2e_sph path with that dummy shell
-    // already yields the (ij|k) 3-center and (i|k) 2-center integrals.
+    // Determine whether the (non-dummy) bases are cartesian or spherical. psi4
+    // uses one convention per calculation (the PUREAM option), so a single flag
+    // suffices; the l=0 dummy shell is identical either way. Density fitting is
+    // handled by the dummy s-shell (l=0, exp=0) that psi4 places in the absent
+    // center's slot -- see append_basis / normalize_shells.
+    cart_ = false;
     for (const auto *bs : {original_bs1_.get(), original_bs2_.get(), original_bs3_.get(), original_bs4_.get()}) {
-        if (is_dummy_basis(*bs)) continue;  // handled shell-by-shell below
+        if (is_dummy_basis(*bs)) continue;
         for (int s = 0; s < bs->nshell(); ++s)
-            if (bs->shell(s).is_cartesian())
-                throw PSIEXCEPTION("LIBCINT backend: cartesian basis sets are not yet supported (spherical only).");
+            if (bs->shell(s).is_cartesian() && bs->shell(s).am() > 0) cart_ = true;
     }
 
     build_environment();
@@ -136,7 +141,7 @@ void LibcintTwoElectronInt::common_init() {
     int maxam = 0;
     for (const auto *bs : {original_bs1_.get(), original_bs2_.get(), original_bs3_.get(), original_bs4_.get()})
         maxam = std::max(maxam, bs->max_am());
-    const size_t nmax = static_cast<size_t>(2 * maxam + 1);
+    const size_t nmax = static_cast<size_t>(cart_ ? ncart(maxam) : 2 * maxam + 1);
     const size_t blk = nmax * nmax * nmax * nmax;
     target_store_.assign(blk, 0.0);
     cint_buf_.assign(blk, 0.0);
@@ -249,11 +254,19 @@ void LibcintTwoElectronInt::normalize_shells() {
         // Skip the dummy/unit shell (exp=0): its self-overlap diverges and it
         // must stay the bare constant to mirror libint2's unit shell.
         if (nprim == 1 && l == 0 && env_[exp_off] == 0.0) continue;
-        const int nf = 2 * l + 1;
+        const int nf = cart_ ? ncart(l) : 2 * l + 1;
         ov.assign(static_cast<size_t>(nf) * nf, 0.0);
         int shls[2] = {g, g};
-        int1e_ovlp_sph(ov.data(), nullptr, shls, atm_.data(), natm, bas_.data(), nbas, env_.data(), nullptr, nullptr);
-        const double s = ov[0];  // diagonal self-overlap (equal for all components)
+        if (cart_)
+            int1e_ovlp_cart(ov.data(), nullptr, shls, atm_.data(), natm, bas_.data(), nbas, env_.data(), nullptr, nullptr);
+        else
+            int1e_ovlp_sph(ov.data(), nullptr, shls, atm_.data(), natm, bas_.data(), nbas, env_.data(), nullptr, nullptr);
+        // ov[0] is the axial (l,0,0) cartesian / m=0 spherical self-overlap.
+        // Normalizing it to 1 matches libint2: for spherical every component
+        // shares this norm; for cartesian libint2 likewise normalizes the axial
+        // component and lets the off-axis ones follow, and libcint differs only
+        // by a single per-shell scale, so this one factor aligns the whole shell.
+        const double s = ov[0];
         if (s > 0.0) {
             const double inv = 1.0 / std::sqrt(s);
             for (int p = 0; p < nprim; ++p) env_[coef_off + p] *= inv;
@@ -261,32 +274,40 @@ void LibcintTwoElectronInt::normalize_shells() {
     }
 }
 
-size_t LibcintTwoElectronInt::compute_quartet(int g1, int g2, int g3, int g4, int n1, int n2, int n3, int n4) {
-    const int l1 = (n1 - 1) / 2, l2 = (n2 - 1) / 2, l3 = (n3 - 1) / 2, l4 = (n4 - 1) / 2;
+size_t LibcintTwoElectronInt::compute_quartet(int g1, int g2, int g3, int g4, int l1, int l2, int l3, int l4) {
+    const int n1 = cart_ ? ncart(l1) : 2 * l1 + 1;
+    const int n2 = cart_ ? ncart(l2) : 2 * l2 + 1;
+    const int n3 = cart_ ? ncart(l3) : 2 * l3 + 1;
+    const int n4 = cart_ ? ncart(l4) : 2 * l4 + 1;
     const size_t n = static_cast<size_t>(n1) * n2 * n3 * n4;
     if (cint_buf_.size() < n) cint_buf_.assign(n, 0.0);
 
     int shls[4] = {g1, g2, g3, g4};
     const int nbas = static_cast<int>(bas_.size() / BAS_SLOTS);
     const int natm = static_cast<int>(atm_.size() / ATM_SLOTS);
-    int ok = int2e_sph(cint_buf_.data(), nullptr, shls, atm_.data(), natm, bas_.data(), nbas, env_.data(),
-                       static_cast<CINTOpt *>(opt_), nullptr);
+    int ok = cart_ ? int2e_cart(cint_buf_.data(), nullptr, shls, atm_.data(), natm, bas_.data(), nbas, env_.data(),
+                                static_cast<CINTOpt *>(opt_), nullptr)
+                   : int2e_sph(cint_buf_.data(), nullptr, shls, atm_.data(), natm, bas_.data(), nbas, env_.data(),
+                               static_cast<CINTOpt *>(opt_), nullptr);
     double *tgt = target_full_;
     if (!ok) {
         std::fill(tgt, tgt + n, 0.0);
         return 0;
     }
 
-    // Repack: libcint is col-major (index 1 fastest) in m = -l..+l order;
-    // psi4 is row-major (index 1 slowest) in Gaussian-m order. Signs all +1.
+    // Repack libcint (col-major, index 1 fastest) into psi4 (row-major, index 1
+    // slowest), mapping each shell's components. Spherical: libcint m-order ->
+    // psi4 Gaussian-m order (all +1 signs). Cartesian: identity (libcint's
+    // cartesian order already equals psi4's CartesianIter order).
+    auto slot = [&](int i, int l) { return cart_ ? i : psi4_slot(libcint_m(i, l)); };
     for (int a = 0; a < n1; ++a) {
-        const int pa = psi4_slot(libcint_m(a, l1));
+        const int pa = slot(a, l1);
         for (int b = 0; b < n2; ++b) {
-            const int pb = psi4_slot(libcint_m(b, l2));
+            const int pb = slot(b, l2);
             for (int c = 0; c < n3; ++c) {
-                const int pc = psi4_slot(libcint_m(c, l3));
+                const int pc = slot(c, l3);
                 for (int d = 0; d < n4; ++d) {
-                    const int pd = psi4_slot(libcint_m(d, l4));
+                    const int pd = slot(d, l4);
                     const size_t iC =
                         static_cast<size_t>(a) + n1 * (static_cast<size_t>(b) + n2 * (static_cast<size_t>(c) + static_cast<size_t>(n3) * d));
                     const size_t iP = (((static_cast<size_t>(pa) * n2 + pb) * n3 + pc) * n4 + pd);
@@ -303,14 +324,13 @@ size_t LibcintTwoElectronInt::compute_shell(const AOShellCombinationsIterator &s
 }
 
 size_t LibcintTwoElectronInt::compute_shell(int s1, int s2, int s3, int s4) {
-    const int n1 = original_bs1_->shell(s1).nfunction();
-    const int n2 = original_bs2_->shell(s2).nfunction();
-    const int n3 = original_bs3_->shell(s3).nfunction();
-    const int n4 = original_bs4_->shell(s4).nfunction();
-    curr_buff_size_ = n1 * n2 * n3 * n4;
+    const int l1 = original_bs1_->shell(s1).am(), l2 = original_bs2_->shell(s2).am();
+    const int l3 = original_bs3_->shell(s3).am(), l4 = original_bs4_->shell(s4).am();
+    curr_buff_size_ = original_bs1_->shell(s1).nfunction() * original_bs2_->shell(s2).nfunction() *
+                      original_bs3_->shell(s3).nfunction() * original_bs4_->shell(s4).nfunction();
 
     const size_t ret = compute_quartet(bas_start_[0] + s1, bas_start_[1] + s2, bas_start_[2] + s3, bas_start_[3] + s4,
-                                       n1, n2, n3, n4);
+                                       l1, l2, l3, l4);
     buffers_[0] = target_full_;
     return ret;
 }
@@ -322,13 +342,11 @@ size_t LibcintTwoElectronInt::compute_shell_for_sieve(const std::shared_ptr<Basi
         if (kv.first == bs.get()) start = kv.second;
     if (start < 0) throw PSIEXCEPTION("LIBCINT backend: sieve basis not found in libcint environment.");
 
-    const int n1 = bs->shell(s1).nfunction();
-    const int n2 = bs->shell(s2).nfunction();
-    const int n3 = bs->shell(s3).nfunction();
-    const int n4 = bs->shell(s4).nfunction();
-    curr_buff_size_ = n1 * n2 * n3 * n4;
+    const int l1 = bs->shell(s1).am(), l2 = bs->shell(s2).am(), l3 = bs->shell(s3).am(), l4 = bs->shell(s4).am();
+    curr_buff_size_ = bs->shell(s1).nfunction() * bs->shell(s2).nfunction() * bs->shell(s3).nfunction() *
+                      bs->shell(s4).nfunction();
 
-    const size_t ret = compute_quartet(start + s1, start + s2, start + s3, start + s4, n1, n2, n3, n4);
+    const size_t ret = compute_quartet(start + s1, start + s2, start + s3, start + s4, l1, l2, l3, l4);
     buffers_[0] = target_full_;
     return ret;
 }

--- a/psi4/src/psi4/libmints/libcinteri.cc
+++ b/psi4/src/psi4/libmints/libcinteri.cc
@@ -80,12 +80,13 @@ LibcintTwoElectronInt::LibcintTwoElectronInt(const IntegralFactory *integral, in
         throw PSIEXCEPTION("LIBCINT backend: integral derivatives are not implemented (use INTEGRAL_PACKAGE LIBINT2).");
 
     // Spherical harmonics only for now; cartesian normalization differs from
-    // psi4's and would need a separate per-component rescale.
+    // psi4's and would need a separate per-component rescale. Density fitting
+    // is supported by a simple jerry-rig: psi4 passes the "absent" center as a
+    // dummy s-shell (l=0, exp=0, coef=1) -- exactly libint2's unit shell, a
+    // constant function -- so the 4-center int2e_sph path with that dummy shell
+    // already yields the (ij|k) 3-center and (i|k) 2-center integrals.
     for (const auto *bs : {original_bs1_.get(), original_bs2_.get(), original_bs3_.get(), original_bs4_.get()}) {
-        if (is_dummy_basis(*bs))
-            throw PSIEXCEPTION(
-                "LIBCINT backend: density-fitting (2-/3-center) integrals are handled by the native eri_2c/eri_3c "
-                "interface, not the 4-center path.");
+        if (is_dummy_basis(*bs)) continue;  // handled shell-by-shell below
         for (int s = 0; s < bs->nshell(); ++s)
             if (bs->shell(s).is_cartesian())
                 throw PSIEXCEPTION("LIBCINT backend: cartesian basis sets are not yet supported (spherical only).");
@@ -127,10 +128,16 @@ void LibcintTwoElectronInt::common_init() {
     int2e_optimizer(&o, atm_.data(), natm, bas_.data(), nbas, env_.data());
     opt_ = o;
 
-    // Largest single-quartet block (spherical) across the four bases.
-    auto maxn = [](const BasisSet &bs) { return 2 * bs.max_am() + 1; };
-    const size_t blk = static_cast<size_t>(maxn(*original_bs1_)) * maxn(*original_bs2_) * maxn(*original_bs3_) *
-                       maxn(*original_bs4_);
+    // Size scratch for the largest quartet block we may compute. This must
+    // cover not only the factory's (bs1,bs2,bs3,bs4) block but also the Schwarz
+    // sieve, which computes (MN|MN) over a single basis -- so a block up to
+    // (2*maxam+1)^4 for the largest-am basis (e.g. the auxiliary in DF, whose
+    // (MN|MN) blocks dwarf the aux*dummy*prim*prim factory block).
+    int maxam = 0;
+    for (const auto *bs : {original_bs1_.get(), original_bs2_.get(), original_bs3_.get(), original_bs4_.get()})
+        maxam = std::max(maxam, bs->max_am());
+    const size_t nmax = static_cast<size_t>(2 * maxam + 1);
+    const size_t blk = nmax * nmax * nmax * nmax;
     target_store_.assign(blk, 0.0);
     cint_buf_.assign(blk, 0.0);
     target_full_ = target_store_.data();
@@ -160,7 +167,22 @@ int LibcintTwoElectronInt::append_basis(const BasisSet &bs) {
         // (verified in-tree: unit shell self-overlap, ERIs to ~1e-13).
         const int l = sh.am();
         const int coef_off = static_cast<int>(env_.size());
-        for (int p = 0; p < nprim; ++p) env_.push_back(sh.original_coef(p) * CINTgto_norm(l, sh.exp(p)));
+        const bool dummy = (nprim == 1 && l == 0 && sh.exp(0) == 0.0);
+        if (dummy) {
+            // Unit shell = the bare constant function "1", matching
+            // libint2::Shell::unit() (its renorm() skips alpha==0, leaving
+            // coeff=1). CINTgto_norm is singular at exp=0 and cannot be used, so
+            // it is not applied here -- but libcint's spherical transform still
+            // folds the Y_00 = 1/sqrt(4*pi) normalization into every s shell.
+            // Feed sqrt(4*pi) to cancel it, so the dummy is a true constant 1 and
+            // the DF metric (P|Q) and 3-center (Q|mn) are *identical* to the
+            // Libint2 path, not merely proportional. A global scale on the metric
+            // would otherwise change which vectors a fixed linear-dependence
+            // threshold discards when it is inverted.
+            env_.push_back(std::sqrt(4.0 * M_PI));
+        } else {
+            for (int p = 0; p < nprim; ++p) env_.push_back(sh.original_coef(p) * CINTgto_norm(l, sh.exp(p)));
+        }
 
         bas_.push_back(bs.shell_to_center(s));  // ATOM_OF
         bas_.push_back(sh.am());                // ANG_OF
@@ -223,6 +245,10 @@ void LibcintTwoElectronInt::normalize_shells() {
         const int l = bas_[g * BAS_SLOTS + ANG_OF];
         const int nprim = bas_[g * BAS_SLOTS + NPRIM_OF];
         const int coef_off = bas_[g * BAS_SLOTS + PTR_COEFF];
+        const int exp_off = bas_[g * BAS_SLOTS + PTR_EXP];
+        // Skip the dummy/unit shell (exp=0): its self-overlap diverges and it
+        // must stay the bare constant to mirror libint2's unit shell.
+        if (nprim == 1 && l == 0 && env_[exp_off] == 0.0) continue;
         const int nf = 2 * l + 1;
         ov.assign(static_cast<size_t>(nf) * nf, 0.0);
         int shls[2] = {g, g};

--- a/psi4/src/psi4/libmints/libcinteri.cc
+++ b/psi4/src/psi4/libmints/libcinteri.cc
@@ -1,0 +1,343 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include "psi4/libmints/libcinteri.h"
+
+#include <algorithm>
+
+#include "psi4/libmints/integral.h"
+#include "psi4/libmints/basisset.h"
+#include "psi4/libmints/gshell.h"
+#include "psi4/libmints/molecule.h"
+#include "psi4/libpsi4util/exception.h"
+
+#include <cmath>
+
+extern "C" {
+#include <cint.h>
+int int2e_sph(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env, CINTOpt *opt,
+              double *cache);
+void int2e_optimizer(CINTOpt **opt, int *atm, int natm, int *bas, int nbas, double *env);
+int int1e_ovlp_sph(double *out, int *dims, int *shls, int *atm, int natm, int *bas, int nbas, double *env,
+                   CINTOpt *opt, double *cache);
+double CINTgto_norm(int n, double a);
+}
+
+namespace psi {
+
+namespace {
+
+/// Is this psi4 basis the density-fitting dummy (BasisSet::zero_ao_basis_set)?
+bool is_dummy_basis(const BasisSet &bs) {
+    return bs.nshell() == 1 && bs.nprimitive() == 1 && bs.shell(0).am() == 0 && bs.shell(0).exp(0) == 0.0;
+}
+
+/// psi4 / libint2-Gaussian spherical slot for magnetic quantum number m
+/// (m == 0 -> 0, m > 0 -> 2m-1, m < 0 -> -2m). All relative signs are +1
+/// (machine-verified against libint2 in Gaussian ordering, l = 0..4).
+inline int psi4_slot(int m) { return m == 0 ? 0 : (m > 0 ? 2 * m - 1 : -2 * m); }
+
+/// Magnetic quantum number of libcint spherical slot i for an l-shell. libcint
+/// orders l >= 2 as m = -l..+l (so m = i - l), but p functions (l == 1) are the
+/// special cartesian-like order (px, py, pz) = m(+1, -1, 0). Verified against
+/// libint2 (Gaussian ordering) to ~1e-14 for l = 0..4.
+inline int libcint_m(int i, int l) {
+    if (l == 1) return i == 0 ? +1 : (i == 1 ? -1 : 0);
+    return i - l;
+}
+
+}  // namespace
+
+LibcintTwoElectronInt::LibcintTwoElectronInt(const IntegralFactory *integral, int deriv, double omega,
+                                             bool use_shell_pairs, bool needs_exchange)
+    : TwoBodyAOInt(integral, deriv), opt_(nullptr), omega_(omega) {
+    if (deriv_ != 0)
+        throw PSIEXCEPTION("LIBCINT backend: integral derivatives are not implemented (use INTEGRAL_PACKAGE LIBINT2).");
+
+    // Spherical harmonics only for now; cartesian normalization differs from
+    // psi4's and would need a separate per-component rescale.
+    for (const auto *bs : {original_bs1_.get(), original_bs2_.get(), original_bs3_.get(), original_bs4_.get()}) {
+        if (is_dummy_basis(*bs))
+            throw PSIEXCEPTION(
+                "LIBCINT backend: density-fitting (2-/3-center) integrals are handled by the native eri_2c/eri_3c "
+                "interface, not the 4-center path.");
+        for (int s = 0; s < bs->nshell(); ++s)
+            if (bs->shell(s).is_cartesian())
+                throw PSIEXCEPTION("LIBCINT backend: cartesian basis sets are not yet supported (spherical only).");
+    }
+
+    build_environment();
+    common_init();
+}
+
+LibcintTwoElectronInt::LibcintTwoElectronInt(const LibcintTwoElectronInt &rhs)
+    : TwoBodyAOInt(rhs),
+      atm_(rhs.atm_),
+      bas_(rhs.bas_),
+      env_(rhs.env_),
+      opt_(nullptr),
+      basis_starts_(rhs.basis_starts_),
+      omega_(rhs.omega_) {
+    bas_start_[0] = rhs.bas_start_[0];
+    bas_start_[1] = rhs.bas_start_[1];
+    bas_start_[2] = rhs.bas_start_[2];
+    bas_start_[3] = rhs.bas_start_[3];
+    common_init();
+}
+
+LibcintTwoElectronInt::~LibcintTwoElectronInt() {
+    if (opt_) {
+        CINTOpt *o = static_cast<CINTOpt *>(opt_);
+        CINTdel_optimizer(&o);
+    }
+}
+
+void LibcintTwoElectronInt::common_init() {
+    // Range separation: env[PTR_RANGE_OMEGA] > 0 -> erf (long-range), < 0 -> erfc.
+    env_[PTR_RANGE_OMEGA] = omega_;
+
+    const int nbas = static_cast<int>(bas_.size() / BAS_SLOTS);
+    const int natm = static_cast<int>(atm_.size() / ATM_SLOTS);
+    CINTOpt *o = nullptr;
+    int2e_optimizer(&o, atm_.data(), natm, bas_.data(), nbas, env_.data());
+    opt_ = o;
+
+    // Largest single-quartet block (spherical) across the four bases.
+    auto maxn = [](const BasisSet &bs) { return 2 * bs.max_am() + 1; };
+    const size_t blk = static_cast<size_t>(maxn(*original_bs1_)) * maxn(*original_bs2_) * maxn(*original_bs3_) *
+                       maxn(*original_bs4_);
+    target_store_.assign(blk, 0.0);
+    cint_buf_.assign(blk, 0.0);
+    target_full_ = target_store_.data();
+    source_full_ = nullptr;
+    buffers_.resize(1, target_full_);
+
+    setup_sieve();
+    create_blocks();
+}
+
+int LibcintTwoElectronInt::append_basis(const BasisSet &bs) {
+    const int start = static_cast<int>(bas_.size() / BAS_SLOTS);
+    for (int s = 0; s < bs.nshell(); ++s) {
+        const GaussianShell &sh = bs.shell(s);
+        const int nprim = sh.nprimitive();
+
+        const int exp_off = static_cast<int>(env_.size());
+        for (int p = 0; p < nprim; ++p) env_.push_back(sh.exp(p));
+
+        // libcint takes env coefficients as multipliers of the *unnormalized*
+        // primitive, expecting the primitive normalization baked in via
+        // CINTgto_norm (the standard pyscf convention). psi4's *original*
+        // coefficients are the same normalized-contraction coefficients psi4
+        // hands libint2 (basisset.cc update_l2_shells), so
+        //   env_coef_p = original_coef_p * CINTgto_norm(l, a_p)
+        // reproduces libint2's embed-normalized basis function exactly
+        // (verified in-tree: unit shell self-overlap, ERIs to ~1e-13).
+        const int l = sh.am();
+        const int coef_off = static_cast<int>(env_.size());
+        for (int p = 0; p < nprim; ++p) env_.push_back(sh.original_coef(p) * CINTgto_norm(l, sh.exp(p)));
+
+        bas_.push_back(bs.shell_to_center(s));  // ATOM_OF
+        bas_.push_back(sh.am());                // ANG_OF
+        bas_.push_back(nprim);                  // NPRIM_OF
+        bas_.push_back(1);                      // NCTR_OF
+        bas_.push_back(0);                      // KAPPA_OF
+        bas_.push_back(exp_off);                // PTR_EXP
+        bas_.push_back(coef_off);               // PTR_COEFF
+        bas_.push_back(0);                      // RESERVE
+    }
+    return start;
+}
+
+void LibcintTwoElectronInt::build_environment() {
+    env_.assign(PTR_ENV_START, 0.0);
+
+    // Atoms: all four bases share one molecule (primary/auxiliary on the same
+    // nuclei), so one atm/coord table indexed by shell_to_center() suffices.
+    auto mol = original_bs1_->molecule();
+    const int natom = mol->natom();
+    for (int a = 0; a < natom; ++a) {
+        const int coord_off = static_cast<int>(env_.size());
+        env_.push_back(mol->x(a));
+        env_.push_back(mol->y(a));
+        env_.push_back(mol->z(a));
+        atm_.push_back(static_cast<int>(mol->true_atomic_number(a)));  // CHARGE_OF
+        atm_.push_back(coord_off);                                     // PTR_COORD
+        atm_.push_back(0);                                             // NUC_MOD_OF
+        atm_.push_back(0);                                             // PTR_ZETA
+        atm_.push_back(0);
+        atm_.push_back(0);
+    }
+
+    const BasisSet *bs[4] = {original_bs1_.get(), original_bs2_.get(), original_bs3_.get(), original_bs4_.get()};
+    for (int i = 0; i < 4; ++i) {
+        int start = -1;
+        for (const auto &kv : basis_starts_)
+            if (kv.first == bs[i]) start = kv.second;
+        if (start < 0) {
+            start = append_basis(*bs[i]);
+            basis_starts_.emplace_back(bs[i], start);
+        }
+        bas_start_[i] = start;
+    }
+
+    normalize_shells();
+}
+
+void LibcintTwoElectronInt::normalize_shells() {
+    // Rescale each shell's contraction to unit self-overlap, matching libint2's
+    // embed_normalization. Doing this through libcint's own int1e_ovlp keeps us
+    // convention-agnostic: generally-contracted bases that psi4 splits into
+    // segmented shells arrive here un-normalized, and this restores unit norm
+    // exactly as the Libint2 path does. Single-primitive shells are already
+    // unit-normalized via CINTgto_norm, so they are left effectively unchanged.
+    const int nbas = static_cast<int>(bas_.size() / BAS_SLOTS);
+    const int natm = static_cast<int>(atm_.size() / ATM_SLOTS);
+    std::vector<double> ov;
+    for (int g = 0; g < nbas; ++g) {
+        const int l = bas_[g * BAS_SLOTS + ANG_OF];
+        const int nprim = bas_[g * BAS_SLOTS + NPRIM_OF];
+        const int coef_off = bas_[g * BAS_SLOTS + PTR_COEFF];
+        const int nf = 2 * l + 1;
+        ov.assign(static_cast<size_t>(nf) * nf, 0.0);
+        int shls[2] = {g, g};
+        int1e_ovlp_sph(ov.data(), nullptr, shls, atm_.data(), natm, bas_.data(), nbas, env_.data(), nullptr, nullptr);
+        const double s = ov[0];  // diagonal self-overlap (equal for all components)
+        if (s > 0.0) {
+            const double inv = 1.0 / std::sqrt(s);
+            for (int p = 0; p < nprim; ++p) env_[coef_off + p] *= inv;
+        }
+    }
+}
+
+size_t LibcintTwoElectronInt::compute_quartet(int g1, int g2, int g3, int g4, int n1, int n2, int n3, int n4) {
+    const int l1 = (n1 - 1) / 2, l2 = (n2 - 1) / 2, l3 = (n3 - 1) / 2, l4 = (n4 - 1) / 2;
+    const size_t n = static_cast<size_t>(n1) * n2 * n3 * n4;
+    if (cint_buf_.size() < n) cint_buf_.assign(n, 0.0);
+
+    int shls[4] = {g1, g2, g3, g4};
+    const int nbas = static_cast<int>(bas_.size() / BAS_SLOTS);
+    const int natm = static_cast<int>(atm_.size() / ATM_SLOTS);
+    int ok = int2e_sph(cint_buf_.data(), nullptr, shls, atm_.data(), natm, bas_.data(), nbas, env_.data(),
+                       static_cast<CINTOpt *>(opt_), nullptr);
+    double *tgt = target_full_;
+    if (!ok) {
+        std::fill(tgt, tgt + n, 0.0);
+        return 0;
+    }
+
+    // Repack: libcint is col-major (index 1 fastest) in m = -l..+l order;
+    // psi4 is row-major (index 1 slowest) in Gaussian-m order. Signs all +1.
+    for (int a = 0; a < n1; ++a) {
+        const int pa = psi4_slot(libcint_m(a, l1));
+        for (int b = 0; b < n2; ++b) {
+            const int pb = psi4_slot(libcint_m(b, l2));
+            for (int c = 0; c < n3; ++c) {
+                const int pc = psi4_slot(libcint_m(c, l3));
+                for (int d = 0; d < n4; ++d) {
+                    const int pd = psi4_slot(libcint_m(d, l4));
+                    const size_t iC =
+                        static_cast<size_t>(a) + n1 * (static_cast<size_t>(b) + n2 * (static_cast<size_t>(c) + static_cast<size_t>(n3) * d));
+                    const size_t iP = (((static_cast<size_t>(pa) * n2 + pb) * n3 + pc) * n4 + pd);
+                    tgt[iP] = cint_buf_[iC];
+                }
+            }
+        }
+    }
+    return n;
+}
+
+size_t LibcintTwoElectronInt::compute_shell(const AOShellCombinationsIterator &shellIter) {
+    return compute_shell(shellIter.p(), shellIter.q(), shellIter.r(), shellIter.s());
+}
+
+size_t LibcintTwoElectronInt::compute_shell(int s1, int s2, int s3, int s4) {
+    const int n1 = original_bs1_->shell(s1).nfunction();
+    const int n2 = original_bs2_->shell(s2).nfunction();
+    const int n3 = original_bs3_->shell(s3).nfunction();
+    const int n4 = original_bs4_->shell(s4).nfunction();
+    curr_buff_size_ = n1 * n2 * n3 * n4;
+
+    const size_t ret = compute_quartet(bas_start_[0] + s1, bas_start_[1] + s2, bas_start_[2] + s3, bas_start_[3] + s4,
+                                       n1, n2, n3, n4);
+    buffers_[0] = target_full_;
+    return ret;
+}
+
+size_t LibcintTwoElectronInt::compute_shell_for_sieve(const std::shared_ptr<BasisSet> bs, int s1, int s2, int s3,
+                                                      int s4, bool /*is_bra*/) {
+    int start = -1;
+    for (const auto &kv : basis_starts_)
+        if (kv.first == bs.get()) start = kv.second;
+    if (start < 0) throw PSIEXCEPTION("LIBCINT backend: sieve basis not found in libcint environment.");
+
+    const int n1 = bs->shell(s1).nfunction();
+    const int n2 = bs->shell(s2).nfunction();
+    const int n3 = bs->shell(s3).nfunction();
+    const int n4 = bs->shell(s4).nfunction();
+    curr_buff_size_ = n1 * n2 * n3 * n4;
+
+    const size_t ret = compute_quartet(start + s1, start + s2, start + s3, start + s4, n1, n2, n3, n4);
+    buffers_[0] = target_full_;
+    return ret;
+}
+
+void LibcintTwoElectronInt::compute_shell_blocks(int shellpair12, int shellpair34, int /*npair12*/, int /*npair34*/) {
+    // This engine does not batch shells, so each block is a single quartet.
+    const int s1 = blocks12_[shellpair12][0].first;
+    const int s2 = blocks12_[shellpair12][0].second;
+    const int s3 = blocks34_[shellpair34][0].first;
+    const int s4 = blocks34_[shellpair34][0].second;
+    compute_shell(s1, s2, s3, s4);
+}
+
+size_t LibcintTwoElectronInt::compute_shell_deriv1(int, int, int, int) {
+    throw PSIEXCEPTION("LIBCINT backend: gradients are not implemented (use INTEGRAL_PACKAGE LIBINT2).");
+}
+
+size_t LibcintTwoElectronInt::compute_shell_deriv2(int, int, int, int) {
+    throw PSIEXCEPTION("LIBCINT backend: Hessians are not implemented (use INTEGRAL_PACKAGE LIBINT2).");
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+LibcintERI::LibcintERI(const IntegralFactory *integral, int deriv, bool use_shell_pairs, bool needs_exchange)
+    : LibcintTwoElectronInt(integral, deriv, 0.0, use_shell_pairs, needs_exchange) {}
+LibcintERI::LibcintERI(const LibcintERI &rhs) : LibcintTwoElectronInt(rhs) {}
+
+LibcintErfERI::LibcintErfERI(double omega, const IntegralFactory *integral, int deriv, bool use_shell_pairs,
+                             bool needs_exchange)
+    : LibcintTwoElectronInt(integral, deriv, omega, use_shell_pairs, needs_exchange) {}
+LibcintErfERI::LibcintErfERI(const LibcintErfERI &rhs) : LibcintTwoElectronInt(rhs) {}
+
+LibcintErfComplementERI::LibcintErfComplementERI(double omega, const IntegralFactory *integral, int deriv,
+                                                 bool use_shell_pairs, bool needs_exchange)
+    : LibcintTwoElectronInt(integral, deriv, -omega, use_shell_pairs, needs_exchange) {}
+LibcintErfComplementERI::LibcintErfComplementERI(const LibcintErfComplementERI &rhs) : LibcintTwoElectronInt(rhs) {}
+
+}  // namespace psi

--- a/psi4/src/psi4/libmints/libcinteri.h
+++ b/psi4/src/psi4/libmints/libcinteri.h
@@ -54,14 +54,20 @@ class IntegralFactory;
  *     unit self-overlap via libcint's own int1e_ovlp (normalize_shells) --
  *     matching libint2's embed_normalization, including split general
  *     contractions.
- *   - Component ordering: libcint uses m = -l..+l for l != 1 and the cartesian
- *     order (px,py,pz) for l == 1; psi4 (libint2, Gaussian solid-harmonic
- *     ordering) uses m = 0,+1,-1,+2,-2,... All relative signs are +1.
+ *   - Component ordering: for spherical shells libcint uses m = -l..+l for
+ *     l != 1 and the cartesian order (px,py,pz) for l == 1, while psi4 (libint2,
+ *     Gaussian solid-harmonic ordering) uses m = 0,+1,-1,+2,-2,...; for
+ *     cartesian shells (int2e_cart) libcint's order already equals psi4's
+ *     CartesianIter order, so the map is the identity. All relative signs +1.
+ *   - Cartesian normalization: libcint's cartesian shell differs from psi4's by
+ *     a single per-shell scale; normalizing the axial (l,0,0) self-overlap to 1
+ *     via int1e_ovlp_cart (see normalize_shells) cancels it.
  *   - libcint writes col-major (first index fastest); psi4 wants row-major
  *     (first index slowest). Both are handled in the same repack.
  *
- *  Current scope: 4-center (ab|cd), spherical basis sets, deriv=0, plus the
- *  range-separated erf/erfc variants (env[PTR_RANGE_OMEGA]). Density-fitting
+ *  Current scope: 4-center (ab|cd), spherical and cartesian basis sets,
+ *  deriv=0, plus the range-separated erf/erfc variants (env[PTR_RANGE_OMEGA]).
+ *  Density-fitting
  *  (2-/3-center) works too: psi4 passes the absent center as a dummy s-shell
  *  (l=0, exp=0) which is fed to libcint as a bare constant matching libint2's
  *  unit shell, so int2e_sph over the dummy yields (ij|k)/(i|k) integrals
@@ -91,6 +97,9 @@ class LibcintTwoElectronInt : public TwoBodyAOInt {
     /// (0 = full Coulomb, >0 = erf/long-range, <0 = erfc/short-range).
     double omega_;
 
+    /// Whether the (non-dummy) bases are cartesian (int2e_cart) or spherical.
+    bool cart_;
+
     void common_init();
 
     /// Build the libcint atm/bas/env arrays from the four psi4 basis sets.
@@ -102,9 +111,9 @@ class LibcintTwoElectronInt : public TwoBodyAOInt {
     /// Rescale each shell's contraction to unit self-overlap (matches libint2).
     void normalize_shells();
 
-    /// Compute one shell quartet into target_full_ in psi4 order. Returns the
-    /// number of integrals computed.
-    size_t compute_quartet(int g1, int g2, int g3, int g4, int n1, int n2, int n3, int n4);
+    /// Compute one shell quartet (given libcint bas indices and angular momenta)
+    /// into target_full_ in psi4 order. Returns the number of integrals computed.
+    size_t compute_quartet(int g1, int g2, int g3, int g4, int l1, int l2, int l3, int l4);
 
     size_t compute_shell_for_sieve(const std::shared_ptr<BasisSet> bs, int s1, int s2, int s3, int s4,
                                    bool is_bra) override;

--- a/psi4/src/psi4/libmints/libcinteri.h
+++ b/psi4/src/psi4/libmints/libcinteri.h
@@ -62,7 +62,11 @@ class IntegralFactory;
  *
  *  Current scope: 4-center (ab|cd), spherical basis sets, deriv=0, plus the
  *  range-separated erf/erfc variants (env[PTR_RANGE_OMEGA]). Density-fitting
- *  (2-/3-center) is handled by the native eri_2c/eri_3c interface, not here.
+ *  (2-/3-center) works too: psi4 passes the absent center as a dummy s-shell
+ *  (l=0, exp=0) which is fed to libcint as a bare constant matching libint2's
+ *  unit shell, so int2e_sph over the dummy yields (ij|k)/(i|k) integrals
+ *  bit-identical to the Libint2 path. (A first-class native 2c/3c interface is
+ *  the intended long-term replacement for that dummy-shell route.)
  */
 class LibcintTwoElectronInt : public TwoBodyAOInt {
    protected:

--- a/psi4/src/psi4/libmints/libcinteri.h
+++ b/psi4/src/psi4/libmints/libcinteri.h
@@ -1,0 +1,150 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#ifndef _psi4_libmints_libcinteri_h
+#define _psi4_libmints_libcinteri_h
+
+#include <memory>
+#include <vector>
+
+#include "psi4/libmints/twobody.h"
+
+namespace psi {
+
+class BasisSet;
+class GaussianShell;
+class IntegralFactory;
+
+/*! \ingroup MINTS
+ *  \class LibcintTwoElectronInt
+ *  \brief Two-electron repulsion integrals via libcint (Sun, J. Comput. Chem. 2015).
+ *
+ *  Experimental optional backend, selected with INTEGRAL_PACKAGE LIBCINT.
+ *
+ *  Design (validated against libint2 to ~1e-14 in-tree; ERIs, erf-ERIs and SCF
+ *  energies for s..f, cc-pVDZ/TZ and def2-SVP):
+ *   - Requests spherical integrals from libcint (int2e_sph).
+ *   - Basis functions are reproduced exactly by feeding libcint the *original*
+ *     coefficients scaled by CINTgto_norm, then rescaling each contraction to
+ *     unit self-overlap via libcint's own int1e_ovlp (normalize_shells) --
+ *     matching libint2's embed_normalization, including split general
+ *     contractions.
+ *   - Component ordering: libcint uses m = -l..+l for l != 1 and the cartesian
+ *     order (px,py,pz) for l == 1; psi4 (libint2, Gaussian solid-harmonic
+ *     ordering) uses m = 0,+1,-1,+2,-2,... All relative signs are +1.
+ *   - libcint writes col-major (first index fastest); psi4 wants row-major
+ *     (first index slowest). Both are handled in the same repack.
+ *
+ *  Current scope: 4-center (ab|cd), spherical basis sets, deriv=0, plus the
+ *  range-separated erf/erfc variants (env[PTR_RANGE_OMEGA]). Density-fitting
+ *  (2-/3-center) is handled by the native eri_2c/eri_3c interface, not here.
+ */
+class LibcintTwoElectronInt : public TwoBodyAOInt {
+   protected:
+    /// libcint environment describing all shells of the (deduplicated) bases.
+    std::vector<int> atm_;
+    std::vector<int> bas_;
+    std::vector<double> env_;
+    /// libcint CINTOpt* (held opaquely so the header stays free of <cint.h>).
+    void *opt_;
+
+    /// Global libcint bas-index of shell 0 of each of the four psi4 bases.
+    int bas_start_[4];
+    /// Deduplicated bases and their libcint bas starts (for sieve lookup).
+    std::vector<std::pair<const BasisSet *, int>> basis_starts_;
+
+    /// Owned buffer holding one shell quartet in psi4 order.
+    std::vector<double> target_store_;
+    /// Scratch for libcint's (col-major) output before repack into target_.
+    std::vector<double> cint_buf_;
+
+    /// Range-separation parameter written to env[PTR_RANGE_OMEGA]
+    /// (0 = full Coulomb, >0 = erf/long-range, <0 = erfc/short-range).
+    double omega_;
+
+    void common_init();
+
+    /// Build the libcint atm/bas/env arrays from the four psi4 basis sets.
+    void build_environment();
+
+    /// Append one psi4 basis set's shells to bas_/env_, return its bas start.
+    int append_basis(const BasisSet &bs);
+
+    /// Rescale each shell's contraction to unit self-overlap (matches libint2).
+    void normalize_shells();
+
+    /// Compute one shell quartet into target_full_ in psi4 order. Returns the
+    /// number of integrals computed.
+    size_t compute_quartet(int g1, int g2, int g3, int g4, int n1, int n2, int n3, int n4);
+
+    size_t compute_shell_for_sieve(const std::shared_ptr<BasisSet> bs, int s1, int s2, int s3, int s4,
+                                   bool is_bra) override;
+
+   public:
+    LibcintTwoElectronInt(const IntegralFactory *integral, int deriv = 0, double omega = 0.0,
+                          bool use_shell_pairs = false, bool needs_exchange = false);
+    LibcintTwoElectronInt(const LibcintTwoElectronInt &rhs);
+    ~LibcintTwoElectronInt() override;
+
+    size_t compute_shell(const AOShellCombinationsIterator &) override;
+    size_t compute_shell(int s1, int s2, int s3, int s4) override;
+
+    size_t compute_shell_deriv1(int, int, int, int) override;
+    size_t compute_shell_deriv2(int, int, int, int) override;
+
+    /// Single-shell blocks, mirroring the Libint2 backend.
+    void compute_shell_blocks(int shellpair12, int shellpair34, int npair12 = -1, int npair34 = -1) override;
+};
+
+class LibcintERI : public LibcintTwoElectronInt {
+   public:
+    LibcintERI(const IntegralFactory *integral, int deriv = 0, bool use_shell_pairs = false,
+               bool needs_exchange = false);
+    LibcintERI(const LibcintERI &rhs);
+    LibcintERI *clone() const override { return new LibcintERI(*this); }
+};
+
+class LibcintErfERI : public LibcintTwoElectronInt {
+   public:
+    LibcintErfERI(double omega, const IntegralFactory *integral, int deriv = 0, bool use_shell_pairs = false,
+                  bool needs_exchange = false);
+    LibcintErfERI(const LibcintErfERI &rhs);
+    LibcintErfERI *clone() const override { return new LibcintErfERI(*this); }
+};
+
+class LibcintErfComplementERI : public LibcintTwoElectronInt {
+   public:
+    LibcintErfComplementERI(double omega, const IntegralFactory *integral, int deriv = 0,
+                            bool use_shell_pairs = false, bool needs_exchange = false);
+    LibcintErfComplementERI(const LibcintErfComplementERI &rhs);
+    LibcintErfComplementERI *clone() const override { return new LibcintErfComplementERI(*this); }
+};
+
+}  // namespace psi
+
+#endif

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -162,8 +162,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     /*- Psi4 dies if energy does not converge. !expert -*/
     options.add_bool("DIE_IF_NOT_CONVERGED", true);
     /*- Integral package to use. If compiled with Simint or libcint support, change this option to use them; LibInt2 is
-       used otherwise. LIBCINT is experimental and currently covers 4-center (ab|cd) and range-separated erf/erfc
-       integrals for spherical basis sets (energies only). -*/
+       used otherwise. LIBCINT is experimental and currently covers 4-center (ab|cd), range-separated erf/erfc, and
+       density-fitted (2-/3-center) integrals for spherical basis sets (energies only; no gradients). -*/
     options.add_str("INTEGRAL_PACKAGE", "LIBINT2", "LIBINT2 SIMINT LIBCINT");
 #ifdef USING_BrianQC
     /*- Whether to enable using the BrianQC GPU module -*/

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -161,9 +161,10 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
 
     /*- Psi4 dies if energy does not converge. !expert -*/
     options.add_bool("DIE_IF_NOT_CONVERGED", true);
-    /*- Integral package to use. If compiled with Simint support, change this option to use them; LibInt2 is used
-       otherwise. -*/
-    options.add_str("INTEGRAL_PACKAGE", "LIBINT2", "LIBINT2 SIMINT");
+    /*- Integral package to use. If compiled with Simint or libcint support, change this option to use them; LibInt2 is
+       used otherwise. LIBCINT is experimental and currently covers 4-center (ab|cd) and range-separated erf/erfc
+       integrals for spherical basis sets (energies only). -*/
+    options.add_str("INTEGRAL_PACKAGE", "LIBINT2", "LIBINT2 SIMINT LIBCINT");
 #ifdef USING_BrianQC
     /*- Whether to enable using the BrianQC GPU module -*/
     options.add_bool("BRIANQC_ENABLE", false);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -163,7 +163,7 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     options.add_bool("DIE_IF_NOT_CONVERGED", true);
     /*- Integral package to use. If compiled with Simint or libcint support, change this option to use them; LibInt2 is
        used otherwise. LIBCINT is experimental and currently covers 4-center (ab|cd), range-separated erf/erfc, and
-       density-fitted (2-/3-center) integrals for spherical basis sets (energies only; no gradients). -*/
+       density-fitted (2-/3-center) integrals for spherical and cartesian basis sets (energies only; no gradients). -*/
     options.add_str("INTEGRAL_PACKAGE", "LIBINT2", "LIBINT2 SIMINT LIBCINT");
 #ifdef USING_BrianQC
     /*- Whether to enable using the BrianQC GPU module -*/

--- a/tests/pytests/addons.py
+++ b/tests/pytests/addons.py
@@ -84,6 +84,7 @@ _programs = {
     "psixas": which_import("psixas", return_bool=True),
     "resp": which_import("resp", return_bool=True),
     "simint": psi4.addons("simint"),
+    "libcint": psi4.addons("libcint"),
     "snsmp2": which_import("snsmp2", return_bool=True),
     "v2rdm_casscf": which_import("v2rdm_casscf", return_bool=True),
     "qcdb": False,  # capabilities of in-psi and out-of-psi qcdb not aligned

--- a/tests/pytests/test_libcint.py
+++ b/tests/pytests/test_libcint.py
@@ -1,0 +1,141 @@
+"""Cross-check the optional libcint integral backend against the default Libint2.
+
+libcint (INTEGRAL_PACKAGE=LIBCINT) is an experimental alternative two-electron
+integral engine. Every quantity it produces should match Libint2 to numerical
+precision: 4-center ERIs, range-separated erf ERIs, the density-fitting 2-/3-
+center integrals, and the resulting SCF/MP2 energies -- for both spherical and
+cartesian bases.
+"""
+
+import numpy as np
+import pytest
+
+from addons import uusing
+from utils import compare_values
+
+pytestmark = [pytest.mark.psi, pytest.mark.api]
+
+
+def _water():
+    import psi4
+
+    return psi4.geometry(
+        """
+        O  0.000000  0.000000  0.117790
+        H  0.000000  0.755453 -0.471160
+        H  0.000000 -0.755453 -0.471160
+        units angstrom
+        symmetry c1
+        """
+    )
+
+
+@uusing("libcint")
+@pytest.mark.parametrize("basis,puream", [
+    ("cc-pvdz", True),
+    ("cc-pvtz", True),
+    ("cc-pvdz", False),   # cartesian
+    ("6-31G*", False),    # cartesian
+])
+def test_libcint_ao_eri(basis, puream):
+    """4-center AO ERIs match Libint2 (spherical and cartesian)."""
+    import psi4
+
+    psi4.core.clean()
+    mol = _water()
+    psi4.set_options({"basis": basis, "puream": puream})
+
+    def ao_eri(pkg):
+        psi4.set_options({"integral_package": pkg})
+        wfn = psi4.core.Wavefunction.build(mol, psi4.core.get_global_option("BASIS"))
+        return np.asarray(psi4.core.MintsHelper(wfn.basisset()).ao_eri())
+
+    ref = ao_eri("libint2")
+    tst = ao_eri("libcint")
+    assert compare_values(ref, tst, 11, f"AO ERI {basis} puream={puream}")
+
+
+@uusing("libcint")
+def test_libcint_erf_eri():
+    """Range-separated erf AO ERIs match Libint2."""
+    import psi4
+
+    psi4.core.clean()
+    mol = _water()
+    psi4.set_options({"basis": "cc-pvdz", "puream": True})
+
+    def erf(pkg):
+        psi4.set_options({"integral_package": pkg})
+        wfn = psi4.core.Wavefunction.build(mol, psi4.core.get_global_option("BASIS"))
+        return np.asarray(psi4.core.MintsHelper(wfn.basisset()).ao_erf_eri(0.3))
+
+    assert compare_values(erf("libint2"), erf("libcint"), 11, "AO erf-ERI omega=0.3")
+
+
+@uusing("libcint")
+@pytest.mark.parametrize("puream", [True, False])
+def test_libcint_df_integrals(puream):
+    """Density-fitting 2-center (Q|P) and 3-center (Q|mn) match Libint2."""
+    import psi4
+
+    psi4.core.clean()
+    mol = _water()
+    psi4.set_options({"basis": "cc-pvdz", "puream": puream})
+    zero = psi4.core.BasisSet.zero_ao_basis_set()
+    prim = psi4.core.BasisSet.build(mol, "ORBITAL", "cc-pvdz", puream=puream)
+    aux = psi4.core.BasisSet.build(mol, "DF_BASIS_SCF", "cc-pvdz-jkfit", puream=puream)
+
+    def tensors(pkg):
+        psi4.set_options({"integral_package": pkg})
+        m = psi4.core.MintsHelper(prim)
+        metric = np.asarray(m.ao_eri(aux, zero, aux, zero))    # (Q|P)
+        three = np.asarray(m.ao_eri(aux, zero, prim, prim))    # (Q|mn)
+        return metric, three
+
+    m2, t2 = tensors("libint2")
+    mc, tc = tensors("libcint")
+    assert compare_values(m2, mc, 10, f"DF metric (Q|P) puream={puream}")
+    assert compare_values(t2, tc, 10, f"DF 3-center (Q|mn) puream={puream}")
+
+
+@uusing("libcint")
+@pytest.mark.parametrize("puream", [True, False])
+def test_libcint_scf_conventional(puream):
+    """Conventional (PK, 4-center) RHF energy matches Libint2."""
+    import psi4
+
+    psi4.core.clean()
+    _water()
+    psi4.set_options({
+        "basis": "cc-pvdz", "puream": puream, "scf_type": "pk",
+        "guess": "core", "df_scf_guess": False,
+        "e_convergence": 1e-10, "d_convergence": 1e-10,
+    })
+
+    def scf(pkg):
+        psi4.set_options({"integral_package": pkg})
+        psi4.core.clean()
+        return psi4.energy("scf")
+
+    assert compare_values(scf("libint2"), scf("libcint"), 9, f"PK-SCF puream={puream}")
+
+
+@uusing("libcint")
+@pytest.mark.parametrize("method", ["scf", "mp2"])
+def test_libcint_df_energies(method):
+    """Density-fitted RHF and MP2 energies match Libint2."""
+    import psi4
+
+    psi4.core.clean()
+    _water()
+    psi4.set_options({
+        "basis": "cc-pvdz", "puream": True, "scf_type": "df", "mp2_type": "df",
+        "e_convergence": 1e-9, "d_convergence": 1e-9,
+    })
+
+    def energy(pkg):
+        psi4.set_options({"integral_package": pkg})
+        psi4.core.clean()
+        return psi4.energy(method)
+
+    assert compare_values(energy("libint2"), energy("libcint"), 8, f"DF-{method.upper()}")


### PR DESCRIPTION
## Description

Adds **libcint** ([Sun, *J. Comput. Chem.* **36**, 1664, 2015](https://doi.org/10.1002/jcc.23981)) as an optional alternative to Libint2 for two-electron integrals, selected at runtime with `INTEGRAL_PACKAGE LIBCINT` and enabled at build time with `-DENABLE_libcint=ON`. **Libint2 remains the default; nothing changes unless the option is set.**

This is a first, energy-only backend intended to grow toward a full second integral engine.

### Scope

| Capability | Status |
|---|---|
| 4-center `(ab\|cd)` | ✅ |
| Range-separated erf/erfc | ✅ (`env[PTR_RANGE_OMEGA]`) |
| Density fitting (2-/3-center) | ✅ via the dummy/unit shell psi4 already uses |
| Spherical **and** cartesian bases | ✅ |
| Gradients / Hessians | ❌ throws a clear message (libint2 only) |

Everything is validated against Libint2 to ~1e-14 (integrals) and to convergence (energies): 4-center ERIs, erf ERIs, DF metric `(Q|P)` and 3-center `(Q|mn)`, conventional (PK) RHF, and DF-RHF/DF-MP2 — over H2O/CH4/HCl/NH3 with cc-pVDZ, cc-pVTZ (through f), def2-SVP, and 6-31G*.

### How it works

- Requests `int2e_sph`/`int2e_cart` and repacks libcint's column-major output into psi4's row-major layout, mapping components: spherical uses libcint's `m = -l..+l` (with the `p`-shell `(px,py,pz)` special case) onto psi4's Gaussian solid-harmonic order; cartesian is the identity (libcint's cartesian order already equals psi4's `CartesianIter`).
- Reproduces psi4's basis functions exactly by feeding original coefficients × `CINTgto_norm` and renormalizing each contraction to unit self-overlap through libcint's own `int1e_ovlp` (handles split general contractions the way Libint2's `embed_normalization` does).
- **DF** reuses psi4's existing mechanism (the absent center arrives as a dummy `l=0, exp=0` shell). Feeding that dummy a coefficient of `sqrt(4*pi)` makes it a true constant `1` matching `libint2::Shell::unit()`, so the fitting metric is *identical* (not merely proportional) to the Libint2 path — important so that a fixed linear-dependence threshold prunes the same vectors when the metric is inverted.

### Build

libcint ships no CMake config on some distros (e.g. Fedora); `external/upstream/libcint` locates a system install and synthesizes a config, or builds from source otherwise.

### Tests

`tests/pytests/test_libcint.py` (gated on `@uusing("libcint")`) cross-checks all of the above against Libint2; it skips cleanly when libcint is not compiled in.

### Not included (future work)

- Gradients/Hessians — libcint only returns one center per call (`int2e_ip1`), so all 12/78 derivative buffers must be assembled via translational invariance and finite-difference validated; a focused follow-up each.
- A first-class native 2c/3c `IntegralFactory` interface to replace the dummy-shell DF route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
