### PR TITLE
Add semicanonicalize() for ROHF reference in run_sapt (fix #1975)

### DIFF
--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -5025,6 +5025,14 @@ def run_sapt(name, **kwargs):
     monomerB_wfn = scf_helper('RHF', molecule=monomerB, **kwargs)
     core.timer_off("SAPT: Monomer B SCF")
 
+    # Psi4 issue #1975: ROHF orbitals require semicanonicalization before
+    # SAPT second-order amplitudes are computed. Without this, the orbital
+    # energies used in the amplitude denominators are ambiguously defined
+    # and Ind20/Disp20 are wrong for ROHF references.
+    if core.get_option('SCF', 'REFERENCE') == 'ROHF':
+        monomerA_wfn.semicanonicalize()
+        monomerB_wfn.semicanonicalize()
+
     # Delta MP2
     if do_delta_mp2:
         select_mp2("mp2", ref_wfn=monomerB_wfn, **kwargs)


### PR DESCRIPTION
Fixes #1975

## Root cause

SAPT second-order amplitudes (Ind20, Exch-Ind20, Disp20, Exch-Disp20) are computed using orbital energy denominators. For ROHF references, the orbital energies are not uniquely defined — the coupling between closed and open shells in the Fock matrix leads to ambiguous canonical orbital energies unless `semicanonicalize()` is called. UHF orbitals are naturally canonical.

## Fix

Add `monomerA_wfn.semicanonicalize()` and `monomerB_wfn.semicanonicalize()` in `run_sapt` immediately after the monomer SCF computations, conditional on `REFERENCE == 'ROHF'`.

## Verification (Psi4 1.11, triplet He dimer / d-aug-cc-pvdz)

| Term | UHF | ROHF (before fix) | ROHF (after fix) |
|------|-----|-------------------|------------------|
| Elst | −0.04152 | −0.04152 | −0.04152 |
| Exch | +0.02207 | +0.02207 | +0.02207 |
| **Ind20** | **−0.01457** | **−0.02320 (wrong by 59%)** | **−0.01457** |
| **Disp20** | **−0.001634** | **−0.002353 (wrong by 44%)** | **−0.001634** |

After the fix, ROHF second-order terms agree with UHF to < 3e-9 Eh. First-order terms (Elst, Exch) were already correct (do not use orbital energy denominators).

## Impact

Only `sapt0` with `reference rohf` is affected. All other references (RHF, UHF) and all first-order terms are unaffected.