### PR TITLE
why pull the cuda libxc w/o __cuda?

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -260,6 +260,12 @@ jobs:
         conda info
         conda list
 
+    - name: Analyze Conda dependencies (temp)
+      if: runner.os != 'Windows'
+      run: |
+        conda install conda-tree -c conda-forge
+        conda-tree deptree
+
     - name: Special Config - Force testing OpenOrbitalOptimizer
       if: "(matrix.cfg.label == 'Conda Clang (M-Intel)')"
       run: |


### PR DESCRIPTION
Added a step to analyze Conda dependencies using conda-tree.

## Description
<!-- Provide a brief description of the PR's purpose here. -->


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
<!-- Any questions or decision points on which you need clarification
     from the Psi4 team. -->
- [ ] Question1

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [ ] AI usage

## Checklist
- [ ] Tests added for any new features
- [ ] Docstring or narrative docs/sphinxman/source updated if needed
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [ ] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
