### PR TITLE
Let users set diis vectors in CCENERGY

### DIFF
--- a/psi4/src/psi4/cc/ccenergy/Params.h
+++ b/psi4/src/psi4/cc/ccenergy/Params.h
@@ -51,6 +51,7 @@ struct Params {
     int cachetype;
     int ref;
     int diis;
+    int max_diis_vecs;
     std::string wfn;
     int print;
     int local;

--- a/psi4/src/psi4/cc/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/cc/ccenergy/ccenergy.cc
@@ -59,14 +59,14 @@
 // Forward declaration to call cctriples
 namespace psi {
 namespace cctriples {
-PsiReturnType cctriples(std::shared_ptr<Wavefunction> reference_wavefunction, Options &options);
+PsiReturnType cctriples(std::shared_ptr<Wavefunction> reference_wavefunction, Options& options);
 }
 }  // namespace psi
 
 namespace psi {
 namespace ccenergy {
 
-CCEnergyWavefunction::CCEnergyWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction, Options &options)
+CCEnergyWavefunction::CCEnergyWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction, Options& options)
     : Wavefunction(options) {
     set_reference_wavefunction(reference_wavefunction);
     init();
@@ -86,7 +86,7 @@ void CCEnergyWavefunction::init() {
 
 double CCEnergyWavefunction::compute_energy() {
     int done = 0;
-    int **cachelist;
+    int** cachelist;
 
     moinfo_.iter = 0;
 
@@ -100,7 +100,7 @@ double CCEnergyWavefunction::compute_energy() {
 
     if (params_.ref == 2) { /** UHF **/
         cachelist = cacheprep_uhf(params_.cachelev, cachefiles.data());
-        std::vector<std::pair<Dimension, int *>> spaces;
+        std::vector<std::pair<Dimension, int*>> spaces;
         spaces.emplace_back(moinfo_.aoccpi, moinfo_.aocc_sym);
         spaces.emplace_back(moinfo_.avirtpi, moinfo_.avir_sym);
         spaces.emplace_back(moinfo_.boccpi, moinfo_.bocc_sym);
@@ -112,7 +112,7 @@ double CCEnergyWavefunction::compute_energy() {
         if (params_.df) {
             form_df_ints(options_, cachelist, cachefiles.data());
         } else if (params_.aobasis != "NONE") { /* Set up new DPD's for AO-basis algorithm */
-            std::vector<std::pair<Dimension, int *>> aospaces;
+            std::vector<std::pair<Dimension, int*>> aospaces;
             aospaces.emplace_back(moinfo_.aoccpi, moinfo_.aocc_sym);
             aospaces.emplace_back(moinfo_.sopi, moinfo_.sosym);
             aospaces.emplace_back(moinfo_.boccpi, moinfo_.bocc_sym);
@@ -124,7 +124,7 @@ double CCEnergyWavefunction::compute_energy() {
     } else { /** RHF or ROHF **/
         cachelist = cacheprep_rhf(params_.cachelev, cachefiles.data());
         init_priority_list();
-        std::vector<std::pair<Dimension, int *>> spaces;
+        std::vector<std::pair<Dimension, int*>> spaces;
         spaces.emplace_back(moinfo_.occpi, moinfo_.occ_sym);
         spaces.emplace_back(moinfo_.virtpi, moinfo_.vir_sym);
         dpd_init(0, moinfo_.nirreps, params_.memory, params_.cachetype, cachefiles.data(), cachelist,
@@ -133,7 +133,7 @@ double CCEnergyWavefunction::compute_energy() {
         if (params_.df) {
             form_df_ints(options_, cachelist, cachefiles.data());
         } else if (params_.aobasis != "NONE") { /* Set up new DPD for AO-basis algorithm */
-            std::vector<std::pair<Dimension, int *>> aospaces;
+            std::vector<std::pair<Dimension, int*>> aospaces;
             aospaces.emplace_back(moinfo_.occpi, moinfo_.occ_sym);
             aospaces.emplace_back(moinfo_.sopi, moinfo_.sosym);
             dpd_init(1, moinfo_.nirreps, params_.memory, 0, cachefiles.data(), cachelist, nullptr, aospaces);
@@ -163,7 +163,7 @@ double CCEnergyWavefunction::compute_energy() {
     if (params_.ref == 0 || params_.ref == 2) {
         moinfo_.emp2 = mp2_energy();
         outfile->Printf("MP2 correlation energy %4.16f\n", moinfo_.emp2);
-        psio_write_entry(PSIF_CC_INFO, "MP2 Energy", (char *)&(moinfo_.emp2), sizeof(double));
+        psio_write_entry(PSIF_CC_INFO, "MP2 Energy", (char*)&(moinfo_.emp2), sizeof(double));
         Process::environment.globals["MP2 CORRELATION ENERGY"] = moinfo_.emp2;
         Process::environment.globals["MP2 TOTAL ENERGY"] = moinfo_.emp2 + moinfo_.eref;
         Process::environment.globals["MP2 SINGLES ENERGY"] = moinfo_.emp2_s;
@@ -185,7 +185,7 @@ double CCEnergyWavefunction::compute_energy() {
     moinfo_.ecc = energy();
 
     auto nocc_act = moinfo_.clsdpi.sum();
-    std::vector<double> emp2_aa(nocc_act * (nocc_act - 1) /2);
+    std::vector<double> emp2_aa(nocc_act * (nocc_act - 1) / 2);
     std::vector<double> emp2_ab(nocc_act * nocc_act);
     pair_energies(emp2_aa, emp2_ab);
     double last_energy = 0;
@@ -380,7 +380,7 @@ double CCEnergyWavefunction::compute_energy() {
             outfile->Printf("      * LCC2 (+LMP2) total energy             = %20.15f\n",
                             moinfo_.eref + moinfo_.ecc + local_.weak_pair_energy);
             Process::environment.globals["LCC2 (+LMP2) TOTAL ENERGY"] =
-                            moinfo_.eref + moinfo_.ecc + local_.weak_pair_energy;
+                moinfo_.eref + moinfo_.ecc + local_.weak_pair_energy;
         }
     } else {
         if (params_.scscc) {
@@ -426,7 +426,7 @@ double CCEnergyWavefunction::compute_energy() {
             outfile->Printf("      * LCCSD (+LMP2) total energy            = %20.15f\n",
                             moinfo_.eref + moinfo_.ecc + local_.weak_pair_energy);
             Process::environment.globals["LCCSD (+LMP2) TOTAL ENERGY"] =
-                            moinfo_.eref + moinfo_.ecc + local_.weak_pair_energy;
+                moinfo_.eref + moinfo_.ecc + local_.weak_pair_energy;
         }
     }
     outfile->Printf("\n");
@@ -435,7 +435,7 @@ double CCEnergyWavefunction::compute_energy() {
     if (params_.ref == 0) spinad_amps();
 
     /* Compute pair energies */
-    std::vector<double> ecc_aa(nocc_act * (nocc_act - 1) /2);
+    std::vector<double> ecc_aa(nocc_act * (nocc_act - 1) / 2);
     std::vector<double> ecc_ab(nocc_act * nocc_act);
     if (params_.print_pair_energies) {
         pair_energies(ecc_aa, ecc_ab);
@@ -491,10 +491,14 @@ double CCEnergyWavefunction::compute_energy() {
         // Run cctriples
         if (psi::cctriples::cctriples(reference_wavefunction_, options_) == Success) {
             energy_ = Process::environment.globals["CURRENT ENERGY"];
-            set_scalar_variable("(T) CORRECTION ENERGY", reference_wavefunction_->scalar_variable("(T) CORRECTION ENERGY"));
-            set_scalar_variable("CCSD(T) CORRELATION ENERGY", reference_wavefunction_->scalar_variable("CCSD(T) CORRELATION ENERGY"));
-            set_scalar_variable("CCSD(T) TOTAL ENERGY", reference_wavefunction_->scalar_variable("CCSD(T) TOTAL ENERGY"));
-            set_scalar_variable("CURRENT CORRELATION ENERGY", reference_wavefunction_->scalar_variable("CCSD(T) CORRELATION ENERGY"));
+            set_scalar_variable("(T) CORRECTION ENERGY",
+                                reference_wavefunction_->scalar_variable("(T) CORRECTION ENERGY"));
+            set_scalar_variable("CCSD(T) CORRELATION ENERGY",
+                                reference_wavefunction_->scalar_variable("CCSD(T) CORRELATION ENERGY"));
+            set_scalar_variable("CCSD(T) TOTAL ENERGY",
+                                reference_wavefunction_->scalar_variable("CCSD(T) TOTAL ENERGY"));
+            set_scalar_variable("CURRENT CORRELATION ENERGY",
+                                reference_wavefunction_->scalar_variable("CCSD(T) CORRELATION ENERGY"));
             set_scalar_variable("CURRENT ENERGY", reference_wavefunction_->scalar_variable("CCSD(T) TOTAL ENERGY"));
         } else {
             energy_ = 0.0;
@@ -540,7 +544,7 @@ void CCEnergyWavefunction::one_step() {
     moinfo_.ecc = energy();
     outfile->Printf("\n    Values computed from T amplitudes on disk.\n");
     outfile->Printf("Reference expectation value computed: %20.15lf\n", moinfo_.ecc);
-    psio_write_entry(PSIF_CC_HBAR, "Reference expectation value", (char *)&(moinfo_.ecc), sizeof(double));
+    psio_write_entry(PSIF_CC_HBAR, "Reference expectation value", (char*)&(moinfo_.ecc), sizeof(double));
 
     if (params_.just_residuals) {
         Fme_build();

--- a/psi4/src/psi4/cc/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/cc/ccenergy/ccenergy.cc
@@ -82,8 +82,6 @@ void CCEnergyWavefunction::init() {
     // location, make this object's densities point to a different memory locationn
     Da_ = reference_wavefunction_->Da()->clone();
     Db_ = reference_wavefunction_->same_a_b_dens() ? Da_ : reference_wavefunction_->Db()->clone();
-
-    max_diis_vecs_ = options_.get_int("DIIS_MAX_VECS");
 }
 
 double CCEnergyWavefunction::compute_energy() {
@@ -282,7 +280,7 @@ double CCEnergyWavefunction::compute_energy() {
             if (params_.analyze != 0) analyze();
             break;
         }
-        if (params_.diis) diis(moinfo_.iter);
+        if (params_.diis && params_.max_diis_vecs > 0) diis(moinfo_.iter);
         tsave();
         tau_build();
         taut_build();

--- a/psi4/src/psi4/cc/ccenergy/ccenergy.cc
+++ b/psi4/src/psi4/cc/ccenergy/ccenergy.cc
@@ -82,6 +82,8 @@ void CCEnergyWavefunction::init() {
     // location, make this object's densities point to a different memory locationn
     Da_ = reference_wavefunction_->Da()->clone();
     Db_ = reference_wavefunction_->same_a_b_dens() ? Da_ : reference_wavefunction_->Db()->clone();
+
+    max_diis_vecs_ = options_.get_int("DIIS_MAX_VECS");
 }
 
 double CCEnergyWavefunction::compute_energy() {

--- a/psi4/src/psi4/cc/ccenergy/diis_RHF.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis_RHF.cc
@@ -60,7 +60,7 @@ namespace ccenergy {
 */
 
 void CCEnergyWavefunction::diis_RHF(int iter) {
-    int nvector = max_diis_vecs_; /* Number of error vectors to keep */
+    int nvector = params_.max_diis_vecs; /* Number of error vectors to keep */
     dpdfile2 T1, T1a, T1b;
     dpdbuf4 T2, T2a, T2b;
     psio_address start, end;

--- a/psi4/src/psi4/cc/ccenergy/diis_RHF.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis_RHF.cc
@@ -125,7 +125,7 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
     global_dpd_->buf4_close(&T2b);
 
     start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
-    psio_write(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)error[0], vector_length * sizeof(double), start, &end);
+    psio_write(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)error[0], vector_length * sizeof(double), start, &end);
 
     /* Store the current amplitude vector on disk */
     word = 0;
@@ -150,7 +150,7 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
     global_dpd_->buf4_close(&T2a);
 
     start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
-    psio_write(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)error[0], vector_length * sizeof(double), start,
+    psio_write(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char*)error[0], vector_length * sizeof(double), start,
                &end);
 
     /* If we haven't run through enough iterations, set the correct dimensions
@@ -169,7 +169,7 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
     for (int p = 0; p < nvector; p++) {
         start = psio_get_address(PSIO_ZERO, sizeof(double) * p * vector_length);
 
-        psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[0], vector_length * sizeof(double), start,
+        psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)vector[0], vector_length * sizeof(double), start,
                   &end);
 
         product = C_DDOT(vector_length, vector[0], 1, vector[0], 1);
@@ -180,7 +180,7 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
         for (int q = 0; q < p; q++) {
             start = psio_get_address(PSIO_ZERO, sizeof(double) * q * vector_length);
 
-            psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[1], vector_length * sizeof(double), start,
+            psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)vector[1], vector_length * sizeof(double), start,
                       &end);
 
             // dot_arr(vector[1], vector[0], vector_length, &product);
@@ -220,7 +220,7 @@ void CCEnergyWavefunction::diis_RHF(int iter) {
     for (int p = 0; p < nvector; p++) {
         start = psio_get_address(PSIO_ZERO, sizeof(double) * p * vector_length);
 
-        psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)vector[0], vector_length * sizeof(double), start,
+        psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char*)vector[0], vector_length * sizeof(double), start,
                   &end);
 
         for (int q = 0; q < vector_length; q++) error[0][q] += C[p] * vector[0][q];

--- a/psi4/src/psi4/cc/ccenergy/diis_RHF.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis_RHF.cc
@@ -60,7 +60,7 @@ namespace ccenergy {
 */
 
 void CCEnergyWavefunction::diis_RHF(int iter) {
-    int nvector = 8; /* Number of error vectors to keep */
+    int nvector = max_diis_vecs_; /* Number of error vectors to keep */
     dpdfile2 T1, T1a, T1b;
     dpdbuf4 T2, T2a, T2b;
     psio_address start, end;

--- a/psi4/src/psi4/cc/ccenergy/diis_ROHF.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis_ROHF.cc
@@ -168,7 +168,7 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
     global_dpd_->buf4_close(&T2b);
 
     start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
-    psio_write(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)error[0], vector_length * sizeof(double), start, &end);
+    psio_write(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)error[0], vector_length * sizeof(double), start, &end);
 
     /* Store the current amplitude vector on disk */
     word = 0;
@@ -221,7 +221,7 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
     global_dpd_->buf4_close(&T2a);
 
     start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
-    psio_write(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)error[0], vector_length * sizeof(double), start,
+    psio_write(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char*)error[0], vector_length * sizeof(double), start,
                &end);
 
     /* If we haven't run through enough iterations, set the correct dimensions
@@ -240,7 +240,7 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
     for (int p = 0; p < nvector; p++) {
         start = psio_get_address(PSIO_ZERO, sizeof(double) * p * vector_length);
 
-        psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[0], vector_length * sizeof(double), start,
+        psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)vector[0], vector_length * sizeof(double), start,
                   &end);
 
         // dot_arr(vector[0], vector[0], vector_length, &product);
@@ -251,7 +251,7 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
         for (int q = 0; q < p; q++) {
             start = psio_get_address(PSIO_ZERO, sizeof(double) * q * vector_length);
 
-            psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[1], vector_length * sizeof(double), start,
+            psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)vector[1], vector_length * sizeof(double), start,
                       &end);
 
             // dot_arr(vector[1], vector[0], vector_length, &product);
@@ -291,7 +291,7 @@ void CCEnergyWavefunction::diis_ROHF(int iter) {
     for (int p = 0; p < nvector; p++) {
         start = psio_get_address(PSIO_ZERO, sizeof(double) * p * vector_length);
 
-        psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)vector[0], vector_length * sizeof(double), start,
+        psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char*)vector[0], vector_length * sizeof(double), start,
                   &end);
 
         for (int q = 0; q < vector_length; q++) error[0][q] += C[p] * vector[0][q];

--- a/psi4/src/psi4/cc/ccenergy/diis_ROHF.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis_ROHF.cc
@@ -60,7 +60,7 @@ namespace ccenergy {
 */
 
 void CCEnergyWavefunction::diis_ROHF(int iter) {
-    int nvector = max_diis_vecs_; /* Number of error vectors to keep */
+    int nvector = params_.max_diis_vecs; /* Number of error vectors to keep */
     dpdfile2 T1, T1a, T1b;
     dpdbuf4 T2a, T2b;
     psio_address start, end;

--- a/psi4/src/psi4/cc/ccenergy/diis_ROHF.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis_ROHF.cc
@@ -60,7 +60,7 @@ namespace ccenergy {
 */
 
 void CCEnergyWavefunction::diis_ROHF(int iter) {
-    int nvector = 8; /* Number of error vectors to keep */
+    int nvector = max_diis_vecs_; /* Number of error vectors to keep */
     dpdfile2 T1, T1a, T1b;
     dpdbuf4 T2a, T2b;
     psio_address start, end;

--- a/psi4/src/psi4/cc/ccenergy/diis_UHF.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis_UHF.cc
@@ -175,7 +175,7 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
     global_dpd_->buf4_close(&T2b);
 
     start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
-    psio_write(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)error[0], vector_length * sizeof(double), start, &end);
+    psio_write(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)error[0], vector_length * sizeof(double), start, &end);
 
     /* Store the current amplitude vector on disk */
     word = 0;
@@ -229,7 +229,7 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
     global_dpd_->buf4_close(&T2a);
 
     start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
-    psio_write(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)error[0], vector_length * sizeof(double), start,
+    psio_write(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char*)error[0], vector_length * sizeof(double), start,
                &end);
 
     /* If we haven't run through enough iterations, set the correct dimensions
@@ -248,7 +248,7 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
     for (int p = 0; p < nvector; p++) {
         start = psio_get_address(PSIO_ZERO, sizeof(double) * p * vector_length);
 
-        psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[0], vector_length * sizeof(double), start,
+        psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)vector[0], vector_length * sizeof(double), start,
                   &end);
 
         // dot_arr(vector[0], vector[0], vector_length, &product);
@@ -259,7 +259,7 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
         for (int q = 0; q < p; q++) {
             start = psio_get_address(PSIO_ZERO, sizeof(double) * q * vector_length);
 
-            psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[1], vector_length * sizeof(double), start,
+            psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)vector[1], vector_length * sizeof(double), start,
                       &end);
 
             // dot_arr(vector[1], vector[0], vector_length, &product);
@@ -299,7 +299,7 @@ void CCEnergyWavefunction::diis_UHF(int iter) {
     for (int p = 0; p < nvector; p++) {
         start = psio_get_address(PSIO_ZERO, sizeof(double) * p * vector_length);
 
-        psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)vector[0], vector_length * sizeof(double), start,
+        psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char*)vector[0], vector_length * sizeof(double), start,
                   &end);
 
         for (int q = 0; q < vector_length; q++) error[0][q] += C[p] * vector[0][q];

--- a/psi4/src/psi4/cc/ccenergy/diis_UHF.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis_UHF.cc
@@ -60,7 +60,7 @@ namespace ccenergy {
 */
 
 void CCEnergyWavefunction::diis_UHF(int iter) {
-    int nvector = max_diis_vecs_; /* Number of error vectors to keep */
+    int nvector = params_.max_diis_vecs; /* Number of error vectors to keep */
     dpdfile2 T1a, T1b;
     dpdbuf4 T2a, T2b, T2c;
     psio_address start, end;

--- a/psi4/src/psi4/cc/ccenergy/diis_UHF.cc
+++ b/psi4/src/psi4/cc/ccenergy/diis_UHF.cc
@@ -60,7 +60,7 @@ namespace ccenergy {
 */
 
 void CCEnergyWavefunction::diis_UHF(int iter) {
-    int nvector = 8; /* Number of error vectors to keep */
+    int nvector = max_diis_vecs_; /* Number of error vectors to keep */
     dpdfile2 T1a, T1b;
     dpdbuf4 T2a, T2b, T2c;
     psio_address start, end;

--- a/psi4/src/psi4/cc/ccenergy/get_params.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_params.cc
@@ -135,7 +135,7 @@ void CCEnergyWavefunction::get_params(Options& options) {
     params_.max_diis_vecs = options.get_int("DIIS_MAX_VECS");
 
     if (params_.max_diis_vecs <= 0) {
-        params_.diis = 0;
+        params_.diis = false;
     }
 
     params_.t2_coupled = options.get_bool("T2_COUPLED");

--- a/psi4/src/psi4/cc/ccenergy/get_params.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_params.cc
@@ -51,7 +51,7 @@
 namespace psi {
 namespace ccenergy {
 
-void CCEnergyWavefunction::get_params(Options &options) {
+void CCEnergyWavefunction::get_params(Options& options) {
     std::string cachetype = "";
     std::string junk;
 
@@ -134,10 +134,10 @@ void CCEnergyWavefunction::get_params(Options &options) {
     params_.diis = options.get_bool("DIIS");
     params_.max_diis_vecs = options.get_int("DIIS_MAX_VECS");
 
-    if(params_.max_diis_vecs <= 0) {
-      params_.diis = 0;
+    if (params_.max_diis_vecs <= 0) {
+        params_.diis = 0;
     }
-    
+
     params_.t2_coupled = options.get_bool("T2_COUPLED");
     params_.prop = options.get_str("PROPERTY");
     params_.abcd = options.get_str("ABCD");

--- a/psi4/src/psi4/cc/ccenergy/get_params.cc
+++ b/psi4/src/psi4/cc/ccenergy/get_params.cc
@@ -132,6 +132,12 @@ void CCEnergyWavefunction::get_params(Options &options) {
         params_.nthreads = options.get_int("CC_NUM_THREADS");
     }
     params_.diis = options.get_bool("DIIS");
+    params_.max_diis_vecs = options.get_int("DIIS_MAX_VECS");
+
+    if(params_.max_diis_vecs <= 0) {
+      params_.diis = 0;
+    }
+    
     params_.t2_coupled = options.get_bool("T2_COUPLED");
     params_.prop = options.get_str("PROPERTY");
     params_.abcd = options.get_str("ABCD");
@@ -204,6 +210,7 @@ void CCEnergyWavefunction::get_params(Options &options) {
     outfile->Printf("    E_Convergence   =     %3.1e\n", params_.e_convergence);
     outfile->Printf("    Restart         =     %s\n", params_.restart ? "Yes" : "No");
     outfile->Printf("    DIIS            =     %s\n", params_.diis ? "Yes" : "No");
+    outfile->Printf("    DIIS_MAX_VECS   =     %d\n", params_.max_diis_vecs);
     outfile->Printf("    AO Basis        =     %s\n", params_.aobasis.c_str());
     outfile->Printf("    ABCD            =     %s\n", params_.abcd.c_str());
     outfile->Printf("    Cache Level     =     %1d\n", params_.cachelev);

--- a/psi4/src/psi4/cc/cclambda/Params.h
+++ b/psi4/src/psi4/cc/cclambda/Params.h
@@ -55,6 +55,7 @@ struct Params {
     int print;
     int dertype;
     int diis;
+    int max_diis_vecs;
     std::string abcd;
     int sekino; /* Sekino-Bartlett size-extensive models */
                 /* the following should be obseleted now or soon */

--- a/psi4/src/psi4/cc/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cc/cclambda/cclambda.cc
@@ -269,7 +269,7 @@ double CCLambdaWavefunction::compute_energy() {
                 break;
             }
 
-            if (params.diis) diis(moinfo.iter, pL_params[i].irrep);
+            if (params.diis && params.max_diis_vecs > 0) diis(moinfo.iter, pL_params[i].irrep);
             Lsave(pL_params[i].irrep);
             moinfo.lcc = pseudoenergy(pL_params[i]);
             update();

--- a/psi4/src/psi4/cc/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cc/cclambda/cclambda.cc
@@ -70,15 +70,15 @@ void Lmag();
 double overlap(int L_irr);
 void Lsave_index(const struct L_Params& L_params);
 void Lamp_write(const struct L_Params& L_params);
-void check_ortho(struct L_Params *pL_params);
-void projections(struct L_Params *pL_params);
+void check_ortho(struct L_Params* pL_params);
+void projections(struct L_Params* pL_params);
 void L_zero(int irrep);
-void c_clean(dpdfile2 *LIA, dpdfile2 *Lia, dpdbuf4 *LIJAB, dpdbuf4 *Lijab, dpdbuf4 *LIjAb);
+void c_clean(dpdfile2* LIA, dpdfile2* Lia, dpdbuf4* LIJAB, dpdbuf4* Lijab, dpdbuf4* LIjAb);
 void L_clean(const struct L_Params& pL_params);
 void zeta_norm(const struct L_Params& pL_params);
 void spinad_amps();
 void hbar_extra();
-void ortho_Rs(struct L_Params *pL_params, int current_L);
+void ortho_Rs(struct L_Params* pL_params, int current_L);
 
 void cc2_L1_build(const struct L_Params& L_params);
 void cc2_L2_build(const struct L_Params& L_params);
@@ -96,14 +96,14 @@ void cc3_l3l1();
 // Forward declaration to call cctriples
 namespace psi {
 namespace cctriples {
-PsiReturnType cctriples(std::shared_ptr<Wavefunction> ref_wfn, Options &options);
+PsiReturnType cctriples(std::shared_ptr<Wavefunction> ref_wfn, Options& options);
 }
 }  // namespace psi
 
 namespace psi {
 namespace cclambda {
 
-CCLambdaWavefunction::CCLambdaWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction, Options &options)
+CCLambdaWavefunction::CCLambdaWavefunction(std::shared_ptr<Wavefunction> reference_wavefunction, Options& options)
     : CCEnergyWavefunction(reference_wavefunction, options) {
     psio_ = _default_psio_lib_;
     init();
@@ -142,13 +142,13 @@ double CCLambdaWavefunction::compute_energy() {
 
         cachelist = cacheprep_rhf(params.cachelev, cachefiles);
 
-        std::vector<std::pair<Dimension, int *>> spaces;
+        std::vector<std::pair<Dimension, int*>> spaces;
         spaces.emplace_back(moinfo.occpi, moinfo.occ_sym);
         spaces.emplace_back(moinfo.virtpi, moinfo.vir_sym);
         dpd_init(0, moinfo.nirreps, params.memory, 0, cachefiles, cachelist, nullptr, spaces);
 
         if (params.aobasis) { /* Set up new DPD for AO-basis algorithm */
-            std::vector<std::pair<Dimension, int *>> aospaces;
+            std::vector<std::pair<Dimension, int*>> aospaces;
             aospaces.emplace_back(moinfo.occpi, moinfo.occ_sym);
             aospaces.emplace_back(moinfo.sopi, moinfo.sosym);
             dpd_init(1, moinfo.nirreps, params.memory, 0, cachefiles, cachelist, nullptr, aospaces);
@@ -158,7 +158,7 @@ double CCLambdaWavefunction::compute_energy() {
     } else if (params.ref == 2) { /** UHF **/
 
         cachelist = cacheprep_uhf(params.cachelev, cachefiles);
-        std::vector<std::pair<Dimension, int *>> spaces;
+        std::vector<std::pair<Dimension, int*>> spaces;
         spaces.emplace_back(moinfo.aoccpi, moinfo.aocc_sym);
         spaces.emplace_back(moinfo.avirtpi, moinfo.avir_sym);
         spaces.emplace_back(moinfo.boccpi, moinfo.bocc_sym);
@@ -167,7 +167,7 @@ double CCLambdaWavefunction::compute_energy() {
         dpd_init(0, moinfo.nirreps, params.memory, 0, cachefiles, cachelist, nullptr, spaces);
 
         if (params.aobasis) { /* Set up new DPD's for AO-basis algorithm */
-            std::vector<std::pair<Dimension, int *>> aospaces;
+            std::vector<std::pair<Dimension, int*>> aospaces;
             aospaces.emplace_back(moinfo.aoccpi, moinfo.aocc_sym);
             aospaces.emplace_back(moinfo.sopi, moinfo.sosym);
             aospaces.emplace_back(moinfo.boccpi, moinfo.bocc_sym);
@@ -285,7 +285,7 @@ double CCLambdaWavefunction::compute_energy() {
         }
         if (pL_params[i].ground) {
             auto LR_overlap = overlap(pL_params[i].irrep);
-            std::string gs_name; // Which theory's lambda equations did we just solve?
+            std::string gs_name;  // Which theory's lambda equations did we just solve?
             if (params.wfn == "CC3" || params.wfn == "EOM_CC3") {
                 gs_name = "CC3";
             } else if (params.wfn == "CC2" || params.wfn == "EOM_CC2") {
@@ -334,10 +334,14 @@ double CCLambdaWavefunction::compute_energy() {
         // Run cctriples
         if (psi::cctriples::cctriples(reference_wavefunction_, options_) == Success) {
             energy_ = Process::environment.globals["CURRENT ENERGY"];
-            set_scalar_variable("A-(T) CORRECTION ENERGY", reference_wavefunction_->scalar_variable("A-(T) CORRECTION ENERGY"));
-            set_scalar_variable("A-CCSD(T) CORRELATION ENERGY", reference_wavefunction_->scalar_variable("A-CCSD(T) CORRELATION ENERGY"));
-            set_scalar_variable("A-CCSD(T) TOTAL ENERGY", reference_wavefunction_->scalar_variable("A-CCSD(T) TOTAL ENERGY"));
-            set_scalar_variable("CURRENT CORRELATION ENERGY", reference_wavefunction_->scalar_variable("A-CCSD(T) CORRELATION ENERGY"));
+            set_scalar_variable("A-(T) CORRECTION ENERGY",
+                                reference_wavefunction_->scalar_variable("A-(T) CORRECTION ENERGY"));
+            set_scalar_variable("A-CCSD(T) CORRELATION ENERGY",
+                                reference_wavefunction_->scalar_variable("A-CCSD(T) CORRELATION ENERGY"));
+            set_scalar_variable("A-CCSD(T) TOTAL ENERGY",
+                                reference_wavefunction_->scalar_variable("A-CCSD(T) TOTAL ENERGY"));
+            set_scalar_variable("CURRENT CORRELATION ENERGY",
+                                reference_wavefunction_->scalar_variable("A-CCSD(T) CORRELATION ENERGY"));
             set_scalar_variable("CURRENT ENERGY", reference_wavefunction_->scalar_variable("A-CCSD(T) TOTAL ENERGY"));
         } else {
             energy_ = 0.0;
@@ -403,12 +407,12 @@ void Lsave_index(const struct L_Params& L_params) {
     int L_irr;
     dpdfile2 L1;
     dpdbuf4 L2, LIjAb, LIjbA;
-    const char *L1A_lbl = L_params.L1A_lbl;
-    const char *L1B_lbl = L_params.L1B_lbl;
-    const char *L2AA_lbl = L_params.L2AA_lbl;
-    const char *L2BB_lbl = L_params.L2BB_lbl;
-    const char *L2AB_lbl = L_params.L2AB_lbl;
-    const char *L2RHF_lbl = L_params.L2RHF_lbl;
+    const char* L1A_lbl = L_params.L1A_lbl;
+    const char* L1B_lbl = L_params.L1B_lbl;
+    const char* L2AA_lbl = L_params.L2AA_lbl;
+    const char* L2BB_lbl = L_params.L2BB_lbl;
+    const char* L2AB_lbl = L_params.L2AB_lbl;
+    const char* L2RHF_lbl = L_params.L2RHF_lbl;
     L_irr = L_params.irrep;
 
     if (params.ref == 0 || params.ref == 1) { /** ROHF **/

--- a/psi4/src/psi4/cc/cclambda/diis.cc
+++ b/psi4/src/psi4/cc/cclambda/diis.cc
@@ -62,7 +62,7 @@ namespace cclambda {
 */
 
 void CCLambdaWavefunction::diis(int iter, int L_irr) {
-    int nvector = 8; /* Number of error vectors to keep */
+    int nvector = params.max_diis_vecs; /* Number of error vectors to keep */
     int h, nirreps;
     int row, col, word, p, q, i;
     int diis_cycle;

--- a/psi4/src/psi4/cc/cclambda/diis.cc
+++ b/psi4/src/psi4/cc/cclambda/diis.cc
@@ -71,7 +71,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
     dpdfile2 L1, L1a, L1b;
     dpdbuf4 L2, L2a, L2b, L2c;
     psio_address start, end, next;
-    double **error;
+    double** error;
     double **B, *C, **vector;
     double product, determinant, maximum;
 
@@ -135,7 +135,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
         global_dpd_->buf4_close(&L2b);
 
         start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
-        psio_write(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)error[0], vector_length * sizeof(double), start,
+        psio_write(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)error[0], vector_length * sizeof(double), start,
                    &end);
 
         /* Store the current amplitude vector on disk */
@@ -161,7 +161,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
         global_dpd_->buf4_close(&L2a);
 
         start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
-        psio_write(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)error[0], vector_length * sizeof(double), start,
+        psio_write(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char*)error[0], vector_length * sizeof(double), start,
                    &end);
 
         /* If we haven't run through enough iterations, set the correct dimensions
@@ -180,7 +180,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
         for (p = 0; p < nvector; p++) {
             start = psio_get_address(PSIO_ZERO, sizeof(double) * p * vector_length);
 
-            psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[0], vector_length * sizeof(double), start,
+            psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)vector[0], vector_length * sizeof(double), start,
                       &end);
 
             /*
@@ -196,7 +196,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
             for (q = 0; q < p; q++) {
                 start = psio_get_address(PSIO_ZERO, sizeof(double) * q * vector_length);
 
-                psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[1], vector_length * sizeof(double),
+                psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)vector[1], vector_length * sizeof(double),
                           start, &end);
 
                 // dot_arr(vector[1], vector[0], vector_length, &product);
@@ -249,7 +249,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
 
             start = psio_get_address(PSIO_ZERO, sizeof(double) * p * vector_length);
 
-            psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)vector[0], vector_length * sizeof(double),
+            psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char*)vector[0], vector_length * sizeof(double),
                       start, &end);
 
             for (q = 0; q < vector_length; q++) error[0][q] += C[p] * vector[0][q];
@@ -392,7 +392,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
         global_dpd_->buf4_close(&L2b);
 
         start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
-        psio_write(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)error[0], vector_length * sizeof(double), start,
+        psio_write(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)error[0], vector_length * sizeof(double), start,
                    &end);
 
         /* Store the current amplitude vector on disk */
@@ -446,7 +446,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
         global_dpd_->buf4_close(&L2a);
 
         start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
-        psio_write(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)error[0], vector_length * sizeof(double), start,
+        psio_write(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char*)error[0], vector_length * sizeof(double), start,
                    &end);
 
         /* If we haven't run through enough iterations, set the correct dimensions
@@ -463,7 +463,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
         vector = init_matrix(nvector, vector_length);
         next = PSIO_ZERO;
         for (p = 0; p < nvector; p++)
-            psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char *)vector[p], vector_length * sizeof(double), next,
+            psio_read(PSIF_CC_DIIS_ERR, "DIIS Error Vectors", (char*)vector[p], vector_length * sizeof(double), next,
                       &next);
 
         /* Build B matrix of error vector products */
@@ -502,7 +502,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
         /* Grab the old amplitude vectors */
         next = PSIO_ZERO;
         for (p = 0; p < nvector; p++)
-            psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)vector[p], vector_length * sizeof(double),
+            psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char*)vector[p], vector_length * sizeof(double),
                       next, &next);
 
         /* Build the new amplitude vector from the old ones */
@@ -566,7 +566,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
         free_matrix(B, nvector + 1);
         free(C);
         global_dpd_->free_dpd_block(error, 1, vector_length);
-    }                           /** ROHF **/
+    } /** ROHF **/
     else if (params.ref == 2) { /** UHF **/
 
         /* Compute the length of a single error vector */
@@ -673,7 +673,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
         global_dpd_->buf4_close(&L2b);
 
         start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
-        psio_write(PSIF_CC_DIIS_ERR, "DIIS Error[0] Vectors", (char *)error[0], vector_length * sizeof(double), start,
+        psio_write(PSIF_CC_DIIS_ERR, "DIIS Error[0] Vectors", (char*)error[0], vector_length * sizeof(double), start,
                    &end);
 
         /* Store the current amplitude vector on disk */
@@ -727,7 +727,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
         global_dpd_->buf4_close(&L2a);
 
         start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
-        psio_write(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)error[0], vector_length * sizeof(double), start,
+        psio_write(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char*)error[0], vector_length * sizeof(double), start,
                    &end);
 
         /* If we haven't run through enough iterations, set the correct dimensions
@@ -744,8 +744,8 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
         vector = init_matrix(nvector, vector_length);
         next = PSIO_ZERO;
         for (p = 0; p < nvector; p++)
-            psio_read(PSIF_CC_DIIS_ERR, "DIIS Error[0] Vectors", (char *)vector[p], vector_length * sizeof(double),
-                      next, &next);
+            psio_read(PSIF_CC_DIIS_ERR, "DIIS Error[0] Vectors", (char*)vector[p], vector_length * sizeof(double), next,
+                      &next);
 
         /* Build B matrix of error[0] vector products */
         B = init_matrix(nvector + 1, nvector + 1);
@@ -783,7 +783,7 @@ void CCLambdaWavefunction::diis(int iter, int L_irr) {
         /* Grab the old amplitude vectors */
         next = PSIO_ZERO;
         for (p = 0; p < nvector; p++)
-            psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char *)vector[p], vector_length * sizeof(double),
+            psio_read(PSIF_CC_DIIS_AMP, "DIIS Amplitude Vectors", (char*)vector[p], vector_length * sizeof(double),
                       next, &next);
 
         /* Build the new amplitude vector from the old ones */

--- a/psi4/src/psi4/cc/cclambda/get_params.cc
+++ b/psi4/src/psi4/cc/cclambda/get_params.cc
@@ -101,7 +101,7 @@ void CCLambdaWavefunction::get_params(Options& options) {
     params.max_diis_vecs = options.get_int("DIIS_MAX_VECS");
 
     if (params.max_diis_vecs <= 0) {
-        params.diis = 0;
+        params.diis = false;
     }
 
     params.aobasis = 0;

--- a/psi4/src/psi4/cc/cclambda/get_params.cc
+++ b/psi4/src/psi4/cc/cclambda/get_params.cc
@@ -98,6 +98,12 @@ void CCLambdaWavefunction::get_params(Options &options) {
     params.diis = 1;
     params.diis = options.get_bool("DIIS");
 
+    params.max_diis_vecs = options.get_int("DIIS_MAX_VECS");
+
+    if(params.max_diis_vecs <= 0) {
+      params.diis = 0;
+    }
+
     params.aobasis = 0;
     params.aobasis = options.get_bool("AO_BASIS");
     params.aobasis = 0; /* AO basis code not yet working for lambda */
@@ -426,6 +432,7 @@ void CCLambdaWavefunction::get_params(Options &options) {
     outfile->Printf("\tCache Level       =     %1d\n", params.cachelev);
     outfile->Printf("\tModel III         =     %s\n", params.sekino ? "Yes" : "No");
     outfile->Printf("\tDIIS              =     %s\n", params.diis ? "Yes" : "No");
+    outfile->Printf("\tDIIS_MAX_VECS     =     %d\n", params.max_diis_vecs);
     outfile->Printf("\tAO Basis          =     %s\n", params.aobasis ? "Yes" : "No");
     outfile->Printf("\tABCD              =     %s\n", params.abcd.c_str());
     outfile->Printf("\tLocal CC          =     %s\n", params.local ? "Yes" : "No");

--- a/psi4/src/psi4/cc/cclambda/get_params.cc
+++ b/psi4/src/psi4/cc/cclambda/get_params.cc
@@ -52,7 +52,7 @@
 namespace psi {
 namespace cclambda {
 
-void CCLambdaWavefunction::get_params(Options &options) {
+void CCLambdaWavefunction::get_params(Options& options) {
     int errcod, iconv, i, j, k, l, prop_sym, prop_root, excited_method = 0;
     int prop_all, lambda_and_Ls = 0;
     std::vector<int> states_per_irrep;
@@ -64,15 +64,15 @@ void CCLambdaWavefunction::get_params(Options &options) {
     excited_method = cc_excited(params.wfn);
 
     if (params.wfn == "CC2" || params.wfn == "EOM_CC2") {
-        psio_read_entry(PSIF_CC_INFO, "CC2 Energy", (char *)&(moinfo.ecc), sizeof(double));
+        psio_read_entry(PSIF_CC_INFO, "CC2 Energy", (char*)&(moinfo.ecc), sizeof(double));
         outfile->Printf("\tCC2 energy          (CC_INFO) = %20.15f\n", moinfo.ecc);
         outfile->Printf("\tTotal CC2 energy    (CC_INFO) = %20.15f\n", moinfo.eref + moinfo.ecc);
     } else if (params.wfn == "CCSD" || params.wfn == "EOM_CCSD") {
-        psio_read_entry(PSIF_CC_INFO, "CCSD Energy", (char *)&(moinfo.ecc), sizeof(double));
+        psio_read_entry(PSIF_CC_INFO, "CCSD Energy", (char*)&(moinfo.ecc), sizeof(double));
         outfile->Printf("\tCCSD energy         (CC_INFO) = %20.15f\n", moinfo.ecc);
         outfile->Printf("\tTotal CCSD energy   (CC_INFO) = %20.15f\n", moinfo.eref + moinfo.ecc);
     } else if (params.wfn == "CC3" || params.wfn == "EOM_CC3") {
-        psio_read_entry(PSIF_CC_INFO, "CC3 Energy", (char *)&(moinfo.ecc), sizeof(double));
+        psio_read_entry(PSIF_CC_INFO, "CC3 Energy", (char*)&(moinfo.ecc), sizeof(double));
         outfile->Printf("\tCC3 energy          (CC_INFO) = %20.15f\n", moinfo.ecc);
         outfile->Printf("\tTotal CC3 energy    (CC_INFO) = %20.15f\n", moinfo.eref + moinfo.ecc);
     }
@@ -100,8 +100,8 @@ void CCLambdaWavefunction::get_params(Options &options) {
 
     params.max_diis_vecs = options.get_int("DIIS_MAX_VECS");
 
-    if(params.max_diis_vecs <= 0) {
-      params.diis = 0;
+    if (params.max_diis_vecs <= 0) {
+        params.diis = 0;
     }
 
     params.aobasis = 0;
@@ -235,8 +235,8 @@ void CCLambdaWavefunction::get_params(Options &options) {
 
     if (params.zeta) { /* only use Xi to solve for Zeta */
         params.nstates = 1;
-        pL_params = (struct L_Params *)malloc(params.nstates * sizeof(struct L_Params));
-        psio_read_entry(PSIF_CC_INFO, "XI Irrep", (char *)&i, sizeof(int));
+        pL_params = (struct L_Params*)malloc(params.nstates * sizeof(struct L_Params));
+        psio_read_entry(PSIF_CC_INFO, "XI Irrep", (char*)&i, sizeof(int));
         outfile->Printf("\tIrrep of Zeta       (CC_INFO) = %d\n", i);
         pL_params[0].irrep = prop_sym = i; /* is this always A1? I forget */
         pL_params[0].root = prop_root = 0;
@@ -252,7 +252,7 @@ void CCLambdaWavefunction::get_params(Options &options) {
     } else if (params.dertype == 1) {  /* analytic gradient, ignore prop_all */
         if (!cc_excited(params.wfn)) { /* do only lambda for ground state */
             params.nstates = 1;
-            pL_params = (struct L_Params *)malloc(params.nstates * sizeof(struct L_Params));
+            pL_params = (struct L_Params*)malloc(params.nstates * sizeof(struct L_Params));
             pL_params[0].irrep = 0;
             pL_params[0].root = -1;
             pL_params[0].ground = 1;
@@ -266,25 +266,25 @@ void CCLambdaWavefunction::get_params(Options &options) {
             sprintf(pL_params[0].L2RHF_lbl, "2LIjAb - LIjbA %d %d", 0, -1);
         } else { /* do only one L for excited state */
             params.nstates = 1;
-            pL_params = (struct L_Params *)malloc(params.nstates * sizeof(struct L_Params));
+            pL_params = (struct L_Params*)malloc(params.nstates * sizeof(struct L_Params));
             pL_params[0].irrep = prop_sym;
             pL_params[0].root = prop_root;
             pL_params[0].ground = 0;
             if (params.wfn == "EOM_CC2") {
                 sprintf(lbl, "EOM CC2 Energy for root %d %d", prop_sym, prop_root);
-                psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[0].cceom_energy), sizeof(double));
+                psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[0].cceom_energy), sizeof(double));
                 sprintf(lbl, "EOM CC2 R0 for root %d %d", prop_sym, prop_root);
-                psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[0].R0), sizeof(double));
+                psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[0].R0), sizeof(double));
             } else if (params.wfn == "EOM_CCSD") {
                 sprintf(lbl, "EOM CCSD Energy for root %d %d", prop_sym, prop_root);
-                psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[0].cceom_energy), sizeof(double));
+                psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[0].cceom_energy), sizeof(double));
                 sprintf(lbl, "EOM CCSD R0 for root %d %d", prop_sym, prop_root);
-                psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[0].R0), sizeof(double));
+                psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[0].R0), sizeof(double));
             } else if (params.wfn == "EOM_CC3") {
                 sprintf(lbl, "EOM CC3 Energy for root %d %d", prop_sym, prop_root);
-                psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[0].cceom_energy), sizeof(double));
+                psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[0].cceom_energy), sizeof(double));
                 sprintf(lbl, "EOM CC3 R0 for root %d %d", prop_sym, prop_root);
-                psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[0].R0), sizeof(double));
+                psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[0].R0), sizeof(double));
             }
             sprintf(pL_params[0].L1A_lbl, "LIA %d %d", prop_sym, prop_root);
             sprintf(pL_params[0].L1B_lbl, "Lia %d %d", prop_sym, prop_root);
@@ -296,7 +296,7 @@ void CCLambdaWavefunction::get_params(Options &options) {
     } else if (params.dertype == 3) {  /* response calculation */
         if (!cc_excited(params.wfn)) { /* ground state */
             params.nstates = 1;
-            pL_params = (struct L_Params *)malloc(params.nstates * sizeof(struct L_Params));
+            pL_params = (struct L_Params*)malloc(params.nstates * sizeof(struct L_Params));
             pL_params[0].irrep = 0;
             pL_params[0].root = -1;
             pL_params[0].ground = 1;
@@ -314,7 +314,7 @@ void CCLambdaWavefunction::get_params(Options &options) {
     } else if (params.dertype == 0) {
         if (!cc_excited(params.wfn)) { /* ground state */
             params.nstates = 1;
-            pL_params = (struct L_Params *)malloc(params.nstates * sizeof(struct L_Params));
+            pL_params = (struct L_Params*)malloc(params.nstates * sizeof(struct L_Params));
             pL_params[0].irrep = 0;
             pL_params[0].root = -1;
             pL_params[0].ground = 1;
@@ -341,7 +341,7 @@ void CCLambdaWavefunction::get_params(Options &options) {
             params.nstates += 1; /* do only one L */
         }
 
-        pL_params = (struct L_Params *)malloc(params.nstates * sizeof(struct L_Params));
+        pL_params = (struct L_Params*)malloc(params.nstates * sizeof(struct L_Params));
 
         /* ground state */
         pL_params[0].irrep = 0;
@@ -366,19 +366,19 @@ void CCLambdaWavefunction::get_params(Options &options) {
 
                     if (params.wfn == "EOM_CC2") {
                         sprintf(lbl, "EOM CC2 Energy for root %d %d", i, j);
-                        psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[k].cceom_energy), sizeof(double));
+                        psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[k].cceom_energy), sizeof(double));
                         sprintf(lbl, "EOM CC2 R0 for root %d %d", i, j);
-                        psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[k].R0), sizeof(double));
+                        psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[k].R0), sizeof(double));
                     } else if (params.wfn == "EOM_CCSD") {
                         sprintf(lbl, "EOM CCSD Energy for root %d %d", i, j);
-                        psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[k].cceom_energy), sizeof(double));
+                        psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[k].cceom_energy), sizeof(double));
                         sprintf(lbl, "EOM CCSD R0 for root %d %d", i, j);
-                        psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[k].R0), sizeof(double));
+                        psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[k].R0), sizeof(double));
                     } else if (params.wfn == "EOM_CC3") {
                         sprintf(lbl, "EOM CC3 Energy for root %d %d", i, j);
-                        psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[k].cceom_energy), sizeof(double));
+                        psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[k].cceom_energy), sizeof(double));
                         sprintf(lbl, "EOM CC3 R0 for root %d %d", i, j);
-                        psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[k].R0), sizeof(double));
+                        psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[k].R0), sizeof(double));
                     }
 
                     sprintf(pL_params[k].L1A_lbl, "LIA %d %d", i, j);
@@ -397,19 +397,19 @@ void CCLambdaWavefunction::get_params(Options &options) {
 
             if (params.wfn == "EOM_CC2") {
                 sprintf(lbl, "EOM CC2 Energy for root %d %d", prop_sym, prop_root);
-                psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[1].cceom_energy), sizeof(double));
+                psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[1].cceom_energy), sizeof(double));
                 sprintf(lbl, "EOM CC2 R0 for root %d %d", prop_sym, prop_root);
-                psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[1].R0), sizeof(double));
+                psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[1].R0), sizeof(double));
             } else if (params.wfn == "EOM_CCSD") {
                 sprintf(lbl, "EOM CCSD Energy for root %d %d", prop_sym, prop_root);
-                psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[1].cceom_energy), sizeof(double));
+                psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[1].cceom_energy), sizeof(double));
                 sprintf(lbl, "EOM CCSD R0 for root %d %d", prop_sym, prop_root);
-                psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[1].R0), sizeof(double));
+                psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[1].R0), sizeof(double));
             } else if (params.wfn == "EOM_CC3") {
                 sprintf(lbl, "EOM CC3 Energy for root %d %d", prop_sym, prop_root);
-                psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[1].cceom_energy), sizeof(double));
+                psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[1].cceom_energy), sizeof(double));
                 sprintf(lbl, "EOM CC3 R0 for root %d %d", prop_sym, prop_root);
