### PR TITLE
Add missing include

### DIFF
--- a/psi4/src/psi4/libqt/timer.cc
+++ b/psi4/src/psi4/libqt/timer.cc
@@ -118,6 +118,7 @@ typedef int omp_lock_t;
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/exception.h"
+#include "psi4/libqt/qt.h"
 
 /* guess for HZ, if missing */
 #ifndef HZ


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Solves the compile error
```
/home/work/psi4/psi4/psi4/src/psi4/libqt/timer.cc:1344:98: error: ‘TimerRecord’ was not declared in this scope
 1344 |                              const std::vector<std::string>& parent_path, int level, std::vector<TimerRecord>& records) {
      |                                                                                                  ^~~~~~~~~~~
/home/work/psi4/psi4/psi4/src/psi4/libqt/timer.cc:1344:109: error: template argument 1 is invalid
 1344 |                              const std::vector<std::string>& parent_path, int level, std::vector<TimerRecord>& records) {
      |                                                                                                             ^
/home/work/psi4/psi4/psi4/src/psi4/libqt/timer.cc:1344:109: error: template argument 2 is invalid
/home/work/psi4/psi4/psi4/src/psi4/libqt/timer.cc: In function ‘void psi::timer_to_records_helper(const Timer_Structure&, const std::string&, const std::vector<std::__cxx11::basic_string<char> >&, int, int&)’:
/home/work/psi4/psi4/psi4/src/psi4/libqt/timer.cc:1354:9: error: ‘TimerRecord’ was not declared in this scope
 1354 |         TimerRecord record;
      |         ^~~~~~~~~~~
/home/work/psi4/psi4/psi4/src/psi4/libqt/timer.cc:1355:9: error: ‘record’ was not declared in this scope; did you mean ‘records’?
 1355 |         record.timer_id = timer_id;
      |         ^~~~~~
      |         records
/home/work/psi4/psi4/psi4/src/psi4/libqt/timer.cc:1364:17: error: request for member ‘push_back’ in ‘records’, which is of non-class type ‘int’
 1364 |         records.push_back(record);
      |                 ^~~~~~~~~
/home/work/psi4/psi4/psi4/src/psi4/libqt/timer.cc: At global scope:
/home/work/psi4/psi4/psi4/src/psi4/libqt/timer.cc:1374:21: error: ‘TimerRecord’ was not declared in this scope
 1374 | PSI_API std::vector<TimerRecord> get_timer_records() {
      |                     ^~~~~~~~~~~
/home/work/psi4/psi4/psi4/src/psi4/libqt/timer.cc:1374:32: error: template argument 1 is invalid
 1374 | PSI_API std::vector<TimerRecord> get_timer_records() {
      |                                ^
/home/work/psi4/psi4/psi4/src/psi4/libqt/timer.cc:1374:32: error: template argument 2 is invalid
```

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [ ] RN 1
- [ ] RN 2

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [ ] Feature1
- [ ] Feature2

## Questions
<!-- Any questions or decision points on which you need clarification
     from the Psi4 team. -->
- [ ] Question1

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [ ] AI usage

## Checklist
- [ ] Tests added for any new features
- [ ] Docstring or narrative docs/sphinxman/source updated if needed
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
