### PR TITLE
Thread the density-fitted and one-electron nuclear-Hessian integral loops

### DIFF
--- a/psi4/src/psi4/scfgrad/jk_grad.cc
+++ b/psi4/src/psi4/scfgrad/jk_grad.cc
@@ -1342,8 +1342,17 @@ void DFJKGrad::compute_hessian() {
     auto Pmnfactory = std::make_shared<IntegralFactory>(auxiliary_, BasisSet::zero_ao_basis_set(), primary_, primary_);
     auto PQfactory = std::make_shared<IntegralFactory>(auxiliary_, BasisSet::zero_ao_basis_set(), auxiliary_,
                                                        BasisSet::zero_ao_basis_set());
-    std::shared_ptr<TwoBodyAOInt> Pmnint(Pmnfactory->eri(2));
-    std::shared_ptr<TwoBodyAOInt> PQint(PQfactory->eri(2));
+    // Per-thread integral engines (the deriv-2 object also serves the deriv0/1
+    // calls). Mirrors DFJKGrad::compute_gradient so the shell loops below can
+    // be threaded over the auxiliary index.
+    int nthread = df_ints_num_threads_;
+    std::vector<std::shared_ptr<TwoBodyAOInt>> Pmnints(nthread), PQints(nthread);
+    Pmnints[0] = std::shared_ptr<TwoBodyAOInt>(Pmnfactory->eri(2));
+    PQints[0] = std::shared_ptr<TwoBodyAOInt>(PQfactory->eri(2));
+    for (int t = 1; t < nthread; t++) {
+        Pmnints[t] = std::shared_ptr<TwoBodyAOInt>(Pmnints[0]->clone());
+        PQints[t] = std::shared_ptr<TwoBodyAOInt>(PQints[0]->clone());
+    }
     auto Amn = std::make_shared<Matrix>("(A|mn)", np, nso*nso);
     auto Aa_mi = std::make_shared<Matrix>("(A|mi)", np, nso*na);
     auto Aa_ij = std::make_shared<Matrix>("(A|ij)", np, na*na);
@@ -1372,7 +1381,12 @@ void DFJKGrad::compute_hessian() {
     double **Bb_mnp = Bb_mn->pointer();
     double **Db_PQp = Db_PQ->pointer();
 
+#pragma omp parallel for schedule(dynamic) num_threads(nthread)
     for (int P = 0; P < nauxshell; ++P) {
+        int thread = 0;
+#ifdef _OPENMP
+        thread = omp_get_thread_num();
+#endif
         int nP = auxiliary_->shell(P).nfunction();
         int oP = auxiliary_->shell(P).function_index();
         for (int M = 0; M < nshell; ++M) {
@@ -1382,8 +1396,8 @@ void DFJKGrad::compute_hessian() {
                 int nN = primary_->shell(N).nfunction();
                 int oN = primary_->shell(N).function_index();
 
-                Pmnint->compute_shell(P, 0, M, N);
-                const double* buffer = Pmnint->buffer();
+                Pmnints[thread]->compute_shell(P, 0, M, N);
+                const double* buffer = Pmnints[thread]->buffer();
 
                 for (int p = oP; p < oP+nP; p++) {
                     for (int m = oM; m < oM+nM; m++) {
@@ -1456,12 +1470,21 @@ void DFJKGrad::compute_hessian() {
 
     int maxp = auxiliary_->max_function_per_shell();
     int maxm = primary_->max_function_per_shell();
-    auto Ta = std::make_shared<Matrix>("Ta", maxp, maxm*na);
-    double **Tap = Ta->pointer();
-    auto Tb = std::make_shared<Matrix>("Tb", maxp, maxm*nb);
-    double **Tbp = Tb->pointer();
+    // Per-thread scratch for the K intermediates below.
+    std::vector<std::shared_ptr<Matrix>> Ta_vec(nthread), Tb_vec(nthread);
+    for (int t = 0; t < nthread; t++) {
+        Ta_vec[t] = std::make_shared<Matrix>("Ta", maxp, maxm*na);
+        Tb_vec[t] = std::make_shared<Matrix>("Tb", maxp, maxm*nb);
+    }
 
+#pragma omp parallel for schedule(dynamic) num_threads(nthread)
     for (int P = 0; P < nauxshell; ++P) {
+        int thread = 0;
+#ifdef _OPENMP
+        thread = omp_get_thread_num();
+#endif
+        double **Tap = Ta_vec[thread]->pointer();
+        double **Tbp = Tb_vec[thread]->pointer();
         int nP = auxiliary_->shell(P).nfunction();
         int oP = auxiliary_->shell(P).function_index();
         int Pcenter = auxiliary_->shell(P).ncenter();
@@ -1486,9 +1509,9 @@ void DFJKGrad::compute_hessian() {
                 int ny = 3 * Ncenter + 1;
                 int nz = 3 * Ncenter + 2;
 
-                Pmnint->compute_shell_deriv1(P, 0, M, N);
-                const double* buffer = Pmnint->buffer();
-                const auto& buffers = Pmnint->buffers();
+                Pmnints[thread]->compute_shell_deriv1(P, 0, M, N);
+                const double* buffer = Pmnints[thread]->buffer();
+                const auto& buffers = Pmnints[thread]->buffers();
                 const double* PxBuf = buffers[0];
                 const double* PyBuf = buffers[1];
                 const double* PzBuf = buffers[2];
@@ -1612,7 +1635,12 @@ void DFJKGrad::compute_hessian() {
     // dd[x][A] = dc[x][B] Minv[B][A]
     C_DGEMM('N', 'N', 3 * natoms, np, np, 1.0, dcp[0], np, PQp[0], np, 0.0, ddp[0], np);
 
+#pragma omp parallel for schedule(dynamic) num_threads(nthread)
     for (int P = 0; P < nauxshell; ++P) {
+        int thread = 0;
+#ifdef _OPENMP
+        thread = omp_get_thread_num();
+#endif
         int nP = auxiliary_->shell(P).nfunction();
         int oP = auxiliary_->shell(P).function_index();
         int Pcenter = auxiliary_->shell(P).ncenter();
@@ -1631,8 +1659,8 @@ void DFJKGrad::compute_hessian() {
 
             //size_t stride = static_cast<size_t>(Pncart) * Qncart;
 
-            PQint->compute_shell_deriv1(P, 0, Q, 0);
-            const auto& buffers = PQint->buffers();
+            PQints[thread]->compute_shell_deriv1(P, 0, Q, 0);
+            const auto& buffers = PQints[thread]->buffers();
             const double* Pxbuf = buffers[0];
             const double* Pybuf = buffers[1];
             const double* Pzbuf = buffers[2];
@@ -1677,7 +1705,24 @@ void DFJKGrad::compute_hessian() {
         }
     }
 
+    // Per-thread Hessian accumulators for the two second-derivative integral
+    // loops below (loops write to the shared J/K Hessian, indexed by atom
+    // coordinate pairs, so they cannot be partitioned by the auxiliary index).
+    // Reduced into hessians_ after the second loop, before the serial tail.
+    std::vector<std::shared_ptr<Matrix>> JHess_local(nthread), KHess_local(nthread);
+    for (int t = 0; t < nthread; t++) {
+        JHess_local[t] = std::make_shared<Matrix>("JHess local", 3 * natom, 3 * natom);
+        KHess_local[t] = std::make_shared<Matrix>("KHess local", 3 * natom, 3 * natom);
+    }
+
+#pragma omp parallel for schedule(dynamic) num_threads(nthread)
     for (int P = 0; P < nauxshell; ++P) {
+        int thread = 0;
+#ifdef _OPENMP
+        thread = omp_get_thread_num();
+#endif
+        double** JHessp = JHess_local[thread]->pointer();
+        double** KHessp = KHess_local[thread]->pointer();
         int nP = auxiliary_->shell(P).nfunction();
         int oP = auxiliary_->shell(P).function_index();
         int Pcenter = auxiliary_->shell(P).ncenter();
@@ -1702,8 +1747,8 @@ void DFJKGrad::compute_hessian() {
                 int ny = 3 * Ncenter + 1;
                 int nz = 3 * Ncenter + 2;
 
-                Pmnint->compute_shell_deriv2(P, 0, M, N);
-                const auto& buffers = Pmnint->buffers();
+                Pmnints[thread]->compute_shell_deriv2(P, 0, M, N);
+                const auto& buffers = Pmnints[thread]->buffers();
                 const double* PxPxBuf = buffers[0];
                 const double* PxPyBuf = buffers[1];
                 const double* PxPzBuf = buffers[2];
@@ -1980,7 +2025,14 @@ void DFJKGrad::compute_hessian() {
         }
     }
 
+#pragma omp parallel for schedule(dynamic) num_threads(nthread)
     for (int P = 0; P < nauxshell; ++P) {
+        int thread = 0;
+#ifdef _OPENMP
+        thread = omp_get_thread_num();
+#endif
+        double** JHessp = JHess_local[thread]->pointer();
+        double** KHessp = KHess_local[thread]->pointer();
         int nP = auxiliary_->shell(P).nfunction();
         int oP = auxiliary_->shell(P).function_index();
         int Pcenter = auxiliary_->shell(P).ncenter();
@@ -1997,8 +2049,8 @@ void DFJKGrad::compute_hessian() {
             int Qy = 3 * Qcenter + 1;
             int Qz = 3 * Qcenter + 2;
 
-            PQint->compute_shell_deriv2(P, 0, Q, 0);
-            const auto& buffers = PQint->buffers();
+            PQints[thread]->compute_shell_deriv2(P, 0, Q, 0);
+            const auto& buffers = PQints[thread]->buffers();
             const double* PxPxBuf = buffers[0];
             const double* PxPyBuf = buffers[1];
             const double* PxPzBuf = buffers[2];
@@ -2138,6 +2190,14 @@ void DFJKGrad::compute_hessian() {
                 }
             }
         }
+    }
+
+    // Reduce the per-thread second-derivative integral Hessians into the
+    // totals before the serial tail (symmetrization + intermediate stitching)
+    // resumes using the shared JHessp/KHessp pointers.
+    for (auto& h : JHess_local) hessians_["Coulomb"]->add(h);
+    if (do_K_) {
+        for (auto& h : KHess_local) hessians_["Exchange"]->add(h);
     }
 
     // Add permutational symmetry components missing from the above

--- a/psi4/src/psi4/scfgrad/response.cc
+++ b/psi4/src/psi4/scfgrad/response.cc
@@ -830,13 +830,36 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response() {
                 std::make_shared<IntegralFactory>(auxiliary_, BasisSet::zero_ao_basis_set(), basisset_, basisset_);
             auto PQfactory = std::make_shared<IntegralFactory>(auxiliary_, BasisSet::zero_ao_basis_set(), auxiliary_,
                                                                BasisSet::zero_ao_basis_set());
-            std::shared_ptr<TwoBodyAOInt> Pmnint(Pmnfactory->eri(2));
-            std::shared_ptr<TwoBodyAOInt> PQint(PQfactory->eri(2));
             int np = auxiliary_->nbf();
             int nso = basisset_->nbf();
             int nauxshell = auxiliary_->nshell();
             int nshell = basisset_->nshell();
             int maxp = auxiliary_->max_function_per_shell();
+
+            // Re-budget the perturbation batch for the threaded derivative loops
+            // below. Each of the nthreads worker threads keeps a private copy of
+            // the batch accumulators (nso^2 per in-core perturbation) plus an
+            // nP x nso^2 K-scratch, on top of the shared dGmats. Shrink max_a so
+            // that all the per-thread copies fit inside the 0.9*memory budget;
+            // the min(3*natom) cap keeps a single batch for small molecules.
+            int nthreads = Process::environment.get_n_threads();
+            {
+                size_t df_mem = 0.9 * memory_ / 8L;
+                size_t fixed = (size_t)nthreads * maxp * (size_t)nso * nso;
+                df_mem = (df_mem > 2 * fixed) ? df_mem - fixed : df_mem / 2;
+                size_t new_max_a = df_mem / ((size_t)(1 + nthreads) * (size_t)nso * nso);
+                // Batches must be atom-aligned: the loops mark a whole atom
+                // in-core when any of its perturbations falls in the batch and
+                // then write all three of its Fock derivatives, so max_a has to
+                // be a positive multiple of 3.
+                new_max_a = (new_max_a / 3) * 3;
+                if (new_max_a < 3) new_max_a = 3;
+                if (new_max_a > (size_t)(3 * natom)) new_max_a = 3 * natom;
+                max_a = new_max_a;
+                dGmats.clear();
+                for (size_t a = 0; a < max_a; ++a)
+                    dGmats.push_back(std::make_shared<Matrix>("G derivative contribution", nso, nso));
+            }
 
             auto Amn = std::make_shared<Matrix>("(A|mn)", np, nso * nso);
             auto Ami = std::make_shared<Matrix>("(A|mi)", np, nso * nocc);
@@ -869,13 +892,13 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response() {
             // first derivative terms needed for the Fock matrix derivatives.
             //
             // The (A|mn) build writes disjoint aux-function columns per P, so it
-            // threads over P with per-thread engines without any reduction. (The
-            // perturbation-batched derivative loops below stay serial: they
-            // accumulate into per-perturbation Fock-derivative matrices whose
-            // batch size max_a is already sized to fill ~90% of memory, so
-            // per-thread duplication is not memory-safe; threading them well
-            // needs a memory-guarded per-thread-accumulator redesign.)
-            int nthreads = Process::environment.get_n_threads();
+            // threads over P with per-thread engines without any reduction. The
+            // perturbation-batched metric and (A|mn)^x derivative loops below are
+            // threaded too: they accumulate into per-perturbation Fock-derivative
+            // matrices keyed by shell centers (not partitioned by P), so each
+            // thread scatters into a private copy of the batch and the copies are
+            // reduced into dGmats afterward. max_a was shrunk above to keep those
+            // per-thread copies within the memory budget.
             std::vector<std::shared_ptr<TwoBodyAOInt>> Amn_ints(nthreads);
             Amn_ints[0] = std::shared_ptr<TwoBodyAOInt>(Pmnfactory->eri(2));
             for (int t = 1; t < nthreads; ++t) Amn_ints[t] = std::shared_ptr<TwoBodyAOInt>(Amn_ints[0]->clone());
@@ -928,6 +951,27 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response() {
             for (int p = 0; p < np; ++p)
                 C_DGEMM('t', 'n', nso, nso, nso, 1.0, Dap[0], nso, Bmnp[p], nso, 0.0, pTmn[p], nso);
 
+            // Per-thread integral engines, batch accumulators, and scratch for the
+            // threaded metric and (A|mn)^x derivative loops. Each thread scatters
+            // its P contributions into a private copy of the batch (dG_thread) via
+            // its own pdG map; the copies are reduced into dGmats after the loops.
+            std::vector<std::shared_ptr<TwoBodyAOInt>> PQ_ints(nthreads), Pmn_ints(nthreads);
+            PQ_ints[0] = std::shared_ptr<TwoBodyAOInt>(PQfactory->eri(2));
+            Pmn_ints[0] = std::shared_ptr<TwoBodyAOInt>(Pmnfactory->eri(2));
+            for (int t = 1; t < nthreads; ++t) {
+                PQ_ints[t] = std::shared_ptr<TwoBodyAOInt>(PQ_ints[0]->clone());
+                Pmn_ints[t] = std::shared_ptr<TwoBodyAOInt>(Pmn_ints[0]->clone());
+            }
+            std::vector<std::vector<SharedMatrix>> dG_thread(nthreads);
+            std::vector<std::vector<double**>> pdG_thread(nthreads, std::vector<double**>(3 * natom));
+            std::vector<SharedMatrix> TempP_thread(nthreads), TempPmn_thread(nthreads);
+            for (int t = 0; t < nthreads; ++t) {
+                for (size_t a = 0; a < max_a; ++a)
+                    dG_thread[t].push_back(std::make_shared<Matrix>("G deriv thread", nso, nso));
+                TempP_thread[t] = std::make_shared<Matrix>("Temp[P] thread", 9, maxp);
+                TempPmn_thread[t] = std::make_shared<Matrix>("Temp[P][mn] thread", maxp, nso * nso);
+            }
+
             for (int A = 0; A < 3 * natom; A += max_a) {
                 int nA = (A + max_a >= 3 * natom ? 3 * natom - A : max_a);
 
@@ -939,8 +983,25 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response() {
                     pdG[A + a] = dGmats[a]->pointer();
                     dGmats[a]->zero();
                 }
+                // Map each thread's private accumulator copies onto the in-core
+                // perturbations and zero them for this batch.
+                for (int t = 0; t < nthreads; ++t) {
+                    std::fill(pdG_thread[t].begin(), pdG_thread[t].end(), (double**)nullptr);
+                    for (int a = 0; a < nA; a++) {
+                        pdG_thread[t][A + a] = dG_thread[t][a]->pointer();
+                        dG_thread[t][a]->zero();
+                    }
+                }
 
+#pragma omp parallel for schedule(dynamic) num_threads(nthreads)
                 for (int P = 0; P < nauxshell; ++P) {
+                    int thread = 0;
+#ifdef _OPENMP
+                    thread = omp_get_thread_num();
+#endif
+                    auto& pdG = pdG_thread[thread];
+                    double** pTempP = TempP_thread[thread]->pointer();
+                    double** pTmpPmn = TempPmn_thread[thread]->pointer();
                     int nP = auxiliary_->shell(P).nfunction();
                     int oP = auxiliary_->shell(P).function_index();
                     int Pcenter = auxiliary_->shell(P).ncenter();
@@ -960,8 +1021,8 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response() {
 
                         if (!pert_incore[Pcenter] && !pert_incore[Qcenter]) continue;
 
-                        PQint->compute_shell_deriv1(P, 0, Q, 0);
-                        const auto& buffers = PQint->buffers();
+                        PQ_ints[thread]->compute_shell_deriv1(P, 0, Q, 0);
+                        const auto& buffers = PQ_ints[thread]->buffers();
                         const double* PxBuf = buffers[0];
                         const double* PyBuf = buffers[1];
                         const double* PzBuf = buffers[2];
@@ -1040,7 +1101,14 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response() {
                     }
                 }
 
+#pragma omp parallel for schedule(dynamic) num_threads(nthreads)
                 for (int P = 0; P < nauxshell; ++P) {
+                    int thread = 0;
+#ifdef _OPENMP
+                    thread = omp_get_thread_num();
+#endif
+                    auto& pdG = pdG_thread[thread];
+                    double** pTempP = TempP_thread[thread]->pointer();
                     int nP = auxiliary_->shell(P).nfunction();
                     int oP = auxiliary_->shell(P).function_index();
                     int Pcenter = auxiliary_->shell(P).ncenter();
@@ -1068,8 +1136,8 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response() {
 
                             if (!pert_incore[Pcenter] && !pert_incore[Mcenter] && !pert_incore[Ncenter]) continue;
 
-                            Pmnint->compute_shell_deriv1(P, 0, M, N);
-                            const auto& buffers = Pmnint->buffers();
+                            Pmn_ints[thread]->compute_shell_deriv1(P, 0, M, N);
+                            const auto& buffers = Pmn_ints[thread]->buffers();
                             const double* PxBuf = buffers[0];
                             const double* PyBuf = buffers[1];
                             const double* PzBuf = buffers[2];
@@ -1219,6 +1287,11 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response() {
                         }
                     }
                 }
+
+                // Reduce the per-thread batch accumulators into the shared dGmats.
+                for (int a = 0; a < nA; ++a)
+                    for (int t = 0; t < nthreads; ++t)
+                        dGmats[a]->add(dG_thread[t][a]);
 
                 for (int a = 0; a < nA; ++a) {
                     // Symmetrize the derivative Fock contributions
@@ -3653,13 +3726,33 @@ void USCFDeriv::JK_deriv1(std::shared_ptr<Matrix> D1,
 
         auto Pmnfactory = std::make_shared<IntegralFactory>(auxiliary_, BasisSet::zero_ao_basis_set(), basisset_, basisset_);
         auto PQfactory = std::make_shared<IntegralFactory>(auxiliary_, BasisSet::zero_ao_basis_set(), auxiliary_, BasisSet::zero_ao_basis_set());
-        std::shared_ptr<TwoBodyAOInt> Pmnint(Pmnfactory->eri(2));
-        std::shared_ptr<TwoBodyAOInt> PQint(PQfactory->eri(2));
         int np = auxiliary_->nbf();
         int nso = basisset_->nbf();
         int nauxshell = auxiliary_->nshell();
         int nshell = basisset_->nshell();
         int maxp = auxiliary_->max_function_per_shell();
+
+        // Re-budget the perturbation batch for the threaded derivative loops
+        // below so each thread's private accumulator copies fit in memory
+        // (see RSCFDeriv::hessian_response for the rationale).
+        int nthreads = Process::environment.get_n_threads();
+        {
+            size_t df_mem = 0.9 * memory_ / 8L;
+            size_t fixed = (size_t)nthreads * maxp * (size_t)nso * nso;
+            df_mem = (df_mem > 2 * fixed) ? df_mem - fixed : df_mem / 2;
+            size_t new_max_a = df_mem / ((size_t)(1 + nthreads) * (size_t)nso * nso);
+            // Batches must be atom-aligned: the loops mark a whole atom in-core
+            // when any of its perturbations falls in the batch and then write all
+            // three of its Fock derivatives, so max_a has to be a positive
+            // multiple of 3.
+            new_max_a = (new_max_a / 3) * 3;
+            if (new_max_a < 3) new_max_a = 3;
+            if (new_max_a > (size_t)(3 * natom)) new_max_a = 3 * natom;
+            max_a = new_max_a;
+            dGmats.clear();
+            for (size_t a = 0; a < max_a; ++a)
+                dGmats.push_back(std::make_shared<Matrix>("G derivative contribution", nso, nso));
+        }
 
         auto Amn = std::make_shared<Matrix>("(A|mn)", np, nso*nso);
         auto Ami = std::make_shared<Matrix>("(A|mi)", np, nso*nocc);
@@ -3692,11 +3785,11 @@ void USCFDeriv::JK_deriv1(std::shared_ptr<Matrix> D1,
         // first derivative terms needed for the Fock matrix derivatives.
         //
         // The (A|mn) build writes disjoint aux-function columns per P, so it
-        // threads over P with per-thread engines without any reduction. (The
-        // perturbation-batched derivative loops below stay serial: their batch
-        // size max_a is sized to fill ~90% of memory, so per-thread duplication
-        // of the accumulators is not memory-safe.)
-        int nthreads = Process::environment.get_n_threads();
+        // threads over P with per-thread engines without any reduction. The
+        // perturbation-batched metric and (A|mn)^x derivative loops below are
+        // threaded too, each thread scattering into a private copy of the batch
+        // that is reduced into dGmats afterward; max_a was shrunk above to keep
+        // those copies within the memory budget.
         std::vector<std::shared_ptr<TwoBodyAOInt>> Amn_ints(nthreads);
         Amn_ints[0] = std::shared_ptr<TwoBodyAOInt>(Pmnfactory->eri(2));
         for (int t = 1; t < nthreads; ++t) Amn_ints[t] = std::shared_ptr<TwoBodyAOInt>(Amn_ints[0]->clone());
@@ -3743,6 +3836,25 @@ void USCFDeriv::JK_deriv1(std::shared_ptr<Matrix> D1,
         for(int p = 0; p < np; ++p)
             C_DGEMM('t', 'n', nso, nso, nso, 1.0, D1p[0], nso, Bmnp[p], nso, 0.0, pTmn[p], nso);
 
+        // Per-thread integral engines, batch accumulators, and scratch for the
+        // threaded metric and (A|mn)^x derivative loops (see the restricted
+        // hessian_response for the layout).
+        std::vector<std::shared_ptr<TwoBodyAOInt>> PQ_ints(nthreads), Pmn_ints(nthreads);
+        PQ_ints[0] = std::shared_ptr<TwoBodyAOInt>(PQfactory->eri(2));
+        Pmn_ints[0] = std::shared_ptr<TwoBodyAOInt>(Pmnfactory->eri(2));
+        for (int t = 1; t < nthreads; ++t) {
+            PQ_ints[t] = std::shared_ptr<TwoBodyAOInt>(PQ_ints[0]->clone());
+            Pmn_ints[t] = std::shared_ptr<TwoBodyAOInt>(Pmn_ints[0]->clone());
+        }
+        std::vector<std::vector<SharedMatrix>> dG_thread(nthreads);
+        std::vector<std::vector<double**>> pdG_thread(nthreads, std::vector<double**>(3 * natom));
+        std::vector<SharedMatrix> TempP_thread(nthreads), TempPmn_thread(nthreads);
+        for (int t = 0; t < nthreads; ++t) {
+            for (size_t a = 0; a < max_a; ++a)
+                dG_thread[t].push_back(std::make_shared<Matrix>("G deriv thread", nso, nso));
+            TempP_thread[t] = std::make_shared<Matrix>("Temp[P] thread", 9, maxp);
+            TempPmn_thread[t] = std::make_shared<Matrix>("Temp[P][mn] thread", maxp, nso*nso);
+        }
 
         for (int A = 0; A < 3 * natom; A+=max_a) {
             int nA = (A + max_a >= 3 * natom ? 3 * natom - A : max_a);
@@ -3755,8 +3867,25 @@ void USCFDeriv::JK_deriv1(std::shared_ptr<Matrix> D1,
                 pdG[A+a] = dGmats[a]->pointer();
                 dGmats[a]->zero();
             }
+            // Map each thread's private accumulator copies onto the in-core
+            // perturbations and zero them for this batch.
+            for (int t = 0; t < nthreads; ++t) {
+                std::fill(pdG_thread[t].begin(), pdG_thread[t].end(), (double**)nullptr);
+                for (int a = 0; a < nA; a++){
+                    pdG_thread[t][A+a] = dG_thread[t][a]->pointer();
+                    dG_thread[t][a]->zero();
+                }
+            }
 
+#pragma omp parallel for schedule(dynamic) num_threads(nthreads)
             for (int P = 0; P < nauxshell; ++P){
+                int thread = 0;
+#ifdef _OPENMP
+                thread = omp_get_thread_num();
+#endif
+                auto& pdG = pdG_thread[thread];
+                double** pTempP = TempP_thread[thread]->pointer();
+                double** pTmpPmn = TempPmn_thread[thread]->pointer();
                 int nP = auxiliary_->shell(P).nfunction();
                 int oP = auxiliary_->shell(P).function_index();
                 int Pcenter = auxiliary_->shell(P).ncenter();
@@ -3776,8 +3905,8 @@ void USCFDeriv::JK_deriv1(std::shared_ptr<Matrix> D1,
                     if(!pert_incore[Pcenter] && !pert_incore[Qcenter])
                         continue;
 
-                    PQint->compute_shell_deriv1(P,0,Q,0);
-                    const auto& buffers = PQint->buffers();
+                    PQ_ints[thread]->compute_shell_deriv1(P,0,Q,0);
+                    const auto& buffers = PQ_ints[thread]->buffers();
                     const double* PxBuf = buffers[0];
                     const double* PyBuf = buffers[1];
                     const double* PzBuf = buffers[2];
@@ -3847,7 +3976,14 @@ void USCFDeriv::JK_deriv1(std::shared_ptr<Matrix> D1,
             }
 
 
+#pragma omp parallel for schedule(dynamic) num_threads(nthreads)
             for (int P = 0; P < nauxshell; ++P){
+                int thread = 0;
+#ifdef _OPENMP
+                thread = omp_get_thread_num();
+#endif
+                auto& pdG = pdG_thread[thread];
+                double** pTempP = TempP_thread[thread]->pointer();
                 int nP = auxiliary_->shell(P).nfunction();
                 int oP = auxiliary_->shell(P).function_index();
                 int Pcenter = auxiliary_->shell(P).ncenter();
@@ -3877,8 +4013,8 @@ void USCFDeriv::JK_deriv1(std::shared_ptr<Matrix> D1,
                                 !pert_incore[Ncenter])
                             continue;
 
-                        Pmnint->compute_shell_deriv1(P,0,M,N);
-                        const auto& buffers = Pmnint->buffers();
+                        Pmn_ints[thread]->compute_shell_deriv1(P,0,M,N);
+                        const auto& buffers = Pmn_ints[thread]->buffers();
                         const double* PxBuf = buffers[0];
                         const double* PyBuf = buffers[1];
                         const double* PzBuf = buffers[2];
@@ -3995,6 +4131,11 @@ void USCFDeriv::JK_deriv1(std::shared_ptr<Matrix> D1,
                     }
                 }
             }
+
+            // Reduce the per-thread batch accumulators into the shared dGmats.
+            for (int a = 0; a < nA; ++a)
+                for (int t = 0; t < nthreads; ++t)
+                    dGmats[a]->add(dG_thread[t][a]);
 
             for(int a = 0; a < nA; ++a){
                 // Symmetrize the derivative Fock contributions

--- a/psi4/src/psi4/scfgrad/response.cc
+++ b/psi4/src/psi4/scfgrad/response.cc
@@ -867,7 +867,24 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response() {
             // Same applies to these terms.  There are already hooks to compute c and d vectors, and store them on disk,
             // so we should make better use of those intermediates between the second derivative integrals and these
             // first derivative terms needed for the Fock matrix derivatives.
+            //
+            // The (A|mn) build writes disjoint aux-function columns per P, so it
+            // threads over P with per-thread engines without any reduction. (The
+            // perturbation-batched derivative loops below stay serial: they
+            // accumulate into per-perturbation Fock-derivative matrices whose
+            // batch size max_a is already sized to fill ~90% of memory, so
+            // per-thread duplication is not memory-safe; threading them well
+            // needs a memory-guarded per-thread-accumulator redesign.)
+            int nthreads = Process::environment.get_n_threads();
+            std::vector<std::shared_ptr<TwoBodyAOInt>> Amn_ints(nthreads);
+            Amn_ints[0] = std::shared_ptr<TwoBodyAOInt>(Pmnfactory->eri(2));
+            for (int t = 1; t < nthreads; ++t) Amn_ints[t] = std::shared_ptr<TwoBodyAOInt>(Amn_ints[0]->clone());
+#pragma omp parallel for schedule(dynamic) num_threads(nthreads)
             for (int P = 0; P < nauxshell; ++P) {
+                int thread = 0;
+#ifdef _OPENMP
+                thread = omp_get_thread_num();
+#endif
                 int nP = auxiliary_->shell(P).nfunction();
                 int oP = auxiliary_->shell(P).function_index();
                 for (int M = 0; M < nshell; ++M) {
@@ -877,8 +894,8 @@ std::shared_ptr<Matrix> RSCFDeriv::hessian_response() {
                         int nN = basisset_->shell(N).nfunction();
                         int oN = basisset_->shell(N).function_index();
 
-                        Pmnint->compute_shell(P, 0, M, N);
-                        const double* buffer = Pmnint->buffer();
+                        Amn_ints[thread]->compute_shell(P, 0, M, N);
+                        const double* buffer = Amn_ints[thread]->buffer();
 
                         for (int p = oP; p < oP+nP; p++) {
                             for (int m = oM; m < oM+nM; m++) {
@@ -3673,7 +3690,22 @@ void USCFDeriv::JK_deriv1(std::shared_ptr<Matrix> D1,
         // Same applies to these terms.  There are already hooks to compute c and d vectors, and store them on disk,
         // so we should make better use of those intermediates between the second derivative integrals and these
         // first derivative terms needed for the Fock matrix derivatives.
+        //
+        // The (A|mn) build writes disjoint aux-function columns per P, so it
+        // threads over P with per-thread engines without any reduction. (The
+        // perturbation-batched derivative loops below stay serial: their batch
+        // size max_a is sized to fill ~90% of memory, so per-thread duplication
+        // of the accumulators is not memory-safe.)
+        int nthreads = Process::environment.get_n_threads();
+        std::vector<std::shared_ptr<TwoBodyAOInt>> Amn_ints(nthreads);
+        Amn_ints[0] = std::shared_ptr<TwoBodyAOInt>(Pmnfactory->eri(2));
+        for (int t = 1; t < nthreads; ++t) Amn_ints[t] = std::shared_ptr<TwoBodyAOInt>(Amn_ints[0]->clone());
+#pragma omp parallel for schedule(dynamic) num_threads(nthreads)
         for (int P = 0; P < nauxshell; ++P){
+            int thread = 0;
+#ifdef _OPENMP
+            thread = omp_get_thread_num();
+#endif
             int nP = auxiliary_->shell(P).nfunction();
             int oP = auxiliary_->shell(P).function_index();
             for(int M = 0; M < nshell; ++M){
@@ -3683,8 +3715,8 @@ void USCFDeriv::JK_deriv1(std::shared_ptr<Matrix> D1,
                     int nN = basisset_->shell(N).nfunction();
                     int oN = basisset_->shell(N).function_index();
 
-                    Pmnint->compute_shell(P,0,M,N);
-                    const double* buffer = Pmnint->buffers()[0];
+                    Amn_ints[thread]->compute_shell(P,0,M,N);
+                    const double* buffer = Amn_ints[thread]->buffers()[0];
 
                     for (int p = oP; p < oP+nP; p++) {
                         for (int m = oM; m < oM+nM; m++) {

--- a/psi4/src/psi4/scfgrad/scf_grad.cc
+++ b/psi4/src/psi4/scfgrad/scf_grad.cc
@@ -443,11 +443,24 @@ SharedMatrix SCFDeriv::compute_hessian()
         double** Vp = hessians_["Potential"]->pointer();
 
         // Potential energy derivatives
-        std::shared_ptr<OneBodyAOInt> Vint(integral_->ao_potential(2));
-        const auto& shell_pairs = Vint->shellpairs();
+        int nthreads = Process::environment.get_n_threads();
+        std::vector<std::shared_ptr<OneBodyAOInt>> Vints(nthreads);
+        for (int t = 0; t < nthreads; ++t) Vints[t] = std::shared_ptr<OneBodyAOInt>(integral_->ao_potential(2));
+        const auto& shell_pairs = Vints[0]->shellpairs();
         size_t n_pairs = shell_pairs.size();
 
+        // Per-thread Hessian accumulators, reduced after the shell-pair loop.
+        int vdim = hessians_["Potential"]->rowdim();
+        std::vector<SharedMatrix> Vp_local(nthreads);
+        for (int t = 0; t < nthreads; ++t) Vp_local[t] = std::make_shared<Matrix>("Potential Hess local", vdim, vdim);
+
+#pragma omp parallel for schedule(dynamic) num_threads(nthreads)
         for (size_t p = 0; p < n_pairs; ++p) {
+            int thread = 0;
+#ifdef _OPENMP
+            thread = omp_get_thread_num();
+#endif
+            double** Vp_t = Vp_local[thread]->pointer();
             auto P = shell_pairs[p].first;
             auto Q = shell_pairs[p].second;
             const GaussianShell& s1 = basisset_->shell(P);
@@ -469,8 +482,8 @@ SharedMatrix SCFDeriv::compute_hessian()
 #if DEBUGINTS
             outfile->Printf("AM1 %d AM2 %d a1 %f a2 %f center1 %d center2 %d\n", s1.am(), s2.am(), s1.exp(0), s2.exp(0), s1.ncenter(), s2.ncenter());
 #endif
-            Vint->compute_shell_deriv2(P, Q);
-            const auto &buffers = Vint->buffers();
+            Vints[thread]->compute_shell_deriv2(P, Q);
+            const auto &buffers = Vints[thread]->buffers();
 
             std::vector<double> Dvals;
             // find the D values against which this batch will be contracted
@@ -485,8 +498,9 @@ SharedMatrix SCFDeriv::compute_hessian()
                 const double *buffer = buffers[i];
                 Hvals.push_back(std::inner_product(Dvals.begin(), Dvals.end(), buffer, 0.0));
             }
-            process_buffers(Vp, Hvals, aP, aQ, natom, P==Q, true);
+            process_buffers(Vp_t, Hvals, aP, aQ, natom, P==Q, true);
         }
+        for (int t = 0; t < nthreads; ++t) hessians_["Potential"]->add(Vp_local[t]);
         // Symmetrize the result
         int dim = hessians_["Potential"]->rowdim();
         for (int row = 0; row < dim; ++row){
@@ -814,12 +828,25 @@ SharedMatrix SCFDeriv::compute_hessian()
         double** Tp = hessians_["Kinetic"]->pointer();
 
         // Kinetic energy derivatives
-        std::shared_ptr<OneBodyAOInt> Tint(integral_->ao_kinetic(2));
+        int nthreads = Process::environment.get_n_threads();
+        std::vector<std::shared_ptr<OneBodyAOInt>> Tints(nthreads);
+        for (int t = 0; t < nthreads; ++t) Tints[t] = std::shared_ptr<OneBodyAOInt>(integral_->ao_kinetic(2));
 
-        const auto& shell_pairs = Tint->shellpairs();
+        const auto& shell_pairs = Tints[0]->shellpairs();
         size_t n_pairs = shell_pairs.size();
 
+        // Per-thread Hessian accumulators, reduced after the shell-pair loop.
+        int tdim = hessians_["Kinetic"]->rowdim();
+        std::vector<SharedMatrix> Tp_local(nthreads);
+        for (int t = 0; t < nthreads; ++t) Tp_local[t] = std::make_shared<Matrix>("Kinetic Hess local", tdim, tdim);
+
+#pragma omp parallel for schedule(dynamic) num_threads(nthreads)
         for (size_t p = 0; p < n_pairs; ++p) {
+            int thread = 0;
+#ifdef _OPENMP
+            thread = omp_get_thread_num();
+#endif
+            double** Tp_t = Tp_local[thread]->pointer();
             auto P = shell_pairs[p].first;
             auto Q = shell_pairs[p].second;
             const GaussianShell& s1 = basisset_->shell(P);
@@ -834,8 +861,8 @@ SharedMatrix SCFDeriv::compute_hessian()
             int oQ = s2.function_index();
             int aQ = s2.ncenter();
 
-            Tint->compute_shell_deriv2(P, Q);
-            const auto &buffers = Tint->buffers();
+            Tints[thread]->compute_shell_deriv2(P, Q);
+            const auto &buffers = Tints[thread]->buffers();
 
             std::vector<double> Dvals;
             // find the D values against which this batch will be conctracted
@@ -849,8 +876,9 @@ SharedMatrix SCFDeriv::compute_hessian()
             for (const double *buffer : buffers) {
                 Hvals.push_back(std::inner_product(Dvals.begin(), Dvals.end(), buffer, 0.0));
             }
-            process_buffers(Tp, Hvals, aP, aQ, natom, P==Q, false);
+            process_buffers(Tp_t, Hvals, aP, aQ, natom, P==Q, false);
         }
+        for (int t = 0; t < nthreads; ++t) hessians_["Kinetic"]->add(Tp_local[t]);
         // Symmetrize the result
         int dim = hessians_["Kinetic"]->rowdim();
         for (int row = 0; row < dim; ++row){
@@ -898,12 +926,25 @@ SharedMatrix SCFDeriv::compute_hessian()
         double** Sp = hessians_["Overlap"]->pointer();
 
         // Overlap derivatives
-        std::shared_ptr<OneBodyAOInt> Sint(integral_->ao_overlap(2));
+        int nthreads = Process::environment.get_n_threads();
+        std::vector<std::shared_ptr<OneBodyAOInt>> Sints(nthreads);
+        for (int t = 0; t < nthreads; ++t) Sints[t] = std::shared_ptr<OneBodyAOInt>(integral_->ao_overlap(2));
 
-        const auto& shell_pairs = Sint->shellpairs();
+        const auto& shell_pairs = Sints[0]->shellpairs();
         size_t n_pairs = shell_pairs.size();
 
+        // Per-thread Hessian accumulators, reduced after the shell-pair loop.
+        int sdim = hessians_["Overlap"]->rowdim();
+        std::vector<SharedMatrix> Sp_local(nthreads);
+        for (int t = 0; t < nthreads; ++t) Sp_local[t] = std::make_shared<Matrix>("Overlap Hess local", sdim, sdim);
+
+#pragma omp parallel for schedule(dynamic) num_threads(nthreads)
         for (size_t p = 0; p < n_pairs; ++p) {
+            int thread = 0;
+#ifdef _OPENMP
+            thread = omp_get_thread_num();
+#endif
+            double** Sp_t = Sp_local[thread]->pointer();
             auto P = shell_pairs[p].first;
             auto Q = shell_pairs[p].second;
             const GaussianShell& s1 = basisset_->shell(P);
@@ -918,8 +959,8 @@ SharedMatrix SCFDeriv::compute_hessian()
             int Py = 3 * aP + 1;
             int Pz = 3 * aP + 2;
 
-            Sint->compute_shell_deriv2(P, Q);
-            const auto &buffers = Sint->buffers();
+            Sints[thread]->compute_shell_deriv2(P, Q);
+            const auto &buffers = Sints[thread]->buffers();
 
             std::vector<double> Wvals;
             // find the W values against which this batch will be contracted
@@ -934,8 +975,9 @@ SharedMatrix SCFDeriv::compute_hessian()
                 const double *buffer = buffers[i];
                 Hvals.push_back(std::inner_product(Wvals.begin(), Wvals.end(), buffer, 0.0));
             }
-            process_buffers(Sp, Hvals, aP, aQ, natom, P==Q, false);
+            process_buffers(Sp_t, Hvals, aP, aQ, natom, P==Q, false);
         }
+        for (int t = 0; t < nthreads; ++t) hessians_["Overlap"]->add(Sp_local[t]);
         // Symmetrize the result
         int dim = hessians_["Overlap"]->rowdim();
         for (int row = 0; row < dim; ++row){


### PR DESCRIPTION
## What

The analytic nuclear Hessian evaluated most of its integral work **serially on a single core**, even though the sibling gradient code has long been threaded. This PR threads those loops, mirroring the established `DFJKGrad::compute_gradient` pattern (per-thread integral engines + a parallel loop over auxiliary/primary shells, with per-thread accumulators reduced afterwards). No math changes — only parallelization.

Threaded regions:

1. **DF two-electron second-derivative Hessian** (`DFJKGrad::compute_hessian`, `jk_grad.cc`) — the dominant cost. All five auxiliary-shell loops (the `(A|mn)` build, the first/second-derivative `(A|mn)^x`/`(A|mn)^xy` loops, and the metric `(A|B)^x`/`(A|B)^xy` loops) now run in parallel. Loops writing aux-partitioned intermediates are race-free by construction; the deriv1 K-scratch is made per-thread; the two `compute_shell_deriv2` loops accumulate into per-thread `JHess`/`KHess` reduced into `hessians_` before the serial tail.

2. **DF orbital-response (CPHF) perturbed-Fock build** (`RSCFDeriv::hessian_response` + `USCFDeriv::JK_deriv1`, `response.cc`) — the `(A|mn)` build plus the metric and main `(A|mn)^x` contraction loops. These scatter into per-perturbation Fock matrices keyed by shell centers (not partitioned by P), so each thread scatters into a **private copy of the perturbation batch** that is reduced afterwards. The batch size `max_a` is re-budgeted so the per-thread copies fit inside the memory budget (`df_mem / ((1+nthreads)·nso²)`, capped at `3·natom`).

3. **One-electron Hessian terms** (`SCFDeriv::compute_hessian`, `scf_grad.cc`) — the Potential, Kinetic, and Overlap shell-pair loops, with per-thread one-electron engines and a per-thread accumulator. (ECP left serial — rare, differently structured.)

## Bonus bug fix

While threading (2), fixed a **pre-existing latent fault** in the multi-batch response path: the loops mark a whole atom in-core when *any* of its perturbations falls in a batch and then write all three of its Fock derivatives, so a batch boundary that split an atom wrote into an unmapped accumulator (segfault). `max_a` is now forced to a multiple of 3 (atom-aligned).

## Validation

Analytic DF Hessians (def2-SVP, `scf_type df`) computed at 1 vs 6 threads, RHF and UHF:

- Small molecules (H2O, NH2), single batch: agreement to **1e-10 … 6e-10**.
- Multi-batch reduction isolated at fixed thread count (single vs multi batch): **~7e-9** — the same magnitude as two *identical* runs of the same configuration (**~1e-8** for a water tetramer), i.e. pure floating-point summation-order noise from the threaded reduction (dynamic scheduling), not a correctness difference. This is the same run-to-run nondeterminism already present in psi4's other threaded quadrature/JK code, and is physically negligible for a Hessian.

Normal-memory runs use a single batch (`max_a` capped at `3·natom`), so results there are identical to the previous serial code up to threading FP noise; existing Hessian tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)