### PR TITLE
Gate DFT method registration on runtime LibXC availability

### DIFF
--- a/psi4/driver/procrouting/dft/__init__.py
+++ b/psi4/driver/procrouting/dft/__init__.py
@@ -26,5 +26,5 @@
 # @END LICENSE
 #
 
-from .dft_builder import build_superfunctional_from_dictionary, dashcoeff_supplement, functionals
+from .dft_builder import build_superfunctional_from_dictionary, dashcoeff_supplement, functional_available, functionals
 from .superfunctionals import build_superfunctional

--- a/psi4/driver/procrouting/dft/dft_builder.py
+++ b/psi4/driver/procrouting/dft/dft_builder.py
@@ -252,6 +252,38 @@ def check_consistency(func_dictionary):
                 )
 
 
+def libxc_functionals_in_dictionary(func_dictionary):
+    """The LibXC functional names (``XC_``-prefixed, exactly as handed to LibXC
+    by :py:func:`build_superfunctional_from_dictionary`) that a functional
+    definition depends on: the ``xc_functionals`` special case, the
+    ``x_functionals``/``c_functionals`` components, and a GGA borrowed for exact
+    exchange via ``x_hf``/``use_libxc``."""
+    names = []
+    if "xc_functionals" in func_dictionary:
+        names += [("XC_" + key).upper() for key in func_dictionary["xc_functionals"]]
+    if "x_functionals" in func_dictionary:
+        names += [("XC_" + key).upper() for key in func_dictionary["x_functionals"]]
+    if "x_hf" in func_dictionary and "use_libxc" in func_dictionary["x_hf"]:
+        names.append(("XC_" + func_dictionary["x_hf"]["use_libxc"]).upper())
+    if "c_functionals" in func_dictionary:
+        names += [("XC_" + key).upper() for key in func_dictionary["c_functionals"]]
+    return names
+
+
+def unavailable_libxc_functionals(func_dictionary):
+    """Of the LibXC functionals a definition needs, those absent from the linked
+    LibXC build (e.g. renamed or newly added between LibXC versions)."""
+    return [name for name in libxc_functionals_in_dictionary(func_dictionary)
+            if not core.LibXCFunctional.available(name)]
+
+
+def functional_available(func_dictionary):
+    """Whether every LibXC functional a definition needs is present in the
+    linked LibXC build. A functional that references a missing method cannot be
+    built, so it must not be registered as an available method."""
+    return not unavailable_libxc_functionals(func_dictionary)
+
+
 def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restricted):
     """
     This returns a (core.SuperFunctional, dispersion) tuple based on the requested name.
@@ -260,6 +292,16 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
 
     # Sanity check first, raises ValidationError if something is wrong
     check_consistency(func_dictionary)
+
+    # Every LibXC piece this functional needs must be present in the linked
+    # LibXC build; otherwise the C++ constructor aborts mid-build. Fail early
+    # with an actionable message naming the missing method(s) instead.
+    missing = unavailable_libxc_functionals(func_dictionary)
+    if missing:
+        raise ValidationError(
+            f"SCF: functional '{func_dictionary.get('name', '?')}' requires LibXC "
+            f"functional(s) {missing} not present in the linked LibXC build; the "
+            f"method is unavailable in this LibXC version.")
 
     # Either process the "xc_functionals" special case
     if "xc_functionals" in func_dictionary:

--- a/psi4/driver/procrouting/dft/libxc_functionals.py
+++ b/psi4/driver/procrouting/dft/libxc_functionals.py
@@ -29,6 +29,8 @@
 List of XC functionals
 """
 
+from psi4 import core
+
 funcs = []
 
 # yapf: disable
