### PR TITLE
use v1 conda compilers for now

### DIFF
--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -244,7 +244,7 @@ jobs:
         echo "::endgroup::"
 
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v4
+      uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: p4build
         environment-file: env_p4build.yaml

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -145,7 +145,7 @@ jobs:
     runs-on: ${{ matrix.cfg.runs-on }}
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
 
     steps:
 
@@ -262,6 +262,7 @@ jobs:
 
     - name: Diagnose Conda compiler activation
       run: |
+        printenv
         echo "=== activated environment ==="
         env | grep -E '^(CONDA_TOOLCHAIN_HOST|CC|CXX|FC)=' || true
 
@@ -281,6 +282,8 @@ jobs:
         print("conda info CONDA_TOOLCHAIN_HOST =",
               info.get("env_vars", {}).get("CONDA_TOOLCHAIN_HOST"))
         PY
+        conda activate p4build
+        printenv
 
     - name: Special Config - Force testing OpenOrbitalOptimizer
       if: "(matrix.cfg.label == 'Conda Clang (M-Intel)')"

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -260,6 +260,28 @@ jobs:
         conda info
         conda list
 
+    - name: Diagnose Conda compiler activation
+      run: |
+        echo "=== activated environment ==="
+        env | grep -E '^(CONDA_TOOLCHAIN_HOST|CC|CXX|FC)=' || true
+
+        echo
+        echo "=== conda info --json env_vars ==="
+        python - <<'PY'
+        import json
+        import os
+        import subprocess
+
+        info = json.loads(
+            subprocess.check_output(["conda", "info", "--json"], text=True)
+        )
+
+        print("os.environ CONDA_TOOLCHAIN_HOST =",
+              os.environ.get("CONDA_TOOLCHAIN_HOST"))
+        print("conda info CONDA_TOOLCHAIN_HOST =",
+              info.get("env_vars", {}).get("CONDA_TOOLCHAIN_HOST"))
+        PY
+
     - name: Special Config - Force testing OpenOrbitalOptimizer
       if: "(matrix.cfg.label == 'Conda Clang (M-Intel)')"
       run: |

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -145,7 +145,7 @@ jobs:
     runs-on: ${{ matrix.cfg.runs-on }}
     defaults:
       run:
-        shell: bash -el {0}
+        shell: bash -l {0}
 
     steps:
 
@@ -244,7 +244,7 @@ jobs:
         echo "::endgroup::"
 
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v4
       with:
         activate-environment: p4build
         environment-file: env_p4build.yaml
@@ -259,31 +259,6 @@ jobs:
       run: |
         conda info
         conda list
-
-    - name: Diagnose Conda compiler activation
-      run: |
-        printenv
-        echo "=== activated environment ==="
-        env | grep -E '^(CONDA_TOOLCHAIN_HOST|CC|CXX|FC)=' || true
-
-        echo
-        echo "=== conda info --json env_vars ==="
-        python - <<'PY'
-        import json
-        import os
-        import subprocess
-
-        info = json.loads(
-            subprocess.check_output(["conda", "info", "--json"], text=True)
-        )
-
-        print("os.environ CONDA_TOOLCHAIN_HOST =",
-              os.environ.get("CONDA_TOOLCHAIN_HOST"))
-        print("conda info CONDA_TOOLCHAIN_HOST =",
-              info.get("env_vars", {}).get("CONDA_TOOLCHAIN_HOST"))
-        PY
-        conda activate p4build
-        printenv
 
     - name: Special Config - Force testing OpenOrbitalOptimizer
       if: "(matrix.cfg.label == 'Conda Clang (M-Intel)')"

--- a/codedeps.yaml
+++ b/codedeps.yaml
@@ -50,7 +50,7 @@ data:
     conda:
       channel: conda-forge
       name: c-compiler
-      constraint: null
+      constraint: "<2"
       cmake:
         # {CMAKE_CXX_COMPILER_ID}_{Conda_platform}
         GNU_linux-64:
@@ -94,7 +94,7 @@ data:
     conda:
       channel: conda-forge
       name: cxx-compiler
-      constraint: null
+      constraint: "<2"
       aux_build_names:
         linux-64:
           - "//dpcpp_linux-64"
@@ -147,7 +147,7 @@ data:
     conda:
       channel: conda-forge
       name: fortran-compiler
-      constraint: null
+      constraint: "<2"
       skip_win: true
       skip_win_note: "Presently pulls in an old Flang."
       aux_build_names:


### PR DESCRIPTION
Conda v2 compiler metapackages are designed to be easier to use _outside_ conda-build, with names like `g++`, not `x86_64-conda-linux-gnu-c++`, and fewer enironment variables, and less (no?) flag injection. However, this does throw a wrench in the path-advisor handling that was closely attended to the envvar the v1 metapackages set. I'll have to take a closer look at changes for v2, but this should get us past the immediate CI crisis.