### PR TITLE
Don't let a broken optional mpi4py abort `import psi4`

### DIFF
--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -62,7 +62,11 @@ except ImportError:
 try:
     from mpi4py import MPI
     use_mpi4py = True
-except ImportError:
+except Exception:
+    # mpi4py is optional and only used for MDI runs. Catch any failure, not
+    # just ImportError: mpi4py >= 4 dlopens libmpi at import time to probe the
+    # MPI ABI and raises RuntimeError (not ImportError) when no MPI runtime is
+    # present, which would otherwise abort "import psi4" entirely.
     use_mpi4py = False
 
 

--- a/psi4/driver/mdi_engine.py
+++ b/psi4/driver/mdi_engine.py
@@ -62,11 +62,20 @@ except ImportError:
 try:
     from mpi4py import MPI
     use_mpi4py = True
-except Exception:
-    # mpi4py is optional and only used for MDI runs. Catch any failure, not
-    # just ImportError: mpi4py >= 4 dlopens libmpi at import time to probe the
-    # MPI ABI and raises RuntimeError (not ImportError) when no MPI runtime is
-    # present, which would otherwise abort "import psi4" entirely.
+except ImportError:
+    # mpi4py is optional and only used for MDI runs; not being installed is fine.
+    use_mpi4py = False
+except Exception as exc:
+    # mpi4py is installed but failed to import -- e.g. mpi4py >= 4 dlopens libmpi
+    # at import time to probe the MPI ABI and raises RuntimeError (not
+    # ImportError) when no MPI runtime is present. Don't abort "import psi4",
+    # but do warn, since a present-but-broken mpi4py failing silently is a
+    # frustrating surprise.
+    import warnings
+    warnings.warn(
+        f"psi4: mpi4py is installed but could not be imported ({exc!r}); "
+        "MDI runs will proceed without MPI support."
+    )
     use_mpi4py = False
 
 


### PR DESCRIPTION
Currently psi4 doesn't work if mpi4py is installed on my system, since the MPI stack in Fedora is behind environment modules due to the ABI incompatibility of OpenMPI and MPICH. This PR fixes the import exception to the case where mpi4py is available but the MPI library doesn't resolve.

# AI summary

## Problem

`psi4/driver/mdi_engine.py` imports `mpi4py` only for MDI (MolSSI Driver Interface) runs, and already guards the import as optional:

```python
try:
    from mpi4py import MPI
    use_mpi4py = True
except ImportError:
    use_mpi4py = False
```

But it catches only `ImportError`. **mpi4py ≥ 4** `dlopen`s `libmpi` *at import time* to probe the MPI ABI, and raises **`RuntimeError`** (not `ImportError`) when no MPI runtime library is present. That escapes the guard and aborts `import psi4` entirely — for any user who has mpi4py installed without a loadable MPI library, even though nothing outside MDI uses mpi4py.

Observed traceback:
```
  File ".../psi4/driver/mdi_engine.py", line 63, in <module>
    from mpi4py import MPI
  ...
  File ".../mpi4py/_mpiabi.py", line 210, in _dlopen_libmpi
RuntimeError: cannot load MPI library
```

## Fix

Catch `Exception` instead of `ImportError`, so *any* failure to bring in the optional MPI support simply disables it (`use_mpi4py = False`) — the intended behavior for an optional dependency.

## Verification

A stand-in `mpi4py` that raises `RuntimeError` at import (mimicking the 4.x ABI probe) confirms the behavior change:

```
old guard (except ImportError): UNCAUGHT RuntimeError: cannot load MPI library  <-- aborts 'import psi4'
new guard (except Exception):   use_mpi4py=False (caught)
```

Only the MDI code path reads `use_mpi4py`, so nothing else is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

