### PR TITLE
Don't allocate exchange-Hessian intermediates for pure functionals

### DIFF
--- a/psi4/src/psi4/scfgrad/jk_grad.cc
+++ b/psi4/src/psi4/scfgrad/jk_grad.cc
@@ -1322,10 +1322,24 @@ void DFJKGrad::compute_hessian() {
     auto dc = std::make_shared<Matrix>("dc[x][A] = (mn|A)^x D[m][n]",  3*natoms, np);
     double **dcp = dc->pointer();
 
-    auto dAa_ij = std::make_shared<Matrix>("dAij[x][A,i,j] = (mn|A)^x C[m][i] C[n][j]",  3*natoms, np*na*na);
-    double **dAa_ijp = dAa_ij->pointer();
-    auto dAb_ij = std::make_shared<Matrix>("dAij[x][A,i,j] = (mn|A)^x C[m][i] C[n][j]",  3*natoms, np*nb*nb);
-    double **dAb_ijp = dAb_ij->pointer();
+    // Exchange (K) intermediates. These dominate the Hessian's memory
+    // (each is 3*natom * naux * nocc^2 doubles) and Matrix zeroes its storage
+    // on construction, so allocating them touches the pages. Only build them
+    // when exact exchange is actually present (pure functionals leave do_K_
+    // false), and only build the beta copies when the orbitals differ --
+    // otherwise a pure meta-GGA Hessian pointlessly reserves several GB and
+    // can drive the process into swap. Their uses below are already guarded by
+    // do_K_ / same_ab, so the pointers stay null when unused.
+    SharedMatrix dAa_ij, dAb_ij;
+    double **dAa_ijp = nullptr, **dAb_ijp = nullptr;
+    if (do_K_) {
+        dAa_ij = std::make_shared<Matrix>("dAij[x][A,i,j] = (mn|A)^x C[m][i] C[n][j]",  3*natoms, np*na*na);
+        dAa_ijp = dAa_ij->pointer();
+        if (!same_ab) {
+            dAb_ij = std::make_shared<Matrix>("dAij[x][A,i,j] = (mn|A)^x C[m][i] C[n][j]",  3*natoms, np*nb*nb);
+            dAb_ijp = dAb_ij->pointer();
+        }
+    }
 
     auto d = std::make_shared<Vector>("d[A] = Minv[A][B] C[B]", np);
     double *dp = d->pointer();
@@ -1333,10 +1347,16 @@ void DFJKGrad::compute_hessian() {
     double **ddp = dd->pointer();
     auto de = std::make_shared<Matrix>("de[x][A] = (A|B)^x d[B] ", 3*natoms, np);
     double **dep = de->pointer();
-    auto dea_ij = std::make_shared<Matrix>("deij[x][A,i,j] = (A|B)^x Bij[B,i,j]", 3*natoms, np*na*na);
-    double **dea_ijp = dea_ij->pointer();
-    auto deb_ij = std::make_shared<Matrix>("deij[x][A,i,j] = (A|B)^x Bij[B,i,j]", 3*natoms, np*nb*nb);
-    double **deb_ijp = deb_ij->pointer();
+    SharedMatrix dea_ij, deb_ij;
+    double **dea_ijp = nullptr, **deb_ijp = nullptr;
+    if (do_K_) {
+        dea_ij = std::make_shared<Matrix>("deij[x][A,i,j] = (A|B)^x Bij[B,i,j]", 3*natoms, np*na*na);
+        dea_ijp = dea_ij->pointer();
+        if (!same_ab) {
+            deb_ij = std::make_shared<Matrix>("deij[x][A,i,j] = (A|B)^x Bij[B,i,j]", 3*natoms, np*nb*nb);
+            deb_ijp = deb_ij->pointer();
+        }
+    }
 
     // Build some integral factories
     auto Pmnfactory = std::make_shared<IntegralFactory>(auxiliary_, BasisSet::zero_ao_basis_set(), primary_, primary_);


### PR DESCRIPTION
## Problem

`DFJKGrad::compute_hessian()` unconditionally allocates the exchange (K) intermediates `dAa_ij`, `dAb_ij`, `dea_ij`, `deb_ij` — each `3*natom * naux * nocc^2` doubles — regardless of whether exact exchange is present, and allocates the beta copies even for a restricted reference. Their *uses* are already guarded by `do_K_` / `!same_ab`, but the allocations are not. Since `Matrix` zeroes its storage on construction, these buffers are **committed** (touched), not merely reserved.

For a **pure functional** (`do_K_ == false` — every non-hybrid GGA/meta-GGA: PBE, TPSS, SCAN, r²SCAN, M06-L, …) this is several GB of memory the run never reads:

| system | wasted allocation (4 buffers) |
|---|---|
| benzene / def2-SVP | ~0.17 GB |
| naphthalene / def2-SVP | ~1.8 GB |
| caffeine / def2-SVP | ~6.6 GB |

On a memory-limited machine this drives the process into swap. A caffeine/def2-SVP pure-meta-GGA Hessian on an 8 GB machine spent hours thrashing on ~6.6 GB of dead buffers.

## Fix

Guard the allocations by `do_K_`, and the beta copies by `!same_ab`. Every use of these pointers is already under the same conditions, so they simply stay `nullptr` when unused. Hybrid UKS is unaffected (all four still allocated); hybrid RKS additionally drops the redundant beta pair.

## Validation

- **Numerically inert.** Single-threaded (deterministic) TPSS/def2-SVP analytic Hessian, with vs without the change: **bitwise identical** (`max|Δ| = 0`), energy identical to 12 digits. The change only skips allocating buffers that are never read.
- **Memory.** Confirmed the buffers are the dominant Hessian allocation and scale as `4 * 3*natom * naux * nocc^2`; removing them for a pure functional recovers the full amount above.
- **Guards audited** across all use sites (the deriv-1 (A|mn) loop, the (A|B) loop, and the final K-Hessian contraction): alpha buffers used only under `do_K_`, beta only under `do_K_ && !same_ab`.

The exchange Hessian path itself (hybrids) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

