### PR TITLE
Support for Dimension range-based for loop

### DIFF
--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -116,6 +116,14 @@ class PSI_API Dimension {
 
     void print() const;
 
+    // Forward underlying vector's iterators
+    // This allows for range-based for loops:
+    //    for (auto h : nsopi_) { ... }
+    auto begin() { return blocks_.begin(); }
+    auto end() { return blocks_.end(); }
+    auto begin() const { return blocks_.begin(); }
+    auto end() const { return blocks_.end(); }
+
     // Only used for python
     const int& get(size_t i) const { return blocks_[i]; }
     void set(size_t i, int val) { blocks_[i] = val; }

--- a/psi4/src/psi4/libmints/dimension.h
+++ b/psi4/src/psi4/libmints/dimension.h
@@ -119,10 +119,10 @@ class PSI_API Dimension {
     // Forward underlying vector's iterators
     // This allows for range-based for loops:
     //    for (auto h : nsopi_) { ... }
-    auto begin() { return blocks_.begin(); }
-    auto end() { return blocks_.end(); }
-    auto begin() const { return blocks_.begin(); }
-    auto end() const { return blocks_.end(); }
+    auto begin() noexcept { return blocks_.begin(); }
+    auto end() noexcept { return blocks_.end(); }
+    auto begin() const noexcept { return blocks_.begin(); }
+    auto end() const noexcept { return blocks_.end(); }
 
     // Only used for python
     const int& get(size_t i) const { return blocks_[i]; }


### PR DESCRIPTION
## Description

Allows the following syntax:
```c++
for (auto& h : nmopi_) { h *= 2; }
```
Or for einsums-type quantities
```c++
std::vector<size_t> dim(nirreps_);
for (auto&& [h, d] : std::views::zip(nsopi_, dim)) {
    d = static_cast<size_t>(2*h);
}
ComplexMatrix D_{"Density", dim, dim};
```
This showed up in my ComplexWavefunction work a bit and I think it makes things a bit easier.

## User API & Changelog headlines

- [x] Added `Dimension::begin()` and `::end()`. Forwards to internal `blocks_.begin()` and `end()`. Allows for range-based for loops over Dimension objects.

## AI
None

## Checklist
- [x] Tests added for any new features

## Status
- [x] Ready for review