-                psio_read_entry(PSIF_CC_INFO, lbl, (char *)&(pL_params[1].R0), sizeof(double));
+                psio_read_entry(PSIF_CC_INFO, lbl, (char*)&(pL_params[1].R0), sizeof(double));
             }
 
             sprintf(pL_params[1].L1A_lbl, "LIA %d %d", prop_sym, prop_root);

--- a/psi4/src/psi4/cc/ccresponse/Params.h
+++ b/psi4/src/psi4/cc/ccresponse/Params.h
@@ -48,6 +48,7 @@ struct Params {
     double convergence; /* convergence criterion for perturbed wfns */
     int restart;        /* boolean for allowing a restart from on-disk amps */
     int diis;           /* boolean for using DIIS extrapolation */
+    int max_diis_vecs;
     std::string prop;   /* user-selected property */
     int local;          /* boolean for simluation of local correlation */
     int analyze;

--- a/psi4/src/psi4/cc/ccresponse/Params.h
+++ b/psi4/src/psi4/cc/ccresponse/Params.h
@@ -42,15 +42,15 @@ struct Params {
     long int memory;    /* Memory available (in bytes) */
     int cachelev;       /* cacheing level for libdpd */
     int ref;            /* reference determinant (0=RHF, 1=ROHF, 2=UHF) */
-    double *omega;      /* energy of applied field (a.u) for dynamic polarizabilities */
+    double* omega;      /* energy of applied field (a.u) for dynamic polarizabilities */
     int nomega;         /* number of field energies desired */
     int maxiter;        /* maximum number of iterations allowed to converge perturbed amp eqns. */
     double convergence; /* convergence criterion for perturbed wfns */
     int restart;        /* boolean for allowing a restart from on-disk amps */
     int diis;           /* boolean for using DIIS extrapolation */
     int max_diis_vecs;
-    std::string prop;   /* user-selected property */
-    int local;          /* boolean for simluation of local correlation */
+    std::string prop; /* user-selected property */
+    int local;        /* boolean for simluation of local correlation */
     int analyze;
     int dertype;
     std::string gauge; /* choice of gauge for optical rotation */
@@ -64,4 +64,3 @@ struct Params {
 }  // namespace ccresponse
 }  // namespace psi
 #endif
-

--- a/psi4/src/psi4/cc/ccresponse/compute_X.cc
+++ b/psi4/src/psi4/cc/ccresponse/compute_X.cc
@@ -119,7 +119,7 @@ void compute_X(const char *pert, int irrep, double omega) {
 
             break;
         }
-        if (params.diis) diis(iter, pert, irrep, omega);
+        if (params.diis && params.max_diis_vecs > 0) diis(iter, pert, irrep, omega);
         save_X(pert, irrep, omega);
         if (params.wfn == "CC2")
             cc2_sort_X(pert, irrep, omega);

--- a/psi4/src/psi4/cc/ccresponse/compute_X.cc
+++ b/psi4/src/psi4/cc/ccresponse/compute_X.cc
@@ -47,26 +47,26 @@
 namespace psi {
 namespace ccresponse {
 
-void init_X(const char *pert, int irrep, double omega);
-void sort_X(const char *pert, int irrep, double omega);
-void cc2_sort_X(const char *pert, int irrep, double omega);
-void X1_build(const char *pert, int irrep, double omega);
-void X2_build(const char *pert, int irrep, double omega);
-void cc2_X1_build(const char *pert, int irrep, double omega);
-void cc2_X2_build(const char *pert, int irrep, double omega);
-double converged(const char *pert, int irrep, double omega);
-void save_X(const char *pert, int irrep, double omega);
-void print_X(const char *pert, int irrep, double omega);
-void update_X(const char *pert, int irrep, double omega);
-void diis(int iter, const char *pert, int irrep, double omega);
-double pseudopolar(const char *pert, int irrep, double omega);
+void init_X(const char* pert, int irrep, double omega);
+void sort_X(const char* pert, int irrep, double omega);
+void cc2_sort_X(const char* pert, int irrep, double omega);
+void X1_build(const char* pert, int irrep, double omega);
+void X2_build(const char* pert, int irrep, double omega);
+void cc2_X1_build(const char* pert, int irrep, double omega);
+void cc2_X2_build(const char* pert, int irrep, double omega);
+double converged(const char* pert, int irrep, double omega);
+void save_X(const char* pert, int irrep, double omega);
+void print_X(const char* pert, int irrep, double omega);
+void update_X(const char* pert, int irrep, double omega);
+void diis(int iter, const char* pert, int irrep, double omega);
+double pseudopolar(const char* pert, int irrep, double omega);
 void cleanup();
 void exit_io();
-void amp_write(const char *pert, int irrep, double omega);
+void amp_write(const char* pert, int irrep, double omega);
 
-void analyze(const char *pert, int irrep, double omega);
+void analyze(const char* pert, int irrep, double omega);
 
-void compute_X(const char *pert, int irrep, double omega) {
+void compute_X(const char* pert, int irrep, double omega) {
     int i, iter = 0, done = 0;
     double rms, polar, X2_norm;
     char lbl[32];

--- a/psi4/src/psi4/cc/ccresponse/diis.cc
+++ b/psi4/src/psi4/cc/ccresponse/diis.cc
@@ -63,7 +63,7 @@ namespace ccresponse {
 ** Modified for ccresponse, TDC, 5/03
 */
 
-void diis(int iter, const char *pert, int irrep, double omega) {
+void diis(int iter, const char* pert, int irrep, double omega) {
     int nvector = params.max_diis_vecs; /* Number of error vectors to keep */
     int h, nirreps;
     int row, col, word, p, q;
@@ -73,7 +73,7 @@ void diis(int iter, const char *pert, int irrep, double omega) {
     dpdfile2 T1, T1a, T1b;
     dpdbuf4 T2, T2a, T2b, T2c;
     psio_address start, end, next;
-    double **error;
+    double** error;
     double **B, *C, **vector;
     double product, determinant, maximum;
     char lbl[32];
@@ -135,7 +135,7 @@ void diis(int iter, const char *pert, int irrep, double omega) {
 
         start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
         sprintf(lbl, "DIIS %s Error Vectors", pert);
-        psio_write(PSIF_CC_DIIS_ERR, lbl, (char *)error[0], vector_length * sizeof(double), start, &end);
+        psio_write(PSIF_CC_DIIS_ERR, lbl, (char*)error[0], vector_length * sizeof(double), start, &end);
 
         /* Store the current amplitude vector on disk */
         word = 0;
@@ -163,7 +163,7 @@ void diis(int iter, const char *pert, int irrep, double omega) {
 
         start = psio_get_address(PSIO_ZERO, sizeof(double) * diis_cycle * vector_length);
         sprintf(lbl, "DIIS %s Amplitude Vectors", pert);
-        psio_write(PSIF_CC_DIIS_AMP, lbl, (char *)error[0], vector_length * sizeof(double), start, &end);
+        psio_write(PSIF_CC_DIIS_AMP, lbl, (char*)error[0], vector_length * sizeof(double), start, &end);
 
         /* If we haven't run through enough iterations, set the correct dimensions
            for the extrapolation */
@@ -182,7 +182,7 @@ void diis(int iter, const char *pert, int irrep, double omega) {
             start = psio_get_address(PSIO_ZERO, sizeof(double) * p * vector_length);
 
             sprintf(lbl, "DIIS %s Error Vectors", pert);
-            psio_read(PSIF_CC_DIIS_ERR, lbl, (char *)vector[0], vector_length * sizeof(double), start, &end);
+            psio_read(PSIF_CC_DIIS_ERR, lbl, (char*)vector[0], vector_length * sizeof(double), start, &end);
 
             // dot_arr(vector[0], vector[0], vector_length, &product);
             product = C_DDOT(vector_length, vector[0], 1, vector[0], 1);
@@ -193,7 +193,7 @@ void diis(int iter, const char *pert, int irrep, double omega) {
                 start = psio_get_address(PSIO_ZERO, sizeof(double) * q * vector_length);
 
                 sprintf(lbl, "DIIS %s Error Vectors", pert);
-                psio_read(PSIF_CC_DIIS_ERR, lbl, (char *)vector[1], vector_length * sizeof(double), start, &end);
+                psio_read(PSIF_CC_DIIS_ERR, lbl, (char*)vector[1], vector_length * sizeof(double), start, &end);
 
                 // dot_arr(vector[1], vector[0], vector_length, &product);
                 product = C_DDOT(vector_length, vector[1], 1, vector[0], 1);
@@ -238,7 +238,7 @@ void diis(int iter, const char *pert, int irrep, double omega) {
             start = psio_get_address(PSIO_ZERO, sizeof(double) * p * vector_length);
 
             sprintf(lbl, "DIIS %s Amplitude Vectors", pert);
-            psio_read(PSIF_CC_DIIS_AMP, lbl, (char *)vector[0], vector_length * sizeof(double), start, &end);
+            psio_read(PSIF_CC_DIIS_AMP, lbl, (char*)vector[0], vector_length * sizeof(double), start, &end);
 
             for (q = 0; q < vector_length; q++) error[0][q] += C[p] * vector[0][q];
         }

--- a/psi4/src/psi4/cc/ccresponse/diis.cc
+++ b/psi4/src/psi4/cc/ccresponse/diis.cc
@@ -64,7 +64,7 @@ namespace ccresponse {
 */
 
 void diis(int iter, const char *pert, int irrep, double omega) {
-    int nvector = 8; /* Number of error vectors to keep */
+    int nvector = params.max_diis_vecs; /* Number of error vectors to keep */
     int h, nirreps;
     int row, col, word, p, q;
     int diis_cycle;

--- a/psi4/src/psi4/cc/ccresponse/get_params.cc
+++ b/psi4/src/psi4/cc/ccresponse/get_params.cc
@@ -159,7 +159,7 @@ void get_params(std::shared_ptr<Wavefunction> wfn, Options& options) {
     params.max_diis_vecs = options.get_int("DIIS_MAX_VECS");
 
     if (params.max_diis_vecs <= 0) {
-        params.diis = 0;
+        params.diis = false;
     }
 
     params.prop = options.get_str("PROPERTY");

--- a/psi4/src/psi4/cc/ccresponse/get_params.cc
+++ b/psi4/src/psi4/cc/ccresponse/get_params.cc
@@ -226,7 +226,7 @@ void get_params(std::shared_ptr<Wavefunction> wfn, Options &options) {
     outfile->Printf("\tConvergence      =    %3.1e\n", params.convergence);
     outfile->Printf("\tRestart          =    %s\n", params.restart ? "Allowed" : "Not Allowed");
     outfile->Printf("\tDIIS             =    %s\n", params.diis ? "Yes" : "No");
-    outfile->Printf("\tDIIS_MAX_VECS    =    %d\n", params.diis_max_vecs);
+    outfile->Printf("\tDIIS_MAX_VECS    =    %d\n", params.max_diis_vecs);
     outfile->Printf("\tModel III        =    %s\n", params.sekino ? "Yes" : "No");
     outfile->Printf("\tLinear Model     =    %s\n", params.linear ? "Yes" : "No");
     outfile->Printf("\tABCD             =    %s\n", params.abcd.c_str());

--- a/psi4/src/psi4/cc/ccresponse/get_params.cc
+++ b/psi4/src/psi4/cc/ccresponse/get_params.cc
@@ -56,7 +56,7 @@
 namespace psi {
 namespace ccresponse {
 
-void get_params(std::shared_ptr<Wavefunction> wfn, Options &options) {
+void get_params(std::shared_ptr<Wavefunction> wfn, Options& options) {
     int i, errcod, ref, count, iconv, *tmpi;
     std::string units;
     std::string junk;
@@ -158,8 +158,8 @@ void get_params(std::shared_ptr<Wavefunction> wfn, Options &options) {
     params.diis = options.get_bool("DIIS");
     params.max_diis_vecs = options.get_int("DIIS_MAX_VECS");
 
-    if(params.max_diis_vecs <= 0) {
-      params.diis = 0;
+    if (params.max_diis_vecs <= 0) {
+        params.diis = 0;
     }
 
     params.prop = options.get_str("PROPERTY");

--- a/psi4/src/psi4/cc/ccresponse/get_params.cc
+++ b/psi4/src/psi4/cc/ccresponse/get_params.cc
@@ -156,6 +156,11 @@ void get_params(std::shared_ptr<Wavefunction> wfn, Options &options) {
     params.maxiter = options.get_int("MAXITER");
     params.convergence = options.get_double("R_CONVERGENCE");
     params.diis = options.get_bool("DIIS");
+    params.max_diis_vecs = options.get_int("DIIS_MAX_VECS");
+
+    if(params.max_diis_vecs <= 0) {
+      params.diis = 0;
+    }
 
     params.prop = options.get_str("PROPERTY");
     if (params.prop != "POLARIZABILITY" && params.prop != "ROTATION" && params.prop != "ROA" &&
@@ -221,6 +226,7 @@ void get_params(std::shared_ptr<Wavefunction> wfn, Options &options) {
     outfile->Printf("\tConvergence      =    %3.1e\n", params.convergence);
     outfile->Printf("\tRestart          =    %s\n", params.restart ? "Allowed" : "Not Allowed");
     outfile->Printf("\tDIIS             =    %s\n", params.diis ? "Yes" : "No");
+    outfile->Printf("\tDIIS_MAX_VECS    =    %d\n", params.diis_max_vecs);
     outfile->Printf("\tModel III        =    %s\n", params.sekino ? "Yes" : "No");
     outfile->Printf("\tLinear Model     =    %s\n", params.linear ? "Yes" : "No");
     outfile->Printf("\tABCD             =    %s\n", params.abcd.c_str());

--- a/psi4/src/psi4/cc/ccwave.h
+++ b/psi4/src/psi4/cc/ccwave.h
@@ -204,6 +204,7 @@ class CCEnergyWavefunction : public Wavefunction {
     MOInfo moinfo_;
     Params params_;
     Local local_;
+    int max_diis_vecs_;
     std::array<dpd_file4_cache_entry, 113> cache_priority_list_;
 };
 

--- a/psi4/src/psi4/cc/ccwave.h
+++ b/psi4/src/psi4/cc/ccwave.h
@@ -204,7 +204,6 @@ class CCEnergyWavefunction : public Wavefunction {
     MOInfo moinfo_;
     Params params_;
     Local local_;
-    int max_diis_vecs_;
     std::array<dpd_file4_cache_entry, 113> cache_priority_list_;
 };
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2524,6 +2524,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_int("CC_NUM_THREADS", 1);
         /*- Do use DIIS extrapolation to accelerate convergence? -*/
         options.add_bool("DIIS", true);
+	/*- Set the maximum number of DIIS vectors to use. -*/
+	options.add_int("DIIS_MAX_VECS", 8);
         /*- -*/
         options.add_bool("T2_COUPLED", false);
         /*- The response property desired.  Acceptable values are ``POLARIZABILITY``

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2102,6 +2102,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_bool("SEKINO", false);
         /*- Do use DIIS extrapolation to accelerate convergence? -*/
         options.add_bool("DIIS", true);
+	/*- Maximum number of DIIS vectors to use. -*/
+	options.add_int("DIIS_MAX_VECS", 8);
         /*- The algorithm to use for the $\left\langle VV||VV \right\rangle$ terms -*/
         options.add_str("AO_BASIS", "NONE", "NONE DISK DIRECT");
         /*- Type of ABCD algorithm will be used -*/
@@ -2343,6 +2345,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("R_CONVERGENCE", 1e-7);
         /*- Do use DIIS extrapolation to accelerate convergence? -*/
         options.add_bool("DIIS", 1);
+	/*- Maximum number of DIIS vectors. -*/
+	options.add_int("DIIS_MAX_VECS", 8);
         /*- The response property desired.  Acceptable values are ``POLARIZABILITY``
         (default) for dipole polarizabilities, ``ROTATION`` for specific rotations,
         ``ROA`` for Raman Optical Activity (``ROA_TENSOR`` for each displacement),

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2528,8 +2528,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_int("CC_NUM_THREADS", 1);
         /*- Do use DIIS extrapolation to accelerate convergence? -*/
         options.add_bool("DIIS", true);
-	/*- Set the maximum number of DIIS vectors to use. -*/
-	options.add_int("DIIS_MAX_VECS", 8);
+        /*- Set the maximum number of DIIS vectors to use. -*/
+        options.add_int("DIIS_MAX_VECS", 8);
         /*- -*/
         options.add_bool("T2_COUPLED", false);
         /*- The response property desired.  Acceptable values are ``POLARIZABILITY``

--- a/tests/cc57/CMakeLists.txt
+++ b/tests/cc57/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(cc57 "psi;quicktests;smoketests;cc")

--- a/tests/cc57/input.dat
+++ b/tests/cc57/input.dat
@@ -1,0 +1,42 @@
+#! RHF-CCSD 6-31G** all-electron optimization of the H2O molecule
+
+molecule h2o {
+    O
+    H 1 0.97
+    H 1 0.97 2 103.0
+}
+
+set {
+    basis 6-31G**
+}
+
+set CCENERGY {
+    diis_max_vecs 4
+}
+
+wfn = optimize('ccsd', return_wfn=True)[1]
+
+refnuc   =   9.1654609427539  #TEST
+refscf   = -76.0229427274435  #TEST
+refccsd  = -0.20823570806196  #TEST
+reftotal = -76.2311784355056  #TEST
+scfT     =  75.7989532323351  #TEST
+scfVT    =   2.0029550473401  #TEST
+scfV     =   - scfVT * scfT   #TEST
+ccT      =   0.1474216520850  #TEST
+ccVT     =   2.4125178001909  #TEST
+ccV      =   -  ccVT *  ccT   #TEST
+totalVT  =   2.0037500611607  #TEST
+
+compare_values(refnuc,   h2o.nuclear_repulsion_energy(),          3, "Nuclear repulsion energy") #TEST
+compare_values(refscf,   variable("SCF total energy"),        5, "SCF energy")               #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
+compare_values(reftotal, variable("Current energy"),          7, "Total energy")             #TEST
+compare_values(scfT,     variable("HF Kinetic Energy"),       5, "HF Kinetic Energy")        #TEST
+compare_values(scfV,     variable("HF Potential Energy"),     5, "HF Potential Energy")      #TEST
+compare_values(scfVT,    variable("HF Virial Ratio"),         5, "HF Virial Ratio")          #TEST
+compare_values(ccT,      wfn.variable("CC Correlation Kinetic Energy"),       5, "CC Correlation Kinetic Energy")        #TEST
+compare_values(ccV,      wfn.variable("CC Correlation Potential Energy"),     5, "CC Correlation Potential Energy")      #TEST
+compare_values(ccVT,     wfn.variable("CC Correlation Virial Ratio"),         5, "CC Correlation Virial Ratio")          #TEST
+compare_values(totalVT,  wfn.variable("CC Virial Ratio"),         5, "CC Virial Ratio")      #TEST
+

--- a/tests/cc57/input.dat
+++ b/tests/cc57/input.dat
@@ -14,6 +14,10 @@ set CCENERGY {
     diis_max_vecs 4
 }
 
+set CCLAMBDA {
+    diis_max_vecs 5
+}
+
 wfn = optimize('ccsd', return_wfn=True)[1]
 
 refnuc   =   9.1654609427539  #TEST

--- a/tests/cc57/output.ref
+++ b/tests/cc57/output.ref
@@ -1,0 +1,2622 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.1rc3.dev5 
+
+                         Git: Rev {master} 3fbd859 
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. in press (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Monday, 15 May 2017 03:33PM
+
+    Process ID:  11968
+    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! RHF-CCSD 6-31G** all-electron optimization of the H2O molecule
+
+molecule h2o {
+    O
+    H 1 0.97
+    H 1 0.97 2 103.0
+}
+
+set {
+    basis 6-31G**
+}
+
+optimize('ccsd')
+
+refnuc   =   9.1654609427539  #TEST
+refscf   = -76.0229427274435  #TEST
+refccsd  = -0.20823570806196  #TEST
+reftotal = -76.2311784355056  #TEST
+
+compare_values(refnuc,   h2o.nuclear_repulsion_energy(),          3, "Nuclear repulsion energy") #TEST
+compare_values(refscf,   get_variable("SCF total energy"),        5, "SCF energy")               #TEST
+compare_values(refccsd,  get_variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
+compare_values(reftotal, get_variable("Current energy"),          7, "Total energy")             #TEST
+--------------------------------------------------------------------------
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:52 2017
+
+   => Loading Basis Set <=
+
+    Name: 6-31G**
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   140 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2-3 entry H          line    35 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
+
+    There are an even number of electrons - assuming singlet.
+    Specify the multiplicity in the molecule input block.
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.067578587269    15.994914619560
+           H          0.000000000000    -0.759129912147     0.536260610269     1.007825032070
+           H          0.000000000000     0.759129912147     0.536260610269     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     25.82761  B =     14.51273  C =      9.29167 [cm^-1]
+  Rotational constants: A = 774292.15647  B = 435080.73208  C = 278557.26010 [MHz]
+  Nuclear repulsion =    9.077238153630930
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G**
+    Blend: 6-31G**
+    Number of shells: 12
+    Number of basis function: 25
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        12      12       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      25      25       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             25
+      Number of atomic orbitals:        25
+      Number of basis functions:        25
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 105950 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+  Minimum eigenvalue in the overlap matrix is 2.2308645666E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -75.95492261751966   -7.59549e+01   1.14488e-01 
+   @RHF iter   1:   -75.97837615968200   -2.34535e-02   2.17692e-02 
+   @RHF iter   2:   -76.01219021646442   -3.38141e-02   1.14813e-02 DIIS
+   @RHF iter   3:   -76.02158202461503   -9.39181e-03   1.55978e-03 DIIS
+   @RHF iter   4:   -76.02196350344684   -3.81479e-04   4.25856e-04 DIIS
+   @RHF iter   5:   -76.02199704584848   -3.35424e-05   6.17940e-05 DIIS
+   @RHF iter   6:   -76.02199785623192   -8.10383e-07   7.71295e-06 DIIS
+   @RHF iter   7:   -76.02199786797981   -1.17479e-08   7.44815e-07 DIIS
+   @RHF iter   8:   -76.02199786811084   -1.31038e-10   1.89640e-07 DIIS
+   @RHF iter   9:   -76.02199786812271   -1.18661e-11   3.57448e-08 DIIS
+   @RHF iter  10:   -76.02199786812304   -3.26850e-13   2.53291e-09 DIIS
+   @RHF iter  11:   -76.02199786812301    2.84217e-14   4.31863e-10 DIIS
+   @RHF iter  12:   -76.02199786812307   -5.68434e-14   3.56270e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.563756     2A1    -1.335128     1B2    -0.693868  
+       3A1    -0.569546     1B1    -0.496894  
+
+    Virtual:                                                              
+
+       4A1     0.209148     2B2     0.301190     3B2     0.992987  
+       5A1     1.080901     6A1     1.131133     2B1     1.168613  
+       4B2     1.294487     7A1     1.418369     1A2     1.805555  
+       8A1     1.805556     3B1     1.919426     9A1     2.554725  
+       5B2     2.571406     6B2     2.778746     2A2     2.955797  
+       4B1     2.985114    10A1     3.349725    11A1     3.681198  
+       7B2     3.913090    12A1     4.093637  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -76.02199786812307
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.0772381536309297
+    One-Electron Energy =                -122.8800883803116193
+    Two-Electron Energy =                  37.7808523585576239
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0219978681230657
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     1.0051
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.1315
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.8736     Total:     0.8736
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     2.2205     Total:     2.2205
+
+
+*** tstop() called on psinet at Mon May 15 15:33:53 2017
+Module time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of threads:                 1
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of SO shells:               9
+      Number of primitives:             25
+      Number of atomic orbitals:        25
+      Number of basis functions:        25
+
+      Number of irreps:                  4
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [  12    2    4    7 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 13665 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:53 2017
+
+
+	Wfn Parameters:
+	--------------------
+	Wavefunction         = CCSD
+	Number of irreps     = 4
+	Number of MOs        = 25
+	Number of active MOs = 25
+	AO-Basis             = NONE
+	Semicanonical        = false
+	Reference            = RHF
+	Print Level          = 1
+
+	IRREP	# MOs	# FZDC	# DOCC	# SOCC	# VIRT	# FZVR
+	-----	-----	------	------	------	------	------
+	 A1	   12	    0	    3	    0	    9	    0
+	 A2	   2	    0	    0	    0	    2	    0
+	 B1	   4	    0	    1	    0	    3	    0
+	 B2	   7	    0	    1	    0	    6	    0
+	Transforming integrals...
+	IWL integrals will be deleted.
+	(OO|OO)...
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Transforming the one-electron integrals and constructing Fock matrices
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OO)...
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OO)...
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	Frozen core energy     =      0.00000000000000
+
+	Size of irrep 0 of <ab|cd> integrals:      0.017 (MW) /      0.135 (MB)
+	Size of irrep 1 of <ab|cd> integrals:      0.005 (MW) /      0.041 (MB)
+	Size of irrep 2 of <ab|cd> integrals:      0.006 (MW) /      0.049 (MB)
+	Size of irrep 3 of <ab|cd> integrals:      0.014 (MW) /      0.115 (MB)
+	Total:                                     0.043 (MW) /      0.341 (MB)
+
+	Size of irrep 0 of <ia|bc> integrals:      0.005 (MW) /      0.037 (MB)
+	Size of irrep 1 of <ia|bc> integrals:      0.001 (MW) /      0.009 (MB)
+	Size of irrep 2 of <ia|bc> integrals:      0.002 (MW) /      0.012 (MB)
+	Size of irrep 3 of <ia|bc> integrals:      0.003 (MW) /      0.028 (MB)
+	Total:                                     0.011 (MW) /      0.086 (MB)
+
+	Size of irrep 0 of tijab amplitudes:       0.001 (MW) /      0.011 (MB)
+	Size of irrep 1 of tijab amplitudes:       0.000 (MW) /      0.001 (MB)
+	Size of irrep 2 of tijab amplitudes:       0.000 (MW) /      0.004 (MB)
+	Size of irrep 3 of tijab amplitudes:       0.001 (MW) /      0.006 (MB)
+	Total:                                     0.003 (MW) /      0.022 (MB)
+
+	Nuclear Rep. energy          =      9.07723815363093
+	SCF energy                   =    -76.02199786812307
+	One-electron energy          =   -122.88008838046106
+	Two-electron energy          =     37.78085235870709
+	Reference energy             =    -76.02199786812304
+
+*** tstop() called on psinet at Mon May 15 15:33:53 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.43 seconds =       0.01 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:53 2017
+
+            **************************
+            *                        *
+            *        CCENERGY        *
+            *                        *
+            **************************
+
+    Nuclear Rep. energy (wfn)     =    9.077238153630930
+    SCF energy          (wfn)     =  -76.021997868123066
+    Reference energy    (file100) =  -76.021997868123037
+
+    Input parameters:
+    -----------------
+    Wave function   =     CCSD
+    Reference wfn   =     RHF
+    Brueckner       =     No
+    Memory (Mbytes) =     524.3
+    Maxiter         =     50
+    R_Convergence   =     1.0e-07
+    E_Convergence   =     1.0e-08
+    Restart         =     Yes
+    DIIS            =     Yes
+    AO Basis        =     NONE
+    ABCD            =     NEW
+    Cache Level     =     2
+    Cache Type      =     LOW
+    Print Level     =     1
+    Num. of threads =     1
+    # Amps to Print =     10
+    Print MP2 Amps? =     No
+    Analyze T2 Amps =     No
+    Print Pair Ener =     No
+    Local CC        =     No
+    SCS-MP2         =     False
+    SCSN-MP2        =     False
+    SCS-CCSD        =     False
+
+MP2 correlation energy -0.2002845909709956
+                Solving CC Amplitude Equations
+                ------------------------------
+  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
+  ----     ---------------------    ---------   ----------  ----------  ----------   --------
+     0        -0.200284590970996    0.000e+00    0.000000    0.000000    0.000000    0.110456
+     1        -0.204524507808414    2.733e-02    0.004508    0.008904    0.008904    0.117194
+     2        -0.208454941715412    9.794e-03    0.005161    0.010333    0.010333    0.122601
+     3        -0.208976359457238    2.795e-03    0.005693    0.011917    0.011917    0.124028
+     4        -0.208980680929654    6.466e-04    0.005747    0.012228    0.012228    0.124248
+     5        -0.208995521945257    2.053e-04    0.005786    0.012422    0.012422    0.124291
+     6        -0.208991621201328    6.453e-05    0.005799    0.012493    0.012493    0.124278
+     7        -0.208991063379036    1.565e-05    0.005803    0.012511    0.012511    0.124275
+     8        -0.208991044225871    2.937e-06    0.005803    0.012514    0.012514    0.124275
+     9        -0.208990967367835    7.070e-07    0.005803    0.012514    0.012514    0.124275
+    10        -0.208990987589477    1.507e-07    0.005803    0.012514    0.012514    0.124275
+    11        -0.208990985952284    2.941e-08    0.005803    0.012514    0.012514    0.124275
+    12        -0.208990986344438    4.776e-09    0.005803    0.012514    0.012514    0.124275
+
+    Iterations converged.
+
+
+    Largest TIA Amplitudes:
+              2   0         0.0108430097
+              3  11        -0.0066539440
+              4  14        -0.0062968539
+              4  18         0.0053909632
+              4  16         0.0049115272
+              1   2         0.0043626421
+              2   5         0.0040679853
+              1   0        -0.0026726422
+              1   7         0.0023396379
+              2   1         0.0022229038
+
+    Largest TIjAb Amplitudes:
+      3   3  11  11        -0.0518990472
+      4   4  14  14        -0.0394129214
+      2   2   2   2        -0.0298937647
+      4   4  15  15        -0.0287516408
+      2   3   2  11         0.0252440967
+      3   2  11   2         0.0252440967
+      3   4  11  16        -0.0248319621
+      4   3  16  11        -0.0248319621
+      4   4  16  16        -0.0246255030
+      3   4  11  14        -0.0244548497
+
+    SCF energy       (wfn)                    =  -76.021997868123066
+    Reference energy (file100)                =  -76.021997868123037
+
+    Opposite-spin MP2 correlation energy      =   -0.149954968993970
+    Same-spin MP2 correlation energy          =   -0.050329621977026
+    MP2 correlation energy                    =   -0.200284590970996
+      * MP2 total energy                      =  -76.222282459094032
+
+    Opposite-spin CCSD correlation energy     =   -0.164400081018819
+    Same-spin CCSD correlation energy         =   -0.044590905326741
+    CCSD correlation energy                   =   -0.208990986344438
+      * CCSD total energy                     =  -76.230988854467469
+
+
+*** tstop() called on psinet at Mon May 15 15:33:53 2017
+Module time:
+	user time   =       0.08 seconds =       0.00 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.51 seconds =       0.01 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:53 2017
+
+
+			**************************
+			*                        *
+			*         CCHBAR         *
+			*                        *
+			**************************
+
+
+*** tstop() called on psinet at Mon May 15 15:33:53 2017
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.52 seconds =       0.01 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:53 2017
+
+
+			**************************
+			*        CCLAMBDA        *
+			**************************
+
+
+	Nuclear Rep. energy (wfn)     =    9.077238153630930
+	Reference           (wfn)     =                    0
+	SCF energy          (wfn)     =  -76.021997868123066
+	Reference energy    (CC_INFO) =  -76.021997868123037
+	CCSD energy         (CC_INFO) =   -0.208990986344438
+	Total CCSD energy   (CC_INFO) =  -76.230988854467469
+
+	Input parameters:
+	-----------------
+	Maxiter           =     50
+	Convergence       = 1.0e-07
+	Restart           =     No
+	Cache Level       =     2
+	Model III         =     No
+	DIIS              =     Yes
+	AO Basis          =     No
+	ABCD              =     NEW
+	Local CC          =     No
+	Paramaters for left-handed eigenvectors:
+	    Irr   Root  Ground-State?    EOM energy        R0
+	  1   0     0        Yes       0.0000000000   1.0000000000
+	Labels for eigenvector 1:
+	LIA 0 -1, Lia 0 -1, LIJAB 0 -1, Lijab 0 -1, LIjAb 0 -1, 2LIjAb - LIjbA 0 -1
+	Symmetry of left-hand state: A1
+	Symmetry of left-hand eigenvector: A1
+
+	          Solving Lambda Equations
+	          ------------------------
+	Iter     PseudoEnergy or Norm         RMS  
+	----     ---------------------     --------
+	   0        -0.209027793961870    0.000e+00
+	   1        -0.206495158157615    7.993e-03
+	   2        -0.206067358865376    1.345e-03
+	   3        -0.205981813889801    6.208e-04
+	   4        -0.205975121506444    2.062e-04
+	   5        -0.205978821663800    6.254e-05
+	   6        -0.205978789400414    1.506e-05
+	   7        -0.205978877336368    3.417e-06
+	   8        -0.205978906807562    5.200e-07
+	   9        -0.205978904853383    9.017e-08
+
+	Largest LIA Amplitudes:
+	          2   0         0.0072417875
+	          4  16         0.0050589428
+	          4  18         0.0046513006
+	          3  11        -0.0039991750
+	          2   5         0.0036194748
+	          1   2         0.0032129565
+	          4  14        -0.0031907785
+	          1   3        -0.0025293241
+	          1   7         0.0021477529
+	          4  15        -0.0021208252
+
+	Largest LIjAb Amplitudes:
+	  3   3  11  11        -0.0516330686
+	  4   4  14  14        -0.0384957240
+	  2   2   2   2        -0.0295153608
+	  4   4  15  15        -0.0280304768
+	  2   3   2  11         0.0250935139
+	  3   2  11   2         0.0250935139
+	  3   4  11  16        -0.0246412024
+	  4   3  16  11        -0.0246412024
+	  4   4  16  16        -0.0243635802
+	  3   4  11  14        -0.0241957737
+
+	Iterations converged.
+
+	Overlap <L|e^T> =        0.94273433070
+
+*** tstop() called on psinet at Mon May 15 15:33:53 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.54 seconds =       0.01 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:53 2017
+
+
+			**************************
+			*                        *
+			*        CCDENSITY       *
+			*                        *
+			**************************
+
+
+	Input parameters:
+	-----------------
+	Wave function    =   CCSD
+	Reference wfn    =   RHF
+	Dertype          = 1
+	Tolerance        = 1.0e-14
+	Cache Level      = 2
+	AO Basis         = No
+	OPDM Only        = No
+	Relax OPDM       = Yes
+	Compute Xi       = No
+	Use Zeta         = No
+	Xi connected     = Yes
+	Compute NO       = No
+
+	Nuclear Rep. energy (wfn)     =    9.077238153630930
+	SCF energy          (wfn)     =  -76.021997868123066
+	Reference energy    (file100) =  -76.021997868123037
+	CCSD energy         (CC_INFO) =   -0.208990986344438
+	Total CCSD energy   (CC_INFO) =  -76.230988854467469
+	Number of States = 1
+
+	Ground?  State     EOM Energy       R0
+	  Yes     0 A1    0.0000000000   1.00000000
+
+	Energies re-computed from CC density:
+	-------------------------------------
+	One-electron energy        =    0.221186777554142
+	IJKL energy                =    0.041993252069384
+	IJKA energy                =   -0.001393403084655
+	IJAB energy                =   -0.412136978683156
+	IBJA energy                =   -0.101198077117444
+	CIAB energy                =   -0.000203578390496
+	ABCD energy                =    0.042761021202647
+	Total two-electron energy  =   -0.430177764003719
+	CCSD    correlation energy =   -0.208990986449577
+	Total CCSD    energy       =  -76.230988854572615
+
+	Virial Theorem Data:
+	--------------------
+	Kinetic energy (ref)   =   75.764057172198534
+	Kinetic energy (corr)  =    0.151616977812720
+	Kinetic energy (total) =   75.915674150011256
+	-V/T (ref)             =    2.003404525913102
+	-V/T (corr)            =    2.378414141736737
+	-V/T (total)           =    2.004153486193552
+
+	Energies re-computed from Fock-adjusted CC density:
+	---------------------------------------------------
+	One-electron energy        =    0.245781755450261
+	IJKL energy                =   -0.672858135803440
+	IJKA energy                =   -0.047236968456078
+	IJAB energy                =   -0.412136978683156
+	IBJA energy                =    0.634901898228761
+	CIAB energy                =   -0.000203578390496
+	ABCD energy                =    0.042761021202647
+	Total two-electron energy  =   -0.454772741901761
+	   CCSD correlation energy =   -0.208990986451499
+	Total    CCSD energy       =  -76.230988854574534
+
+	Energies re-computed from Mulliken density:
+	-------------------------------------------
+	One-electron energy        =    0.245781755450261
+	IJKL energy                =   -0.672858135803440
+	IJKA energy                =   -0.047236968456078
+	IJAB energy                =   -0.381058775762284
+	IBJA energy                =    0.603823695307889
+	CIAB energy                =   -0.000203578390496
+	ABCD energy                =    0.042761021202647
+	Total two-electron energy  =   -0.454772741901761
+	   CCSD correlation energy =   -0.208990986451500
+	Total    CCSD energy       =  -76.230988854574534
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the CC density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     1.0051
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.1730
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.8322     Total:     0.8322
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     2.1151     Total:     2.1151
+
+  Quadrupole Moment: (Debye Ang)
+    XX:    -7.2492     YY:    -4.3222     ZZ:    -5.7834
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: (Debye Ang)
+    XX:    -1.4643     YY:     1.4627     ZZ:     0.0016
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     O     4.31583  4.31583  0.00000 -0.63166
+       2     H     0.34209  0.34209  0.00000  0.31583
+       3     H     0.34209  0.34209  0.00000  0.31583
+
+   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    1 B1    1.972
+  HONO-1 :    3 A1    1.966
+  HONO-0 :    1 B2    1.964
+  LUNO+0 :    2 B2    0.027
+  LUNO+1 :    4 A1    0.025
+  LUNO+2 :    2 B1    0.017
+  LUNO+3 :    5 A1    0.011
+
+
+*** tstop() called on psinet at Mon May 15 15:33:54 2017
+Module time:
+	user time   =       0.10 seconds =       0.00 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.64 seconds =       0.01 minutes
+	system time =       0.36 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+  Cartesian Displacement SALCs
+  By SALC:
+  Number of SALCs: 3, nirreps: 1
+  Project out translations: False
+  Project out rotations: False
+	irrep = 0, ncomponent = 1
+		0: atom 0, direction z, coef 1.000000
+	irrep = 0, ncomponent = 2
+		0: atom 1, direction y, coef 0.707107
+		1: atom 2, direction y, coef -0.707107
+	irrep = 0, ncomponent = 2
+		0: atom 1, direction z, coef 0.707107
+		1: atom 2, direction z, coef 0.707107
+
+  By Atomic Center:
+  Number of atomic centers: 3
+   Atomic Center 0:
+	x component, size = 0
+	y component, size = 0
+	z component, size = 1
+		0: salc 0, irrep 0, coef 1.000000
+   Atomic Center 1:
+	x component, size = 0
+	y component, size = 1
+		0: salc 1, irrep 0, coef 0.707107
+	z component, size = 1
+		0: salc 2, irrep 0, coef 0.707107
+   Atomic Center 2:
+	x component, size = 0
+	y component, size = 1
+		0: salc 1, irrep 0, coef -0.707107
+	z component, size = 1
+		0: salc 2, irrep 0, coef 0.707107
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.127705022386
+           H          0.000000000000    -1.434547633239     1.013385689263
+           H          0.000000000000     1.434547633239     1.013385689263
+
+	Presorting MO-basis TPDM.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDM.
+	First half integral transformation complete.
+
+
+  -Nuclear Repulsion Energy 1st Derivatives:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     2.964342245725
+       2       -0.000000000000     1.984825954516    -1.482171122862
+       3        0.000000000000    -1.984825954516    -1.482171122862
+
+
+  -One-electron contribution to gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000    -6.872400560046
+       2        0.000000000000    -4.509660605611     3.436200280023
+       3       -0.000000000000     4.509660605611     3.436200280023
+
+
+  -Lagrangian contribution to gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.411443443502
+       2       -0.000000000000     0.245759878510    -0.205721721751
+       3        0.000000000000    -0.245759878510    -0.205721721751
+
+
+  -Two-electron contribution to gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     3.483428206432
+       2       -0.000000000000     2.272612742504    -1.741714103216
+       3        0.000000000000    -2.272612742504    -1.741714103216
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000    -0.013186664387
+       2        0.000000000000    -0.006462030081     0.006593332193
+       3       -0.000000000000     0.006462030081     0.006593332193
+
+
+			-----------------------------------------
+			 OPTKING 2.0: for geometry optimizations 
+			  - R.A. King,  Bethel University        
+			-----------------------------------------
+
+	Internal coordinates to be generated automatically.
+	Detected frag 1 with atoms:  1 2 3
+	---Fragment 1 Bond Connectivity---
+	 1 : 2 3
+	 2 : 1
+	 3 : 1
+
+	---Fragment 1 Geometry and Gradient---
+	 O           0.0000000000        0.0000000000       -0.1277050224
+	 H           0.0000000000       -1.4345476332        1.0133856893
+	 H           0.0000000000        1.4345476332        1.0133856893
+	             0.0000000000        0.0000000000       -0.0131866644
+	             0.0000000000       -0.0064620301        0.0065933322
+	            -0.0000000000        0.0064620301        0.0065933322
+
+	Previous optimization step data not found.  Starting new optimization.
+
+	---Fragment 1 Intrafragment Coordinates---
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         1.833034	       0.970000
+	 R(1,3)           =         1.833034	       0.970000
+	 B(2,1,3)         =         1.797689	     103.000000
+
+	Current energy   :       -76.2309888545
+
+	Generating empirical Hessian (Schlegel '84) for each fragment.
+	Taking RFO optimization step.
+	Going to follow RFO solution 1.
+	Using RFO vector 1.
+	Norm of target step-size    0.02752
+	Projected energy change by RFO approximation:        -0.0000218299
+
+	Back-transformation to cartesian coordinates...
+	Successfully converged to displaced geometry.
+
+	--- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	 ---------------------------------------------------------------------------
+	   Coordinate                Previous        Force       Change         New 
+	   ----------                --------       ------       ------       ------
+	    1 R(1,2)          =      0.970000    -0.075481    -0.009077     0.960923
+	    2 R(1,3)          =      0.970000    -0.075481    -0.009077     0.960923
+	    3 B(2,1,3)        =    103.000000     0.000159     0.744934   103.744934
+	 ---------------------------------------------------------------------------
+	Successfully symmetrized geometry.
+
+  ==> Convergence Check <==
+
+  Measures of convergence in internal coordinates in au.
+  Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+  --------------------------------------------------------------------------------------------- ~
+   Step     Total Energy     Delta E     MAX Force     RMS Force      MAX Disp      RMS Disp    ~
+  --------------------------------------------------------------------------------------------- ~
+    Convergence Criteria    1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o  ~
+  --------------------------------------------------------------------------------------------- ~
+      1     -76.23098885   -7.62e+01      9.16e-03      7.58e-03 o    1.72e-02      1.59e-02 o  ~
+  ---------------------------------------------------------------------------------------------
+
+	Writing optimization data to binary file.
+	Structure for next step:
+	Cartesian Geometry (in Angstrom)
+	    O     0.0000000000   0.0000000000  -0.0605439489
+	    H     0.0000000000  -0.7558989055   0.5327432911
+	    H     0.0000000000   0.7558989055   0.5327432911
+			--------------------------
+			 OPTKING Finished Execution 
+			--------------------------
+
+    Structure for next step:
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+    O       
+    H             1    0.960923
+    H             1    0.960923      2  103.744934
+
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:54 2017
+
+   => Loading Basis Set <=
+
+    Name: 6-31G**
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   140 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2-3 entry H          line    35 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.066397666276    15.994914619560
+           H          0.000000000000    -0.755898905515     0.526889573702     1.007825032070
+           H          0.000000000000     0.755898905515     0.526889573702     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     26.75449  B =     14.63706  C =      9.46104 [cm^-1]
+  Rotational constants: A = 802079.55576  B = 438808.09054  C = 283634.86362 [MHz]
+  Nuclear repulsion =    9.161180837150805
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G**
+    Blend: 6-31G**
+    Number of shells: 12
+    Number of basis function: 25
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        12      12       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      25      25       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             25
+      Number of atomic orbitals:        25
+      Number of basis functions:        25
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 105950 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+  Minimum eigenvalue in the overlap matrix is 2.2007011557E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -76.03442224369516   -7.60344e+01   1.69791e-03 
+   @RHF iter   1:   -76.02286068245994    1.15616e-02   2.53762e-04 
+   @RHF iter   2:   -76.02286887130417   -8.18884e-06   1.16147e-04 DIIS
+   @RHF iter   3:   -76.02287001874517   -1.14744e-06   3.24612e-05 DIIS
+   @RHF iter   4:   -76.02287026551789   -2.46773e-07   1.11408e-05 DIIS
+   @RHF iter   5:   -76.02287029779359   -3.22757e-08   2.03245e-06 DIIS
+   @RHF iter   6:   -76.02287029902574   -1.23215e-09   3.09442e-07 DIIS
+   @RHF iter   7:   -76.02287029904868   -2.29363e-11   5.01345e-08 DIIS
+   @RHF iter   8:   -76.02287029904919   -5.11591e-13   5.85236e-09 DIIS
+   @RHF iter   9:   -76.02287029904920   -1.42109e-14   6.44692e-10 DIIS
+   @RHF iter  10:   -76.02287029904917    2.84217e-14   6.79679e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.561713     2A1    -1.339083     1B2    -0.700031  
+       3A1    -0.569655     1B1    -0.497204  
+
+    Virtual:                                                              
+
+       4A1     0.211209     2B2     0.303715     3B2     0.999716  
+       5A1     1.085843     6A1     1.132387     2B1     1.168726  
+       4B2     1.294665     7A1     1.416760     1A2     1.804934  
+       8A1     1.811543     3B1     1.922519     9A1     2.566521  
+       5B2     2.577347     6B2     2.798940     2A2     2.971042  
+       4B1     2.991295    10A1     3.369113    11A1     3.701471  
+       7B2     3.923869    12A1     4.102790  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -76.02287029904917
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1611808371508054
+    One-Electron Energy =                -123.0327302720779130
+    Two-Electron Energy =                  37.8486791358779300
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0228702990491740
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.9876
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.1218
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.8658     Total:     0.8658
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     2.2006     Total:     2.2006
+
+
+*** tstop() called on psinet at Mon May 15 15:33:54 2017
+Module time:
+	user time   =       0.14 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.85 seconds =       0.01 minutes
+	system time =       0.38 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of threads:                 1
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of SO shells:               9
+      Number of primitives:             25
+      Number of atomic orbitals:        25
+      Number of basis functions:        25
+
+      Number of irreps:                  4
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [  12    2    4    7 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 13803 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:54 2017
+
+
+	Wfn Parameters:
+	--------------------
+	Wavefunction         = CCSD
+	Number of irreps     = 4
+	Number of MOs        = 25
+	Number of active MOs = 25
+	AO-Basis             = NONE
+	Semicanonical        = false
+	Reference            = RHF
+	Print Level          = 1
+
+	IRREP	# MOs	# FZDC	# DOCC	# SOCC	# VIRT	# FZVR
+	-----	-----	------	------	------	------	------
+	 A1	   12	    0	    3	    0	    9	    0
+	 A2	   2	    0	    0	    0	    2	    0
+	 B1	   4	    0	    1	    0	    3	    0
+	 B2	   7	    0	    1	    0	    6	    0
+	Transforming integrals...
+	IWL integrals will be deleted.
+	(OO|OO)...
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Transforming the one-electron integrals and constructing Fock matrices
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OO)...
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OO)...
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	Frozen core energy     =      0.00000000000000
+
+	Size of irrep 0 of <ab|cd> integrals:      0.017 (MW) /      0.135 (MB)
+	Size of irrep 1 of <ab|cd> integrals:      0.005 (MW) /      0.041 (MB)
+	Size of irrep 2 of <ab|cd> integrals:      0.006 (MW) /      0.049 (MB)
+	Size of irrep 3 of <ab|cd> integrals:      0.014 (MW) /      0.115 (MB)
+	Total:                                     0.043 (MW) /      0.341 (MB)
+
+	Size of irrep 0 of <ia|bc> integrals:      0.005 (MW) /      0.037 (MB)
+	Size of irrep 1 of <ia|bc> integrals:      0.001 (MW) /      0.009 (MB)
+	Size of irrep 2 of <ia|bc> integrals:      0.002 (MW) /      0.012 (MB)
+	Size of irrep 3 of <ia|bc> integrals:      0.003 (MW) /      0.028 (MB)
+	Total:                                     0.011 (MW) /      0.086 (MB)
+
+	Size of irrep 0 of tijab amplitudes:       0.001 (MW) /      0.011 (MB)
+	Size of irrep 1 of tijab amplitudes:       0.000 (MW) /      0.001 (MB)
+	Size of irrep 2 of tijab amplitudes:       0.000 (MW) /      0.004 (MB)
+	Size of irrep 3 of tijab amplitudes:       0.001 (MW) /      0.006 (MB)
+	Total:                                     0.003 (MW) /      0.022 (MB)
+
+	Nuclear Rep. energy          =      9.16118083715081
+	SCF energy                   =    -76.02287029904917
+	One-electron energy          =   -123.03273027160742
+	Two-electron energy          =     37.84867913540743
+	Reference energy             =    -76.02287029904919
+
+*** tstop() called on psinet at Mon May 15 15:33:54 2017
+Module time:
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.90 seconds =       0.02 minutes
+	system time =       0.41 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:54 2017
+
+            **************************
+            *                        *
+            *        CCENERGY        *
+            *                        *
+            **************************
+
+    Nuclear Rep. energy (wfn)     =    9.161180837150805
+    SCF energy          (wfn)     =  -76.022870299049174
+    Reference energy    (file100) =  -76.022870299049188
+
+    Input parameters:
+    -----------------
+    Wave function   =     CCSD
+    Reference wfn   =     RHF
+    Brueckner       =     No
+    Memory (Mbytes) =     524.3
+    Maxiter         =     50
+    R_Convergence   =     1.0e-07
+    E_Convergence   =     1.0e-08
+    Restart         =     Yes
+    DIIS            =     Yes
+    AO Basis        =     NONE
+    ABCD            =     NEW
+    Cache Level     =     2
+    Cache Type      =     LOW
+    Print Level     =     1
+    Num. of threads =     1
+    # Amps to Print =     10
+    Print MP2 Amps? =     No
+    Analyze T2 Amps =     No
+    Print Pair Ener =     No
+    Local CC        =     No
+    SCS-MP2         =     False
+    SCSN-MP2        =     False
+    SCS-CCSD        =     False
+
+    Using old T1 amplitudes.
+    Using old T2 amplitudes.
+
+MP2 correlation energy -0.1995779298155369
+                Solving CC Amplitude Equations
+                ------------------------------
+  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
+  ----     ---------------------    ---------   ----------  ----------  ----------   --------
+     0        -0.208832766977767    0.000e+00    0.005803    0.012514    0.012514    0.124275
+     1        -0.208352192758995    5.808e-03    0.005946    0.013119    0.013119    0.123305
+     2        -0.208351928562426    1.321e-03    0.005758    0.012502    0.012502    0.123122
+     3        -0.208313705185478    3.912e-04    0.005714    0.012347    0.012347    0.123013
+     4        -0.208305450393528    1.391e-04    0.005681    0.012212    0.012212    0.122982
+     5        -0.208304246786706    3.956e-05    0.005671    0.012166    0.012166    0.122978
+     6        -0.208304581255638    1.130e-05    0.005669    0.012152    0.012152    0.122979
+     7        -0.208304662444435    2.163e-06    0.005669    0.012150    0.012150    0.122980
+     8        -0.208304702846171    3.869e-07    0.005669    0.012150    0.012150    0.122980
+     9        -0.208304705056091    8.612e-08    0.005669    0.012150    0.012150    0.122980
+    10        -0.208304706208642    1.903e-08    0.005669    0.012150    0.012150    0.122980
+
+    Iterations converged.
+
+
+    Largest TIA Amplitudes:
+              2   0         0.0104578565
+              3  11        -0.0065599589
+              4  14        -0.0062679699
+              4  18         0.0052425993
+              4  16         0.0046299439
+              1   2         0.0042751583
+              2   5         0.0039508040
+              1   0        -0.0028721033
+              1   7         0.0023730140
+              2   1         0.0022659231
+
+    Largest TIjAb Amplitudes:
+      3   3  11  11        -0.0518782951
+      4   4  14  14        -0.0381048556
+      2   2   2   2        -0.0288684547
+      4   4  15  15        -0.0286603421
+      3   4  11  16        -0.0248103170
+      4   3  16  11        -0.0248103170
+      4   4  16  16        -0.0246764511
+      2   3   2  11         0.0246211685
+      3   2  11   2         0.0246211685
+      3   4  11  14        -0.0242303543
+
+    SCF energy       (wfn)                    =  -76.022870299049174
+    Reference energy (file100)                =  -76.022870299049188
+
+    Opposite-spin MP2 correlation energy      =   -0.149388403575212
+    Same-spin MP2 correlation energy          =   -0.050189526240325
+    MP2 correlation energy                    =   -0.199577929815537
+      * MP2 total energy                      =  -76.222448228864721
+
+    Opposite-spin CCSD correlation energy     =   -0.163737341181464
+    Same-spin CCSD correlation energy         =   -0.044567365024164
+    CCSD correlation energy                   =   -0.208304706208642
+      * CCSD total energy                     =  -76.231175005257825
+
+
+*** tstop() called on psinet at Mon May 15 15:33:54 2017
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.97 seconds =       0.02 minutes
+	system time =       0.57 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:54 2017
+
+
+			**************************
+			*                        *
+			*         CCHBAR         *
+			*                        *
+			**************************
+
+
+*** tstop() called on psinet at Mon May 15 15:33:54 2017
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.98 seconds =       0.02 minutes
+	system time =       0.58 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:54 2017
+
+
+			**************************
+			*        CCLAMBDA        *
+			**************************
+
+
+	Nuclear Rep. energy (wfn)     =    9.161180837150805
+	Reference           (wfn)     =                    0
+	SCF energy          (wfn)     =  -76.022870299049174
+	Reference energy    (CC_INFO) =  -76.022870299049188
+	CCSD energy         (CC_INFO) =   -0.208304706208642
+	Total CCSD energy   (CC_INFO) =  -76.231175005257825
+
+	Input parameters:
+	-----------------
+	Maxiter           =     50
+	Convergence       = 1.0e-07
+	Restart           =     No
+	Cache Level       =     2
+	Model III         =     No
+	DIIS              =     Yes
+	AO Basis          =     No
+	ABCD              =     NEW
+	Local CC          =     No
+	Paramaters for left-handed eigenvectors:
+	    Irr   Root  Ground-State?    EOM energy        R0
+	  1   0     0        Yes       0.0000000000   1.0000000000
+	Labels for eigenvector 1:
+	LIA 0 -1, Lia 0 -1, LIJAB 0 -1, Lijab 0 -1, LIjAb 0 -1, 2LIjAb - LIjbA 0 -1
+	Symmetry of left-hand state: A1
+	Symmetry of left-hand eigenvector: A1
+
+	          Solving Lambda Equations
+	          ------------------------
+	Iter     PseudoEnergy or Norm         RMS  
+	----     ---------------------     --------
+	   0        -0.208341272342194    9.017e-08
+	   1        -0.205855816883735    7.969e-03
+	   2        -0.205434039982074    1.315e-03
+	   3        -0.205350569998591    6.037e-04
+	   4        -0.205344216692114    1.999e-04
+	   5        -0.205347757159083    6.066e-05
+	   6        -0.205347737519131    1.456e-05
+	   7        -0.205347817975305    3.263e-06
+	   8        -0.205347846127468    4.958e-07
+	   9        -0.205347844166032    8.424e-08
+
+	Largest LIA Amplitudes:
+	          2   0         0.0069579999
+	          4  16         0.0048367196
+	          4  18         0.0045278770
+	          3  11        -0.0038906253
+	          2   5         0.0035178270
+	          4  14        -0.0031666919
+	          1   2         0.0031569145
+	          1   3        -0.0024467761
+	          1   7         0.0021792656
+	          4  15        -0.0020511924
+
+	Largest LIjAb Amplitudes:
+	  3   3  11  11        -0.0515965313
+	  4   4  14  14        -0.0372313767
+	  2   2   2   2        -0.0285001142
+	  4   4  15  15        -0.0279512386
+	  3   4  11  16        -0.0246236949
+	  4   3  16  11        -0.0246236949
+	  2   3   2  11         0.0244701826
+	  3   2  11   2         0.0244701826
+	  4   4  16  16        -0.0244234386
+	  3   4  11  14        -0.0239728041
+
+	Iterations converged.
+
+	Overlap <L|e^T> =        0.94342446404
+
+*** tstop() called on psinet at Mon May 15 15:33:54 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.00 seconds =       0.02 minutes
+	system time =       0.61 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:54 2017
+
+
+			**************************
+			*                        *
+			*        CCDENSITY       *
+			*                        *
+			**************************
+
+
+	Input parameters:
+	-----------------
+	Wave function    =   CCSD
+	Reference wfn    =   RHF
+	Dertype          = 1
+	Tolerance        = 1.0e-14
+	Cache Level      = 2
+	AO Basis         = No
+	OPDM Only        = No
+	Relax OPDM       = Yes
+	Compute Xi       = No
+	Use Zeta         = No
+	Xi connected     = Yes
+	Compute NO       = No
+
+	Nuclear Rep. energy (wfn)     =    9.161180837150805
+	SCF energy          (wfn)     =  -76.022870299049174
+	Reference energy    (file100) =  -76.022870299049188
+	CCSD energy         (CC_INFO) =   -0.208304706208642
+	Total CCSD energy   (CC_INFO) =  -76.231175005257825
+	Number of States = 1
+
+	Ground?  State     EOM Energy       R0
+	  Yes     0 A1    0.0000000000   1.00000000
+
+	Energies re-computed from CC density:
+	-------------------------------------
+	One-electron energy        =    0.220401428909322
+	IJKL energy                =    0.041624272800223
+	IJKA energy                =   -0.001380495813622
+	IJAB energy                =   -0.410871757238811
+	IBJA energy                =   -0.100224187354571
+	CIAB energy                =   -0.000154378287070
+	ABCD energy                =    0.042300410465944
+	Total two-electron energy  =   -0.428706135427907
+	CCSD    correlation energy =   -0.208304706518585
+	Total CCSD    energy       =  -76.231175005567763
+
+	Virial Theorem Data:
+	--------------------
+	Kinetic energy (ref)   =   75.797290302742311
+	Kinetic energy (corr)  =    0.147813059281767
+	Kinetic energy (total) =   75.945103362024085
+	-V/T (ref)             =    2.002976095786615
+	-V/T (corr)            =    2.409244265836916
+	-V/T (total)           =    2.003766821435084
+
+	Energies re-computed from Fock-adjusted CC density:
+	---------------------------------------------------
+	One-electron energy        =    0.246368008846171
+	IJKL energy                =   -0.666765074537129
+	IJKA energy                =   -0.047671155273339
+	IJAB energy                =   -0.410871757238811
+	IBJA energy                =    0.628489239511619
+	CIAB energy                =   -0.000154378287070
+	ABCD energy                =    0.042300410465944
+	Total two-electron energy  =   -0.454672715358786
+	   CCSD correlation energy =   -0.208304706512615
+	Total    CCSD energy       =  -76.231175005561795
+
+	Energies re-computed from Mulliken density:
+	-------------------------------------------
+	One-electron energy        =    0.246368008846171
+	IJKL energy                =   -0.666765074537129
+	IJKA energy                =   -0.047671155273339
+	IJAB energy                =   -0.379953584434570
+	IBJA energy                =    0.597571066707377
+	CIAB energy                =   -0.000154378287070
+	ABCD energy                =    0.042300410465944
+	Total two-electron energy  =   -0.454672715358786
+	   CCSD correlation energy =   -0.208304706512615
+	Total    CCSD energy       =  -76.231175005561795
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the CC density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.9876
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.1611
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.8265     Total:     0.8265
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     2.1007     Total:     2.1007
+
+  Quadrupole Moment: (Debye Ang)
+    XX:    -7.2294     YY:    -4.3023     ZZ:    -5.8039
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: (Debye Ang)
+    XX:    -1.4509     YY:     1.4762     ZZ:    -0.0254
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     O     4.31575  4.31575  0.00000 -0.63150
+       2     H     0.34213  0.34213  0.00000  0.31575
+       3     H     0.34213  0.34213  0.00000  0.31575
+
+   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    1 B1    1.972
+  HONO-1 :    3 A1    1.966
+  HONO-0 :    1 B2    1.964
+  LUNO+0 :    2 B2    0.027
+  LUNO+1 :    4 A1    0.025
+  LUNO+2 :    2 B1    0.017
+  LUNO+3 :    5 A1    0.011
+
+
+*** tstop() called on psinet at Mon May 15 15:33:54 2017
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.07 seconds =       0.02 minutes
+	system time =       0.65 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+  Cartesian Displacement SALCs
+  By SALC:
+  Number of SALCs: 3, nirreps: 1
+  Project out translations: False
+  Project out rotations: False
+	irrep = 0, ncomponent = 1
+		0: atom 0, direction z, coef 1.000000
+	irrep = 0, ncomponent = 2
+		0: atom 1, direction y, coef 0.707107
+		1: atom 2, direction y, coef -0.707107
+	irrep = 0, ncomponent = 2
+		0: atom 1, direction z, coef 0.707107
+		1: atom 2, direction z, coef 0.707107
+
+  By Atomic Center:
+  Number of atomic centers: 3
+   Atomic Center 0:
+	x component, size = 0
+	y component, size = 0
+	z component, size = 1
+		0: salc 0, irrep 0, coef 1.000000
+   Atomic Center 1:
+	x component, size = 0
+	y component, size = 1
+		0: salc 1, irrep 0, coef 0.707107
+	z component, size = 1
+		0: salc 2, irrep 0, coef 0.707107
+   Atomic Center 2:
+	x component, size = 0
+	y component, size = 1
+		0: salc 1, irrep 0, coef -0.707107
+	z component, size = 1
+		0: salc 2, irrep 0, coef 0.707107
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.125473405125
+           H          0.000000000000    -1.428441915571     0.995676996570
+           H          0.000000000000     1.428441915571     0.995676996570
+
+	Presorting MO-basis TPDM.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDM.
+	First half integral transformation complete.
+
+
+  -Nuclear Repulsion Energy 1st Derivatives:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     2.995860335503
+       2       -0.000000000000     2.031013916398    -1.497930167751
+       3        0.000000000000    -2.031013916398    -1.497930167751
+
+
+  -One-electron contribution to gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000    -6.905252322721
+       2        0.000000000000    -4.604556154403     3.452626161361
+       3       -0.000000000000     4.604556154403     3.452626161361
+
+
+  -Lagrangian contribution to gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.413316411295
+       2       -0.000000000000     0.251209963720    -0.206658205648
+       3        0.000000000000    -0.251209963720    -0.206658205648
+
+
+  -Two-electron contribution to gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     3.494694252764
+       2       -0.000000000000     2.322323860800    -1.747347126382
+       3        0.000000000000    -2.322323860800    -1.747347126382
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000    -0.001381323159
+       2        0.000000000000    -0.000008413485     0.000690661580
+       3       -0.000000000000     0.000008413485     0.000690661580
+
+
+			-----------------------------------------
+			 OPTKING 2.0: for geometry optimizations 
+			  - R.A. King,  Bethel University        
+			-----------------------------------------
+
+	Previous internal coordinate definitions found.
+	---Fragment 1 Geometry and Gradient---
+	 O           0.0000000000        0.0000000000       -0.1254734051
+	 H           0.0000000000       -1.4284419156        0.9956769966
+	 H           0.0000000000        1.4284419156        0.9956769966
+	             0.0000000000        0.0000000000       -0.0013813232
+	             0.0000000000       -0.0000084135        0.0006906616
+	            -0.0000000000        0.0000084135        0.0006906616
+
+	---Fragment 1 Intrafragment Coordinates---
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         1.815881	       0.960923
+	 R(1,3)           =         1.815881	       0.960923
+	 B(2,1,3)         =         1.810691	     103.744934
+
+	Current energy   :       -76.2311750053
+
+	Energy change for the previous step:
+		Projected    :        -0.0000218299
+		Actual       :        -0.0001861508
+	Energy ratio indicates good step: Trust radius increased to 1.000e+00.
+
+
+	Performing BFGS update.
+	Previous computed or guess Hessian on step 1.
+	Steps to be used in Hessian update: 1
+	Taking RFO optimization step.
+	Going to follow RFO solution 1.
+	Using RFO vector 1.
+	Norm of target step-size    0.00703
+	Projected energy change by RFO approximation:        -0.0000110992
+
+	Back-transformation to cartesian coordinates...
+	Successfully converged to displaced geometry.
+
+	--- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	 ---------------------------------------------------------------------------
+	   Coordinate                Previous        Force       Change         New 
+	   ----------                --------       ------       ------       ------
+	    1 R(1,2)          =      0.960923    -0.003568    -0.000606     0.960317
+	    2 R(1,3)          =      0.960923    -0.003568    -0.000606     0.960317
+	    3 B(2,1,3)        =    103.744934     0.000074     0.391908   104.136842
+	 ---------------------------------------------------------------------------
+	Successfully symmetrized geometry.
+
+  ==> Convergence Check <==
+
+  Measures of convergence in internal coordinates in au.
+  Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+  ---------------------------------------------------------------------------------------------
+   Step     Total Energy     Delta E     MAX Force     RMS Force      MAX Disp      RMS Disp   
+  ---------------------------------------------------------------------------------------------
+    Convergence Criteria    1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+  ---------------------------------------------------------------------------------------------
+      2     -76.23117501   -1.86e-04      9.77e-04      6.66e-04 o    6.84e-03      4.06e-03 o  ~
+  ---------------------------------------------------------------------------------------------
+
+	Writing optimization data to binary file.
+	Structure for next step:
+	Cartesian Geometry (in Angstrom)
+	    O     0.0000000000   0.0000000000  -0.0644236367
+	    H     0.0000000000  -0.7574457602   0.5259025589
+	    H     0.0000000000   0.7574457602   0.5259025589
+			--------------------------
+			 OPTKING Finished Execution 
+			--------------------------
+
+    Structure for next step:
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+    O       
+    H             1    0.960317
+    H             1    0.960317      2  104.136842
+
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:54 2017
+
+   => Loading Basis Set <=
+
+    Name: 6-31G**
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   140 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2-3 entry H          line    35 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, and Andy Simmonett
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.066066281368    15.994914619560
+           H          0.000000000000    -0.757445760189     0.524259914212     1.007825032070
+           H          0.000000000000     0.757445760189     0.524259914212     1.007825032070
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     27.02357  B =     14.57734  C =      9.46931 [cm^-1]
+  Rotational constants: A = 810146.11155  B = 437017.65408  C = 283882.64868 [MHz]
+  Nuclear repulsion =    9.166023988379742
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is READ.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: 6-31G**
+    Blend: 6-31G**
+    Number of shells: 12
+    Number of basis function: 25
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+  Reading orbitals from file 180, no projection.
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        12      12       0       0       0       0
+     A2         2       2       0       0       0       0
+     B1         4       4       0       0       0       0
+     B2         7       7       0       0       0       0
+   -------------------------------------------------------
+    Total      25      25       5       5       5       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             25
+      Number of atomic orbitals:        25
+      Number of basis functions:        25
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 105950 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+  Minimum eigenvalue in the overlap matrix is 2.1994436500E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Orbitals guess was supplied from a previous computation.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   0:   -76.02380171615275   -7.60238e+01   1.80303e-04 
+   @RHF iter   1:   -76.02294253402849    8.59182e-04   2.94478e-05 
+   @RHF iter   2:   -76.02294269563227   -1.61604e-07   1.02584e-05 DIIS
+   @RHF iter   3:   -76.02294272529872   -2.96665e-08   2.46211e-06 DIIS
+   @RHF iter   4:   -76.02294272737615   -2.07743e-09   5.58770e-07 DIIS
+   @RHF iter   5:   -76.02294272747062   -9.44738e-11   1.40271e-07 DIIS
+   @RHF iter   6:   -76.02294272747235   -1.73372e-12   3.28717e-08 DIIS
+   @RHF iter   7:   -76.02294272747244   -8.52651e-14   5.66373e-09 DIIS
+   @RHF iter   8:   -76.02294272747244    0.00000e+00   5.01550e-10 DIIS
+   @RHF iter   9:   -76.02294272747245   -1.42109e-14   7.73112e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies (a.u.)
+    -----------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.561381     2A1    -1.339051     1B2    -0.701081  
+       3A1    -0.568958     1B1    -0.497085  
+
+    Virtual:                                                              
+
+       4A1     0.211398     2B2     0.303908     3B2     1.001473  
+       5A1     1.085201     6A1     1.132402     2B1     1.168831  
+       4B2     1.294708     7A1     1.415334     1A2     1.804140  
+       8A1     1.814637     3B1     1.923918     9A1     2.567000  
+       5B2     2.575439     6B2     2.800748     2A2     2.974152  
+       4B1     2.989342    10A1     3.371075    11A1     3.703144  
+       7B2     3.923362    12A1     4.105025  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  Energy converged.
+
+  @RHF Final Energy:   -76.02294272747245
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1660239883797416
+    One-Electron Energy =                -123.0428193375948922
+    Two-Electron Energy =                  37.8538526217426892
+    DFT Exchange-Correlation Energy =       0.0000000000000000
+    Empirical Dispersion Energy =           0.0000000000000000
+    PCM Polarization Energy =               0.0000000000000000
+    EFP Energy =                            0.0000000000000000
+    Total Energy =                        -76.0229427274724543
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.9826
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.1197
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.8630     Total:     0.8630
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     2.1935     Total:     2.1935
+
+
+*** tstop() called on psinet at Mon May 15 15:33:55 2017
+Module time:
+	user time   =       0.14 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       1.27 seconds =       0.02 minutes
+	system time =       0.68 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+ MINTS: Wrapper to libmints.
+   by Justin Turney
+
+   Calculation information:
+      Number of threads:                 1
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of SO shells:               9
+      Number of primitives:             25
+      Number of atomic orbitals:        25
+      Number of basis functions:        25
+
+      Number of irreps:                  4
+      Integral cutoff                 0.00e+00
+      Number of functions per irrep: [  12    2    4    7 ]
+
+ OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
+         stored in file 35.
+
+      Computing two-electron integrals...done
+      Computed 13803 non-zero two-electron integrals.
+        Stored in file 33.
+
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:55 2017
+
+
+	Wfn Parameters:
+	--------------------
+	Wavefunction         = CCSD
+	Number of irreps     = 4
+	Number of MOs        = 25
+	Number of active MOs = 25
+	AO-Basis             = NONE
+	Semicanonical        = false
+	Reference            = RHF
+	Print Level          = 1
+
+	IRREP	# MOs	# FZDC	# DOCC	# SOCC	# VIRT	# FZVR
+	-----	-----	------	------	------	------	------
+	 A1	   12	    0	    3	    0	    9	    0
+	 A2	   2	    0	    0	    0	    2	    0
+	 B1	   4	    0	    1	    0	    3	    0
+	 B2	   7	    0	    1	    0	    6	    0
+	Transforming integrals...
+	IWL integrals will be deleted.
+	(OO|OO)...
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Transforming the one-electron integrals and constructing Fock matrices
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OO|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OO)...
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(OV|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OO)...
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|OV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	(VV|VV)...
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+	Frozen core energy     =      0.00000000000000
+
+	Size of irrep 0 of <ab|cd> integrals:      0.017 (MW) /      0.135 (MB)
+	Size of irrep 1 of <ab|cd> integrals:      0.005 (MW) /      0.041 (MB)
+	Size of irrep 2 of <ab|cd> integrals:      0.006 (MW) /      0.049 (MB)
+	Size of irrep 3 of <ab|cd> integrals:      0.014 (MW) /      0.115 (MB)
+	Total:                                     0.043 (MW) /      0.341 (MB)
+
+	Size of irrep 0 of <ia|bc> integrals:      0.005 (MW) /      0.037 (MB)
+	Size of irrep 1 of <ia|bc> integrals:      0.001 (MW) /      0.009 (MB)
+	Size of irrep 2 of <ia|bc> integrals:      0.002 (MW) /      0.012 (MB)
+	Size of irrep 3 of <ia|bc> integrals:      0.003 (MW) /      0.028 (MB)
+	Total:                                     0.011 (MW) /      0.086 (MB)
+
+	Size of irrep 0 of tijab amplitudes:       0.001 (MW) /      0.011 (MB)
+	Size of irrep 1 of tijab amplitudes:       0.000 (MW) /      0.001 (MB)
+	Size of irrep 2 of tijab amplitudes:       0.000 (MW) /      0.004 (MB)
+	Size of irrep 3 of tijab amplitudes:       0.001 (MW) /      0.006 (MB)
+	Total:                                     0.003 (MW) /      0.022 (MB)
+
+	Nuclear Rep. energy          =      9.16602398837974
+	SCF energy                   =    -76.02294272747245
+	One-electron energy          =   -123.04281933713332
+	Two-electron energy          =     37.85385262128116
+	Reference energy             =    -76.02294272747241
+
+*** tstop() called on psinet at Mon May 15 15:33:55 2017
+Module time:
+	user time   =       0.02 seconds =       0.00 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.31 seconds =       0.02 minutes
+	system time =       0.72 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:55 2017
+
+            **************************
+            *                        *
+            *        CCENERGY        *
+            *                        *
+            **************************
+
+    Nuclear Rep. energy (wfn)     =    9.166023988379742
+    SCF energy          (wfn)     =  -76.022942727472454
+    Reference energy    (file100) =  -76.022942727472412
+
+    Input parameters:
+    -----------------
+    Wave function   =     CCSD
+    Reference wfn   =     RHF
+    Brueckner       =     No
+    Memory (Mbytes) =     524.3
+    Maxiter         =     50
+    R_Convergence   =     1.0e-07
+    E_Convergence   =     1.0e-08
+    Restart         =     Yes
+    DIIS            =     Yes
+    AO Basis        =     NONE
+    ABCD            =     NEW
+    Cache Level     =     2
+    Cache Type      =     LOW
+    Print Level     =     1
+    Num. of threads =     1
+    # Amps to Print =     10
+    Print MP2 Amps? =     No
+    Analyze T2 Amps =     No
+    Print Pair Ener =     No
+    Local CC        =     No
+    SCS-MP2         =     False
+    SCSN-MP2        =     False
+    SCS-CCSD        =     False
+
+    Using old T1 amplitudes.
+    Using old T2 amplitudes.
+
+MP2 correlation energy -0.1995040063196544
+                Solving CC Amplitude Equations
+                ------------------------------
+  Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
+  ----     ---------------------    ---------   ----------  ----------  ----------   --------
+     0        -0.208268287456194    0.000e+00    0.005669    0.012150    0.012150    0.122980
+     1        -0.208244055733640    2.214e-03    0.005668    0.012188    0.012188    0.122873
+     2        -0.208237384994156    4.332e-04    0.005667    0.012186    0.012186    0.122853
+     3        -0.208236780134826    1.029e-04    0.005661    0.012157    0.012157    0.122849
+     4        -0.208235960457360    2.790e-05    0.005659    0.012145    0.012145    0.122847
+     5        -0.208235796613253    8.944e-06    0.005657    0.012136    0.012136    0.122847
+     6        -0.208235697987067    3.175e-06    0.005656    0.012133    0.012133    0.122847
+     7        -0.208235708470845    8.031e-07    0.005656    0.012131    0.012131    0.122847
+     8        -0.208235706203810    1.161e-07    0.005656    0.012131    0.012131    0.122847
+     9        -0.208235707703749    2.206e-08    0.005656    0.012131    0.012131    0.122847
+
+    Iterations converged.
+
+
+    Largest TIA Amplitudes:
+              2   0         0.0104323196
+              3  11        -0.0065456050
+              4  14        -0.0062450491
+              4  18         0.0052212200
+              4  16         0.0045986029
+              1   2         0.0042996542
+              2   5         0.0039394159
+              1   0        -0.0029165700
+              1   7         0.0023786971
+              2   1         0.0022535244
+
+    Largest TIjAb Amplitudes:
+      3   3  11  11        -0.0518796271
+      4   4  14  14        -0.0379246361
+      2   2   2   2        -0.0294934793
+      4   4  15  15        -0.0286548824
+      2   3   2  11         0.0249912264
+      3   2  11   2         0.0249912264
+      3   4  11  16        -0.0247855671
+      4   3  16  11        -0.0247855671
+      4   4  16  16        -0.0246442486
+      3   4  11  14        -0.0242044003
+
+    SCF energy       (wfn)                    =  -76.022942727472454
+    Reference energy (file100)                =  -76.022942727472412
+
+    Opposite-spin MP2 correlation energy      =   -0.149329780446274
+    Same-spin MP2 correlation energy          =   -0.050174225873380
+    MP2 correlation energy                    =   -0.199504006319654
+      * MP2 total energy                      =  -76.222446733792069
+
+    Opposite-spin CCSD correlation energy     =   -0.163672920668938
+    Same-spin CCSD correlation energy         =   -0.044562787030826
+    CCSD correlation energy                   =   -0.208235707703749
+      * CCSD total energy                     =  -76.231178435176162
+
+
+*** tstop() called on psinet at Mon May 15 15:33:55 2017
+Module time:
+	user time   =       0.06 seconds =       0.00 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.37 seconds =       0.02 minutes
+	system time =       0.85 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:55 2017
+
+
+			**************************
+			*                        *
+			*         CCHBAR         *
+			*                        *
+			**************************
+
+
+*** tstop() called on psinet at Mon May 15 15:33:55 2017
+Module time:
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.38 seconds =       0.02 minutes
+	system time =       0.86 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:55 2017
+
+
+			**************************
+			*        CCLAMBDA        *
+			**************************
+
+
+	Nuclear Rep. energy (wfn)     =    9.166023988379742
+	Reference           (wfn)     =                    0
+	SCF energy          (wfn)     =  -76.022942727472454
+	Reference energy    (CC_INFO) =  -76.022942727472412
+	CCSD energy         (CC_INFO) =   -0.208235707703749
+	Total CCSD energy   (CC_INFO) =  -76.231178435176162
+
+	Input parameters:
+	-----------------
+	Maxiter           =     50
+	Convergence       = 1.0e-07
+	Restart           =     No
+	Cache Level       =     2
+	Model III         =     No
+	DIIS              =     Yes
+	AO Basis          =     No
+	ABCD              =     NEW
+	Local CC          =     No
+	Paramaters for left-handed eigenvectors:
+	    Irr   Root  Ground-State?    EOM energy        R0
+	  1   0     0        Yes       0.0000000000   1.0000000000
+	Labels for eigenvector 1:
+	LIA 0 -1, Lia 0 -1, LIJAB 0 -1, Lijab 0 -1, LIjAb 0 -1, 2LIjAb - LIjbA 0 -1
+	Symmetry of left-hand state: A1
+	Symmetry of left-hand eigenvector: A1
+
+	          Solving Lambda Equations
+	          ------------------------
+	Iter     PseudoEnergy or Norm         RMS  
+	----     ---------------------     --------
+	   0        -0.208272250244322    8.424e-08
+	   1        -0.205791571603518    7.966e-03
+	   2        -0.205370449732212    1.311e-03
+	   3        -0.205287149728528    6.018e-04
+	   4        -0.205280812287258    1.995e-04
+	   5        -0.205284337782511    6.063e-05
+	   6        -0.205284319210553    1.453e-05
+	   7        -0.205284399271237    3.249e-06
+	   8        -0.205284427373706    4.934e-07
+	   9        -0.205284425415476    8.358e-08
+
+	Largest LIA Amplitudes:
+	          2   0         0.0069443473
+	          4  16         0.0048125197
+	          4  18         0.0045116184
+	          3  11        -0.0038738412
+	          2   5         0.0035067222
+	          1   2         0.0031832273
+	          4  14        -0.0031482601
+	          1   3        -0.0024367341
+	          1   7         0.0021847180
+	          4  15        -0.0020294267
+
+	Largest LIjAb Amplitudes:
+	  3   3  11  11        -0.0515962964
+	  4   4  14  14        -0.0370577347
+	  2   2   2   2        -0.0291206210
+	  4   4  15  15        -0.0279479976
+	  2   3   2  11         0.0248383034
+	  3   2  11   2         0.0248383034
+	  3   4  11  16        -0.0245997973
+	  4   3  16  11        -0.0245997973
+	  4   4  16  16        -0.0243928874
+	  3   4  11  14        -0.0239471063
+
+	Iterations converged.
+
+	Overlap <L|e^T> =        0.94348490443
+
+*** tstop() called on psinet at Mon May 15 15:33:55 2017
+Module time:
+	user time   =       0.03 seconds =       0.00 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.41 seconds =       0.02 minutes
+	system time =       0.89 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on psinet
+*** at Mon May 15 15:33:55 2017
+
+
+			**************************
+			*                        *
+			*        CCDENSITY       *
+			*                        *
+			**************************
+
+
+	Input parameters:
+	-----------------
+	Wave function    =   CCSD
+	Reference wfn    =   RHF
+	Dertype          = 1
+	Tolerance        = 1.0e-14
+	Cache Level      = 2
+	AO Basis         = No
+	OPDM Only        = No
+	Relax OPDM       = Yes
+	Compute Xi       = No
+	Use Zeta         = No
+	Xi connected     = Yes
+	Compute NO       = No
+
+	Nuclear Rep. energy (wfn)     =    9.166023988379742
+	SCF energy          (wfn)     =  -76.022942727472454
+	Reference energy    (file100) =  -76.022942727472412
+	CCSD energy         (CC_INFO) =   -0.208235707703749
+	Total CCSD energy   (CC_INFO) =  -76.231178435176162
+	Number of States = 1
+
+	Ground?  State     EOM Energy       R0
+	  Yes     0 A1    0.0000000000   1.00000000
+
+	Energies re-computed from CC density:
+	-------------------------------------
+	One-electron energy        =    0.220328521191786
+	IJKL energy                =    0.041592574317710
+	IJKA energy                =   -0.001379373913453
+	IJAB energy                =   -0.410744547471779
+	IBJA energy                =   -0.100141807517814
+	CIAB energy                =   -0.000149333681920
+	ABCD energy                =    0.042258259031188
+	Total two-electron energy  =   -0.428564229236068
+	CCSD    correlation energy =   -0.208235708044282
+	Total CCSD    energy       =  -76.231178435516696
+
+	Virial Theorem Data:
+	--------------------
+	Kinetic energy (ref)   =   75.798953232335137
+	Kinetic energy (corr)  =    0.147421652085087
+	Kinetic energy (total) =   75.946374884420223
+	-V/T (ref)             =    2.002955047340175
+	-V/T (corr)            =    2.412517800190988
+	-V/T (total)           =    2.003750061160777
+
+	Energies re-computed from Fock-adjusted CC density:
+	---------------------------------------------------
+	One-electron energy        =    0.246470720035091
+	IJKL energy                =   -0.666215041724314
+	IJKA energy                =   -0.047742719110717
+	IJAB energy                =   -0.410744547471779
+	IBJA energy                =    0.627886954888693
+	CIAB energy                =   -0.000149333681920
+	ABCD energy                =    0.042258259031188
+	Total two-electron energy  =   -0.454706428068848
+	   CCSD correlation energy =   -0.208235708033758
+	Total    CCSD energy       =  -76.231178435506166
+
+	Energies re-computed from Mulliken density:
+	-------------------------------------------
+	One-electron energy        =    0.246470720035091
+	IJKL energy                =   -0.666215041724314
+	IJKA energy                =   -0.047742719110717
+	IJAB energy                =   -0.379840536152271
+	IBJA energy                =    0.596982943569185
+	CIAB energy                =   -0.000149333681920
+	ABCD energy                =    0.042258259031188
+	Total two-electron energy  =   -0.454706428068849
+	   CCSD correlation energy =   -0.208235708033759
+	Total    CCSD energy       =  -76.231178435506166
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+
+Properties computed using the CC density matrix
+
+  Nuclear Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.9826
+
+  Electronic Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:    -0.1586
+
+  Dipole Moment: (a.u.)
+     X:     0.0000      Y:     0.0000      Z:     0.8240     Total:     0.8240
+
+  Dipole Moment: (Debye)
+     X:     0.0000      Y:     0.0000      Z:     2.0944     Total:     2.0944
+
+  Quadrupole Moment: (Debye Ang)
+    XX:    -7.2281     YY:    -4.2858     ZZ:    -5.8153
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Traceless Quadrupole Moment: (Debye Ang)
+    XX:    -1.4517     YY:     1.4906     ZZ:    -0.0389
+    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
+
+  Mulliken Charges: (a.u.)
+   Center  Symbol    Alpha    Beta     Spin     Total
+       1     O     4.31608  4.31608  0.00000 -0.63215
+       2     H     0.34196  0.34196  0.00000  0.31608
+       3     H     0.34196  0.34196  0.00000  0.31608
+
+   Total alpha =  5.00000, Total beta =  5.00000, Total charge =  0.00000
+
+  Natural Orbital Occupations:
+
+  Total Occupations:
+  HONO-2 :    1 B1    1.972
+  HONO-1 :    3 A1    1.966
+  HONO-0 :    1 B2    1.965
+  LUNO+0 :    2 B2    0.027
+  LUNO+1 :    4 A1    0.025
+  LUNO+2 :    2 B1    0.017
+  LUNO+3 :    5 A1    0.011
+
+
+*** tstop() called on psinet at Mon May 15 15:33:55 2017
+Module time:
+	user time   =       0.07 seconds =       0.00 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.48 seconds =       0.02 minutes
+	system time =       0.92 seconds =       0.02 minutes
+	total time  =          3 seconds =       0.05 minutes
+  Cartesian Displacement SALCs
+  By SALC:
+  Number of SALCs: 3, nirreps: 1
+  Project out translations: False
+  Project out rotations: False
+	irrep = 0, ncomponent = 1
+		0: atom 0, direction z, coef 1.000000
+	irrep = 0, ncomponent = 2
+		0: atom 1, direction y, coef 0.707107
+		1: atom 2, direction y, coef -0.707107
+	irrep = 0, ncomponent = 2
+		0: atom 1, direction z, coef 0.707107
+		1: atom 2, direction z, coef 0.707107
+
+  By Atomic Center:
+  Number of atomic centers: 3
+   Atomic Center 0:
+	x component, size = 0
+	y component, size = 0
+	z component, size = 1
+		0: salc 0, irrep 0, coef 1.000000
+   Atomic Center 1:
+	x component, size = 0
+	y component, size = 1
+		0: salc 1, irrep 0, coef 0.707107
+	z component, size = 1
+		0: salc 2, irrep 0, coef 0.707107
+   Atomic Center 2:
+	x component, size = 0
+	y component, size = 1
+		0: salc 1, irrep 0, coef -0.707107
+	z component, size = 1
+		0: salc 2, irrep 0, coef 0.707107
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+           O          0.000000000000     0.000000000000    -0.124847178403
+           H          0.000000000000    -1.431365047272     0.990707660311
+           H          0.000000000000     1.431365047272     0.990707660311
+
+	Presorting MO-basis TPDM.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDM.
+	First half integral transformation complete.
+
+
+  -Nuclear Repulsion Energy 1st Derivatives:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     2.986552801441
+       2       -0.000000000000     2.038040739774    -1.493276400720
+       3        0.000000000000    -2.038040739774    -1.493276400720
+
+
+  -One-electron contribution to gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000    -6.872925847395
+       2        0.000000000000    -4.625842243325     3.436462923698
+       3       -0.000000000000     4.625842243325     3.436462923698
+
+
+  -Lagrangian contribution to gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.411353806916
+       2       -0.000000000000     0.252558749244    -0.205676903458
+       3        0.000000000000    -0.252558749244    -0.205676903458
+
+
+  -Two-electron contribution to gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     3.475093977029
+       2       -0.000000000000     2.335175545186    -1.737546988515
+       3        0.000000000000    -2.335175545186    -1.737546988515
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.000074737990
+       2        0.000000000000    -0.000067209121    -0.000037368995
+       3       -0.000000000000     0.000067209121    -0.000037368995
+
+
+			-----------------------------------------
+			 OPTKING 2.0: for geometry optimizations 
+			  - R.A. King,  Bethel University        
+			-----------------------------------------
+
+	Previous internal coordinate definitions found.
+	---Fragment 1 Geometry and Gradient---
+	 O           0.0000000000        0.0000000000       -0.1248471784
+	 H           0.0000000000       -1.4313650473        0.9907076603
+	 H           0.0000000000        1.4313650473        0.9907076603
+	             0.0000000000        0.0000000000        0.0000747380
+	             0.0000000000       -0.0000672091       -0.0000373690
+	            -0.0000000000        0.0000672091       -0.0000373690
+
+	---Fragment 1 Intrafragment Coordinates---
+	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
+	 R(1,2)           =         1.814736	       0.960317
+	 R(1,3)           =         1.814736	       0.960317
+	 B(2,1,3)         =         1.817531	     104.136842
+
+	Current energy   :       -76.2311784352
+
+	Energy change for the previous step:
+		Projected    :        -0.0000110992
+		Actual       :        -0.0000034299
+
+	Performing BFGS update.
+	Previous computed or guess Hessian on step 1.
+	Steps to be used in Hessian update: 2 1
+	Taking RFO optimization step.
+	Going to follow RFO solution 1.
+	Using RFO vector 1.
+	Norm of target step-size    0.00076
+	Projected energy change by RFO approximation:        -0.0000000623
+
+	Back-transformation to cartesian coordinates...
+	Successfully converged to displaced geometry.
+
+	--- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	 ---------------------------------------------------------------------------
+	   Coordinate                Previous        Force       Change         New 
+	   ----------                --------       ------       ------       ------
+	    1 R(1,2)          =      0.960317    -0.000247    -0.000007     0.960311
+	    2 R(1,3)          =      0.960317    -0.000247    -0.000007     0.960311
+	    3 B(2,1,3)        =    104.136842    -0.000010    -0.043373   104.093469
+	 ---------------------------------------------------------------------------
+	Successfully symmetrized geometry.
+
+  ==> Convergence Check <==
+
+  Measures of convergence in internal coordinates in au.
+  Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
+  ---------------------------------------------------------------------------------------------
+   Step     Total Energy     Delta E     MAX Force     RMS Force      MAX Disp      RMS Disp   
+  ---------------------------------------------------------------------------------------------
+    Convergence Criteria    1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+  ---------------------------------------------------------------------------------------------
+      3     -76.23117844   -3.43e-06      1.28e-04 *    7.81e-05 o    7.57e-04 *    4.37e-04 o  ~
+  ---------------------------------------------------------------------------------------------
+
+
+  **** Optimization is complete! (in 3 steps) ****
+
+  ==> Optimization Summary <==
+
+  Measures of convergence in internal coordinates in au.
+  --------------------------------------------------------------------------------------------------------------- ~
+   Step         Total Energy             Delta E       MAX Force       RMS Force        MAX Disp        RMS Disp  ~
+  --------------------------------------------------------------------------------------------------------------- ~
+      1     -76.230988854467    -76.230988854467      0.00916168      0.00757669      0.01715315      0.01589026  ~
+      2     -76.231175005258     -0.000186150790      0.00097714      0.00066579      0.00684009      0.00405823  ~
+      3     -76.231178435176     -0.000003429918      0.00012846      0.00007812      0.00075700      0.00043717  ~
+  --------------------------------------------------------------------------------------------------------------- ~
+
+	Writing optimization data to binary file.
+	Final energy is    -76.2311784351762
+	Final (previous) structure:
+	Cartesian Geometry (in Angstrom)
+	    O     0.0000000000   0.0000000000  -0.0660662814
+	    H     0.0000000000  -0.7574457602   0.5242599142
+	    H     0.0000000000   0.7574457602   0.5242599142
+	Saving final (previous) structure.
+			--------------------------
+			 OPTKING Finished Execution 
+			--------------------------
+
+    Final optimized geometry and variables:
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+    O       
+    H             1    0.960317
+    H             1    0.960317      2  104.136842
+
+	Cleaning optimization helper files.
+	Nuclear repulsion energy..........................................PASSED
+	SCF energy........................................................PASSED
+	CCSD contribution.................................................PASSED
+	Total energy......................................................PASSED
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc57/output.ref
+++ b/tests/cc57/output.ref
@@ -1,30 +1,51 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.1rc3.dev5 
+                               Psi4 1.12a1.dev11 
 
-                         Git: Rev {master} 3fbd859 
+                         Git: Rev {diis-vecs} d587464 dirty
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. in press (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, D. L. Poole, T. Győri, E. C. Mitchell, J. P. Pederson,
+    and A. M. Wallace
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    https://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 15 May 2017 03:33PM
+    Psi4 started on: Wednesday, 05 August 2026 05:35PM
 
-    Process ID:  11968
-    PSIDATADIR: /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4
+    Process ID: 3207512
+    Host:       cgbriggs99-debian-workstation
+    PSIDATADIR: /home/connor/psi4/share/psi4
     Memory:     500.0 MiB
     Threads:    1
-    
+    Addons:     adcc, a̶m̶b̶i̶t̶, bse, c̶c̶t̶3̶, c̶f̶o̶u̶r̶, c̶h̶e̶m̶p̶s̶2̶, cppe, ddx, dftd3, dftd4, d̶k̶h̶,
+                e̶c̶p̶i̶n̶t̶, e̶i̶n̶s̶u̶m̶s̶, f̶o̶r̶t̶e̶, g̶a̶u̶x̶c̶, gcp, gdma, geometric,
+                g̶p̶u̶_̶d̶f̶c̶c̶, i̶n̶t̶e̶g̶r̶a̶t̶o̶r̶x̶x̶, ipi, libefp, mdi, m̶p̶2̶d̶,
+                m̶r̶c̶c̶, o̶o̶o̶, o̶p̶e̶n̶f̶e̶r̶m̶i̶o̶n̶p̶s̶i̶4̶, p̶c̶m̶s̶o̶l̶v̶e̶r̶,
+                p̶s̶i̶4̶f̶o̶c̶k̶c̶i̶, p̶s̶i̶x̶a̶s̶, p̶y̶e̶i̶n̶s̶u̶m̶s̶, qcmanybody, resp,
+                s̶i̶m̶i̶n̶t̶, s̶n̶s̶m̶p̶2̶, v̶2̶r̶d̶m̶_̶c̶a̶s̶s̶c̶f̶
+
   ==> Input File <==
 
 --------------------------------------------------------------------------
@@ -40,38 +61,63 @@ set {
     basis 6-31G**
 }
 
-optimize('ccsd')
+set CCENERGY {
+    diis_max_vecs 10
+}
+
+wfn = optimize('ccsd', return_wfn=True)[1]
 
 refnuc   =   9.1654609427539  #TEST
 refscf   = -76.0229427274435  #TEST
 refccsd  = -0.20823570806196  #TEST
 reftotal = -76.2311784355056  #TEST
+scfT     =  75.7989532323351  #TEST
+scfVT    =   2.0029550473401  #TEST
+scfV     =   - scfVT * scfT   #TEST
+ccT      =   0.1474216520850  #TEST
+ccVT     =   2.4125178001909  #TEST
+ccV      =   -  ccVT *  ccT   #TEST
+totalVT  =   2.0037500611607  #TEST
 
 compare_values(refnuc,   h2o.nuclear_repulsion_energy(),          3, "Nuclear repulsion energy") #TEST
-compare_values(refscf,   get_variable("SCF total energy"),        5, "SCF energy")               #TEST
-compare_values(refccsd,  get_variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
-compare_values(reftotal, get_variable("Current energy"),          7, "Total energy")             #TEST
---------------------------------------------------------------------------
-gradient() will perform analytic gradient computation.
+compare_values(refscf,   variable("SCF total energy"),        5, "SCF energy")               #TEST
+compare_values(refccsd,  variable("CCSD correlation energy"), 4, "CCSD contribution")        #TEST
+compare_values(reftotal, variable("Current energy"),          7, "Total energy")             #TEST
+compare_values(scfT,     variable("HF Kinetic Energy"),       5, "HF Kinetic Energy")        #TEST
+compare_values(scfV,     variable("HF Potential Energy"),     5, "HF Potential Energy")      #TEST
+compare_values(scfVT,    variable("HF Virial Ratio"),         5, "HF Virial Ratio")          #TEST
+compare_values(ccT,      wfn.variable("CC Correlation Kinetic Energy"),       5, "CC Correlation Kinetic Energy")        #TEST
+compare_values(ccV,      wfn.variable("CC Correlation Potential Energy"),     5, "CC Correlation Potential Energy")      #TEST
+compare_values(ccVT,     wfn.variable("CC Correlation Virial Ratio"),         5, "CC Correlation Virial Ratio")          #TEST
+compare_values(totalVT,  wfn.variable("CC Virial Ratio"),         5, "CC Virial Ratio")      #TEST
 
-*** tstart() called on psinet
-*** at Mon May 15 15:33:52 2017
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on cgbriggs99-debian-workstation
+*** at Wed Aug  5 17:35:46 2026
 
    => Loading Basis Set <=
 
     Name: 6-31G**
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   140 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
-    atoms 2-3 entry H          line    35 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
-
-    There are an even number of electrons - assuming singlet.
-    Specify the multiplicity in the molecule input block.
+    atoms 1   entry O          line   149 file /home/connor/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2-3 entry H          line    44 file /home/connor/psi4/share/psi4/basis/6-31gss.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -85,15 +131,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.067578587269    15.994914619560
-           H          0.000000000000    -0.759129912147     0.536260610269     1.007825032070
-           H          0.000000000000     0.759129912147     0.536260610269     1.007825032070
+         O            0.000000000000     0.000000000000    -0.067578587279    15.994914619570
+         H            0.000000000000    -0.759129912147     0.536260610260     1.007825032230
+         H            0.000000000000     0.759129912147     0.536260610260     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     25.82761  B =     14.51273  C =      9.29167 [cm^-1]
-  Rotational constants: A = 774292.15647  B = 435080.73208  C = 278557.26010 [MHz]
-  Nuclear repulsion =    9.077238153630930
+  Rotational constants: A = 774292.16226  B = 435080.73532  C = 278557.26218 [MHz]
+  Nuclear repulsion =    9.077238189310194
 
   Charge       = 0
   Multiplicity = 1
@@ -110,30 +156,17 @@ gradient() will perform analytic gradient computation.
   Guess Type is SAD.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: 6-31G**
     Blend: 6-31G**
     Number of shells: 12
-    Number of basis function: 25
+    Number of basis functions: 25
     Number of Cartesian functions: 25
     Spherical Harmonics?: false
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        12      12       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      25      25       5       5       5       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -152,42 +185,60 @@ gradient() will perform analytic gradient computation.
   Using 105950 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.2308645666E-02.
-  Using Symmetric Orthogonalization.
 
-  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+  Minimum eigenvalue in the overlap matrix is 2.1501314989E-02.
+  Reciprocal condition number of the overlap matrix is 4.8539442250E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        12      12 
+     A2         2       2 
+     B1         4       4 
+     B2         7       7 
+   -------------------------
+    Total      25      25
+   -------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -75.95492261751966   -7.59549e+01   1.14488e-01 
-   @RHF iter   1:   -75.97837615968200   -2.34535e-02   2.17692e-02 
-   @RHF iter   2:   -76.01219021646442   -3.38141e-02   1.14813e-02 DIIS
-   @RHF iter   3:   -76.02158202461503   -9.39181e-03   1.55978e-03 DIIS
-   @RHF iter   4:   -76.02196350344684   -3.81479e-04   4.25856e-04 DIIS
-   @RHF iter   5:   -76.02199704584848   -3.35424e-05   6.17940e-05 DIIS
-   @RHF iter   6:   -76.02199785623192   -8.10383e-07   7.71295e-06 DIIS
-   @RHF iter   7:   -76.02199786797981   -1.17479e-08   7.44815e-07 DIIS
-   @RHF iter   8:   -76.02199786811084   -1.31038e-10   1.89640e-07 DIIS
-   @RHF iter   9:   -76.02199786812271   -1.18661e-11   3.57448e-08 DIIS
-   @RHF iter  10:   -76.02199786812304   -3.26850e-13   2.53291e-09 DIIS
-   @RHF iter  11:   -76.02199786812301    2.84217e-14   4.31863e-10 DIIS
-   @RHF iter  12:   -76.02199786812307   -5.68434e-14   3.56270e-11 DIIS
+   @RHF iter SAD:   -75.50729373443482   -7.55073e+01   0.00000e+00 
+   @RHF iter   1:   -75.95231123128870   -4.45017e-01   2.80327e-02 DIIS/ADIIS
+   @RHF iter   2:   -76.00295317475175   -5.06419e-02   1.63838e-02 DIIS/ADIIS
+   @RHF iter   3:   -76.02144234460285   -1.84892e-02   2.10489e-03 DIIS/ADIIS
+   @RHF iter   4:   -76.02197436238160   -5.32018e-04   3.72203e-04 DIIS/ADIIS
+   @RHF iter   5:   -76.02199691392215   -2.25515e-05   6.36020e-05 DIIS
+   @RHF iter   6:   -76.02199784301759   -9.29095e-07   9.96049e-06 DIIS
+   @RHF iter   7:   -76.02199786790553   -2.48879e-08   1.47609e-06 DIIS
+   @RHF iter   8:   -76.02199786848789   -5.82361e-10   3.28554e-07 DIIS
+   @RHF iter   9:   -76.02199786852104   -3.31539e-11   5.76953e-08 DIIS
+   @RHF iter  10:   -76.02199786852184   -7.95808e-13   5.50818e-09 DIIS
+   @RHF iter  11:   -76.02199786852185   -1.42109e-14   7.37930e-10 DIIS
+   @RHF iter  12:   -76.02199786852182    2.84217e-14   4.63257e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -207,50 +258,49 @@ gradient() will perform analytic gradient computation.
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
+    NA   [     3,    0,    1,    1 ]
+    NB   [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:   -76.02199786812307
+  @RHF Final Energy:   -76.02199786852182
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.0772381536309297
-    One-Electron Energy =                -122.8800883803116193
-    Two-Electron Energy =                  37.7808523585576239
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0219978681230657
+    Nuclear Repulsion Energy =              9.0772381893101937
+    One-Electron Energy =                -122.8800884444663097
+    Two-Electron Energy =                  37.7808523866343080
+    Total Energy =                        -76.0219978685218081
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0051
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.1315
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.8736     Total:     0.8736
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     2.2205     Total:     2.2205
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.1315042            1.0051312            0.8736269
+ Magnitude           :                                                    0.8736269
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:33:53 2017
+*** tstop() called on cgbriggs99-debian-workstation at Wed Aug  5 17:35:46 2026
 Module time:
-	user time   =       0.38 seconds =       0.01 minutes
+	user time   =       0.07 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.38 seconds =       0.01 minutes
+	user time   =       0.07 seconds =       0.00 minutes
 	system time =       0.01 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	total time  =          0 seconds =       0.00 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -264,19 +314,19 @@ Total time:
       Number of basis functions:        25
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  12    2    4    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 13665 non-zero two-electron integrals.
+      Computed 13617 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:33:53 2017
+*** tstart() called on cgbriggs99-debian-workstation
+*** at Wed Aug  5 17:35:46 2026
 
 
 	Wfn Parameters:
@@ -301,7 +351,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -357,34 +407,30 @@ Total time:
 	Size of irrep 3 of tijab amplitudes:       0.001 (MW) /      0.006 (MB)
 	Total:                                     0.003 (MW) /      0.022 (MB)
 
-	Nuclear Rep. energy          =      9.07723815363093
-	SCF energy                   =    -76.02199786812307
-	One-electron energy          =   -122.88008838046106
-	Two-electron energy          =     37.78085235870709
-	Reference energy             =    -76.02199786812304
+	Nuclear Rep. energy          =      9.07723818931019
+	SCF energy                   =    -76.02199786852182
+	One-electron energy          =   -122.88008844441860
+	Two-electron energy          =     37.78085238658650
+	Reference energy             =    -76.02199786852192
 
-*** tstop() called on psinet at Mon May 15 15:33:53 2017
+*** tstop() called on cgbriggs99-debian-workstation at Wed Aug  5 17:35:46 2026
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       0.00 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.43 seconds =       0.01 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:33:53 2017
-
+	user time   =       0.08 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.077238153630930
-    SCF energy          (wfn)     =  -76.021997868123066
-    Reference energy    (file100) =  -76.021997868123037
+    Nuclear Rep. energy (wfn)     =    9.077238189310194
+    SCF energy          (wfn)     =  -76.021997868521822
+    Reference energy    (file100) =  -76.021997868521922
 
     Input parameters:
     -----------------
@@ -397,6 +443,7 @@ Total time:
     E_Convergence   =     1.0e-08
     Restart         =     Yes
     DIIS            =     Yes
+    DIIS_MAX_VECS   =     10
     AO Basis        =     NONE
     ABCD            =     NEW
     Cache Level     =     2
@@ -412,78 +459,65 @@ Total time:
     SCSN-MP2        =     False
     SCS-CCSD        =     False
 
-MP2 correlation energy -0.2002845909709956
+MP2 correlation energy -0.2002845907019309
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.200284590970996    0.000e+00    0.000000    0.000000    0.000000    0.110456
-     1        -0.204524507808414    2.733e-02    0.004508    0.008904    0.008904    0.117194
-     2        -0.208454941715412    9.794e-03    0.005161    0.010333    0.010333    0.122601
-     3        -0.208976359457238    2.795e-03    0.005693    0.011917    0.011917    0.124028
-     4        -0.208980680929654    6.466e-04    0.005747    0.012228    0.012228    0.124248
-     5        -0.208995521945257    2.053e-04    0.005786    0.012422    0.012422    0.124291
-     6        -0.208991621201328    6.453e-05    0.005799    0.012493    0.012493    0.124278
-     7        -0.208991063379036    1.565e-05    0.005803    0.012511    0.012511    0.124275
-     8        -0.208991044225871    2.937e-06    0.005803    0.012514    0.012514    0.124275
-     9        -0.208990967367835    7.070e-07    0.005803    0.012514    0.012514    0.124275
-    10        -0.208990987589477    1.507e-07    0.005803    0.012514    0.012514    0.124275
-    11        -0.208990985952284    2.941e-08    0.005803    0.012514    0.012514    0.124275
-    12        -0.208990986344438    4.776e-09    0.005803    0.012514    0.012514    0.124275
+     0        -0.200284590701931    0.000e+00    0.000000    0.000000    0.000000    0.110456
+     1        -0.204524507586106    2.733e-02    0.004508    0.008904    0.008904    0.117194
+     2        -0.208454941459523    9.794e-03    0.005161    0.010333    0.010333    0.122601
+     3        -0.208976359193851    2.795e-03    0.005693    0.011917    0.011917    0.124028
+     4        -0.208980680666034    6.466e-04    0.005747    0.012228    0.012228    0.124248
+     5        -0.208995521681339    2.053e-04    0.005786    0.012422    0.012422    0.124291
+     6        -0.208991620937479    6.453e-05    0.005799    0.012493    0.012493    0.124278
+     7        -0.208991063115183    1.565e-05    0.005803    0.012511    0.012511    0.124275
+     8        -0.208991043962022    2.937e-06    0.005803    0.012514    0.012514    0.124275
+     9        -0.208990982758643    7.070e-07    0.005803    0.012514    0.012514    0.124275
+    10        -0.208990985961526    1.245e-07    0.005803    0.012514    0.012514    0.124275
+    11        -0.208990986127079    2.015e-08    0.005803    0.012514    0.012514    0.124275
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              2   0         0.0108430097
-              3  11        -0.0066539440
-              4  14        -0.0062968539
-              4  18         0.0053909632
-              4  16         0.0049115272
-              1   2         0.0043626421
-              2   5         0.0040679853
-              1   0        -0.0026726422
+              2   0         0.0108430068
+              3  11        -0.0066539444
+              4  14        -0.0062968523
+              4  18         0.0053909630
+              4  16         0.0049115271
+              1   2         0.0043626425
+              2   5         0.0040679849
+              1   0        -0.0026726439
               1   7         0.0023396379
-              2   1         0.0022229038
+              2   1         0.0022229024
 
     Largest TIjAb Amplitudes:
-      3   3  11  11        -0.0518990472
-      4   4  14  14        -0.0394129214
-      2   2   2   2        -0.0298937647
-      4   4  15  15        -0.0287516408
-      2   3   2  11         0.0252440967
-      3   2  11   2         0.0252440967
+      3   3  11  11        -0.0518990476
+      4   4  14  14        -0.0394129218
+      2   2   2   2        -0.0298937644
+      4   4  15  15        -0.0287516411
+      2   3   2  11         0.0252440963
+      3   2  11   2         0.0252440963
       3   4  11  16        -0.0248319621
       4   3  16  11        -0.0248319621
-      4   4  16  16        -0.0246255030
-      3   4  11  14        -0.0244548497
+      4   4  16  16        -0.0246255036
+      3   4  11  14        -0.0244548494
 
-    SCF energy       (wfn)                    =  -76.021997868123066
-    Reference energy (file100)                =  -76.021997868123037
+    SCF energy       (wfn)                    =  -76.021997868521822
+    Reference energy (file100)                =  -76.021997868521922
 
-    Opposite-spin MP2 correlation energy      =   -0.149954968993970
-    Same-spin MP2 correlation energy          =   -0.050329621977026
-    MP2 correlation energy                    =   -0.200284590970996
-      * MP2 total energy                      =  -76.222282459094032
+    Opposite-spin MP2 correlation energy      =   -0.149954968776829
+    Same-spin MP2 correlation energy          =   -0.050329621925102
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.200284590701931
+      * MP2 total energy                      =  -76.222282459223848
 
-    Opposite-spin CCSD correlation energy     =   -0.164400081018819
-    Same-spin CCSD correlation energy         =   -0.044590905326741
-    CCSD correlation energy                   =   -0.208990986344438
-      * CCSD total energy                     =  -76.230988854467469
-
-
-*** tstop() called on psinet at Mon May 15 15:33:53 2017
-Module time:
-	user time   =       0.08 seconds =       0.00 minutes
-	system time =       0.19 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.51 seconds =       0.01 minutes
-	system time =       0.25 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:33:53 2017
+    Opposite-spin CCSD correlation energy     =   -0.164400080854070
+    Same-spin CCSD correlation energy         =   -0.044590905273008
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.208990986127079
+      * CCSD total energy                     =  -76.230988854648999
 
 
 			**************************
@@ -493,31 +527,17 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:33:53 2017
-Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.52 seconds =       0.01 minutes
-	system time =       0.27 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:33:53 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =    9.077238153630930
+	Nuclear Rep. energy (wfn)     =    9.077238189310194
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     =  -76.021997868123066
-	Reference energy    (CC_INFO) =  -76.021997868123037
-	CCSD energy         (CC_INFO) =   -0.208990986344438
-	Total CCSD energy   (CC_INFO) =  -76.230988854467469
+	SCF energy          (wfn)     =  -76.021997868521822
+	Reference energy    (CC_INFO) =  -76.021997868521922
+	CCSD energy         (CC_INFO) =   -0.208990986127079
+	Total CCSD energy   (CC_INFO) =  -76.230988854648999
 
 	Input parameters:
 	-----------------
@@ -527,10 +547,11 @@ Total time:
 	Cache Level       =     2
 	Model III         =     No
 	DIIS              =     Yes
+	DIIS_MAX_VECS     =     8
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -542,58 +563,44 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.209027793961870    0.000e+00
-	   1        -0.206495158157615    7.993e-03
-	   2        -0.206067358865376    1.345e-03
-	   3        -0.205981813889801    6.208e-04
-	   4        -0.205975121506444    2.062e-04
-	   5        -0.205978821663800    6.254e-05
-	   6        -0.205978789400414    1.506e-05
-	   7        -0.205978877336368    3.417e-06
-	   8        -0.205978906807562    5.200e-07
-	   9        -0.205978904853383    9.017e-08
+	   0        -0.209027793736679    0.000e+00
+	   1        -0.206495157927453    7.993e-03
+	   2        -0.206067358660612    1.345e-03
+	   3        -0.205981813675148    6.208e-04
+	   4        -0.205975121274253    2.062e-04
+	   5        -0.205978821423714    6.254e-05
+	   6        -0.205978789160144    1.506e-05
+	   7        -0.205978877096290    3.417e-06
+	   8        -0.205978906567598    5.200e-07
+	   9        -0.205978904613431    9.017e-08
 
 	Largest LIA Amplitudes:
-	          2   0         0.0072417875
-	          4  16         0.0050589428
-	          4  18         0.0046513006
+	          2   0         0.0072417876
+	          4  16         0.0050589427
+	          4  18         0.0046513005
 	          3  11        -0.0039991750
 	          2   5         0.0036194748
 	          1   2         0.0032129565
 	          4  14        -0.0031907785
-	          1   3        -0.0025293241
+	          1   3        -0.0025293240
 	          1   7         0.0021477529
 	          4  15        -0.0021208252
 
 	Largest LIjAb Amplitudes:
 	  3   3  11  11        -0.0516330686
-	  4   4  14  14        -0.0384957240
-	  2   2   2   2        -0.0295153608
+	  4   4  14  14        -0.0384957236
+	  2   2   2   2        -0.0295153599
 	  4   4  15  15        -0.0280304768
-	  2   3   2  11         0.0250935139
-	  3   2  11   2         0.0250935139
+	  2   3   2  11         0.0250935133
+	  3   2  11   2         0.0250935133
 	  3   4  11  16        -0.0246412024
 	  4   3  16  11        -0.0246412024
-	  4   4  16  16        -0.0243635802
+	  4   4  16  16        -0.0243635803
 	  3   4  11  14        -0.0241957737
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.94273433070
-
-*** tstop() called on psinet at Mon May 15 15:33:53 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.54 seconds =       0.01 minutes
-	system time =       0.31 seconds =       0.01 minutes
-	total time  =          1 seconds =       0.02 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:33:53 2017
-
+	Overlap <L|e^T> =        0.94273433104
 
 			**************************
 			*                        *
@@ -617,152 +624,24 @@ Total time:
 	Xi connected     = Yes
 	Compute NO       = No
 
-	Nuclear Rep. energy (wfn)     =    9.077238153630930
-	SCF energy          (wfn)     =  -76.021997868123066
-	Reference energy    (file100) =  -76.021997868123037
-	CCSD energy         (CC_INFO) =   -0.208990986344438
-	Total CCSD energy   (CC_INFO) =  -76.230988854467469
+	Nuclear Rep. energy (wfn)     =    9.077238189310194
+	SCF energy          (wfn)     =  -76.021997868521822
+	Reference energy    (file100) =  -76.021997868521922
+	CCSD energy         (CC_INFO) =   -0.208990986127079
+	Total CCSD energy   (CC_INFO) =  -76.230988854648999
 	Number of States = 1
 
 	Ground?  State     EOM Energy       R0
 	  Yes     0 A1    0.0000000000   1.00000000
 
-	Energies re-computed from CC density:
-	-------------------------------------
-	One-electron energy        =    0.221186777554142
-	IJKL energy                =    0.041993252069384
-	IJKA energy                =   -0.001393403084655
-	IJAB energy                =   -0.412136978683156
-	IBJA energy                =   -0.101198077117444
-	CIAB energy                =   -0.000203578390496
-	ABCD energy                =    0.042761021202647
-	Total two-electron energy  =   -0.430177764003719
-	CCSD    correlation energy =   -0.208990986449577
-	Total CCSD    energy       =  -76.230988854572615
-
 	Virial Theorem Data:
 	--------------------
-	Kinetic energy (ref)   =   75.764057172198534
-	Kinetic energy (corr)  =    0.151616977812720
-	Kinetic energy (total) =   75.915674150011256
-	-V/T (ref)             =    2.003404525913102
-	-V/T (corr)            =    2.378414141736737
-	-V/T (total)           =    2.004153486193552
-
-	Energies re-computed from Fock-adjusted CC density:
-	---------------------------------------------------
-	One-electron energy        =    0.245781755450261
-	IJKL energy                =   -0.672858135803440
-	IJKA energy                =   -0.047236968456078
-	IJAB energy                =   -0.412136978683156
-	IBJA energy                =    0.634901898228761
-	CIAB energy                =   -0.000203578390496
-	ABCD energy                =    0.042761021202647
-	Total two-electron energy  =   -0.454772741901761
-	   CCSD correlation energy =   -0.208990986451499
-	Total    CCSD energy       =  -76.230988854574534
-
-	Energies re-computed from Mulliken density:
-	-------------------------------------------
-	One-electron energy        =    0.245781755450261
-	IJKL energy                =   -0.672858135803440
-	IJKA energy                =   -0.047236968456078
-	IJAB energy                =   -0.381058775762284
-	IBJA energy                =    0.603823695307889
-	CIAB energy                =   -0.000203578390496
-	ABCD energy                =    0.042761021202647
-	Total two-electron energy  =   -0.454772741901761
-	   CCSD correlation energy =   -0.208990986451500
-	Total    CCSD energy       =  -76.230988854574534
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     1.0051
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.1730
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.8322     Total:     0.8322
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     2.1151     Total:     2.1151
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -7.2492     YY:    -4.3222     ZZ:    -5.7834
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -1.4643     YY:     1.4627     ZZ:     0.0016
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.31583  4.31583  0.00000 -0.63166
-       2     H     0.34209  0.34209  0.00000  0.31583
-       3     H     0.34209  0.34209  0.00000  0.31583
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B1    1.972
-  HONO-1 :    3 A1    1.966
-  HONO-0 :    1 B2    1.964
-  LUNO+0 :    2 B2    0.027
-  LUNO+1 :    4 A1    0.025
-  LUNO+2 :    2 B1    0.017
-  LUNO+3 :    5 A1    0.011
-
-
-*** tstop() called on psinet at Mon May 15 15:33:54 2017
-Module time:
-	user time   =       0.10 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-Total time:
-	user time   =       0.64 seconds =       0.01 minutes
-	system time =       0.36 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-  Cartesian Displacement SALCs
-  By SALC:
-  Number of SALCs: 3, nirreps: 1
-  Project out translations: False
-  Project out rotations: False
-	irrep = 0, ncomponent = 1
-		0: atom 0, direction z, coef 1.000000
-	irrep = 0, ncomponent = 2
-		0: atom 1, direction y, coef 0.707107
-		1: atom 2, direction y, coef -0.707107
-	irrep = 0, ncomponent = 2
-		0: atom 1, direction z, coef 0.707107
-		1: atom 2, direction z, coef 0.707107
-
-  By Atomic Center:
-  Number of atomic centers: 3
-   Atomic Center 0:
-	x component, size = 0
-	y component, size = 0
-	z component, size = 1
-		0: salc 0, irrep 0, coef 1.000000
-   Atomic Center 1:
-	x component, size = 0
-	y component, size = 1
-		0: salc 1, irrep 0, coef 0.707107
-	z component, size = 1
-		0: salc 2, irrep 0, coef 0.707107
-   Atomic Center 2:
-	x component, size = 0
-	y component, size = 1
-		0: salc 1, irrep 0, coef -0.707107
-	z component, size = 1
-		0: salc 2, irrep 0, coef 0.707107
-
+	Kinetic energy (ref)   =   75.764057186793579
+	Kinetic energy (corr)  =    0.151616973244697
+	Kinetic energy (total) =   75.915674160038279
+	-V/T (ref)             =    2.003404525725073
+	-V/T (corr)            =    2.378414181832957
+	-V/T (total)           =    2.004153486063313
     Molecular point group: c2v
     Full point group: C2v
 
@@ -770,9 +649,9 @@ Total time:
 
        Center              X                  Y                   Z       
     ------------   -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.127705022386
-           H          0.000000000000    -1.434547633239     1.013385689263
-           H          0.000000000000     1.434547633239     1.013385689263
+         O            0.000000000000     0.000000000000    -0.127705021902
+         H            0.000000000000    -1.434547627600     1.013385685262
+         H            0.000000000000     1.434547627600     1.013385685262
 
 	Presorting MO-basis TPDM.
 	Sorting File: MO TPDM (AA|AA) nbuckets = 1
@@ -781,117 +660,70 @@ Total time:
 	First half integral transformation complete.
 
 
-  -Nuclear Repulsion Energy 1st Derivatives:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     2.964342245725
-       2       -0.000000000000     1.984825954516    -1.482171122862
-       3        0.000000000000    -1.984825954516    -1.482171122862
-
-
-  -One-electron contribution to gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000    -6.872400560046
-       2        0.000000000000    -4.509660605611     3.436200280023
-       3       -0.000000000000     4.509660605611     3.436200280023
-
-
-  -Lagrangian contribution to gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.411443443502
-       2       -0.000000000000     0.245759878510    -0.205721721751
-       3        0.000000000000    -0.245759878510    -0.205721721751
-
-
-  -Two-electron contribution to gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     3.483428206432
-       2       -0.000000000000     2.272612742504    -1.741714103216
-       3        0.000000000000    -2.272612742504    -1.741714103216
-
-
   -Total gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000    -0.013186664387
-       2        0.000000000000    -0.006462030081     0.006593332193
-       3       -0.000000000000     0.006462030081     0.006593332193
+       1        0.000000000000     0.000000000000    -0.013186660531
+       2        0.000000000000    -0.006462027058     0.006593330266
+       3       -0.000000000000     0.006462027058     0.006593330266
 
 
-			-----------------------------------------
-			 OPTKING 2.0: for geometry optimizations 
-			  - R.A. King,  Bethel University        
-			-----------------------------------------
+    			-----------------------------------------
 
-	Internal coordinates to be generated automatically.
-	Detected frag 1 with atoms:  1 2 3
-	---Fragment 1 Bond Connectivity---
-	 1 : 2 3
-	 2 : 1
-	 3 : 1
+    			 OPTKING 3.0: for geometry optimizations 
 
-	---Fragment 1 Geometry and Gradient---
-	 O           0.0000000000        0.0000000000       -0.1277050224
-	 H           0.0000000000       -1.4345476332        1.0133856893
-	 H           0.0000000000        1.4345476332        1.0133856893
-	             0.0000000000        0.0000000000       -0.0131866644
-	             0.0000000000       -0.0064620301        0.0065933322
-	            -0.0000000000        0.0064620301        0.0065933322
+    			     By R.A. King, Bethel University     
 
-	Previous optimization step data not found.  Starting new optimization.
+    			        with contributions from          
 
-	---Fragment 1 Intrafragment Coordinates---
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       8.000000            15.994915          0.00000000  0.00000000 -0.12770502   
+	       1.000000             1.007825          0.00000000 -1.43454763  1.01338569   
+	       1.000000             1.007825          0.00000000  1.43454763  1.01338569   
+
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
-	 R(1,2)           =         1.833034	       0.970000
-	 R(1,3)           =         1.833034	       0.970000
-	 B(2,1,3)         =         1.797689	     103.000000
+	 R(1,2)           =         1.833034           0.970000
+	 R(1,3)           =         1.833034           0.970000
+	 B(2,1,3)         =         1.797689         103.000000
 
-	Current energy   :       -76.2309888545
 
-	Generating empirical Hessian (Schlegel '84) for each fragment.
-	Taking RFO optimization step.
-	Going to follow RFO solution 1.
-	Using RFO vector 1.
-	Norm of target step-size    0.02752
-	Projected energy change by RFO approximation:        -0.0000218299
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       0.97000       -0.07548       -0.00908       0.96092
+	               R(1,3)       0.97000       -0.07548       -0.00908       0.96092
+	             B(2,1,3)     103.00000        0.00016        0.74493     103.74493
+	-------------------------------------------------------------------------------
 
-	Back-transformation to cartesian coordinates...
-	Successfully converged to displaced geometry.
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
 
-	--- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
-	 ---------------------------------------------------------------------------
-	   Coordinate                Previous        Force       Change         New 
-	   ----------                --------       ------       ------       ------
-	    1 R(1,2)          =      0.970000    -0.075481    -0.009077     0.960923
-	    2 R(1,3)          =      0.970000    -0.075481    -0.009077     0.960923
-	    3 B(2,1,3)        =    103.000000     0.000159     0.744934   103.744934
-	 ---------------------------------------------------------------------------
-	Successfully symmetrized geometry.
+	----------------------------------------------------------------------------------------------~
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   ~
+	----------------------------------------------------------------------------------------------~
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o~
+	----------------------------------------------------------------------------------------------~
+	     1     -76.23098885   -7.62e+01      9.16e-03      7.58e-03 o    1.72e-02      1.59e-02 o  ~
+	----------------------------------------------------------------------------------------------
 
-  ==> Convergence Check <==
+Next Geometry in Ang 
+	Fragment 1 (Ang)
 
-  Measures of convergence in internal coordinates in au.
-  Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
-  --------------------------------------------------------------------------------------------- ~
-   Step     Total Energy     Delta E     MAX Force     RMS Force      MAX Disp      RMS Disp    ~
-  --------------------------------------------------------------------------------------------- ~
-    Convergence Criteria    1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o  ~
-  --------------------------------------------------------------------------------------------- ~
-      1     -76.23098885   -7.62e+01      9.16e-03      7.58e-03 o    1.72e-02      1.59e-02 o  ~
-  ---------------------------------------------------------------------------------------------
+	    O   0.0000000000  -0.0000000000  -0.0605439493
+	    H   0.0000000000  -0.7558989096   0.5327432913
+	    H   0.0000000000   0.7558989096   0.5327432913
 
-	Writing optimization data to binary file.
-	Structure for next step:
-	Cartesian Geometry (in Angstrom)
-	    O     0.0000000000   0.0000000000  -0.0605439489
-	    H     0.0000000000  -0.7558989055   0.5327432911
-	    H     0.0000000000   0.7558989055   0.5327432911
-			--------------------------
-			 OPTKING Finished Execution 
-			--------------------------
 
     Structure for next step:
     Molecular point group: c2v
@@ -903,23 +735,32 @@ Total time:
     H             1    0.960923
     H             1    0.960923      2  103.744934
 
-gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Mon May 15 15:33:54 2017
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on cgbriggs99-debian-workstation
+*** at Wed Aug  5 17:35:46 2026
 
    => Loading Basis Set <=
 
     Name: 6-31G**
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   140 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
-    atoms 2-3 entry H          line    35 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 1   entry O          line   149 file /home/connor/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2-3 entry H          line    44 file /home/connor/psi4/share/psi4/basis/6-31gss.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -933,15 +774,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.066397666276    15.994914619560
-           H          0.000000000000    -0.755898905515     0.526889573702     1.007825032070
-           H          0.000000000000     0.755898905515     0.526889573702     1.007825032070
+         O            0.000000000000     0.000000000000    -0.066397666357    15.994914619570
+         H            0.000000000000    -0.755898909624     0.526889574259     1.007825032230
+         H            0.000000000000     0.755898909624     0.526889574259     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     26.75449  B =     14.63706  C =      9.46104 [cm^-1]
-  Rotational constants: A = 802079.55576  B = 438808.09054  C = 283634.86362 [MHz]
-  Nuclear repulsion =    9.161180837150805
+  Rotational constants: A = 802079.56004  B = 438808.08904  C = 283634.86353 [MHz]
+  Nuclear repulsion =    9.161180838005905
 
   Charge       = 0
   Multiplicity = 1
@@ -958,32 +799,27 @@ gradient() will perform analytic gradient computation.
   Guess Type is READ.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: 6-31G**
     Blend: 6-31G**
     Number of shells: 12
-    Number of basis function: 25
+    Number of basis functions: 25
     Number of Cartesian functions: 25
     Spherical Harmonics?: false
     Max angular momentum: 2
 
-  Reading orbitals from file 180, no projection.
+   => Loading Basis Set <=
 
-  ==> Pre-Iterations <==
+    Name: 6-31G**
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   149 file /home/connor/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2-3 entry H          line    44 file /home/connor/psi4/share/psi4/basis/6-31gss.gbs 
 
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        12      12       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      25      25       5       5       5       0
-   -------------------------------------------------------
+  Reading orbitals from file /tmp/output.h2o.3207512.180.npy, no projection.
 
   ==> Integral Setup <==
 
@@ -1002,40 +838,58 @@ gradient() will perform analytic gradient computation.
   Using 105950 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.2007011557E-02.
-  Using Symmetric Orthogonalization.
+
+  Minimum eigenvalue in the overlap matrix is 2.1198065045E-02.
+  Reciprocal condition number of the overlap matrix is 4.7694521543E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        12      12       3       3       3       0
+     A2         2       2       0       0       0       0
+     B1         4       4       1       1       1       0
+     B2         7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      25      25       5       5       5       0
+   -------------------------------------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -76.03442224369516   -7.60344e+01   1.69791e-03 
-   @RHF iter   1:   -76.02286068245994    1.15616e-02   2.53762e-04 
-   @RHF iter   2:   -76.02286887130417   -8.18884e-06   1.16147e-04 DIIS
-   @RHF iter   3:   -76.02287001874517   -1.14744e-06   3.24612e-05 DIIS
-   @RHF iter   4:   -76.02287026551789   -2.46773e-07   1.11408e-05 DIIS
-   @RHF iter   5:   -76.02287029779359   -3.22757e-08   2.03245e-06 DIIS
-   @RHF iter   6:   -76.02287029902574   -1.23215e-09   3.09442e-07 DIIS
-   @RHF iter   7:   -76.02287029904868   -2.29363e-11   5.01345e-08 DIIS
-   @RHF iter   8:   -76.02287029904919   -5.11591e-13   5.85236e-09 DIIS
-   @RHF iter   9:   -76.02287029904920   -1.42109e-14   6.44692e-10 DIIS
-   @RHF iter  10:   -76.02287029904917    2.84217e-14   6.79679e-11 DIIS
+   @RHF iter   0:   -76.03442223924912   -7.60344e+01   1.69791e-03 
+   @RHF iter   1:   -76.02286068249802    1.15616e-02   2.53762e-04 DIIS/ADIIS
+   @RHF iter   2:   -76.02286887133685   -8.18884e-06   1.16147e-04 DIIS/ADIIS
+   @RHF iter   3:   -76.02287001877428   -1.14744e-06   3.24588e-05 DIIS
+   @RHF iter   4:   -76.02287026554956   -2.46775e-07   1.11408e-05 DIIS
+   @RHF iter   5:   -76.02287029782531   -3.22758e-08   2.03245e-06 DIIS
+   @RHF iter   6:   -76.02287029905749   -1.23218e-09   3.09442e-07 DIIS
+   @RHF iter   7:   -76.02287029908032   -2.28368e-11   5.01345e-08 DIIS
+   @RHF iter   8:   -76.02287029908086   -5.40012e-13   5.85236e-09 DIIS
+   @RHF iter   9:   -76.02287029908089   -2.84217e-14   6.44691e-10 DIIS
+   @RHF iter  10:   -76.02287029908084    5.68434e-14   6.79677e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -1055,50 +909,49 @@ gradient() will perform analytic gradient computation.
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
+    NA   [     3,    0,    1,    1 ]
+    NB   [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:   -76.02287029904917
+  @RHF Final Energy:   -76.02287029908084
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1611808371508054
-    One-Electron Energy =                -123.0327302720779130
-    Two-Electron Energy =                  37.8486791358779300
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0228702990491740
+    Nuclear Repulsion Energy =              9.1611808380059045
+    One-Electron Energy =                -123.0327302745108540
+    Two-Electron Energy =                  37.8486791374240994
+    Total Energy =                        -76.0228702990808500
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.9876
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.1218
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.8658     Total:     0.8658
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     2.2006     Total:     2.2006
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.1217688            0.9875667            0.8657979
+ Magnitude           :                                                    0.8657979
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:33:54 2017
+*** tstop() called on cgbriggs99-debian-workstation at Wed Aug  5 17:35:46 2026
 Module time:
-	user time   =       0.14 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
+	user time   =       0.05 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.85 seconds =       0.01 minutes
-	system time =       0.38 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       0.20 seconds =       0.00 minutes
+	system time =       0.05 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -1112,19 +965,19 @@ Total time:
       Number of basis functions:        25
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  12    2    4    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 13803 non-zero two-electron integrals.
+      Computed 13617 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:33:54 2017
+*** tstart() called on cgbriggs99-debian-workstation
+*** at Wed Aug  5 17:35:46 2026
 
 
 	Wfn Parameters:
@@ -1149,7 +1002,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -1205,34 +1058,30 @@ Total time:
 	Size of irrep 3 of tijab amplitudes:       0.001 (MW) /      0.006 (MB)
 	Total:                                     0.003 (MW) /      0.022 (MB)
 
-	Nuclear Rep. energy          =      9.16118083715081
-	SCF energy                   =    -76.02287029904917
-	One-electron energy          =   -123.03273027160742
-	Two-electron energy          =     37.84867913540743
-	Reference energy             =    -76.02287029904919
+	Nuclear Rep. energy          =      9.16118083800590
+	SCF energy                   =    -76.02287029908084
+	One-electron energy          =   -123.03273027398460
+	Two-electron energy          =     37.84867913689784
+	Reference energy             =    -76.02287029908085
 
-*** tstop() called on psinet at Mon May 15 15:33:54 2017
+*** tstop() called on cgbriggs99-debian-workstation at Wed Aug  5 17:35:46 2026
 Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.90 seconds =       0.02 minutes
-	system time =       0.41 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:33:54 2017
-
+	user time   =       0.21 seconds =       0.00 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.161180837150805
-    SCF energy          (wfn)     =  -76.022870299049174
-    Reference energy    (file100) =  -76.022870299049188
+    Nuclear Rep. energy (wfn)     =    9.161180838005905
+    SCF energy          (wfn)     =  -76.022870299080836
+    Reference energy    (file100) =  -76.022870299080850
 
     Input parameters:
     -----------------
@@ -1245,6 +1094,7 @@ Total time:
     E_Convergence   =     1.0e-08
     Restart         =     Yes
     DIIS            =     Yes
+    DIIS_MAX_VECS   =     10
     AO Basis        =     NONE
     ABCD            =     NEW
     Cache Level     =     2
@@ -1263,76 +1113,64 @@ Total time:
     Using old T1 amplitudes.
     Using old T2 amplitudes.
 
-MP2 correlation energy -0.1995779298155369
+MP2 correlation energy -0.1995779297844355
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.208832766977767    0.000e+00    0.005803    0.012514    0.012514    0.124275
-     1        -0.208352192758995    5.808e-03    0.005946    0.013119    0.013119    0.123305
-     2        -0.208351928562426    1.321e-03    0.005758    0.012502    0.012502    0.123122
-     3        -0.208313705185478    3.912e-04    0.005714    0.012347    0.012347    0.123013
-     4        -0.208305450393528    1.391e-04    0.005681    0.012212    0.012212    0.122982
-     5        -0.208304246786706    3.956e-05    0.005671    0.012166    0.012166    0.122978
-     6        -0.208304581255638    1.130e-05    0.005669    0.012152    0.012152    0.122979
-     7        -0.208304662444435    2.163e-06    0.005669    0.012150    0.012150    0.122980
-     8        -0.208304702846171    3.869e-07    0.005669    0.012150    0.012150    0.122980
-     9        -0.208304705056091    8.612e-08    0.005669    0.012150    0.012150    0.122980
-    10        -0.208304706208642    1.903e-08    0.005669    0.012150    0.012150    0.122980
+     0        -0.208832766880610    0.000e+00    0.005803    0.012514    0.012514    0.124275
+     1        -0.208352192744725    5.808e-03    0.005946    0.013119    0.013119    0.123305
+     2        -0.208351928526215    1.321e-03    0.005758    0.012502    0.012502    0.123122
+     3        -0.208313705160175    3.912e-04    0.005714    0.012347    0.012347    0.123013
+     4        -0.208305450364331    1.391e-04    0.005681    0.012212    0.012212    0.122982
+     5        -0.208304246754940    3.956e-05    0.005671    0.012166    0.012166    0.122978
+     6        -0.208304581222701    1.130e-05    0.005669    0.012152    0.012152    0.122979
+     7        -0.208304662411587    2.163e-06    0.005669    0.012150    0.012150    0.122980
+     8        -0.208304702813352    3.869e-07    0.005669    0.012150    0.012150    0.122980
+     9        -0.208304705466505    8.612e-08    0.005669    0.012150    0.012150    0.122980
+    10        -0.208304706232822    1.680e-08    0.005669    0.012150    0.012150    0.122980
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              2   0         0.0104578565
-              3  11        -0.0065599589
-              4  14        -0.0062679699
+              2   0         0.0104578559
+              3  11        -0.0065599585
+              4  14        -0.0062679709
               4  18         0.0052425993
-              4  16         0.0046299439
+              4  16         0.0046299436
               1   2         0.0042751583
-              2   5         0.0039508040
-              1   0        -0.0028721033
-              1   7         0.0023730140
+              2   5         0.0039508039
+              1   0        -0.0028721034
+              1   7         0.0023730141
               2   1         0.0022659231
 
     Largest TIjAb Amplitudes:
-      3   3  11  11        -0.0518782951
-      4   4  14  14        -0.0381048556
-      2   2   2   2        -0.0288684547
-      4   4  15  15        -0.0286603421
+      3   3  11  11        -0.0518782952
+      4   4  14  14        -0.0381048559
+      2   2   2   2        -0.0288684551
+      4   4  15  15        -0.0286603422
       3   4  11  16        -0.0248103170
       4   3  16  11        -0.0248103170
       4   4  16  16        -0.0246764511
-      2   3   2  11         0.0246211685
-      3   2  11   2         0.0246211685
-      3   4  11  14        -0.0242303543
+      2   3   2  11         0.0246211687
+      3   2  11   2         0.0246211687
+      3   4  11  14        -0.0242303544
 
-    SCF energy       (wfn)                    =  -76.022870299049174
-    Reference energy (file100)                =  -76.022870299049188
+    SCF energy       (wfn)                    =  -76.022870299080836
+    Reference energy (file100)                =  -76.022870299080850
 
-    Opposite-spin MP2 correlation energy      =   -0.149388403575212
-    Same-spin MP2 correlation energy          =   -0.050189526240325
-    MP2 correlation energy                    =   -0.199577929815537
-      * MP2 total energy                      =  -76.222448228864721
+    Opposite-spin MP2 correlation energy      =   -0.149388403550763
+    Same-spin MP2 correlation energy          =   -0.050189526233673
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.199577929784436
+      * MP2 total energy                      =  -76.222448228865289
 
-    Opposite-spin CCSD correlation energy     =   -0.163737341181464
-    Same-spin CCSD correlation energy         =   -0.044567365024164
-    CCSD correlation energy                   =   -0.208304706208642
-      * CCSD total energy                     =  -76.231175005257825
-
-
-*** tstop() called on psinet at Mon May 15 15:33:54 2017
-Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.16 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.97 seconds =       0.02 minutes
-	system time =       0.57 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:33:54 2017
+    Opposite-spin CCSD correlation energy     =   -0.163737341319809
+    Same-spin CCSD correlation energy         =   -0.044567364913013
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.208304706232822
+      * CCSD total energy                     =  -76.231175005313673
 
 
 			**************************
@@ -1342,31 +1180,17 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:33:54 2017
-Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.98 seconds =       0.02 minutes
-	system time =       0.58 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:33:54 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =    9.161180837150805
+	Nuclear Rep. energy (wfn)     =    9.161180838005905
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     =  -76.022870299049174
-	Reference energy    (CC_INFO) =  -76.022870299049188
-	CCSD energy         (CC_INFO) =   -0.208304706208642
-	Total CCSD energy   (CC_INFO) =  -76.231175005257825
+	SCF energy          (wfn)     =  -76.022870299080836
+	Reference energy    (CC_INFO) =  -76.022870299080850
+	CCSD energy         (CC_INFO) =   -0.208304706232822
+	Total CCSD energy   (CC_INFO) =  -76.231175005313673
 
 	Input parameters:
 	-----------------
@@ -1376,10 +1200,11 @@ Total time:
 	Cache Level       =     2
 	Model III         =     No
 	DIIS              =     Yes
+	DIIS_MAX_VECS     =     8
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -1391,58 +1216,44 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.208341272342194    9.017e-08
-	   1        -0.205855816883735    7.969e-03
-	   2        -0.205434039982074    1.315e-03
-	   3        -0.205350569998591    6.037e-04
-	   4        -0.205344216692114    1.999e-04
-	   5        -0.205347757159083    6.066e-05
-	   6        -0.205347737519131    1.456e-05
-	   7        -0.205347817975305    3.263e-06
-	   8        -0.205347846127468    4.958e-07
-	   9        -0.205347844166032    8.424e-08
+	   0        -0.208341272371017    9.017e-08
+	   1        -0.205855816887617    7.969e-03
+	   2        -0.205434039963906    1.315e-03
+	   3        -0.205350569970648    6.037e-04
+	   4        -0.205344216663498    1.999e-04
+	   5        -0.205347757130312    6.066e-05
+	   6        -0.205347737490334    1.456e-05
+	   7        -0.205347817946484    3.263e-06
+	   8        -0.205347846098635    4.958e-07
+	   9        -0.205347844137197    8.424e-08
 
 	Largest LIA Amplitudes:
-	          2   0         0.0069579999
+	          2   0         0.0069579995
 	          4  16         0.0048367196
 	          4  18         0.0045278770
-	          3  11        -0.0038906253
+	          3  11        -0.0038906252
 	          2   5         0.0035178270
-	          4  14        -0.0031666919
+	          4  14        -0.0031666920
 	          1   2         0.0031569145
 	          1   3        -0.0024467761
 	          1   7         0.0021792656
-	          4  15        -0.0020511924
+	          4  15        -0.0020511923
 
 	Largest LIjAb Amplitudes:
 	  3   3  11  11        -0.0515965313
 	  4   4  14  14        -0.0372313767
-	  2   2   2   2        -0.0285001142
+	  2   2   2   2        -0.0285001147
 	  4   4  15  15        -0.0279512386
 	  3   4  11  16        -0.0246236949
 	  4   3  16  11        -0.0246236949
-	  2   3   2  11         0.0244701826
-	  3   2  11   2         0.0244701826
-	  4   4  16  16        -0.0244234386
+	  2   3   2  11         0.0244701829
+	  3   2  11   2         0.0244701829
+	  4   4  16  16        -0.0244234385
 	  3   4  11  14        -0.0239728041
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.94342446404
-
-*** tstop() called on psinet at Mon May 15 15:33:54 2017
-Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.00 seconds =       0.02 minutes
-	system time =       0.61 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:33:54 2017
-
+	Overlap <L|e^T> =        0.94342446403
 
 			**************************
 			*                        *
@@ -1466,152 +1277,24 @@ Total time:
 	Xi connected     = Yes
 	Compute NO       = No
 
-	Nuclear Rep. energy (wfn)     =    9.161180837150805
-	SCF energy          (wfn)     =  -76.022870299049174
-	Reference energy    (file100) =  -76.022870299049188
-	CCSD energy         (CC_INFO) =   -0.208304706208642
-	Total CCSD energy   (CC_INFO) =  -76.231175005257825
+	Nuclear Rep. energy (wfn)     =    9.161180838005905
+	SCF energy          (wfn)     =  -76.022870299080836
+	Reference energy    (file100) =  -76.022870299080850
+	CCSD energy         (CC_INFO) =   -0.208304706232822
+	Total CCSD energy   (CC_INFO) =  -76.231175005313673
 	Number of States = 1
 
 	Ground?  State     EOM Energy       R0
 	  Yes     0 A1    0.0000000000   1.00000000
 
-	Energies re-computed from CC density:
-	-------------------------------------
-	One-electron energy        =    0.220401428909322
-	IJKL energy                =    0.041624272800223
-	IJKA energy                =   -0.001380495813622
-	IJAB energy                =   -0.410871757238811
-	IBJA energy                =   -0.100224187354571
-	CIAB energy                =   -0.000154378287070
-	ABCD energy                =    0.042300410465944
-	Total two-electron energy  =   -0.428706135427907
-	CCSD    correlation energy =   -0.208304706518585
-	Total CCSD    energy       =  -76.231175005567763
-
 	Virial Theorem Data:
 	--------------------
-	Kinetic energy (ref)   =   75.797290302742311
-	Kinetic energy (corr)  =    0.147813059281767
-	Kinetic energy (total) =   75.945103362024085
-	-V/T (ref)             =    2.002976095786615
-	-V/T (corr)            =    2.409244265836916
-	-V/T (total)           =    2.003766821435084
-
-	Energies re-computed from Fock-adjusted CC density:
-	---------------------------------------------------
-	One-electron energy        =    0.246368008846171
-	IJKL energy                =   -0.666765074537129
-	IJKA energy                =   -0.047671155273339
-	IJAB energy                =   -0.410871757238811
-	IBJA energy                =    0.628489239511619
-	CIAB energy                =   -0.000154378287070
-	ABCD energy                =    0.042300410465944
-	Total two-electron energy  =   -0.454672715358786
-	   CCSD correlation energy =   -0.208304706512615
-	Total    CCSD energy       =  -76.231175005561795
-
-	Energies re-computed from Mulliken density:
-	-------------------------------------------
-	One-electron energy        =    0.246368008846171
-	IJKL energy                =   -0.666765074537129
-	IJKA energy                =   -0.047671155273339
-	IJAB energy                =   -0.379953584434570
-	IBJA energy                =    0.597571066707377
-	CIAB energy                =   -0.000154378287070
-	ABCD energy                =    0.042300410465944
-	Total two-electron energy  =   -0.454672715358786
-	   CCSD correlation energy =   -0.208304706512615
-	Total    CCSD energy       =  -76.231175005561795
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.9876
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.1611
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.8265     Total:     0.8265
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     2.1007     Total:     2.1007
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -7.2294     YY:    -4.3023     ZZ:    -5.8039
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -1.4509     YY:     1.4762     ZZ:    -0.0254
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.31575  4.31575  0.00000 -0.63150
-       2     H     0.34213  0.34213  0.00000  0.31575
-       3     H     0.34213  0.34213  0.00000  0.31575
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge = -0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B1    1.972
-  HONO-1 :    3 A1    1.966
-  HONO-0 :    1 B2    1.964
-  LUNO+0 :    2 B2    0.027
-  LUNO+1 :    4 A1    0.025
-  LUNO+2 :    2 B1    0.017
-  LUNO+3 :    5 A1    0.011
-
-
-*** tstop() called on psinet at Mon May 15 15:33:54 2017
-Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.07 seconds =       0.02 minutes
-	system time =       0.65 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
-  Cartesian Displacement SALCs
-  By SALC:
-  Number of SALCs: 3, nirreps: 1
-  Project out translations: False
-  Project out rotations: False
-	irrep = 0, ncomponent = 1
-		0: atom 0, direction z, coef 1.000000
-	irrep = 0, ncomponent = 2
-		0: atom 1, direction y, coef 0.707107
-		1: atom 2, direction y, coef -0.707107
-	irrep = 0, ncomponent = 2
-		0: atom 1, direction z, coef 0.707107
-		1: atom 2, direction z, coef 0.707107
-
-  By Atomic Center:
-  Number of atomic centers: 3
-   Atomic Center 0:
-	x component, size = 0
-	y component, size = 0
-	z component, size = 1
-		0: salc 0, irrep 0, coef 1.000000
-   Atomic Center 1:
-	x component, size = 0
-	y component, size = 1
-		0: salc 1, irrep 0, coef 0.707107
-	z component, size = 1
-		0: salc 2, irrep 0, coef 0.707107
-   Atomic Center 2:
-	x component, size = 0
-	y component, size = 1
-		0: salc 1, irrep 0, coef -0.707107
-	z component, size = 1
-		0: salc 2, irrep 0, coef 0.707107
-
+	Kinetic energy (ref)   =   75.797290304182454
+	Kinetic energy (corr)  =    0.147813059452757
+	Kinetic energy (total) =   75.945103363635212
+	-V/T (ref)             =    2.002976095767977
+	-V/T (corr)            =    2.409244264370286
+	-V/T (total)           =    2.003766821414525
     Molecular point group: c2v
     Full point group: C2v
 
@@ -1619,9 +1302,9 @@ Total time:
 
        Center              X                  Y                   Z       
     ------------   -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.125473405125
-           H          0.000000000000    -1.428441915571     0.995676996570
-           H          0.000000000000     1.428441915571     0.995676996570
+         O            0.000000000000     0.000000000000    -0.125473404784
+         H            0.000000000000    -1.428441917722     0.995676993708
+         H            0.000000000000     1.428441917722     0.995676993708
 
 	Presorting MO-basis TPDM.
 	Sorting File: MO TPDM (AA|AA) nbuckets = 1
@@ -1630,117 +1313,70 @@ Total time:
 	First half integral transformation complete.
 
 
-  -Nuclear Repulsion Energy 1st Derivatives:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     2.995860335503
-       2       -0.000000000000     2.031013916398    -1.497930167751
-       3        0.000000000000    -2.031013916398    -1.497930167751
-
-
-  -One-electron contribution to gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000    -6.905252322721
-       2        0.000000000000    -4.604556154403     3.452626161361
-       3       -0.000000000000     4.604556154403     3.452626161361
-
-
-  -Lagrangian contribution to gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.413316411295
-       2       -0.000000000000     0.251209963720    -0.206658205648
-       3        0.000000000000    -0.251209963720    -0.206658205648
-
-
-  -Two-electron contribution to gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     3.494694252764
-       2       -0.000000000000     2.322323860800    -1.747347126382
-       3        0.000000000000    -2.322323860800    -1.747347126382
-
-
   -Total gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000    -0.001381323159
-       2        0.000000000000    -0.000008413485     0.000690661580
-       3       -0.000000000000     0.000008413485     0.000690661580
+       1        0.000000000000     0.000000000000    -0.001381322537
+       2        0.000000000000    -0.000008413690     0.000690661269
+       3       -0.000000000000     0.000008413690     0.000690661269
 
 
-			-----------------------------------------
-			 OPTKING 2.0: for geometry optimizations 
-			  - R.A. King,  Bethel University        
-			-----------------------------------------
+    			-----------------------------------------
 
-	Previous internal coordinate definitions found.
-	---Fragment 1 Geometry and Gradient---
-	 O           0.0000000000        0.0000000000       -0.1254734051
-	 H           0.0000000000       -1.4284419156        0.9956769966
-	 H           0.0000000000        1.4284419156        0.9956769966
-	             0.0000000000        0.0000000000       -0.0013813232
-	             0.0000000000       -0.0000084135        0.0006906616
-	            -0.0000000000        0.0000084135        0.0006906616
+    			 OPTKING 3.0: for geometry optimizations 
 
-	---Fragment 1 Intrafragment Coordinates---
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       8.000000            15.994915          0.00000000  0.00000000 -0.12547340   
+	       1.000000             1.007825          0.00000000 -1.42844192  0.99567699   
+	       1.000000             1.007825          0.00000000  1.42844192  0.99567699   
+
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
-	 R(1,2)           =         1.815881	       0.960923
-	 R(1,3)           =         1.815881	       0.960923
-	 B(2,1,3)         =         1.810691	     103.744934
-
-	Current energy   :       -76.2311750053
-
-	Energy change for the previous step:
-		Projected    :        -0.0000218299
-		Actual       :        -0.0001861508
-	Energy ratio indicates good step: Trust radius increased to 1.000e+00.
+	 R(1,2)           =         1.815881           0.960923
+	 R(1,3)           =         1.815881           0.960923
+	 B(2,1,3)         =         1.810691         103.744934
 
 
-	Performing BFGS update.
-	Previous computed or guess Hessian on step 1.
-	Steps to be used in Hessian update: 1
-	Taking RFO optimization step.
-	Going to follow RFO solution 1.
-	Using RFO vector 1.
-	Norm of target step-size    0.00703
-	Projected energy change by RFO approximation:        -0.0000110992
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       0.96092       -0.00357       -0.00061       0.96032
+	               R(1,3)       0.96092       -0.00357       -0.00061       0.96032
+	             B(2,1,3)     103.74493        0.00007        0.39191     104.13684
+	-------------------------------------------------------------------------------
 
-	Back-transformation to cartesian coordinates...
-	Successfully converged to displaced geometry.
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
 
-	--- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
-	 ---------------------------------------------------------------------------
-	   Coordinate                Previous        Force       Change         New 
-	   ----------                --------       ------       ------       ------
-	    1 R(1,2)          =      0.960923    -0.003568    -0.000606     0.960317
-	    2 R(1,3)          =      0.960923    -0.003568    -0.000606     0.960317
-	    3 B(2,1,3)        =    103.744934     0.000074     0.391908   104.136842
-	 ---------------------------------------------------------------------------
-	Successfully symmetrized geometry.
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     2     -76.23117501   -1.86e-04      9.77e-04      6.66e-04 o    6.84e-03      4.06e-03 o  ~
+	----------------------------------------------------------------------------------------------
 
-  ==> Convergence Check <==
+Next Geometry in Ang 
+	Fragment 1 (Ang)
 
-  Measures of convergence in internal coordinates in au.
-  Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
-  ---------------------------------------------------------------------------------------------
-   Step     Total Energy     Delta E     MAX Force     RMS Force      MAX Disp      RMS Disp   
-  ---------------------------------------------------------------------------------------------
-    Convergence Criteria    1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
-  ---------------------------------------------------------------------------------------------
-      2     -76.23117501   -1.86e-04      9.77e-04      6.66e-04 o    6.84e-03      4.06e-03 o  ~
-  ---------------------------------------------------------------------------------------------
+	    O   0.0000000000   0.0000000000  -0.0644236380
+	    H   0.0000000000  -0.7574457631   0.5259025601
+	    H   0.0000000000   0.7574457631   0.5259025601
 
-	Writing optimization data to binary file.
-	Structure for next step:
-	Cartesian Geometry (in Angstrom)
-	    O     0.0000000000   0.0000000000  -0.0644236367
-	    H     0.0000000000  -0.7574457602   0.5259025589
-	    H     0.0000000000   0.7574457602   0.5259025589
-			--------------------------
-			 OPTKING Finished Execution 
-			--------------------------
 
     Structure for next step:
     Molecular point group: c2v
@@ -1752,23 +1388,32 @@ Total time:
     H             1    0.960317
     H             1    0.960317      2  104.136842
 
-gradient() will perform analytic gradient computation.
 
-*** tstart() called on psinet
-*** at Mon May 15 15:33:54 2017
+Scratch directory: /tmp/
+gradient() will perform analytic gradient computation.
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on cgbriggs99-debian-workstation
+*** at Wed Aug  5 17:35:46 2026
 
    => Loading Basis Set <=
 
     Name: 6-31G**
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   140 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
-    atoms 2-3 entry H          line    35 file /home/psilocaluser/gits/hrw-direct/objdir4/stage/usr/local/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 1   entry O          line   149 file /home/connor/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2-3 entry H          line    44 file /home/connor/psi4/share/psi4/basis/6-31gss.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
-            by Justin Turney, Rob Parrish, and Andy Simmonett
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
                               RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
@@ -1782,15 +1427,15 @@ gradient() will perform analytic gradient computation.
 
        Center              X                  Y                   Z               Mass       
     ------------   -----------------  -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.066066281368    15.994914619560
-           H          0.000000000000    -0.757445760189     0.524259914212     1.007825032070
-           H          0.000000000000     0.757445760189     0.524259914212     1.007825032070
+         O            0.000000000000     0.000000000000    -0.066066281656    15.994914619570
+         H            0.000000000000    -0.757445763135     0.524259916421     1.007825032230
+         H            0.000000000000     0.757445763135     0.524259916421     1.007825032230
 
   Running in c2v symmetry.
 
   Rotational constants: A =     27.02357  B =     14.57734  C =      9.46931 [cm^-1]
-  Rotational constants: A = 810146.11155  B = 437017.65408  C = 283882.64868 [MHz]
-  Nuclear repulsion =    9.166023988379742
+  Rotational constants: A = 810146.11076  B = 437017.65394  C = 283882.64853 [MHz]
+  Nuclear repulsion =    9.166023987621282
 
   Charge       = 0
   Multiplicity = 1
@@ -1807,32 +1452,27 @@ gradient() will perform analytic gradient computation.
   Guess Type is READ.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
   Basis Set: 6-31G**
     Blend: 6-31G**
     Number of shells: 12
-    Number of basis function: 25
+    Number of basis functions: 25
     Number of Cartesian functions: 25
     Spherical Harmonics?: false
     Max angular momentum: 2
 
-  Reading orbitals from file 180, no projection.
+   => Loading Basis Set <=
 
-  ==> Pre-Iterations <==
+    Name: 6-31G**
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   149 file /home/connor/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2-3 entry H          line    44 file /home/connor/psi4/share/psi4/basis/6-31gss.gbs 
 
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        12      12       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      25      25       5       5       5       0
-   -------------------------------------------------------
+  Reading orbitals from file /tmp/output.h2o.3207512.180.npy, no projection.
 
   ==> Integral Setup <==
 
@@ -1851,39 +1491,57 @@ gradient() will perform analytic gradient computation.
   Using 105950 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
     K tasked:                  Yes
     wK tasked:                  No
-    Memory (MB):               375
+    Memory [MiB]:              375
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 2.1994436500E-02.
-  Using Symmetric Orthogonalization.
+
+  Minimum eigenvalue in the overlap matrix is 2.1186800987E-02.
+  Reciprocal condition number of the overlap matrix is 4.7655976138E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Orbitals guess was supplied from a previous computation.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        12      12       3       3       3       0
+     A2         2       2       0       0       0       0
+     B1         4       4       1       1       1       0
+     B2         7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      25      25       5       5       5       0
+   -------------------------------------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @RHF iter   0:   -76.02380171615275   -7.60238e+01   1.80303e-04 
-   @RHF iter   1:   -76.02294253402849    8.59182e-04   2.94478e-05 
-   @RHF iter   2:   -76.02294269563227   -1.61604e-07   1.02584e-05 DIIS
-   @RHF iter   3:   -76.02294272529872   -2.96665e-08   2.46211e-06 DIIS
-   @RHF iter   4:   -76.02294272737615   -2.07743e-09   5.58770e-07 DIIS
-   @RHF iter   5:   -76.02294272747062   -9.44738e-11   1.40271e-07 DIIS
-   @RHF iter   6:   -76.02294272747235   -1.73372e-12   3.28717e-08 DIIS
-   @RHF iter   7:   -76.02294272747244   -8.52651e-14   5.66373e-09 DIIS
-   @RHF iter   8:   -76.02294272747244    0.00000e+00   5.01550e-10 DIIS
-   @RHF iter   9:   -76.02294272747245   -1.42109e-14   7.73112e-11 DIIS
+   @RHF iter   0:   -76.02380171578541   -7.60238e+01   1.80303e-04 
+   @RHF iter   1:   -76.02294253402155    8.59182e-04   2.94478e-05 DIIS
+   @RHF iter   2:   -76.02294269562513   -1.61604e-07   1.02584e-05 DIIS
+   @RHF iter   3:   -76.02294272529164   -2.96665e-08   2.46211e-06 DIIS
+   @RHF iter   4:   -76.02294272736904   -2.07740e-09   5.58770e-07 DIIS
+   @RHF iter   5:   -76.02294272746343   -9.43885e-11   1.40272e-07 DIIS
+   @RHF iter   6:   -76.02294272746521   -1.77636e-12   3.28716e-08 DIIS
+   @RHF iter   7:   -76.02294272746535   -1.42109e-13   5.66373e-09 DIIS
+   @RHF iter   8:   -76.02294272746533    1.42109e-14   5.01547e-10 DIIS
+   @RHF iter   9:   -76.02294272746535   -1.42109e-14   7.73119e-11 DIIS
+  Energy and wave function converged.
+
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -1903,50 +1561,49 @@ gradient() will perform analytic gradient computation.
     Final Occupation by Irrep:
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
+    NA   [     3,    0,    1,    1 ]
+    NB   [     3,    0,    1,    1 ]
 
-  Energy converged.
-
-  @RHF Final Energy:   -76.02294272747245
+  @RHF Final Energy:   -76.02294272746535
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =              9.1660239883797416
-    One-Electron Energy =                -123.0428193375948922
-    Two-Electron Energy =                  37.8538526217426892
-    DFT Exchange-Correlation Energy =       0.0000000000000000
-    Empirical Dispersion Energy =           0.0000000000000000
-    PCM Polarization Energy =               0.0000000000000000
-    EFP Energy =                            0.0000000000000000
-    Total Energy =                        -76.0229427274724543
+    Nuclear Repulsion Energy =              9.1660239876212817
+    One-Electron Energy =                -123.0428193361738209
+    Two-Electron Energy =                  37.8538526210871851
+    Total Energy =                        -76.0229427274653489
+
+Computation Completed
 
 
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.9826
 
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.1197
+ Multipole Moments:
 
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.8630     Total:     0.8630
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
 
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     2.1935     Total:     2.1935
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.1196501            0.9826379            0.8629878
+ Magnitude           :                                                    0.8629878
 
+ ------------------------------------------------------------------------------------
 
-*** tstop() called on psinet at Mon May 15 15:33:55 2017
+*** tstop() called on cgbriggs99-debian-workstation at Wed Aug  5 17:35:46 2026
 Module time:
-	user time   =       0.14 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.05 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.27 seconds =       0.02 minutes
-	system time =       0.68 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
+	user time   =       0.32 seconds =       0.01 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
  MINTS: Wrapper to libmints.
    by Justin Turney
 
@@ -1960,19 +1617,19 @@ Total time:
       Number of basis functions:        25
 
       Number of irreps:                  4
-      Integral cutoff                 0.00e+00
+      Integral cutoff                 1.00e-12
       Number of functions per irrep: [  12    2    4    7 ]
 
  OEINTS: Overlap, kinetic, potential, dipole, and quadrupole integrals
          stored in file 35.
 
       Computing two-electron integrals...done
-      Computed 13803 non-zero two-electron integrals.
+      Computed 13617 non-zero two-electron integrals.
         Stored in file 33.
 
 
-*** tstart() called on psinet
-*** at Mon May 15 15:33:55 2017
+*** tstart() called on cgbriggs99-debian-workstation
+*** at Wed Aug  5 17:35:46 2026
 
 
 	Wfn Parameters:
@@ -1997,7 +1654,7 @@ Total time:
 	(OO|OO)...
 	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
@@ -2053,34 +1710,30 @@ Total time:
 	Size of irrep 3 of tijab amplitudes:       0.001 (MW) /      0.006 (MB)
 	Total:                                     0.003 (MW) /      0.022 (MB)
 
-	Nuclear Rep. energy          =      9.16602398837974
-	SCF energy                   =    -76.02294272747245
-	One-electron energy          =   -123.04281933713332
-	Two-electron energy          =     37.85385262128116
-	Reference energy             =    -76.02294272747241
+	Nuclear Rep. energy          =      9.16602398762128
+	SCF energy                   =    -76.02294272746535
+	One-electron energy          =   -123.04281933571707
+	Two-electron energy          =     37.85385262063042
+	Reference energy             =    -76.02294272746536
 
-*** tstop() called on psinet at Mon May 15 15:33:55 2017
+*** tstop() called on cgbriggs99-debian-workstation at Wed Aug  5 17:35:46 2026
 Module time:
-	user time   =       0.02 seconds =       0.00 minutes
-	system time =       0.04 seconds =       0.00 minutes
+	user time   =       0.01 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       1.31 seconds =       0.02 minutes
-	system time =       0.72 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:33:55 2017
-
+	user time   =       0.33 seconds =       0.01 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
             **************************
             *                        *
             *        CCENERGY        *
             *                        *
             **************************
 
-    Nuclear Rep. energy (wfn)     =    9.166023988379742
-    SCF energy          (wfn)     =  -76.022942727472454
-    Reference energy    (file100) =  -76.022942727472412
+    Nuclear Rep. energy (wfn)     =    9.166023987621282
+    SCF energy          (wfn)     =  -76.022942727465349
+    Reference energy    (file100) =  -76.022942727465363
 
     Input parameters:
     -----------------
@@ -2093,6 +1746,7 @@ Total time:
     E_Convergence   =     1.0e-08
     Restart         =     Yes
     DIIS            =     Yes
+    DIIS_MAX_VECS   =     10
     AO Basis        =     NONE
     ABCD            =     NEW
     Cache Level     =     2
@@ -2111,34 +1765,34 @@ Total time:
     Using old T1 amplitudes.
     Using old T2 amplitudes.
 
-MP2 correlation energy -0.1995040063196544
+MP2 correlation energy -0.1995040063227589
                 Solving CC Amplitude Equations
                 ------------------------------
   Iter             Energy              RMS        T1Diag      D1Diag    New D1Diag    D2Diag
   ----     ---------------------    ---------   ----------  ----------  ----------   --------
-     0        -0.208268287456194    0.000e+00    0.005669    0.012150    0.012150    0.122980
-     1        -0.208244055733640    2.214e-03    0.005668    0.012188    0.012188    0.122873
-     2        -0.208237384994156    4.332e-04    0.005667    0.012186    0.012186    0.122853
-     3        -0.208236780134826    1.029e-04    0.005661    0.012157    0.012157    0.122849
-     4        -0.208235960457360    2.790e-05    0.005659    0.012145    0.012145    0.122847
-     5        -0.208235796613253    8.944e-06    0.005657    0.012136    0.012136    0.122847
-     6        -0.208235697987067    3.175e-06    0.005656    0.012133    0.012133    0.122847
-     7        -0.208235708470845    8.031e-07    0.005656    0.012131    0.012131    0.122847
-     8        -0.208235706203810    1.161e-07    0.005656    0.012131    0.012131    0.122847
-     9        -0.208235707703749    2.206e-08    0.005656    0.012131    0.012131    0.122847
+     0        -0.208268287515012    0.000e+00    0.005669    0.012150    0.012150    0.122980
+     1        -0.208244055763152    2.214e-03    0.005668    0.012188    0.012188    0.122873
+     2        -0.208237385003745    4.332e-04    0.005667    0.012186    0.012186    0.122853
+     3        -0.208236780136259    1.029e-04    0.005661    0.012157    0.012157    0.122849
+     4        -0.208235960455583    2.790e-05    0.005659    0.012145    0.012145    0.122847
+     5        -0.208235796610610    8.944e-06    0.005657    0.012136    0.012136    0.122847
+     6        -0.208235697984261    3.175e-06    0.005656    0.012133    0.012133    0.122847
+     7        -0.208235708468059    8.031e-07    0.005656    0.012131    0.012131    0.122847
+     8        -0.208235706201059    1.161e-07    0.005656    0.012131    0.012131    0.122847
+     9        -0.208235707701005    2.206e-08    0.005656    0.012131    0.012131    0.122847
 
     Iterations converged.
 
 
     Largest TIA Amplitudes:
-              2   0         0.0104323196
-              3  11        -0.0065456050
-              4  14        -0.0062450491
+              2   0         0.0104323193
+              3  11        -0.0065456049
+              4  14        -0.0062450493
               4  18         0.0052212200
-              4  16         0.0045986029
+              4  16         0.0045986028
               1   2         0.0042996542
               2   5         0.0039394159
-              1   0        -0.0029165700
+              1   0        -0.0029165701
               1   7         0.0023786971
               2   1         0.0022535244
 
@@ -2154,32 +1808,20 @@ MP2 correlation energy -0.1995040063196544
       4   4  16  16        -0.0246442486
       3   4  11  14        -0.0242044003
 
-    SCF energy       (wfn)                    =  -76.022942727472454
-    Reference energy (file100)                =  -76.022942727472412
+    SCF energy       (wfn)                    =  -76.022942727465349
+    Reference energy (file100)                =  -76.022942727465363
 
-    Opposite-spin MP2 correlation energy      =   -0.149329780446274
-    Same-spin MP2 correlation energy          =   -0.050174225873380
-    MP2 correlation energy                    =   -0.199504006319654
-      * MP2 total energy                      =  -76.222446733792069
+    Opposite-spin MP2 correlation energy      =   -0.149329780449305
+    Same-spin MP2 correlation energy          =   -0.050174225873454
+    Singles MP2 correlation energy            =   -0.000000000000000
+    MP2 correlation energy                    =   -0.199504006322759
+      * MP2 total energy                      =  -76.222446733788118
 
-    Opposite-spin CCSD correlation energy     =   -0.163672920668938
-    Same-spin CCSD correlation energy         =   -0.044562787030826
-    CCSD correlation energy                   =   -0.208235707703749
-      * CCSD total energy                     =  -76.231178435176162
-
-
-*** tstop() called on psinet at Mon May 15 15:33:55 2017
-Module time:
-	user time   =       0.06 seconds =       0.00 minutes
-	system time =       0.13 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.37 seconds =       0.02 minutes
-	system time =       0.85 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:33:55 2017
+    Opposite-spin CCSD correlation energy     =   -0.163672920672280
+    Same-spin CCSD correlation energy         =   -0.044562787028725
+    Singles CCSD correlation energy           =    0.000000000000000
+    CCSD correlation energy                   =   -0.208235707701005
+      * CCSD total energy                     =  -76.231178435166370
 
 
 			**************************
@@ -2189,31 +1831,17 @@ Total time:
 			**************************
 
 
-*** tstop() called on psinet at Mon May 15 15:33:55 2017
-Module time:
-	user time   =       0.01 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.38 seconds =       0.02 minutes
-	system time =       0.86 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:33:55 2017
-
-
 			**************************
 			*        CCLAMBDA        *
 			**************************
 
 
-	Nuclear Rep. energy (wfn)     =    9.166023988379742
+	Nuclear Rep. energy (wfn)     =    9.166023987621282
 	Reference           (wfn)     =                    0
-	SCF energy          (wfn)     =  -76.022942727472454
-	Reference energy    (CC_INFO) =  -76.022942727472412
-	CCSD energy         (CC_INFO) =   -0.208235707703749
-	Total CCSD energy   (CC_INFO) =  -76.231178435176162
+	SCF energy          (wfn)     =  -76.022942727465349
+	Reference energy    (CC_INFO) =  -76.022942727465363
+	CCSD energy         (CC_INFO) =   -0.208235707701005
+	Total CCSD energy   (CC_INFO) =  -76.231178435166370
 
 	Input parameters:
 	-----------------
@@ -2223,10 +1851,11 @@ Total time:
 	Cache Level       =     2
 	Model III         =     No
 	DIIS              =     Yes
+	DIIS_MAX_VECS     =     8
 	AO Basis          =     No
 	ABCD              =     NEW
 	Local CC          =     No
-	Paramaters for left-handed eigenvectors:
+	Parameters for left-handed eigenvectors:
 	    Irr   Root  Ground-State?    EOM energy        R0
 	  1   0     0        Yes       0.0000000000   1.0000000000
 	Labels for eigenvector 1:
@@ -2238,25 +1867,25 @@ Total time:
 	          ------------------------
 	Iter     PseudoEnergy or Norm         RMS  
 	----     ---------------------     --------
-	   0        -0.208272250244322    8.424e-08
-	   1        -0.205791571603518    7.966e-03
-	   2        -0.205370449732212    1.311e-03
-	   3        -0.205287149728528    6.018e-04
-	   4        -0.205280812287258    1.995e-04
-	   5        -0.205284337782511    6.063e-05
-	   6        -0.205284319210553    1.453e-05
-	   7        -0.205284399271237    3.249e-06
-	   8        -0.205284427373706    4.934e-07
-	   9        -0.205284425415476    8.358e-08
+	   0        -0.208272250245531    8.424e-08
+	   1        -0.205791571605428    7.966e-03
+	   2        -0.205370449734070    1.311e-03
+	   3        -0.205287149730402    6.018e-04
+	   4        -0.205280812289130    1.995e-04
+	   5        -0.205284337784369    6.063e-05
+	   6        -0.205284319212409    1.453e-05
+	   7        -0.205284399273093    3.249e-06
+	   8        -0.205284427375562    4.934e-07
+	   9        -0.205284425417332    8.358e-08
 
 	Largest LIA Amplitudes:
-	          2   0         0.0069443473
-	          4  16         0.0048125197
+	          2   0         0.0069443471
+	          4  16         0.0048125196
 	          4  18         0.0045116184
-	          3  11        -0.0038738412
+	          3  11        -0.0038738410
 	          2   5         0.0035067222
-	          1   2         0.0031832273
-	          4  14        -0.0031482601
+	          1   2         0.0031832274
+	          4  14        -0.0031482603
 	          1   3        -0.0024367341
 	          1   7         0.0021847180
 	          4  15        -0.0020294267
@@ -2275,21 +1904,7 @@ Total time:
 
 	Iterations converged.
 
-	Overlap <L|e^T> =        0.94348490443
-
-*** tstop() called on psinet at Mon May 15 15:33:55 2017
-Module time:
-	user time   =       0.03 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.41 seconds =       0.02 minutes
-	system time =       0.89 seconds =       0.01 minutes
-	total time  =          3 seconds =       0.05 minutes
-
-*** tstart() called on psinet
-*** at Mon May 15 15:33:55 2017
-
+	Overlap <L|e^T> =        0.94348490444
 
 			**************************
 			*                        *
@@ -2313,152 +1928,24 @@ Total time:
 	Xi connected     = Yes
 	Compute NO       = No
 
-	Nuclear Rep. energy (wfn)     =    9.166023988379742
-	SCF energy          (wfn)     =  -76.022942727472454
-	Reference energy    (file100) =  -76.022942727472412
-	CCSD energy         (CC_INFO) =   -0.208235707703749
-	Total CCSD energy   (CC_INFO) =  -76.231178435176162
+	Nuclear Rep. energy (wfn)     =    9.166023987621282
+	SCF energy          (wfn)     =  -76.022942727465349
+	Reference energy    (file100) =  -76.022942727465363
+	CCSD energy         (CC_INFO) =   -0.208235707701005
+	Total CCSD energy   (CC_INFO) =  -76.231178435166370
 	Number of States = 1
 
 	Ground?  State     EOM Energy       R0
 	  Yes     0 A1    0.0000000000   1.00000000
 
-	Energies re-computed from CC density:
-	-------------------------------------
-	One-electron energy        =    0.220328521191786
-	IJKL energy                =    0.041592574317710
-	IJKA energy                =   -0.001379373913453
-	IJAB energy                =   -0.410744547471779
-	IBJA energy                =   -0.100141807517814
-	CIAB energy                =   -0.000149333681920
-	ABCD energy                =    0.042258259031188
-	Total two-electron energy  =   -0.428564229236068
-	CCSD    correlation energy =   -0.208235708044282
-	Total CCSD    energy       =  -76.231178435516696
-
 	Virial Theorem Data:
 	--------------------
-	Kinetic energy (ref)   =   75.798953232335137
-	Kinetic energy (corr)  =    0.147421652085087
-	Kinetic energy (total) =   75.946374884420223
-	-V/T (ref)             =    2.002955047340175
-	-V/T (corr)            =    2.412517800190988
-	-V/T (total)           =    2.003750061160777
-
-	Energies re-computed from Fock-adjusted CC density:
-	---------------------------------------------------
-	One-electron energy        =    0.246470720035091
-	IJKL energy                =   -0.666215041724314
-	IJKA energy                =   -0.047742719110717
-	IJAB energy                =   -0.410744547471779
-	IBJA energy                =    0.627886954888693
-	CIAB energy                =   -0.000149333681920
-	ABCD energy                =    0.042258259031188
-	Total two-electron energy  =   -0.454706428068848
-	   CCSD correlation energy =   -0.208235708033758
-	Total    CCSD energy       =  -76.231178435506166
-
-	Energies re-computed from Mulliken density:
-	-------------------------------------------
-	One-electron energy        =    0.246470720035091
-	IJKL energy                =   -0.666215041724314
-	IJKA energy                =   -0.047742719110717
-	IJAB energy                =   -0.379840536152271
-	IBJA energy                =    0.596982943569185
-	CIAB energy                =   -0.000149333681920
-	ABCD energy                =    0.042258259031188
-	Total two-electron energy  =   -0.454706428068849
-	   CCSD correlation energy =   -0.208235708033759
-	Total    CCSD energy       =  -76.231178435506166
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the CC density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.9826
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:    -0.1586
-
-  Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.8240     Total:     0.8240
-
-  Dipole Moment: (Debye)
-     X:     0.0000      Y:     0.0000      Z:     2.0944     Total:     2.0944
-
-  Quadrupole Moment: (Debye Ang)
-    XX:    -7.2281     YY:    -4.2858     ZZ:    -5.8153
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Traceless Quadrupole Moment: (Debye Ang)
-    XX:    -1.4517     YY:     1.4906     ZZ:    -0.0389
-    XY:     0.0000     XZ:     0.0000     YZ:     0.0000
-
-  Mulliken Charges: (a.u.)
-   Center  Symbol    Alpha    Beta     Spin     Total
-       1     O     4.31608  4.31608  0.00000 -0.63215
-       2     H     0.34196  0.34196  0.00000  0.31608
-       3     H     0.34196  0.34196  0.00000  0.31608
-
-   Total alpha =  5.00000, Total beta =  5.00000, Total charge =  0.00000
-
-  Natural Orbital Occupations:
-
-  Total Occupations:
-  HONO-2 :    1 B1    1.972
-  HONO-1 :    3 A1    1.966
-  HONO-0 :    1 B2    1.965
-  LUNO+0 :    2 B2    0.027
-  LUNO+1 :    4 A1    0.025
-  LUNO+2 :    2 B1    0.017
-  LUNO+3 :    5 A1    0.011
-
-
-*** tstop() called on psinet at Mon May 15 15:33:55 2017
-Module time:
-	user time   =       0.07 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       1.48 seconds =       0.02 minutes
-	system time =       0.92 seconds =       0.02 minutes
-	total time  =          3 seconds =       0.05 minutes
-  Cartesian Displacement SALCs
-  By SALC:
-  Number of SALCs: 3, nirreps: 1
-  Project out translations: False
-  Project out rotations: False
-	irrep = 0, ncomponent = 1
-		0: atom 0, direction z, coef 1.000000
-	irrep = 0, ncomponent = 2
-		0: atom 1, direction y, coef 0.707107
-		1: atom 2, direction y, coef -0.707107
-	irrep = 0, ncomponent = 2
-		0: atom 1, direction z, coef 0.707107
-		1: atom 2, direction z, coef 0.707107
-
-  By Atomic Center:
-  Number of atomic centers: 3
-   Atomic Center 0:
-	x component, size = 0
-	y component, size = 0
-	z component, size = 1
-		0: salc 0, irrep 0, coef 1.000000
-   Atomic Center 1:
-	x component, size = 0
-	y component, size = 1
-		0: salc 1, irrep 0, coef 0.707107
-	z component, size = 1
-		0: salc 2, irrep 0, coef 0.707107
-   Atomic Center 2:
-	x component, size = 0
-	y component, size = 1
-		0: salc 1, irrep 0, coef -0.707107
-	z component, size = 1
-		0: salc 2, irrep 0, coef 0.707107
-
+	Kinetic energy (ref)   =   75.798953233158386
+	Kinetic energy (corr)  =    0.147421652114229
+	Kinetic energy (total) =   75.946374885272618
+	-V/T (ref)             =    2.002955047329189
+	-V/T (corr)            =    2.412517799893155
+	-V/T (total)           =    2.003750061149383
     Molecular point group: c2v
     Full point group: C2v
 
@@ -2466,9 +1953,9 @@ Total time:
 
        Center              X                  Y                   Z       
     ------------   -----------------  -----------------  -----------------
-           O          0.000000000000     0.000000000000    -0.124847178403
-           H          0.000000000000    -1.431365047272     0.990707660311
-           H          0.000000000000     1.431365047272     0.990707660311
+         O            0.000000000000     0.000000000000    -0.124847178458
+         H            0.000000000000    -1.431365047213     0.990707660590
+         H            0.000000000000     1.431365047213     0.990707660590
 
 	Presorting MO-basis TPDM.
 	Sorting File: MO TPDM (AA|AA) nbuckets = 1
@@ -2477,131 +1964,70 @@ Total time:
 	First half integral transformation complete.
 
 
-  -Nuclear Repulsion Energy 1st Derivatives:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     2.986552801441
-       2       -0.000000000000     2.038040739774    -1.493276400720
-       3        0.000000000000    -2.038040739774    -1.493276400720
-
-
-  -One-electron contribution to gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000    -6.872925847395
-       2        0.000000000000    -4.625842243325     3.436462923698
-       3       -0.000000000000     4.625842243325     3.436462923698
-
-
-  -Lagrangian contribution to gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.411353806916
-       2       -0.000000000000     0.252558749244    -0.205676903458
-       3        0.000000000000    -0.252558749244    -0.205676903458
-
-
-  -Two-electron contribution to gradient:
-     Atom            X                  Y                   Z
-    ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     3.475093977029
-       2       -0.000000000000     2.335175545186    -1.737546988515
-       3        0.000000000000    -2.335175545186    -1.737546988515
-
-
   -Total gradient:
      Atom            X                  Y                   Z
     ------   -----------------  -----------------  -----------------
-       1        0.000000000000     0.000000000000     0.000074737990
-       2        0.000000000000    -0.000067209121    -0.000037368995
-       3       -0.000000000000     0.000067209121    -0.000037368995
+       1       -0.000000000000     0.000000000000     0.000074737773
+       2        0.000000000000    -0.000067209176    -0.000037368886
+       3       -0.000000000000     0.000067209176    -0.000037368886
 
 
-			-----------------------------------------
-			 OPTKING 2.0: for geometry optimizations 
-			  - R.A. King,  Bethel University        
-			-----------------------------------------
+    			-----------------------------------------
 
-	Previous internal coordinate definitions found.
-	---Fragment 1 Geometry and Gradient---
-	 O           0.0000000000        0.0000000000       -0.1248471784
-	 H           0.0000000000       -1.4313650473        0.9907076603
-	 H           0.0000000000        1.4313650473        0.9907076603
-	             0.0000000000        0.0000000000        0.0000747380
-	             0.0000000000       -0.0000672091       -0.0000373690
-	            -0.0000000000        0.0000672091       -0.0000373690
+    			 OPTKING 3.0: for geometry optimizations 
 
-	---Fragment 1 Intrafragment Coordinates---
+    			     By R.A. King, Bethel University     
+
+    			        with contributions from          
+
+    			    A.V. Copan, J. Cayton, A. Heide      
+
+    			-----------------------------------------
+
+    
+	                            ===> Fragment 1 <== 
+
+	 Z (Atomic Numbers)          Masses                          Geom                  
+	       8.000000            15.994915          0.00000000  0.00000000 -0.12484718   
+	       1.000000             1.007825          0.00000000 -1.43136505  0.99070766   
+	       1.000000             1.007825          0.00000000  1.43136505  0.99070766   
+
 	 - Coordinate -           - BOHR/RAD -       - ANG/DEG -
-	 R(1,2)           =         1.814736	       0.960317
-	 R(1,3)           =         1.814736	       0.960317
-	 B(2,1,3)         =         1.817531	     104.136842
-
-	Current energy   :       -76.2311784352
-
-	Energy change for the previous step:
-		Projected    :        -0.0000110992
-		Actual       :        -0.0000034299
-
-	Performing BFGS update.
-	Previous computed or guess Hessian on step 1.
-	Steps to be used in Hessian update: 2 1
-	Taking RFO optimization step.
-	Going to follow RFO solution 1.
-	Using RFO vector 1.
-	Norm of target step-size    0.00076
-	Projected energy change by RFO approximation:        -0.0000000623
-
-	Back-transformation to cartesian coordinates...
-	Successfully converged to displaced geometry.
-
-	--- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
-	 ---------------------------------------------------------------------------
-	   Coordinate                Previous        Force       Change         New 
-	   ----------                --------       ------       ------       ------
-	    1 R(1,2)          =      0.960317    -0.000247    -0.000007     0.960311
-	    2 R(1,3)          =      0.960317    -0.000247    -0.000007     0.960311
-	    3 B(2,1,3)        =    104.136842    -0.000010    -0.043373   104.093469
-	 ---------------------------------------------------------------------------
-	Successfully symmetrized geometry.
-
-  ==> Convergence Check <==
-
-  Measures of convergence in internal coordinates in au.
-  Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
-  ---------------------------------------------------------------------------------------------
-   Step     Total Energy     Delta E     MAX Force     RMS Force      MAX Disp      RMS Disp   
-  ---------------------------------------------------------------------------------------------
-    Convergence Criteria    1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
-  ---------------------------------------------------------------------------------------------
-      3     -76.23117844   -3.43e-06      1.28e-04 *    7.81e-05 o    7.57e-04 *    4.37e-04 o  ~
-  ---------------------------------------------------------------------------------------------
+	 R(1,2)           =         1.814736           0.960317
+	 R(1,3)           =         1.814736           0.960317
+	 B(2,1,3)         =         1.817531         104.136842
 
 
-  **** Optimization is complete! (in 3 steps) ****
+	        --- Internal Coordinate Step in ANG or DEG, aJ/ANG or AJ/DEG ---
+	-------------------------------------------------------------------------------
+	           Coordinate      Previous         Force          Change          New 
+	           ----------      --------        ------          ------        ------
+	               R(1,2)       0.96032       -0.00025       -0.00001       0.96031
+	               R(1,3)       0.96032       -0.00025       -0.00001       0.96031
+	             B(2,1,3)     104.13684       -0.00001       -0.04337     104.09347
+	-------------------------------------------------------------------------------
 
-  ==> Optimization Summary <==
+	                                 ==> Convergence Check <==                                  
+    
+	Measures of convergence in internal coordinates in au.
+    
+	Criteria marked as inactive (o), active & met (*), and active & unmet ( ).
 
-  Measures of convergence in internal coordinates in au.
-  --------------------------------------------------------------------------------------------------------------- ~
-   Step         Total Energy             Delta E       MAX Force       RMS Force        MAX Disp        RMS Disp  ~
-  --------------------------------------------------------------------------------------------------------------- ~
-      1     -76.230988854467    -76.230988854467      0.00916168      0.00757669      0.01715315      0.01589026  ~
-      2     -76.231175005258     -0.000186150790      0.00097714      0.00066579      0.00684009      0.00405823  ~
-      3     -76.231178435176     -0.000003429918      0.00012846      0.00007812      0.00075700      0.00043717  ~
-  --------------------------------------------------------------------------------------------------------------- ~
+	----------------------------------------------------------------------------------------------
+	   Step    Total Energy     Delta E     Max Force     RMS Force      Max Disp      RMS Disp   
+	----------------------------------------------------------------------------------------------
+	  Convergence Criteria     1.00e-06 *    3.00e-04 *             o    1.20e-03 *             o
+	----------------------------------------------------------------------------------------------
+	     3     -76.23117844   -3.43e-06      1.28e-04 *    7.81e-05 o    7.57e-04 *    4.37e-04 o  ~
+	----------------------------------------------------------------------------------------------
 
-	Writing optimization data to binary file.
-	Final energy is    -76.2311784351762
-	Final (previous) structure:
-	Cartesian Geometry (in Angstrom)
-	    O     0.0000000000   0.0000000000  -0.0660662814
-	    H     0.0000000000  -0.7574457602   0.5242599142
-	    H     0.0000000000   0.7574457602   0.5242599142
-	Saving final (previous) structure.
-			--------------------------
-			 OPTKING Finished Execution 
-			--------------------------
+Next Geometry in Ang 
+	Fragment 1 (Ang)
+
+	    O   0.0000000000  -0.0000000000  -0.0662546996
+	    H   0.0000000000  -0.7572171144   0.5243541254
+	    H   0.0000000000   0.7572171144   0.5243541254
+
 
     Final optimized geometry and variables:
     Molecular point group: c2v
@@ -2613,10 +2039,19 @@ Total time:
     H             1    0.960317
     H             1    0.960317      2  104.136842
 
-	Cleaning optimization helper files.
-	Nuclear repulsion energy..........................................PASSED
-	SCF energy........................................................PASSED
-	CCSD contribution.................................................PASSED
-	Total energy......................................................PASSED
+    Nuclear repulsion energy..............................................................PASSED
+    SCF energy............................................................................PASSED
+    CCSD contribution.....................................................................PASSED
+    Total energy..........................................................................PASSED
+    HF Kinetic Energy.....................................................................PASSED
+    HF Potential Energy...................................................................PASSED
+    HF Virial Ratio.......................................................................PASSED
+    CC Correlation Kinetic Energy.........................................................PASSED
+    CC Correlation Potential Energy.......................................................PASSED
+    CC Correlation Virial Ratio...........................................................PASSED
+    CC Virial Ratio.......................................................................PASSED
+
+    Psi4 stopped on: Wednesday, 05 August 2026 05:35PM
+    Psi4 wall time for execution: 0:00:00.89
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cc57/test_input.py
+++ b/tests/cc57/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("quick;smoke;cc")
+def test_cc57():
+    ctest_runner(__file__)
+


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
I noticed that the CCENERGY module didn't have an option for setting the maximum number of DIIS vectors. I looked at the code and noticed that the number was hard-coded to be 8. This PR adds the option `DIIS_MAX_VECS` to the `CCENERGY` module so users can modify it on their own.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Users can now set the number of DIIS vectors to use in the default CCSD and CCSD(T) procedures.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Added the `DIIS_MAX_VECS` option to the `CCENERGY`, `CCLAMBDA`, and `CCRESPONSE` modules.

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [x] None

## Checklist
- [ ] Tests added for any new features
- [x] Docstring or narrative docs/sphinxman/source updated if needed
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