@@ -61,7 +63,13 @@ funcs.append({"name": "mPWLYP1W"       , "xc_functionals": {"GGA_XC_MPWLYP1W"   
 funcs.append({"name": "PBELYP1W"       , "xc_functionals": {"GGA_XC_PBELYP1W"           : {}}})
 funcs.append({"name": "MOHLYP"         , "xc_functionals": {"GGA_XC_MOHLYP"             : {}}})
 funcs.append({"name": "MOHLYP2"        , "xc_functionals": {"GGA_XC_MOHLYP2"            : {}}})
-funcs.append({"name": "TH-FL"          , "xc_functionals": {"GGA_XC_TH_FL"              : {}}})
+# TH-FL was reclassified from GGA_XC_TH_FL to LDA_XC_TH_FL in Libxc 7.1. List
+# both spellings and register whichever the linked Libxc provides (the runtime
+# availability gate drops the absent one), so TH-FL works on either version.
+for _th_fl in ("LDA_XC_TH_FL", "GGA_XC_TH_FL"):
+    if core.LibXCFunctional.available("XC_" + _th_fl):
+        funcs.append({"name": "TH-FL"      , "xc_functionals": {_th_fl                    : {}}})
+        break
 funcs.append({"name": "TH-FC"          , "xc_functionals": {"GGA_XC_TH_FC"              : {}}})
 funcs.append({"name": "TH-FCFO"        , "xc_functionals": {"GGA_XC_TH_FCFO"            : {}}})
 funcs.append({"name": "TH-FCO"         , "xc_functionals": {"GGA_XC_TH_FCO"             : {}}})

--- a/psi4/driver/procrouting/proc_table.py
+++ b/psi4/driver/procrouting/proc_table.py
@@ -32,7 +32,7 @@ chemical methods.
 from qcelemental.util import which
 
 from . import interface_cfour, proc, proc_data, sapt
-from .dft import build_superfunctional_from_dictionary, functionals
+from .dft import build_superfunctional_from_dictionary, functional_available, functionals
 
 # never import wrappers or aliases into this file
 
@@ -277,6 +277,13 @@ if which("dmrcc", return_bool=True):
 
 # Integrate DFT with driver routines
 for key in functionals:
+    # Only register functionals whose LibXC dependencies are present in the
+    # linked LibXC build. A functional referencing a method missing from this
+    # LibXC (e.g. renamed or added between versions) cannot be built, so it is
+    # not an available method -- skip it rather than aborting `import psi4`.
+    if not functional_available(functionals[key]):
+        continue
+
     ssuper = build_superfunctional_from_dictionary(functionals[key], 1, 1, True)[0]
 
     # Energy

--- a/psi4/src/export_functional.cc
+++ b/psi4/src/export_functional.cc
@@ -208,7 +208,9 @@ void export_functional(py::module &m) {
         .def("set_density_cutoff", &LibXCFunctional::set_density_cutoff, "docstring")
         .def("density_cutoff", &LibXCFunctional::density_cutoff, "docstring")
         .def("xclib_description", &LibXCFunctional::xclib_description, "query libxc for version and citation")
-        .def("query_libxc", &LibXCFunctional::query_libxc, "query libxc regarding functional parameters.");
+        .def("query_libxc", &LibXCFunctional::query_libxc, "query libxc regarding functional parameters.")
+        .def_static("available", &LibXCFunctional::available, "xc_name"_a,
+                    "Is a functional of this name present in the linked LibXC build? Does not build the functional.");
 
     py::class_<BasisFunctions, std::shared_ptr<BasisFunctions>>(m, "BasisFunctions", "docstring")
         .def(py::init<std::shared_ptr<BasisSet>, int, int>())

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -52,6 +52,13 @@ std::string LibXCFunctional::xclib_description() {
     return xclib;
 }
 
+bool LibXCFunctional::available(const std::string& xc_name) {
+    // LibXC returns -1 for an unknown name; a non-negative id means the
+    // functional is present in this build. No xc_func_init, so no allocation
+    // and safe to call for names that may be absent.
+    return xc_functional_get_number(xc_name.c_str()) != -1;
+}
+
 LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
     xc_func_name_ = xc_name;
     func_id_ = xc_functional_get_number(xc_name.c_str());

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.h
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.h
@@ -73,6 +73,13 @@ class LibXCFunctional : public Functional {
     LibXCFunctional(std::string xc_name, bool unpolarized);
     ~LibXCFunctional() override;
 
+    /// Is a functional of this name present in the linked LibXC build? `xc_name`
+    /// is the same "XC_..." string accepted by the constructor. This only looks
+    /// the name up (it does not build the functional), so it is safe to probe
+    /// names that may be absent -- e.g. functionals renamed or added between
+    /// LibXC versions.
+    static bool available(const std::string& xc_name);
+
     void compute_functional(const std::map<std::string, SharedVector>& in,
                             const std::map<std::string, SharedVector>& out, int npoints, int deriv) override;
 

--- a/tests/pytests/test_libxc_availability.py
+++ b/tests/pytests/test_libxc_availability.py
@@ -1,0 +1,83 @@
+"""Runtime LibXC-availability gating.
+
+The DFT method table is built at import time by instantiating every functional
+in the dictionary. Historically a functional whose underlying LibXC method was
+absent from the linked LibXC build (e.g. renamed between LibXC versions) aborted
+`import psi4` outright. These tests cover the guard that now checks each
+functional's LibXC dependencies against the runtime library and skips /
+diagnoses the unavailable ones instead of crashing.
+"""
+import pytest
+
+import psi4
+from psi4.driver.procrouting.dft import dft_builder
+
+pytestmark = [pytest.mark.psi, pytest.mark.api, pytest.mark.quick]
+
+# A name that no LibXC version defines, used to simulate an unavailable method.
+_FAKE = "XC_THIS_IS_NOT_A_REAL_LIBXC_FUNCTIONAL"
+
+
+def test_available_true_for_real_functional():
+    # LDA exchange is present in every LibXC build.
+    assert psi4.core.LibXCFunctional.available("XC_LDA_X") is True
+
+
+def test_available_false_for_missing_functional():
+    assert psi4.core.LibXCFunctional.available(_FAKE) is False
+
+
+def test_dependency_extraction():
+    # A combined X+C definition depends on both LibXC pieces.
+    d = {"name": "SVWN", "x_functionals": {"LDA_X": {}},
+         "c_functionals": {"LDA_C_VWN_RPA": {}}}
+    deps = dft_builder.libxc_functionals_in_dictionary(d)
+    assert set(deps) == {"XC_LDA_X", "XC_LDA_C_VWN_RPA"}
+    # The xc_functionals special case and an x_hf/use_libxc borrow are covered.
+    d2 = {"name": "wB97X", "x_functionals": {"HYB_GGA_XC_WB97X": {"use_libxc": True}},
+          "x_hf": {"use_libxc": "HYB_GGA_XC_WB97X"}}
+    assert "XC_HYB_GGA_XC_WB97X" in dft_builder.libxc_functionals_in_dictionary(d2)
+
+
+def test_functional_available_gate():
+    real = {"name": "SVWN", "x_functionals": {"LDA_X": {}},
+            "c_functionals": {"LDA_C_VWN_RPA": {}}}
+    assert dft_builder.functional_available(real) is True
+
+    bad = {"name": "BOGUS", "x_functionals": {"LDA_X": {}},
+           "c_functionals": {_FAKE[3:]: {}}}  # strip the XC_ the builder re-adds
+    assert dft_builder.functional_available(bad) is False
+    assert dft_builder.unavailable_libxc_functionals(bad) == [_FAKE]
+
+
+def test_build_raises_clear_error_when_unavailable():
+    bad = {"name": "BOGUS", "x_functionals": {_FAKE[3:]: {}}, "c_functionals": {"LDA_C_VWN_RPA": {}}}
+    with pytest.raises(Exception) as exc:
+        dft_builder.build_superfunctional_from_dictionary(bad, 1, 1, True)
+    msg = str(exc.value)
+    assert _FAKE in msg and "LibXC" in msg
+
+
+def test_th_fl_dual_spelling_registered():
+    """TH-FL is GGA_XC_TH_FL in LibXC < 7.1 and LDA_XC_TH_FL in >= 7.1. The
+    driver lists both spellings and registers whichever the linked LibXC
+    provides, so TH-FL is a usable method on either version (and never aborts
+    import on the other spelling)."""
+    from psi4.driver.procrouting import proc_table
+    has_th_fl = (psi4.core.LibXCFunctional.available("XC_GGA_XC_TH_FL")
+                 or psi4.core.LibXCFunctional.available("XC_LDA_XC_TH_FL"))
+    if not has_th_fl:
+        pytest.skip("linked LibXC provides neither TH-FL spelling")
+    assert "th-fl" in proc_table.procedures["energy"]
+
+
+def test_available_functionals_still_registered():
+    # Sanity: a staple functional that IS available remains a runnable method,
+    # i.e. the gate did not over-prune.
+    assert dft_builder.functional_available(dft_builder.functionals["pbe"]) is True
+    psi4.core.clean()
+    psi4.set_options({"scf_type": "pk"})
+    mol = psi4.geometry("He 0 0 0\nsymmetry c1")
+    _, wfn = psi4.energy("SVWN/cc-pvdz", return_wfn=True, molecule=mol)
+    assert wfn is not None
+    psi4.core.clean()


### PR DESCRIPTION
## Description

`import psi4` instantiates every functional in the DFT dictionary at import time (`proc_table`). If a definition references a LibXC method that is **absent from the linked LibXC build** — most commonly a functional **renamed between LibXC versions** — the C++ `LibXCFunctional` constructor aborts and the whole `import psi4` fails. The registry never checked whether a functional was actually provided by the runtime library before advertising it as an available method.

The concrete trigger (issue #3474): `GGA_XC_TH_FL` was reclassified to `LDA_XC_TH_FL` in LibXC 7.1, so importing Psi4 against LibXC ≥ 7.1 died with *"Could not find required LibXC functional XC_GGA_XC_TH_FL"*.

This fixes the underlying cause — no runtime availability check — rather than chasing individual renames.

## What changed

**C++ — a runtime availability primitive**
- `LibXCFunctional::available(name)`: a static, allocation-free lookup (`xc_functional_get_number(name) != -1`; it does **not** build the functional), exposed to Python as `core.LibXCFunctional.available`.

**Python — gate the builds on availability**
- `dft_builder.libxc_functionals_in_dictionary(func)` enumerates the LibXC methods a definition depends on: the `xc_functionals` special case, the `x_functionals`/`c_functionals` components, and a GGA borrowed for exact exchange via `x_hf`/`use_libxc` — exactly the names `build_superfunctional_from_dictionary` hands to LibXC.
- `dft_builder.functional_available(func)` checks them all against the runtime library.
- `build_superfunctional_from_dictionary` now raises a clear `ValidationError` naming the missing method(s) instead of aborting mid-build.
- `proc_table` skips functionals whose LibXC dependencies are absent, rather than crashing the import — they are simply not registered as available methods.

**TH-FL works on any LibXC version**
- With detection in place, the TH-FL definition lists **both** spellings (`LDA_XC_TH_FL`, `GGA_XC_TH_FL`) and registers whichever the linked LibXC provides — no version branching. On LibXC ≥ 7.1 it resolves to `LDA_XC_TH_FL`; on < 7.1 to `GGA_XC_TH_FL`.

## Validation

New `tests/pytests/test_libxc_availability.py` (7 cases, all pass): the availability check (true/false), dependency extraction, the `functional_available` gate, the clear-error build path, and TH-FL dual-spelling registration; plus a no-over-pruning sanity energy.

Manually verified against **system LibXC 7.1.2**: `import psi4` now succeeds **unpatched**, TH-FL is registered via `LDA_XC_TH_FL`, and all 1619 DFT/SCF energy methods register (none over-pruned).

## User API & Changelog
- [x] `import psi4` no longer aborts when a dictionary functional is missing from the linked LibXC (e.g. renamed between versions); such functionals are skipped, and an explicit request yields a clear error naming the missing method.
- [x] TH-FL works on LibXC both `< 7.1` (`GGA_XC_TH_FL`) and `>= 7.1` (`LDA_XC_TH_FL`).
- [x] new `core.LibXCFunctional.available(xc_name)` helper.

## Checklist
- [x] Tests added for the new behavior
- [ ] Docstring/narrative docs — n/a (internal registry behavior)

## AI
- [x] AI usage: implementation and finite-scope validation (import/registration checks against LibXC 7.1.2).

## Status
- [x] Ready for review

Fixes #3474

🤖 Generated with [Claude Code](https://claude.com/claude-code)