### PR TITLE
ℂ𝜓 2: Base classes in Python

### DIFF
--- a/doc/sphinxman/source/nitpick-exceptions
+++ b/doc/sphinxman/source/nitpick-exceptions
@@ -7,4 +7,5 @@ py:class pybind11_builtins.pybind11_object
 py:class psi::Options
 py:class psi4.core.PCM.CalcType
 py:class psi::PCM
+py:class psi4.core.ComplexWavefunction
 

--- a/doc/sphinxman/source/variables.rst
+++ b/doc/sphinxman/source/variables.rst
@@ -38,29 +38,29 @@ QCVariables: setting and accessing
 .. table:: API and conventions to access and program with QCVariables.
    :align: left
 
-   +-------------------------------+-----------------------------------------+---------------------------------------------------+--------------------------------+----------------------------------------------+
-   | Operation                     | Py-side Globals [#e1]_ [#e5]_           | Py-side Wavefunction [#e1]_ [#e5]_                | C-side Globals [#e3]_ [#e4]_   | C-side Wavefunction [#e5]_                   |
-   +===============================+=========================================+===================================================+================================+==============================================+
-   | access var                    | :py:func:`~psi4.core.variable()`        | :py:func:`~psi4.core.Wavefunction.variable()`     | ``val = P::e.globals["KEY"];`` | ``Wavefunction::scalar_variable("kEy")``     |
-   |                               |                                         |                                                   | ``val = P::e.arrays["KEY"];``  | ``Wavefunction::array_variable("kEy")``      |
-   +-------------------------------+-----------------------------------------+---------------------------------------------------+--------------------------------+----------------------------------------------+
-   | access all vars               | :py:func:`~psi4.core.variables()`       | :py:func:`~psi4.core.Wavefunction.variables()`    | ``P::e.globals;``              | ``Wavefunction::scalar_variables()``         |
-   |                               |                                         |                                                   | ``P::e.arrays;``               | ``Wavefunction::array_variables()``          |
-   +-------------------------------+-----------------------------------------+---------------------------------------------------+--------------------------------+----------------------------------------------+
-   | is var set?                   | :py:func:`~psi4.core.has_variable()`    | :py:func:`~psi4.core.Wavefunction.has_variable()` | ``P::e.globals.count("KEY");`` | ``Wavefunction::has_scalar_variable("kEy")`` |
-   |                               |                                         |                                                   | ``P::e.arrays.count("KEY");``  | ``Wavefunction::has_array_variable("kEy")``  |
-   +-------------------------------+-----------------------------------------+---------------------------------------------------+--------------------------------+----------------------------------------------+
-   | set a var value [#e2]_        | :py:func:`~psi4.core.set_variable()`    | :py:func:`~psi4.core.Wavefunction.set_variable()` | ``P::e.globals["KEY"] = val;`` | ``Wavefunction::set_scalar_variable("kEy")`` |
-   |                               |                                         |                                                   | ``P::e.arrays["KEY"] = val;``  | ``Wavefunction::set_array_variable("kEy")``  |
-   +-------------------------------+-----------------------------------------+---------------------------------------------------+--------------------------------+----------------------------------------------+
-   | unset var                     | :py:func:`~psi4.core.del_variable()`    | :py:func:`~psi4.core.Wavefunction.del_variable()` | ``P::e.globals.erase("KEY")``  | ``Wavefunction::del_scalar_variable("kEy")`` |
-   |                               |                                         |                                                   | ``P::e.arrays.erase("KEY")``   | ``Wavefunction::del_array_variable("kEy")``  |
-   +-------------------------------+-----------------------------------------+---------------------------------------------------+--------------------------------+----------------------------------------------+
-   | unset all vars                | :py:func:`~psi4.core.clean_variables()` |                                                   |                                |                                              |
-   +-------------------------------+-----------------------------------------+---------------------------------------------------+--------------------------------+----------------------------------------------+
-   | register var with docs [#e6]_ | ``core.set_variable("GIBBS", G) # P::e THERMO`` or                                          | ``P::e.globals["CC T1 DIAG"] = val;`` or                                      |
-   |                               | ``# wfn.set_variable("ROOT n") # P::e ADC``                                                 | ``// P::e.globals["CCSD ROOT n"];``                                           |
-   +-------------------------------+-----------------------------------------+---------------------------------------------------+--------------------------------+----------------------------------------------+
+   +-------------------------------+-----------------------------------------+-------------------------------------------------------+--------------------------------+--------------------------------------------------+
+   | Operation                     | Py-side Globals [#e1]_ [#e5]_           | Py-side Wavefunction [#e1]_ [#e5]_                    | C-side Globals [#e3]_ [#e4]_   | C-side Wavefunction [#e5]_                       |
+   +===============================+=========================================+=======================================================+================================+==================================================+
+   | access var                    | :py:func:`~psi4.core.variable()`        | :py:func:`~psi4.core.BaseWavefunction.variable()`     | ``val = P::e.globals["KEY"];`` | ``BaseWavefunction::scalar_variable("kEy")``     |
+   |                               |                                         |                                                       | ``val = P::e.arrays["KEY"];``  | ``BaseWavefunction::array_variable("kEy")``      |
+   +-------------------------------+-----------------------------------------+-------------------------------------------------------+--------------------------------+--------------------------------------------------+
+   | access all vars               | :py:func:`~psi4.core.variables()`       | :py:func:`~psi4.core.BaseWavefunction.variables()`    | ``P::e.globals;``              | ``BaseWavefunction::scalar_variables()``         |
+   |                               |                                         |                                                       | ``P::e.arrays;``               | ``BaseWavefunction::array_variables()``          |
+   +-------------------------------+-----------------------------------------+-------------------------------------------------------+--------------------------------+--------------------------------------------------+
+   | is var set?                   | :py:func:`~psi4.core.has_variable()`    | :py:func:`~psi4.core.BaseWavefunction.has_variable()` | ``P::e.globals.count("KEY");`` | ``BaseWavefunction::has_scalar_variable("kEy")`` |
+   |                               |                                         |                                                       | ``P::e.arrays.count("KEY");``  | ``BaseWavefunction::has_array_variable("kEy")``  |
+   +-------------------------------+-----------------------------------------+-------------------------------------------------------+--------------------------------+--------------------------------------------------+
+   | set a var value [#e2]_        | :py:func:`~psi4.core.set_variable()`    | :py:func:`~psi4.core.BaseWavefunction.set_variable()` | ``P::e.globals["KEY"] = val;`` | ``BaseWavefunction::set_scalar_variable("kEy")`` |
+   |                               |                                         |                                                       | ``P::e.arrays["KEY"] = val;``  | ``BaseWavefunction::set_array_variable("kEy")``  |
+   +-------------------------------+-----------------------------------------+-------------------------------------------------------+--------------------------------+--------------------------------------------------+
+   | unset var                     | :py:func:`~psi4.core.del_variable()`    | :py:func:`~psi4.core.BaseWavefunction.del_variable()` | ``P::e.globals.erase("KEY")``  | ``BaseWavefunction::del_scalar_variable("kEy")`` |
+   |                               |                                         |                                                       | ``P::e.arrays.erase("KEY")``   | ``BaseWavefunction::del_array_variable("kEy")``  |
+   +-------------------------------+-----------------------------------------+-------------------------------------------------------+--------------------------------+--------------------------------------------------+
+   | unset all vars                | :py:func:`~psi4.core.clean_variables()` |                                                       |                                |                                                  |
+   +-------------------------------+-----------------------------------------+-------------------------------------------------------+--------------------------------+--------------------------------------------------+
+   | register var with docs [#e6]_ | ``core.set_variable("GIBBS", G) # P::e THERMO`` or                                              | ``P::e.globals["CC T1 DIAG"] = val;`` or                                          |
+   |                               | ``# wfn.set_variable("ROOT n") # P::e ADC``                                                     | ``// P::e.globals["CCSD ROOT n"];``                                               |
+   +-------------------------------+-----------------------------------------+-------------------------------------------------------+--------------------------------+--------------------------------------------------+
 
 .. [#e1] Works on float or array variables
 .. [#e2] Py-side, value can be float or :py:class:`psi4.core.Matrix` or ``np.ndarray``. C-side, value can be float or Matrix, and the appropriate function must be used.

--- a/psi4/driver/p4util/python_helpers.py
+++ b/psi4/driver/p4util/python_helpers.py
@@ -202,14 +202,20 @@ core.BasisSet.build = _pybuild_basis
 ## Python wavefunction helps
 
 
-@staticmethod
+@classmethod
 def _core_wavefunction_build(
+        cls,
         mol: core.Molecule,
         basis: Union[None, str, core.BasisSet] = None,
         *,
+        reference: Optional[str] = None,
         quiet: bool = False,
-    ) -> core.Wavefunction:
-    """Build a wavefunction from minimal inputs, molecule and basis set.
+    ) -> core.BaseWavefunction:
+    """Build a Wavefunction or ComplexWavefunction from minimal inputs.
+
+    Shared by :class:`~psi4.core.Wavefunction` and
+    :class:`~psi4.core.ComplexWavefunction` via
+    :class:`~psi4.core.BaseWavefunction`.
 
     Parameters
     ----------
@@ -219,32 +225,49 @@ def _core_wavefunction_build(
         Basis set for which to build the wavefunction instance. If a
         :class:`BasisSet`, taken as-is. If a string, taken as a name for the
         primary basis. If None, name taken from :term:`BASIS <BASIS (MINTS)>`.
+    reference
+        Optional SCF reference string (e.g. ``"RHF"``, ``"CGHF"``).
+        When provided, selects the wavefunction class automatically:
+        ``"CGHF"`` builds :class:`~psi4.core.ComplexWavefunction`,
+        anything else builds :class:`~psi4.core.Wavefunction`.
+        When ``None`` (default), ``cls`` must be a concrete subclass
+        (calling ``BaseWavefunction.build()`` directly raises).
     quiet
         When True, do not print to the output file.
 
     """
+    if reference is not None:
+        if reference == "CGHF":
+            cls = core.ComplexWavefunction
+        else:
+            cls = core.Wavefunction
+    elif cls is core.BaseWavefunction:
+        raise TypeError("Cannot build BaseWavefunction directly; "
+                        "use Wavefunction or ComplexWavefunction, "
+                        "or pass reference= to auto-select.")
+
     if basis is None:
         basis = core.BasisSet.build(mol, quiet=quiet)
     elif isinstance(basis, str):
         basis = core.BasisSet.build(mol, "ORBITAL", basis, quiet=quiet)
 
-    wfn = core.Wavefunction(mol, basis)
+    wfn = cls(mol, basis)
     # Set basis for density-fitted calculations to the zero basis...
     # ...until the user explicitly provides a DF basis.
     wfn.set_basisset("DF_BASIS_SCF", core.BasisSet.zero_ao_basis_set())
     return wfn
 
 
-core.Wavefunction.build = _core_wavefunction_build
+core.BaseWavefunction.build = _core_wavefunction_build
 
 
-def _core_wavefunction_get_scratch_filename(self: core.Wavefunction, filenumber: int) -> str:
+def _core_wavefunction_get_scratch_filename(self: core.BaseWavefunction, filenumber: int) -> str:
     """Return canonical path to scratch file `filenumber` based on molecule on `self`.
 
     Parameters
     ----------
     self
-        Wavefunction instance.
+        Wavefunction or ComplexWavefunction instance.
     filenumber
         Scratch file number from :source:`psi4/include/psi4/psifiles.h`.
 
@@ -254,7 +277,7 @@ def _core_wavefunction_get_scratch_filename(self: core.Wavefunction, filenumber:
     return os.path.join(psi_scratch, fname + '.' + str(filenumber))
 
 
-core.Wavefunction.get_scratch_filename = _core_wavefunction_get_scratch_filename
+core.BaseWavefunction.get_scratch_filename = _core_wavefunction_get_scratch_filename
 
 
 @staticmethod
@@ -1245,13 +1268,13 @@ def _core_has_variable(key: str) -> bool:
     return core.has_scalar_variable(key) or core.has_array_variable(key)
 
 
-def _core_wavefunction_has_variable(self: core.Wavefunction, key: str) -> bool:
+def _core_wavefunction_has_variable(self: core.BaseWavefunction, key: str) -> bool:
     """Whether scalar or array :ref:`QCVariable <sec:appendices:qcvars>` *key* has been set on *self*.
 
     Parameters
     ----------
     self
-        Wavefunction instance.
+        BaseWavefunction instance.
     key
         Case-insensitive key to instance's double or
         :py:class:`~psi4.core.Matrix` storage maps.
@@ -1310,14 +1333,14 @@ def _core_variable(key: str) -> Union[float, core.Matrix, np.ndarray]:
         raise KeyError(f"psi4.core.variable: Requested variable '{key}' was not set!\n")
 
 
-def _core_wavefunction_variable(self: core.Wavefunction, key: str) -> Union[float, core.Matrix, np.ndarray]:
+def _core_wavefunction_variable(self: core.BaseWavefunction, key: str) -> Union[float, core.Matrix, np.ndarray]:
     """Return copy of scalar or array :ref:`QCVariable <sec:appendices:qcvars>`
     *key* from *self*.
 
     Parameters
     ----------
     self
-        Wavefunction instance.
+        BaseWavefunction instance.
     key
         Case-insensitive key to instance's double or :py:class:`~psi4.core.Matrix`
         storage maps.
@@ -1359,7 +1382,7 @@ def _core_wavefunction_variable(self: core.Wavefunction, key: str) -> Union[floa
     elif self.has_array_variable(key):
         return _qcvar_reshape_get(key, self.array_variable(key))
     else:
-        raise KeyError(f"psi4.core.Wavefunction.variable: Requested variable '{key}' was not set!\n")
+        raise KeyError(f"psi4.core.BaseWavefunction.variable: Requested variable '{key}' was not set!\n")
 
 
 def _core_set_variable(key: str, val: Union[core.Matrix, np.ndarray, float]) -> None:
@@ -1431,17 +1454,17 @@ def _core_wavefunction_set_variable(self: core.Wavefunction, key: str, val: Unio
     """
     if isinstance(val, core.Matrix):
         if self.has_scalar_variable(key):
-            raise ValidationError("psi4.core.Wavefunction.set_variable: Target variable '{key}' already a scalar variable!")
+            raise ValidationError("psi4.core.BaseWavefunction.set_variable: Target variable '{key}' already a scalar variable!")
         else:
             self.set_array_variable(key, val)
     elif isinstance(val, np.ndarray):
         if self.has_scalar_variable(key):
-            raise ValidationError("psi4.core.Wavefunction.set_variable: Target variable '{key}' already a scalar variable!")
+            raise ValidationError("psi4.core.BaseWavefunction.set_variable: Target variable '{key}' already a scalar variable!")
         else:
             self.set_array_variable(key, core.Matrix.from_array(_qcvar_reshape_set(key, val)))
     else:
         if self.has_array_variable(key):
-            raise ValidationError("psi4.core.Wavefunction.set_variable: Target variable '{key}' already an array variable!")
+            raise ValidationError("psi4.core.BaseWavefunction.set_variable: Target variable '{key}' already an array variable!")
         else:
             self.set_scalar_variable(key, val)
 
@@ -1520,7 +1543,7 @@ def _core_wavefunction_variables(self, include_deprecated_keys: bool = False) ->
     Parameters
     ----------
     self
-        Wavefunction instance.
+        BaseWavefunction instance.
     include_deprecated_keys
         Also return duplicate entries with keys that have been deprecated.
 
@@ -1532,11 +1555,15 @@ def _core_wavefunction_variables(self, include_deprecated_keys: bool = False) ->
         - Scalar variables are returned as floats.
         - Array variables not naturally 2D (like multipoles or per-atom charges)
           are returned as :class:`~numpy.ndarray` of natural dimensionality.
-        - Other array variables are returned as :py:class:`~psi4.core.Matrix` and
+        - Other real array variables are returned as :py:class:`~psi4.core.Matrix` and
           may have an extra dimension with symmetry information.
-
     """
-    dicary = {**self.scalar_variables(), **{k: _qcvar_reshape_get(k, v) for k, v in self.array_variables().items()}}
+    dicary: Dict[str, Union[float, core.Matrix, np.ndarray]] = dict(self.scalar_variables())
+    array_vars = getattr(self, "array_variables", None)
+    if array_vars is not None:
+        for k, v in array_vars().items():
+            if isinstance(v, core.Matrix):
+                dicary[k] = _qcvar_reshape_get(k, v)
 
     if include_deprecated_keys:
         for old_key, (current_key, version) in _qcvar_transitions.items():
@@ -1552,11 +1579,12 @@ core.set_variable = _core_set_variable
 core.del_variable = _core_del_variable
 core.variables = _core_variables
 
-core.Wavefunction.has_variable = _core_wavefunction_has_variable
-core.Wavefunction.variable = _core_wavefunction_variable
-core.Wavefunction.set_variable = _core_wavefunction_set_variable
-core.Wavefunction.del_variable = _core_wavefunction_del_variable
-core.Wavefunction.variables = _core_wavefunction_variables
+
+core.BaseWavefunction.has_variable = _core_wavefunction_has_variable
+core.BaseWavefunction.variable = _core_wavefunction_variable
+core.BaseWavefunction.variables = _core_wavefunction_variables
+core.BaseWavefunction.set_variable = _core_wavefunction_set_variable
+core.BaseWavefunction.del_variable = _core_wavefunction_del_variable
 
 # removed in v1.10 to reduce API footprint. deprecated 1.4 and no-op since 1.9
 # core.get_variable

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -1902,7 +1902,9 @@ def scf_helper(name, post_scf=True, **kwargs):
     # the FIRST scf call
     if cast:
         # Cast is a special case
-        base_wfn = core.Wavefunction.build(scf_molecule, core.get_global_option('BASIS'))
+        base_wfn = core.BaseWavefunction.build(
+            scf_molecule, core.get_global_option('BASIS'),
+            reference=core.get_option('SCF', 'REFERENCE'))
         core.print_out("\n         ---------------------------------------------------------\n")
         if banner:
             core.print_out("         " + banner.center(58))
@@ -1931,7 +1933,9 @@ def scf_helper(name, post_scf=True, **kwargs):
         core.print_out('\n')
 
     # the SECOND scf call
-    base_wfn = core.Wavefunction.build(scf_molecule, core.get_global_option('BASIS'))
+    base_wfn = core.BaseWavefunction.build(
+        scf_molecule, core.get_global_option('BASIS'),
+        reference=core.get_option('SCF', 'REFERENCE'))
     if banner:
         core.print_out("\n         ---------------------------------------------------------\n")
         core.print_out("         " + banner.center(58))

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -100,30 +100,25 @@ def scf_compute_energy(self):
     return scf_energy
 
 
-def _build_jk(wfn, memory):
-    jk = core.JK.build(wfn.get_basisset("ORBITAL"),
-                       aux=wfn.get_basisset("DF_BASIS_SCF"),
-                       do_wK=wfn.functional().is_x_lrc(),
-                       memory=memory)
-    return jk
-
-
 def initialize_jk(self, memory, jk=None):
 
     functional = self.functional()
     if jk is None:
-        jk = _build_jk(self, memory)
+        jk = self.build_jk(memory)
 
     self.set_jk(jk)
 
     jk.set_print(self.get_print())
     jk.set_memory(memory)
     jk.set_do_K(functional.is_x_hybrid())
-    jk.set_do_wK(functional.is_x_lrc())
-    jk.set_omega(functional.x_omega())
 
-    jk.set_omega_alpha(functional.x_alpha())
-    jk.set_omega_beta(functional.x_beta())
+    # core.ComplexJK does not support any of these yet.
+    if isinstance(jk, core.JK):
+        jk.set_do_wK(functional.is_x_lrc())
+        jk.set_omega(functional.x_omega())
+
+        jk.set_omega_alpha(functional.x_alpha())
+        jk.set_omega_beta(functional.x_beta())
 
     jk.initialize()
     jk.print_header()
@@ -150,12 +145,12 @@ def scf_initialize(self):
 
     # Change allocation for collocation matrices based on DFT type
     initialize_jk_obj = False
-    if isinstance(self.jk(), core.JK):
+    if isinstance(self.jk(), core.BaseJK):
         core.print_out("\nRe-using passed JK object instead of rebuilding\n")
         jk = self.jk()
     else:
         initialize_jk_obj = True
-        jk = _build_jk(self, total_memory)
+        jk = self.build_jk(total_memory)
     jk_size = jk.memory_estimate()
 
     # Give remaining to collocation
@@ -915,15 +910,15 @@ def scf_print_preiterations(self,small=False):
         core.print_out("   -------------------------\n\n")
 
 
-# Bind functions to core.HF class
-core.HF.initialize = scf_initialize
-core.HF.initialize_jk = initialize_jk
-core.HF.iterations = scf_iterate
-core.HF.compute_energy = scf_compute_energy
-core.HF.finalize_energy = scf_finalize_energy
-core.HF.print_energies = scf_print_energies
-core.HF.print_preiterations = scf_print_preiterations
-core.HF.iteration_energies = []
+# Bind functions to core.BaseHF class
+core.BaseHF.initialize = scf_initialize
+core.BaseHF.initialize_jk = initialize_jk
+core.BaseHF.iterations = scf_iterate
+core.BaseHF.compute_energy = scf_compute_energy
+core.BaseHF.finalize_energy = scf_finalize_energy
+core.BaseHF.print_energies = scf_print_energies
+core.BaseHF.print_preiterations = scf_print_preiterations
+core.BaseHF.iteration_energies = []
 
 
 def _converged(e_delta, d_rms, e_conv=None, d_conv=None):
@@ -1082,7 +1077,7 @@ def _validate_soscf():
 
     return enabled
 
-core.HF.validate_diis = _validate_diis
+core.BaseHF.validate_diis = _validate_diis
 
 def efp_field_fn(xyz):
     """Callback function for PylibEFP to compute electric field from electrons

--- a/psi4/src/export_fock.cc
+++ b/psi4/src/export_fock.cc
@@ -46,7 +46,28 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 void export_fock(py::module &m) {
-    py::class_<JK, std::shared_ptr<JK>>(m, "JK", "docstring")
+    py::class_<BaseJK, std::shared_ptr<BaseJK>>(m, "BaseJK", "Shared logistics base for J/K builders")
+        .def("name", &BaseJK::name)
+        .def("basisset", &BaseJK::basisset)
+        .def("set_print", &BaseJK::set_print)
+        .def("set_debug", &BaseJK::set_debug)
+        .def("set_bench", &BaseJK::set_bench)
+        .def("set_cutoff", &BaseJK::set_cutoff)
+        .def("set_memory", &BaseJK::set_memory)
+        .def("set_omp_nthread", &BaseJK::set_omp_nthread)
+        .def("set_do_J", &BaseJK::set_do_J)
+        .def("set_do_K", &BaseJK::set_do_K)
+        .def("initialize", &BaseJK::initialize)
+        .def("compute", &BaseJK::compute)
+        .def("finalize", &BaseJK::finalize)
+        .def("computed_shells_per_iter", py::overload_cast<>(&BaseJK::computed_shells_per_iter),
+             "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during "
+             "each compute call.")
+        .def("computed_shells_per_iter", py::overload_cast<const std::string &>(&BaseJK::computed_shells_per_iter),
+             "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during "
+             "each compute call.");
+
+    py::class_<JK, BaseJK, std::shared_ptr<JK>>(m, "JK", "docstring")
         .def_static("build_JK",
                     [](std::shared_ptr<BasisSet> basis, std::shared_ptr<BasisSet> aux) {
                         return JK::build_JK(basis, aux, Process::environment.options);
@@ -55,16 +76,7 @@ void export_fock(py::module &m) {
                     [](std::shared_ptr<BasisSet> basis, std::shared_ptr<BasisSet> aux, bool do_wK, size_t doubles) {
                         return JK::build_JK(basis, aux, Process::environment.options, do_wK, doubles);
                     })
-        .def("name", &JK::name)
         .def("memory_estimate", &JK::memory_estimate)
-        .def("initialize", &JK::initialize)
-        .def("basisset", &JK::basisset)
-        .def("set_print", &JK::set_print)
-        .def("set_cutoff", &JK::set_cutoff)
-        .def("set_memory", &JK::set_memory)
-        .def("set_omp_nthread", &JK::set_omp_nthread)
-        .def("set_do_J", &JK::set_do_J)
-        .def("set_do_K", &JK::set_do_K)
         .def("set_do_wK", &JK::set_do_wK)
         .def("set_omega", &JK::set_omega, "Dampening term for range separated DFT", "omega"_a)
         .def("get_omega", &JK::get_omega, "Dampening term for range separated DFT")
@@ -74,8 +86,6 @@ void export_fock(py::module &m) {
         .def("get_omega_alpha", &JK::get_omega_alpha, "Weight for HF exchange term in range-separated DFT")
         .def("set_omega_beta", &JK::set_omega_beta, "Weight for dampened exchange term in range-separated DFT", "beta"_a)
         .def("get_omega_beta", &JK::get_omega_beta, "Weight for dampened exchange term in range-separated DFT")
-        .def("compute", &JK::compute)
-        .def("finalize", &JK::finalize)
         .def("C_clear",
              [](JK &jk) {
                  jk.C_left().clear();
@@ -92,8 +102,6 @@ void export_fock(py::module &m) {
         .def("K", &JK::K, py::return_value_policy::reference_internal)
         .def("wK", &JK::wK, py::return_value_policy::reference_internal)
         .def("D", &JK::D, py::return_value_policy::reference_internal)
-        .def("computed_shells_per_iter", py::overload_cast<>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
-        .def("computed_shells_per_iter", py::overload_cast<const std::string&>(&JK::computed_shells_per_iter), "Array containing the number of ERI shell n-lets (triplets, quartets) computed (not screened out) during each compute call.")
         .def("print_header", &JK::print_header, "Prints information about the type and config of the JK object into the output file. Print verbosity may depend on the value of JK::print\\_.");
 
     py::class_<LaplaceDenominator, std::shared_ptr<LaplaceDenominator>>(m, "LaplaceDenominator", "Computer class for a Laplace factorization of the four-index energy denominator in MP2 and coupled-cluster")

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -53,6 +53,7 @@
 #include "psi4/libmints/mintshelper.h"
 #include "psi4/libmints/molecule.h"
 
+#include "psi4/libscf_solver/basehf.h"
 #include "psi4/libscf_solver/hf.h"
 #include "psi4/libscf_solver/rhf.h"
 #include "psi4/libscf_solver/uhf.h"
@@ -82,7 +83,79 @@ using namespace pybind11::literals;
 
 void export_wavefunction(py::module& m) {
     typedef void (Wavefunction::*take_sharedwfn)(SharedWavefunction);
-    py::class_<Wavefunction, std::shared_ptr<Wavefunction>>(m, "Wavefunction", "docstring", py::dynamic_attr())
+
+    py::class_<BaseWavefunction, std::shared_ptr<BaseWavefunction>>(m, "BaseWavefunction",
+                                                                    "Base class for real and complex wavefunctions.",
+                                                                    py::dynamic_attr())
+        .def(py::init<>())
+        .def("molecule", &BaseWavefunction::molecule, "Returns the wavefunction's molecule.")
+        .def("basisset", &BaseWavefunction::basisset, "Returns the current orbital basis.")
+        .def("nfrzc", &BaseWavefunction::nfrzc, "Number of frozen core electrons.")
+        .def("nso", &BaseWavefunction::nso, "Number of symmetry orbitals.")
+        .def("nmo", &BaseWavefunction::nmo, "Number of molecule orbitals.")
+        .def("nirrep", &BaseWavefunction::nirrep, "Number of irreps in the system.")
+        .def("efzc", &BaseWavefunction::efzc, "Returns the frozen-core energy")
+        .def("mintshelper", &BaseWavefunction::mintshelper, "Returns the current MintsHelper object.")
+        .def("sobasisset", &BaseWavefunction::sobasisset, "Returns the symmetry orbitals basis.")
+        .def("get_basisset", &BaseWavefunction::get_basisset, "Returns the requested auxiliary basis.")
+        .def("set_basisset", &BaseWavefunction::set_basisset, "Sets the requested auxiliary basis.")
+        .def("energy", &BaseWavefunction::energy, "Returns the Wavefunction's energy.")
+        .def("options", &BaseWavefunction::options, "Returns the Wavefunction's options object")
+        .def("set_energy", &BaseWavefunction::set_energy,
+             "Sets the Wavefunction's energy. Syncs with Wavefunction's QC variable ``CURRENT ENERGY``.")
+        .def("get_dipole_field_strength", &BaseWavefunction::get_dipole_field_strength,
+             "Returns a vector of length 3, containing the x, y, and z dipole field strengths.")
+        .def("set_name", &BaseWavefunction::set_name, "Sets the level of theory this wavefunction corresponds to.")
+        .def("name", &BaseWavefunction::name, py::return_value_policy::copy,
+             "The level of theory this wavefunction corresponds to.")
+        .def("set_module", &BaseWavefunction::set_module, "module"_a,
+             "Sets name of the last/highest level of theory module (internal or external) touching the wavefunction.")
+        .def("module", &BaseWavefunction::module, py::return_value_policy::copy,
+             "Name of the last/highest level of theory module (internal or external) touching the wavefunction.")
+        .def("nsopi", &BaseWavefunction::nsopi, py::return_value_policy::copy,
+             "Returns the number of symmetry orbitals per irrep.")
+        .def("nmopi", &BaseWavefunction::nmopi, py::return_value_policy::copy,
+             "Returns the number of molecular orbitals per irrep.")
+        .def("frzcpi", &BaseWavefunction::frzcpi, py::return_value_policy::copy,
+             "Returns the number of frozen core orbitals per irrep.")
+        .def("frzvpi", &BaseWavefunction::frzvpi, py::return_value_policy::copy,
+             "Returns the number of frozen virtual orbitals per irrep.")
+        .def("set_print", &BaseWavefunction::set_print, "Sets the print level of the Wavefunction.")
+        .def("get_print", &BaseWavefunction::get_print, "Get the print level of the Wavefunction.")
+        .def("set_external_potential", &BaseWavefunction::set_external_potential, "Sets the requested external potential.")
+        .def("external_pot", &BaseWavefunction::external_pot, "Gets the requested external potential.")
+        .def("has_scalar_variable", &BaseWavefunction::has_scalar_variable,
+             "Is the double QC variable (case-insensitive) set? Prefer :meth:`~psi4.core.Wavefunction.has_variable`.")
+        .def("has_potential_variable", &BaseWavefunction::has_potential_variable,
+             "Is the ExternalPotential QC variable (case-insensitive) set? "
+             "(This function is provisional and might be removed in the future.)")
+        .def("scalar_variable", &BaseWavefunction::scalar_variable,
+             "Returns the requested (case-insensitive) double QC variable. Prefer :meth:`~psi4.core.Wavefunction.variable`.")
+        .def("potential_variable", &BaseWavefunction::potential_variable,
+             "key"_a, "Returns copy of the requested (case-insensitive) ExternalPotential QC variable *key*. "
+             "(This function is provisional and might be removed in the future.)")
+        .def("set_scalar_variable", &BaseWavefunction::set_scalar_variable,
+             "Sets the requested (case-insensitive) double QC variable. Syncs with ``Wavefunction.energy_`` if CURRENT "
+             "ENERGY. Prefer :meth:`~psi4.core.Wavefunction.set_variable`.")
+        .def("set_potential_variable", &BaseWavefunction::set_potential_variable,
+             "Sets the requested (case-insensitive) ExternalPotential QC variable. "
+             "(This function is provisional and might be removed in the future.)")
+        .def("del_scalar_variable", &BaseWavefunction::del_scalar_variable,
+             "Removes the requested (case-insensitive) double QC variable. Prefer :meth:`~psi4.core.Wavefunction.del_variable`.")
+        .def("del_potential_variable", &BaseWavefunction::del_potential_variable,
+             "Removes the requested (case-insensitive) ExternalPotential QC variable. "
+             "(This function is provisional and might be removed in the future.)")
+        .def("scalar_variables", &BaseWavefunction::scalar_variables,
+             "Returns the dictionary of all double QC variables. Prefer :meth:`~psi4.core.Wavefunction.variables`.")
+        .def("potential_variables", &BaseWavefunction::potential_variables, "Returns the dictionary of all ExternalPotential QC variables. "
+             "(This function is provisional and might be removed in the future.)")
+#ifdef USING_PCMSolver
+        .def("set_PCM", &BaseWavefunction::set_PCM, "Set the PCM object")
+        .def("get_PCM", &BaseWavefunction::get_PCM, "Get the PCM object")
+#endif
+        .def("PCM_enabled", &BaseWavefunction::PCM_enabled, "Whether running a PCM calculation");
+
+    py::class_<Wavefunction, std::shared_ptr<Wavefunction>, BaseWavefunction>(m, "Wavefunction", "Real Wavefunction")
         .def(py::init<std::shared_ptr<Molecule>, std::shared_ptr<BasisSet>, Options&>())
         .def(py::init<std::shared_ptr<Molecule>, std::shared_ptr<BasisSet>>())
         .def(py::init<std::shared_ptr<Molecule>, std::shared_ptr<BasisSet>,
@@ -99,13 +172,8 @@ void export_wavefunction(py::module& m) {
         .def("same_a_b_orbs", &Wavefunction::same_a_b_orbs, "Returns true if the alpha and beta orbitals are the same.")
         .def("same_a_b_dens", &Wavefunction::same_a_b_dens,
              "Returns true if the alpha and beta densities are the same.")
-        .def("nfrzc", &Wavefunction::nfrzc, "Number of frozen core electrons.")
         .def("nalpha", &Wavefunction::nalpha, "Number of Alpha electrons.")
         .def("nbeta", &Wavefunction::nbeta, "Number of Beta electrons.")
-        .def("nso", &Wavefunction::nso, "Number of symmetry orbitals.")
-        .def("nmo", &Wavefunction::nmo, "Number of molecule orbitals.")
-        .def("nirrep", &Wavefunction::nirrep, "Number of irreps in the system.")
-        .def("efzc", &Wavefunction::efzc, "Returns the frozen-core energy")
         .def("Ca", &Wavefunction::Ca, "Returns the Alpha Orbitals.")
         .def("Cb", &Wavefunction::Cb, "Returns the Beta Orbitals.")
         .def("Ca_subset", &Wavefunction::Ca_subset, py::return_value_policy::take_ownership, R"pbdoc(
@@ -198,16 +266,7 @@ void export_wavefunction(py::module& m) {
              "Projects a orbital matrix from one basis to another.")
         .def("H", &Wavefunction::H, "Returns the 'Core' Matrix (Potential + Kinetic) Integrals.")
         .def("S", &Wavefunction::S, "Returns the One-electron Overlap Matrix.")
-        .def("mintshelper", &Wavefunction::mintshelper, "Returns the current MintsHelper object.")
         .def("aotoso", &Wavefunction::aotoso, "Returns the Atomic Orbital to Symmetry Orbital transformer.")
-        .def("basisset", &Wavefunction::basisset, "Returns the current orbital basis.")
-        .def("sobasisset", &Wavefunction::sobasisset, "Returns the symmetry orbitals basis.")
-        .def("get_basisset", &Wavefunction::get_basisset, "Returns the requested auxiliary basis.")
-        .def("set_basisset", &Wavefunction::set_basisset, "Sets the requested auxiliary basis.")
-        .def("energy", &Wavefunction::energy, "Returns the Wavefunction's energy.")
-        .def("options", &Wavefunction::options, "Returns the Wavefunction's options object")
-        .def("set_energy", &Wavefunction::set_energy,
-             "Sets the Wavefunction's energy. Syncs with Wavefunction's QC variable ``CURRENT ENERGY``.")
         .def("gradient", &Wavefunction::gradient, "Returns the Wavefunction's gradient.")
         .def("set_gradient", &Wavefunction::set_gradient,
              "Sets the Wavefunction's gradient. Syncs with Wavefunction's QC variable ``CURRENT GRADIENT``.")
@@ -219,15 +278,6 @@ void export_wavefunction(py::module& m) {
         .def("no_occupations", &Wavefunction::get_no_occupations,
              "returns the natural orbital occupations on the wavefunction.")
         .def("atomic_point_charges", &Wavefunction::get_atomic_point_charges, "Returns the set atomic point charges.")
-        .def("get_dipole_field_strength", &Wavefunction::get_dipole_field_strength,
-             "Returns a vector of length 3, containing the x, y, and z dipole field strengths.")
-        .def("set_name", &Wavefunction::set_name, "Sets the level of theory this wavefunction corresponds to.")
-        .def("name", &Wavefunction::name, py::return_value_policy::copy,
-             "The level of theory this wavefunction corresponds to.")
-        .def("set_module", &Wavefunction::set_module, "module"_a,
-             "Sets name of the last/highest level of theory module (internal or external) touching the wavefunction.")
-        .def("module", &Wavefunction::module, py::return_value_policy::copy,
-             "Name of the last/highest level of theory module (internal or external) touching the wavefunction.")
         .def("alpha_orbital_space", &Wavefunction::alpha_orbital_space, "id"_a, "basis"_a, "subset"_a, R"pbdoc(
             Creates OrbitalSpace with information about the requested alpha orbital space.
 
@@ -248,7 +298,6 @@ void export_wavefunction(py::module& m) {
                 Information on *subset* alpha orbitals.
             )pbdoc")
         .def("beta_orbital_space", &Wavefunction::beta_orbital_space, "docstring")
-        .def("molecule", &Wavefunction::molecule, "Returns the Wavefunction's molecule.")
         .def("doccpi", &Wavefunction::doccpi, py::return_value_policy::copy, "assume_socc_alpha"_a = true,
              "Returns the number of doubly occupied orbitals per irrep.")
         .def("force_occpi", &Wavefunction::force_occpi,
@@ -256,81 +305,67 @@ void export_wavefunction(py::module& m) {
              "results in inconsistent Wavefunction objects for SCF, so caution is advised.")
         .def("soccpi", &Wavefunction::soccpi, py::return_value_policy::copy, "assume_socc_alpha"_a = true,
              "Returns the number of singly occupied orbitals per irrep.")
-        .def("nsopi", &Wavefunction::nsopi, py::return_value_policy::copy,
-             "Returns the number of symmetry orbitals per irrep.")
-        .def("nmopi", &Wavefunction::nmopi, py::return_value_policy::copy,
-             "Returns the number of molecular orbitals per irrep.")
         .def("nalphapi", &Wavefunction::nalphapi, py::return_value_policy::copy,
              "Returns the number of alpha orbitals per irrep.")
         .def("nbetapi", &Wavefunction::nbetapi, py::return_value_policy::copy,
              "Returns the number of beta orbitals per irrep.")
-        .def("frzcpi", &Wavefunction::frzcpi, py::return_value_policy::copy,
-             "Returns the number of frozen core orbitals per irrep.")
-        .def("frzvpi", &Wavefunction::frzvpi, py::return_value_policy::copy,
-             "Returns the number of frozen virtual orbitals per irrep.")
-        .def("set_print", &Wavefunction::set_print, "Sets the print level of the Wavefunction.")
-        .def("get_print", &Wavefunction::get_print, "Get the print level of the Wavefunction.")
         .def("compute_energy", &Wavefunction::compute_energy, "Computes the energy of the Wavefunction.")
         .def("compute_gradient", &Wavefunction::compute_gradient, "Computes the gradient of the Wavefunction")
         .def("compute_hessian", &Wavefunction::compute_hessian, "Computes the Hessian of the Wavefunction.")
-        .def("set_external_potential", &Wavefunction::set_external_potential, "Sets the requested external potential.")
-        .def("external_pot", &Wavefunction::external_pot, "Gets the requested external potential.")
-        .def("has_scalar_variable", &Wavefunction::has_scalar_variable,
-             "Is the double QC variable (case-insensitive) set? Prefer :meth:`~psi4.core.Wavefunction.has_variable`.")
         .def("has_array_variable", &Wavefunction::has_array_variable,
              "Is the Matrix QC variable (case-insensitive) set? Prefer :meth:`~psi4.core.Wavefunction.has_variable`.")
-        .def("has_potential_variable", &Wavefunction::has_potential_variable,
-             "Is the ExternalPotential QC variable (case-insensitive) set? "
-             "(This function is provisional and might be removed in the future.)")
-        .def("scalar_variable", &Wavefunction::scalar_variable,
-             "Returns the requested (case-insensitive) double QC variable. Prefer :meth:`~psi4.core.Wavefunction.variable`.")
         .def("array_variable", &Wavefunction::array_variable,
              "Returns copy of the requested (case-insensitive) Matrix QC variable. Prefer :meth:`~psi4.core.Wavefunction.variable`.")
-        .def("potential_variable", &Wavefunction::potential_variable,
-             "key"_a, "Returns copy of the requested (case-insensitive) ExternalPotential QC variable *key*. "
-             "(This function is provisional and might be removed in the future.)")
-        .def("set_scalar_variable", &Wavefunction::set_scalar_variable,
-             "Sets the requested (case-insensitive) double QC variable. Syncs with ``Wavefunction.energy_`` if CURRENT "
-             "ENERGY. Prefer :meth:`~psi4.core.Wavefunction.set_variable`.")
         .def("set_array_variable", &Wavefunction::set_array_variable,
              "Sets the requested (case-insensitive) Matrix QC variable. Syncs with ``Wavefunction.gradient_`` or "
              "``hessian_`` if CURRENT GRADIENT or HESSIAN. Prefer :meth:`~psi4.core.Wavefunction.set_variable`.")
-        .def("set_potential_variable", &Wavefunction::set_potential_variable,
-             "Sets the requested (case-insensitive) ExternalPotential QC variable. "
-             "(This function is provisional and might be removed in the future.)")
-        .def("del_scalar_variable", &Wavefunction::del_scalar_variable,
-             "Removes the requested (case-insensitive) double QC variable. Prefer :meth:`~psi4.core.Wavefunction.del_variable`.")
         .def("del_array_variable", &Wavefunction::del_array_variable,
              "Removes the requested (case-insensitive) Matrix QC variable. Prefer :meth:`~psi4.core.Wavefunction.del_variable`.")
-        .def("del_potential_variable", &Wavefunction::del_potential_variable,
-             "Removes the requested (case-insensitive) ExternalPotential QC variable. "
-             "(This function is provisional and might be removed in the future.)")
-        .def("scalar_variables", &Wavefunction::scalar_variables,
-             "Returns the dictionary of all double QC variables. Prefer :meth:`~psi4.core.Wavefunction.variables`.")
         .def("array_variables", &Wavefunction::array_variables,
              "Returns the dictionary of all Matrix QC variables. Prefer :meth:`~psi4.core.Wavefunction.variables`.")
-        .def("potential_variables", &Wavefunction::potential_variables, "Returns the dictionary of all ExternalPotential QC variables. "
-             "(This function is provisional and might be removed in the future.)")
-
-#ifdef USING_PCMSolver
-        .def("set_PCM", &Wavefunction::set_PCM, "Set the PCM object")
-        .def("get_PCM", &Wavefunction::get_PCM, "Get the PCM object")
-#endif
-        .def("PCM_enabled", &Wavefunction::PCM_enabled, "Whether running a PCM calculation")
         .def("get_density", [](Wavefunction& wfn, std::string name) {return wfn.density_map_[name] ;}, "Experimental!");
 
-    py::class_<scf::HF, std::shared_ptr<scf::HF>, Wavefunction>(m, "HF", "docstring")
-        .def("compute_fvpi", &scf::HF::compute_fvpi, "Update number of frozen virtuals")
-        .def("form_C", &scf::HF::form_C, "Forms the Orbital Matrices from the current Fock Matrices.", "shift"_a = 0.0)
-        .def("form_initial_C", &scf::HF::form_initial_C,
+
+    py::class_<scf::BaseHF, std::shared_ptr<scf::BaseHF>>(m, "BaseHF",
+                                                          "Shared SCF-loop state for real and complex Hartree–Fock.")
+        .def("form_C", &scf::BaseHF::form_C, "Forms the Orbital Matrices from the current Fock Matrices.", "shift"_a = 0.0)
+        .def("form_initial_C", &scf::BaseHF::form_initial_C,
              "Forms the initial Orbital Matrices from the current Fock Matrices.")
-        .def("form_D", &scf::HF::form_D, "Forms the Density Matrices from the current Orbitals Matrices")
-        .def("form_V", &scf::HF::form_V, "Form the Kohn-Sham Potential Matrices from the current Density Matrices")
-        .def("form_G", &scf::HF::form_G, "Forms the G matrix.")
-        .def("form_F", &scf::HF::form_F, "Forms the F matrix.")
-        .def("form_initial_F", &scf::HF::form_initial_F, "Forms the initial F matrix.")
-        .def("form_H", &scf::HF::form_H, "Forms the core Hamiltonian")
-        .def("form_Shalf", &scf::HF::form_Shalf, "Forms the S^1/2 matrix")
+        .def("form_D", &scf::BaseHF::form_D, "Forms the Density Matrices from the current Orbitals Matrices")
+        .def("form_V", &scf::BaseHF::form_V, "Form the Kohn-Sham Potential Matrices from the current Density Matrices")
+        .def("form_G", &scf::BaseHF::form_G, "Forms the G matrix.")
+        .def("form_F", &scf::BaseHF::form_F, "Forms the F matrix.")
+        .def("form_initial_F", &scf::BaseHF::form_initial_F, "Forms the initial F matrix.")
+        .def("form_H", &scf::BaseHF::form_H, "Forms the core Hamiltonian")
+        .def("form_Shalf", &scf::BaseHF::form_Shalf, "Forms the S^1/2 matrix")
+        .def("compute_initial_E", &scf::BaseHF::compute_initial_E, "Compute initial energy (nuclear + Tr(HD)).")
+        .def("compute_E", &scf::BaseHF::compute_E, "Compute total energy for the iteration.")
+        .def("get_energies", &scf::BaseHF::get_energies, "docstring")
+        .def("set_energies", &scf::BaseHF::set_energies, "docstring")
+        .def("print_orbitals", &scf::BaseHF::print_orbitals, "docstring")
+        .def("functional", &scf::BaseHF::functional, "Returns the internal DFT Superfunctional.")
+        .def("scf_type", &scf::BaseHF::scf_type, "Return the value of scf_type used in the SCF computation.")
+        .def_property("reset_occ_", &scf::BaseHF::reset_occ, &scf::BaseHF::set_reset_occ,
+                      "Do reset the occupation after the guess to the inital occupation.")
+        .def_property("sad_", &scf::BaseHF::sad, &scf::BaseHF::set_sad,
+                      "Do assume a non-idempotent density matrix and no orbitals after the guess.")
+        .def_property("diis_manager_", &scf::BaseHF::diis_manager, &scf::BaseHF::set_diis_manager, "The DIIS object.")
+        .def_property("initialized_diis_manager_", &scf::BaseHF::initialized_diis_manager,
+                      &scf::BaseHF::set_initialized_diis_manager, "Has the DIIS object been initialized?")
+        .def_property("iteration_", &scf::BaseHF::iteration, &scf::BaseHF::set_iteration,
+                      "Internal iterator for SCF cycles. After completion, this equals the number of iterations taken "
+                      "to converge the SCF equations.")
+        .def_property("diis_enabled_", &scf::BaseHF::diis_enabled, &scf::BaseHF::set_diis_enabled, "docstring")
+        .def_property("diis_start_", &scf::BaseHF::diis_start, &scf::BaseHF::set_diis_start, "docstring")
+        .def_property("MOM_excited_", &scf::BaseHF::MOM_excited, &scf::BaseHF::set_MOM_excited,
+                      "Are we to do excited-state MOM?")
+        .def_property("MOM_performed_", &scf::BaseHF::MOM_performed, &scf::BaseHF::set_MOM_performed,
+                      "MOM performed current iteration?")
+        .def_property("attempt_number_", &scf::BaseHF::attempt_number, &scf::BaseHF::set_attempt_number,
+                      "Current macroiteration (1-indexed) for stability analysis");
+
+    py::class_<scf::HF, scf::BaseHF, Wavefunction, std::shared_ptr<scf::HF>>(m, "HF", py::multiple_inheritance(), "docstring")
+        .def("compute_fvpi", &scf::HF::compute_fvpi, "Update number of frozen virtuals")
         .def("form_FDSmSDF", &scf::HF::form_FDSmSDF, "Forms the residual of SCF theory")
         .def("guess", &scf::HF::guess, "Forms the guess (guarantees C, D, and E)")
         .def("initialize_gtfock_jk", &scf::HF::initialize_gtfock_jk, "Sets up a GTFock JK object")
@@ -342,58 +377,36 @@ void export_wavefunction(py::module& m) {
         .def("cphf_converged", &scf::HF::cphf_converged, "Adds occupied guess alpha orbitals.")
         .def("guess_Ca", &scf::HF::guess_Ca, "Sets the guess Alpha Orbital Matrix")
         .def("guess_Cb", &scf::HF::guess_Cb, "Sets the guess Beta Orbital Matrix")
-        .def_property("reset_occ_", &scf::HF::reset_occ, &scf::HF::set_reset_occ,
-                      "Do reset the occupation after the guess to the inital occupation.")
-        .def_property("sad_", &scf::HF::sad, &scf::HF::set_sad,
-                      "Do assume a non-idempotent density matrix and no orbitals after the guess.")
         .def("set_sad_basissets", &scf::HF::set_sad_basissets, "Sets the Superposition of Atomic Densities basisset.")
         .def("set_sad_fitting_basissets", &scf::HF::set_sad_fitting_basissets,
              "Sets the Superposition of Atomic Densities density-fitted basisset.")
         .def("Va", &scf::HF::Va, "Returns the Alpha Kohn-Sham Potential Matrix.")
         .def("Vb", &scf::HF::Vb, "Returns the Beta Kohn-Sham Potential Matrix.")
-        .def("jk", &scf::HF::jk, "Returns the internal JK object.")
-        .def("set_jk", &scf::HF::set_jk, "Sets the internal JK object !expert.")
-        .def("functional", &scf::HF::functional, "Returns the internal DFT Superfunctional.")
         .def("V_potential", &scf::HF::V_potential, "Returns the internal DFT V object.")
         .def("finalize", &scf::HF::finalize, "Cleans up the the Wavefunction's temporary data.")
         .def("soscf_update", &scf::HF::soscf_update, "Computes a second-order SCF update.")
         .def("occupation_a", &scf::HF::occupation_a, "Returns the Alpha occupation numbers.")
         .def("occupation_b", &scf::HF::occupation_b, "Returns the Beta occupation numbers.")
         .def("reset_occupation", &scf::HF::reset_occupation, "docstring")
-        .def("compute_E", &scf::HF::compute_E, "docstring")
-        .def("compute_initial_E", &scf::HF::compute_initial_E, "docstring")
         .def("rotate_orbitals", &scf::HF::rotate_orbitals, "docstring")
         .def("save_density_and_energy", &scf::HF::save_density_and_energy, "docstring")
         .def("compute_orbital_gradient", &scf::HF::compute_orbital_gradient, "docstring")
         .def("find_occupation", &scf::HF::find_occupation, "docstring")
         .def("diis", &scf::HF::diis, "docstring")
-        .def_property("diis_manager_", &scf::HF::diis_manager, &scf::HF::set_diis_manager, "The DIIS object.")
-        .def_property("initialized_diis_manager_", &scf::HF::initialized_diis_manager,
-                      &scf::HF::set_initialized_diis_manager, "Has the DIIS object been initialized?")
         .def("damping_update", &scf::HF::damping_update, "docstring")
         .def("check_phases", &scf::HF::check_phases, "docstring")
-        .def("print_orbitals", &scf::HF::print_orbitals, "docstring")
         .def("print_header", &scf::HF::print_header, "docstring")
-        .def("get_energies", &scf::HF::get_energies, "docstring")
-        .def("set_energies", &scf::HF::set_energies, "docstring")
-        .def("scf_type", &scf::HF::scf_type, "Return the value of scf_type used in the SCF computation.")
         .def("clear_external_potentials", &scf::HF::clear_external_potentials, "Clear private external_potentials list")
         .def("push_back_external_potential", &scf::HF::push_back_external_potential,
              "Add an external potential to the private external_potentials list", "V"_a)
         .def("set_external_cpscf_perturbation", &scf::HF::set_external_cpscf_perturbation,
              "Add an external potential/perturbation to the private external_cpscf_perturbations map for CPSCF", "name"_a, "function"_a)
         .def("clear_external_cpscf_perturbations", &scf::HF::clear_external_cpscf_perturbations, "Clear private external_cpscf_perturbations map")
-        .def_property("iteration_", &scf::HF::iteration, &scf::HF::set_iteration, "Internal iterator for SCF cycles. After completion, this equals the number of iterations taken to converge the SCF equations.")
-        .def_property("diis_enabled_", &scf::HF::diis_enabled, &scf::HF::set_diis_enabled, "docstring")
-        .def_property("diis_start_", &scf::HF::diis_start, &scf::HF::set_diis_start, "docstring")
+        .def("jk", &scf::HF::jk, "Returns the internal JK object.")
+        .def("set_jk", &scf::HF::set_jk, "Sets the internal JK object !expert.")
+        .def("build_jk", [](scf::HF& self, double memory) { return self.build_jk(static_cast<size_t>(memory)); }, "Returns a fresh JK object with correct type.")
         .def_property("frac_performed_", &scf::HF::frac_performed, &scf::HF::set_frac_performed,
                       "Frac performed current iteration?")
-        .def_property("MOM_excited_", &scf::HF::MOM_excited, &scf::HF::set_MOM_excited,
-                      "Are we to do excited-state MOM?")
-        .def_property("MOM_performed_", &scf::HF::MOM_performed, &scf::HF::set_MOM_performed,
-                      "MOM performed current iteration?")
-        .def_property("attempt_number_", &scf::HF::attempt_number, &scf::HF::set_attempt_number,
-                      "Current macroiteration (1-indexed) for stability analysis")
         .def("stability_analysis", &scf::HF::stability_analysis, "Assess wfn stability and correct if requested")
         .def("frac_renormalize", &scf::HF::frac_renormalize, "docstring")
         .def("compute_spin_contamination", &scf::HF::compute_spin_contamination, "docstring")

--- a/psi4/src/export_wavefunction.cc
+++ b/psi4/src/export_wavefunction.cc
@@ -125,28 +125,28 @@ void export_wavefunction(py::module& m) {
         .def("set_external_potential", &BaseWavefunction::set_external_potential, "Sets the requested external potential.")
         .def("external_pot", &BaseWavefunction::external_pot, "Gets the requested external potential.")
         .def("has_scalar_variable", &BaseWavefunction::has_scalar_variable,
-             "Is the double QC variable (case-insensitive) set? Prefer :meth:`~psi4.core.Wavefunction.has_variable`.")
+             "Is the double QC variable (case-insensitive) set? Prefer :meth:`~psi4.core.BaseWavefunction.has_variable`.")
         .def("has_potential_variable", &BaseWavefunction::has_potential_variable,
              "Is the ExternalPotential QC variable (case-insensitive) set? "
              "(This function is provisional and might be removed in the future.)")
         .def("scalar_variable", &BaseWavefunction::scalar_variable,
-             "Returns the requested (case-insensitive) double QC variable. Prefer :meth:`~psi4.core.Wavefunction.variable`.")
+             "Returns the requested (case-insensitive) double QC variable. Prefer :meth:`~psi4.core.BaseWavefunction.variable`.")
         .def("potential_variable", &BaseWavefunction::potential_variable,
              "key"_a, "Returns copy of the requested (case-insensitive) ExternalPotential QC variable *key*. "
              "(This function is provisional and might be removed in the future.)")
         .def("set_scalar_variable", &BaseWavefunction::set_scalar_variable,
              "Sets the requested (case-insensitive) double QC variable. Syncs with ``Wavefunction.energy_`` if CURRENT "
-             "ENERGY. Prefer :meth:`~psi4.core.Wavefunction.set_variable`.")
+             "ENERGY. Prefer :meth:`~psi4.core.BaseWavefunction.set_variable`.")
         .def("set_potential_variable", &BaseWavefunction::set_potential_variable,
              "Sets the requested (case-insensitive) ExternalPotential QC variable. "
              "(This function is provisional and might be removed in the future.)")
         .def("del_scalar_variable", &BaseWavefunction::del_scalar_variable,
-             "Removes the requested (case-insensitive) double QC variable. Prefer :meth:`~psi4.core.Wavefunction.del_variable`.")
+             "Removes the requested (case-insensitive) double QC variable. Prefer :meth:`~psi4.core.BaseWavefunction.del_variable`.")
         .def("del_potential_variable", &BaseWavefunction::del_potential_variable,
              "Removes the requested (case-insensitive) ExternalPotential QC variable. "
              "(This function is provisional and might be removed in the future.)")
         .def("scalar_variables", &BaseWavefunction::scalar_variables,
-             "Returns the dictionary of all double QC variables. Prefer :meth:`~psi4.core.Wavefunction.variables`.")
+             "Returns the dictionary of all double QC variables. Prefer :meth:`~psi4.core.BaseWavefunction.variables`.")
         .def("potential_variables", &BaseWavefunction::potential_variables, "Returns the dictionary of all ExternalPotential QC variables. "
              "(This function is provisional and might be removed in the future.)")
 #ifdef USING_PCMSolver
@@ -313,16 +313,16 @@ void export_wavefunction(py::module& m) {
         .def("compute_gradient", &Wavefunction::compute_gradient, "Computes the gradient of the Wavefunction")
         .def("compute_hessian", &Wavefunction::compute_hessian, "Computes the Hessian of the Wavefunction.")
         .def("has_array_variable", &Wavefunction::has_array_variable,
-             "Is the Matrix QC variable (case-insensitive) set? Prefer :meth:`~psi4.core.Wavefunction.has_variable`.")
+             "Is the Matrix QC variable (case-insensitive) set? Prefer :meth:`~psi4.core.BaseWavefunction.has_variable`.")
         .def("array_variable", &Wavefunction::array_variable,
-             "Returns copy of the requested (case-insensitive) Matrix QC variable. Prefer :meth:`~psi4.core.Wavefunction.variable`.")
+             "Returns copy of the requested (case-insensitive) Matrix QC variable. Prefer :meth:`~psi4.core.BaseWavefunction.variable`.")
         .def("set_array_variable", &Wavefunction::set_array_variable,
              "Sets the requested (case-insensitive) Matrix QC variable. Syncs with ``Wavefunction.gradient_`` or "
-             "``hessian_`` if CURRENT GRADIENT or HESSIAN. Prefer :meth:`~psi4.core.Wavefunction.set_variable`.")
+             "``hessian_`` if CURRENT GRADIENT or HESSIAN. Prefer :meth:`~psi4.core.BaseWavefunction.set_variable`.")
         .def("del_array_variable", &Wavefunction::del_array_variable,
-             "Removes the requested (case-insensitive) Matrix QC variable. Prefer :meth:`~psi4.core.Wavefunction.del_variable`.")
+             "Removes the requested (case-insensitive) Matrix QC variable. Prefer :meth:`~psi4.core.BaseWavefunction.del_variable`.")
         .def("array_variables", &Wavefunction::array_variables,
-             "Returns the dictionary of all Matrix QC variables. Prefer :meth:`~psi4.core.Wavefunction.variables`.")
+             "Returns the dictionary of all Matrix QC variables. Prefer :meth:`~psi4.core.BaseWavefunction.variables`.")
         .def("get_density", [](Wavefunction& wfn, std::string name) {return wfn.density_map_[name] ;}, "Experimental!");
 
 

--- a/psi4/src/psi4/libfock/CMakeLists.txt
+++ b/psi4/src/psi4/libfock/CMakeLists.txt
@@ -16,6 +16,7 @@ list(APPEND sources
   apps.cc
   cubature.cc
   hamiltonian.cc
+  basejk.cc
   jk.cc
   points.cc
   sap.cc

--- a/psi4/src/psi4/libfock/basejk.cc
+++ b/psi4/src/psi4/libfock/basejk.cc
@@ -1,0 +1,84 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include "psi4/libfock/basejk.h"
+
+#include "psi4/libmints/basisset.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/process.h"
+
+namespace psi {
+
+BaseJK::BaseJK(std::shared_ptr<BasisSet> primary) : primary_(primary) { init_knobs(); }
+
+void BaseJK::init_knobs() {
+    print_ = 1;
+    debug_ = 0;
+    bench_ = 0;
+
+    // 256 MB default
+    memory_ = 32000000L;
+    omp_nthread_ = 1;
+#ifdef _OPENMP
+    omp_nthread_ = Process::environment.get_n_threads();
+#endif
+    cutoff_ = 1.0E-12;
+
+    do_J_ = true;
+    do_K_ = true;
+    lr_symmetric_ = false;
+
+    num_computed_shells_ = 0L;
+    computed_shells_per_iter_ = {};
+}
+
+void BaseJK::common_init() {}
+
+void BaseJK::allocate_JK() { throw PSIEXCEPTION("allocate_JK not available for this JK type."); }
+
+const std::unordered_map<std::string, std::vector<size_t>>& BaseJK::computed_shells_per_iter() {
+    return computed_shells_per_iter_;
+}
+
+const std::vector<size_t>& BaseJK::computed_shells_per_iter(const std::string& n_let) {
+    return computed_shells_per_iter_[n_let];
+}
+
+size_t BaseJK::num_computed_shells() {
+    outfile->Printf(
+        "WARNING: BaseJK::num_computed_shells() was called, but benchmarking is disabled for the chosen JK algorithm.");
+    outfile->Printf(" Returning 0 as computed shells count.\n");
+
+    return 0;
+}
+
+void BaseJK::initialize() { preiterations(); }
+
+void BaseJK::finalize() { postiterations(); }
+
+}  // namespace psi

--- a/psi4/src/psi4/libfock/basejk.h
+++ b/psi4/src/psi4/libfock/basejk.h
@@ -1,0 +1,242 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#ifndef libmints_basejk_h
+#define libmints_basejk_h
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "psi4/pragma.h"
+#include "psi4/libpsi4util/exception.h"
+
+namespace psi {
+
+class BasisSet;
+
+/**
+ * Class BaseJK
+ *
+ * Shared logistics base for real (JK) and complex (ComplexJK) Fock builders.
+ * Holds print/debug/memory/cutoff/do_J/do_K knobs and related accessors that
+ * are independent of Matrix vs ComplexMatrix storage.
+ */
+class PSI_API BaseJK {
+   protected:
+    // => Utility Variables <= //
+
+    /// Print flag, defaults to 1
+    int print_;
+    /// Debug flag, defaults to 0
+    int debug_;
+    /// Bench flag, defaults to 0
+    int bench_;
+    /// Memory available, in doubles, defaults to 256 MB (32 M doubles)
+    size_t memory_;
+    /// Number of OpenMP threads (defaults to 1 in no OpenMP, Process::environment.get_n_threads() otherwise)
+    int omp_nthread_;
+    /// Integral cutoff (defaults to 0.0)
+    double cutoff_;
+    /// Number of ERI shell quartets computed, i.e., not screened out
+    size_t num_computed_shells_;
+    /// Tally of ERI shell n-lets (triplets, quartets) computed per SCF iteration
+    std::unordered_map<std::string, std::vector<size_t>> computed_shells_per_iter_;
+
+    // => Tasks <= //
+
+    /// Do J matrices? Defaults to true
+    bool do_J_;
+    /// Do K matrices? Defaults to true
+    bool do_K_;
+
+    /// Left-right symmetric? Determined in each call of compute()
+    bool lr_symmetric_;
+
+    /// Primary basis set
+    std::shared_ptr<BasisSet> primary_;
+
+    // => Per-Iteration Setup/Finalize Routines <= //
+
+    /// Build the pseudo-density D_, before compute_JK()
+    virtual void compute_D() = 0;
+    /// Transform current C_left_/C_right_/D_ to C_left_ao_/C_right_ao_/D_ao_, before compute_JK()
+    virtual void USO2AO() { throw PSIEXCEPTION("USO2AO not available for this JK type."); }
+    /// Transform finished J_ao_/K_ao_ to J_/K_, after compute_JK()
+    virtual void AO2USO() { throw PSIEXCEPTION("AO2USO not available for this JK type."); }
+    /// Allocate J_/K_
+    virtual void allocate_JK();
+
+    /**
+     *  Function that sets a number of flags and allocates memory
+     *  and sets up AO2USO.
+     *
+     *  Important note: no other memory is allocated here. That
+     *  needs to be done in your derived class' constructor!!!!
+     *
+     *  Warning: this function is currently shadowed in at least
+     *  one derived class, use with care!!!!!
+     *
+     */
+    virtual void common_init();
+
+    // => Required Algorithm-Specific Methods <= //
+
+    /// Setup integrals, files, etc
+    virtual void preiterations() = 0;
+    /// Compute J/K for current C/D
+    virtual void compute_JK() = 0;
+    /// Delete integrals, files, etc
+    virtual void postiterations() = 0;
+
+    // => Helper Routines <= //
+
+    /**
+     * Return number of ERI shell quartets computed during the JK build process.
+     */
+    virtual size_t num_computed_shells();
+
+    /// Initialize logistics knobs to defaults
+    void init_knobs();
+
+   public:
+    /**
+     * @param primary primary basis set for this system.
+     */
+    BaseJK(std::shared_ptr<BasisSet> primary);
+
+    /// Overriden by subclasses of JK/ComplexJK
+    // TODO: investigate if JK::memory_estimate and all of its derived variants could be made const
+    // Probably requires refactoring DFHelper and MemDFJK first.
+    virtual size_t memory_estimate() = 0;
+
+    /// Destructor
+    virtual ~BaseJK() = default;
+
+    /// Do we need to backtransform to C1 under the hood?
+    virtual bool C1() const = 0;
+    virtual std::string name() = 0;
+
+    // => Knobs <= //
+
+    /**
+     * Cutoff for individual contributions to the J/K matrices
+     * Eventually we hope to use Schwarz/MBIE/Density cutoffs,
+     * for now just Schwarz
+     * @param cutoff ceiling of magnitude of elements to be
+     *        ignored if possible
+     */
+    virtual void set_cutoff(double cutoff) { cutoff_ = cutoff; }
+    double get_cutoff() const { return cutoff_; }
+    /**
+     * Maximum memory to use, in doubles (for tensor-based methods,
+     * integral generation objects typically ignore this)
+     * @param memory maximum number of doubles to allocate
+     */
+    void set_memory(size_t memory) { memory_ = memory; }
+    /**
+     * Maximum number of OpenMP threads to use. It may be necessary
+     * to clamp this to some value smaller than the total number of
+     * cores for machines with a high core-to-memory ratio to avoid
+     * running out of memory due to integral generation objects
+     * @param omp_nthread Maximum number of threads to use in
+     *        integral generation objects (BLAS/LAPACK can still
+     *        run with their original maximum number)
+     */
+    void set_omp_nthread(int omp_nthread) { omp_nthread_ = omp_nthread; }
+    int get_omp_nthread() const { return omp_nthread_; }
+
+    /// Print flag (defaults to 1)
+    void set_print(int print) { print_ = print; }
+    /// Debug flag (defaults to 0)
+    void set_debug(int debug) { debug_ = debug; }
+    /// Bench flag (defaults to 0)
+    void set_bench(int bench) { bench_ = bench; }
+    int get_bench() const { return bench_; }
+    /**
+     * Set to do J tasks
+     * @param do_J do J matrices or not,
+     *        defaults to true
+     */
+    void set_do_J(bool do_J) { do_J_ = do_J; }
+    /**
+     * Set to do K tasks
+     * @param do_K do K matrices or not,
+     *        defaults to true
+     */
+    virtual void set_do_K(bool do_K) { do_K_ = do_K; }
+
+    // => Computers <= //
+
+    /**
+     * Initialize the integral technology.
+     * MUST be called AFTER setting knobs
+     * but BEFORE first call of compute()
+     */
+    void initialize();
+    /**
+     * Compute D/J/K for the current C
+     * Update values in your reference to
+     * C_left/C_right BEFORE calling this,
+     * renew your references to the matrices
+     * in D/J/K AFTER calling this.
+     */
+    virtual void compute() = 0;
+    /**
+     * Method to clear off memory without
+     * totally destroying the object. The
+     * object can be rebuilt later by calling
+     * initialize()
+     */
+    void finalize();
+
+    // => Accessors <= //
+
+    /**
+     * Returns the internal primary basis set.
+     */
+    std::shared_ptr<BasisSet> basisset() { return primary_; }
+
+    /**
+     * Return number of ERI shell n-lets (triplets, quartets) computed per SCF iteration during the JK build process.
+     */
+    const std::unordered_map<std::string, std::vector<size_t>>& computed_shells_per_iter();
+    const std::vector<size_t>& computed_shells_per_iter(const std::string& n_let);
+
+    /**
+     * Print header information regarding ComplexJK
+     * type on output file
+     */
+    virtual void print_header() const = 0;
+};
+
+}  // namespace psi
+
+#endif

--- a/psi4/src/psi4/libfock/jk.cc
+++ b/psi4/src/psi4/libfock/jk.cc
@@ -67,7 +67,7 @@ void _set_dfjk_options(std::shared_ptr<T> jk, Options& options) {
         jk->set_df_ints_num_threads(options.get_int("DF_INTS_NUM_THREADS"));
 }
 
-JK::JK(std::shared_ptr<BasisSet> primary) : primary_(primary) { common_init(); }
+JK::JK(std::shared_ptr<BasisSet> primary) : BaseJK(primary) { common_init(); }
 JK::~JK() {}
 std::shared_ptr<JK> JK::build_JK(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary,
                                  Options& options, std::string jk_type) {
@@ -236,39 +236,14 @@ SharedVector JK::iaia(SharedMatrix /*Ci*/, SharedMatrix /*Ca*/) {
     throw PSIEXCEPTION("JK: (ia|ia) integrals not implemented");
 }
 
-const std::unordered_map<std::string, std::vector<size_t> >& JK::computed_shells_per_iter() {
-    return computed_shells_per_iter_;
-}
-
-const std::vector<size_t>& JK::computed_shells_per_iter(const std::string& n_let) {
-    return computed_shells_per_iter_[n_let];
-}
-
 void JK::common_init() {
-    print_ = 1;
-    debug_ = 0;
-    bench_ = 0;
-
-    // 256 MB default
-    memory_ = 32000000L;
-    omp_nthread_ = 1;
-#ifdef _OPENMP
-    omp_nthread_ = Process::environment.get_n_threads();
-#endif
-    cutoff_ = 1.0E-12;
     do_csam_ = false;
 
-    do_J_ = true;
-    do_K_ = true;
     do_wK_ = false;
     wcombine_ = false;
-    lr_symmetric_ = false;
     omega_ = 0.0;
     omega_alpha_ = 1.0;
     omega_beta_ = 0.0;
-
-    num_computed_shells_ = 0L;
-    computed_shells_per_iter_ = {};
 
     std::shared_ptr<IntegralFactory> integral =
         std::make_shared<IntegralFactory>(primary_, primary_, primary_, primary_);
@@ -590,8 +565,6 @@ void JK::AO2USO() {
     }
     delete[] temp;
 }
-void JK::initialize() { preiterations(); }
-
 void JK::compute() {
     // Is this density symmetric?
     if (C_left_.size() && !C_right_.size()) {
@@ -702,12 +675,4 @@ void JK::zero() {
     }
 }
 
-size_t JK::num_computed_shells() {
-    outfile->Printf("WARNING: JK::num_computed_shells() was called, but benchmarking is disabled for the chosen JK algorithm.");
-    outfile->Printf(" Returning 0 as computed shells count.\n");
-
-    return 0;
-}
-
-void JK::finalize() { postiterations(); }
 }  // namespace psi

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -40,6 +40,7 @@ PRAGMA_WARNING_POP
 #include "psi4/libmints/typedefs.h"
 #include "psi4/libmints/dimension.h"
 
+#include "psi4/libfock/basejk.h"
 #include "psi4/libfock/SplitJK.h"
 
 namespace psi {
@@ -229,37 +230,17 @@ class PKManager;
  *
  *
  */
-class PSI_API JK {
+class PSI_API JK : public BaseJK {
    protected:
     // => Utility Variables <= //
 
-    /// Print flag, defaults to 1
-    int print_;
-    /// Debug flag, defaults to 0
-    int debug_;
-    /// Bench flag, defaults to 0
-    int bench_;
-    /// Memory available, in doubles, defaults to 256 MB (32 M doubles)
-    size_t memory_;
-    /// Number of OpenMP threads (defaults to 1 in no OpenMP, Process::environment.get_n_threads() otherwise)
-    int omp_nthread_;
-    /// Integral cutoff (defaults to 0.0)
-    double cutoff_;
     /// CSAM Screening (defaults to false)
     double do_csam_;
     /// Whether to all desymmetrization, for cases when it's already been performed elsewhere
     std::vector<bool> input_symmetry_cast_map_;
-    /// Number of ERI shell quartets computed, i.e., not screened out
-    size_t num_computed_shells_;
-    /// Tally of ERI shell n-lets (triplets, quartets) computed per SCF iteration 
-    std::unordered_map<std::string, std::vector<size_t> > computed_shells_per_iter_;
 
     // => Tasks <= //
 
-    /// Do J matrices? Defaults to true
-    bool do_J_;
-    /// Do K matrices? Defaults to true
-    bool do_K_;
     /// Do wK matrices? Defaults to false
     bool do_wK_;
 
@@ -274,9 +255,6 @@ class PSI_API JK {
 
     /// omega beta , defaults to 0.0
     double omega_beta_;
-
-    /// Left-right symmetric? Determined in each call of compute()
-    bool lr_symmetric_;
 
     // => Architecture-Level State Variables (Spatial Symmetry) <= //
 
@@ -295,8 +273,6 @@ class PSI_API JK {
 
     // => Microarchitecture-Level State Variables (No Spatial Symmetry) <= //
 
-    /// Primary basis set
-    std::shared_ptr<BasisSet> primary_;
     /// AO2USO transformation matrix
     SharedMatrix AO2USO_;
     /// Pseudo-occupied C matrices, left side
@@ -315,13 +291,13 @@ class PSI_API JK {
     // => Per-Iteration Setup/Finalize Routines <= //
 
     /// Build the pseudo-density D_, before compute_JK()
-    void compute_D();
+    void compute_D() override;
     /// Transform current C_left_/C_right_/D_ to C_left_ao_/C_right_ao_/D_ao_, before compute_JK()
-    void USO2AO();
+    void USO2AO() override;
     /// Transform finished J_ao_/K_ao_ to J_/K_, after compute_JK()
-    void AO2USO();
+    void AO2USO() override;
     /// Allocate J_/K_ should we be using SOs
-    void allocate_JK();
+    void allocate_JK() override;
     /**
      *  Function that sets a number of flags and allocates memory
      *  and sets up AO2USO.
@@ -333,16 +309,7 @@ class PSI_API JK {
      *  one derived class, use with care!!!!!
      *
      */
-    void common_init();
-
-    // => Required Algorithm-Specific Methods <= //
-
-    /// Setup integrals, files, etc
-    virtual void preiterations() = 0;
-    /// Compute J/K for current C/D
-    virtual void compute_JK() = 0;
-    /// Delete integrals, files, etc
-    virtual void postiterations() = 0;
+    void common_init() override;
 
     // => Helper Routines <= //
 
@@ -350,10 +317,6 @@ class PSI_API JK {
     size_t memory_overhead() const;
     /// Zero out all J, K, and wK matrices
     void zero();
-    /**
-    * Return number of ERI shell quartets computed during the JK build process.
-    */
-    virtual size_t num_computed_shells();
 
    public:
     // => Constructors <= //
@@ -374,7 +337,7 @@ class PSI_API JK {
     JK(std::shared_ptr<BasisSet> primary);
 
     /// Destructor
-    virtual ~JK();
+    ~JK() override;
 
     /**
     * Static instance constructor, used to get prebuilt DiskDFJK/DirectJK objects
@@ -390,67 +353,14 @@ class PSI_API JK {
     static std::shared_ptr<JK> build_JK(std::shared_ptr<BasisSet> primary, std::shared_ptr<BasisSet> auxiliary,
                                         Options& options, bool do_wK, size_t doubles);
 
-    /// Do we need to backtransform to C1 under the hood?
-    virtual bool C1() const = 0;
-    virtual std::string name() = 0;
-    // TODO: investigate if JK::memory_estimate and all of its derived variants could be made const
-    // Probably requires refactoring DFHelper and MemDFJK first.
-    virtual size_t memory_estimate() = 0;
-
     // => Knobs <= //
 
-    /**
-     * Cutoff for individual contributions to the J/K matrices
-     * Eventually we hope to use Schwarz/MBIE/Density cutoffs,
-     * for now just Schwarz
-     * @param cutoff ceiling of magnitude of elements to be
-     *        ignored if possible
-     */
-    virtual void set_cutoff(double cutoff) { cutoff_ = cutoff; }
-    double get_cutoff() const { return cutoff_; }
     /**
      * @param do_csam whether to perform CSAM screening instead of
      *      classic Schwarz screening
      */
     void set_csam(bool do_csam) { do_csam_ = do_csam; }
     double get_csam() const { return do_csam_; }
-    /**
-     * Maximum memory to use, in doubles (for tensor-based methods,
-     * integral generation objects typically ignore this)
-     * @param memory maximum number of doubles to allocate
-     */
-    void set_memory(size_t memory) { memory_ = memory; }
-    /**
-     * Maximum number of OpenMP threads to use. It may be necessary
-     * to clamp this to some value smaller than the total number of
-     * cores for machines with a high core-to-memory ratio to avoid
-     * running out of memory due to integral generation objects
-     * @param omp_nthread Maximum number of threads to use in
-     *        integral generation objects (BLAS/LAPACK can still
-     *        run with their original maximum number)
-     */
-    void set_omp_nthread(int omp_nthread) { omp_nthread_ = omp_nthread; }
-    int get_omp_nthread() const { return omp_nthread_; }
-
-    /// Print flag (defaults to 1)
-    void set_print(int print) { print_ = print; }
-    /// Debug flag (defaults to 0)
-    void set_debug(int debug) { debug_ = debug; }
-    /// Bench flag (defaults to 0)
-    void set_bench(int bench) { bench_ = bench; }
-    int get_bench() const { return bench_; }
-    /**
-    * Set to do J tasks
-    * @param do_J do J matrices or not,
-    *        defaults to true
-    */
-    void set_do_J(bool do_J) { do_J_ = do_J; }
-    /**
-    * Set to do K tasks
-    * @param do_K do K matrices or not,
-    *        defaults to true
-    */
-    virtual void set_do_K(bool do_K) { do_K_ = do_K; }
     /**
     * Set to do wK tasks
     * @param do_wK do wK matrices or not,
@@ -490,26 +400,13 @@ class PSI_API JK {
     // => Computers <= //
 
     /**
-     * Initialize the integral technology.
-     * MUST be called AFTER setting knobs
-     * but BEFORE first call of compute()
-     */
-    void initialize();
-    /**
      * Compute D/J/K for the current C
      * Update values in your reference to
      * C_left/C_right BEFORE calling this,
      * renew your references to the matrices
      * in D/J/K AFTER calling this.
      */
-    void compute();
-    /**
-     * Method to clear off memory without
-     * totally destroying the object. The
-     * object can be rebuilt later by calling
-     * initialize()
-     */
-    void finalize();
+    void compute() override;
 
     /**
      * Virtual method to provide (ia|ia) integrals for
@@ -520,11 +417,6 @@ class PSI_API JK {
     virtual SharedVector iaia(SharedMatrix Ci, SharedMatrix Ca);
 
     // => Accessors <= //
-
-    /**
-     * Returns the internal primary basis set.
-     */
-    std::shared_ptr<BasisSet> basisset() { return primary_; }
 
     /**
      * Reference to C_left queue. It is YOUR job to
@@ -574,18 +466,6 @@ class PSI_API JK {
      * @return D vector of D matrices
      */
     const std::vector<SharedMatrix>& D() const { return D_; }
-
-    /**
-    * Return number of ERI shell n-lets (triplets, quartets) computed per SCF iteration during the JK build process.
-    */
-    const std::unordered_map<std::string, std::vector<size_t> >& computed_shells_per_iter();
-    const std::vector<size_t>& computed_shells_per_iter(const std::string& n_let);
-
-    /**
-    * Print header information regarding JK
-    * type on output file
-    */
-    virtual void print_header() const = 0;
 };
 
 // => APPLIED CLASSES <= //
@@ -618,7 +498,7 @@ class PSI_API DiskJK : public JK {
     void postiterations() override;
 
     /// Common initialization
-    void common_init();
+    void common_init() override;
 
    public:
     // => Constructors < = //
@@ -679,7 +559,7 @@ class PSI_API PKJK : public JK {
     void postiterations() override;
 
     /// Common initialization
-    void common_init();
+    void common_init() override;
 
     /// Total number of SOs
     int nso_;
@@ -784,7 +664,7 @@ class PSI_API DirectJK : public JK {
                   std::vector<SharedMatrix>& J, std::vector<SharedMatrix>& K);
 
     /// Common initialization
-    void common_init();
+    void common_init() override;
 
     /**
     * Return number of ERI shell quartets computed during the JK build process.
@@ -954,7 +834,7 @@ class PSI_API DiskDFJK : public JK {
     void postiterations() override;
 
     /// Common initialization
-    void common_init();
+    void common_init() override;
 
     bool is_core();
     size_t memory_temp() const;
@@ -1155,7 +1035,7 @@ class PSI_API MemDFJK : public JK {
     void postiterations() override;
 
     /// Common initialization
-    void common_init();
+    void common_init() override;
 
    public:
     // => Constructors < = //
@@ -1276,7 +1156,7 @@ class PSI_API CompositeJK : public JK {
     void incfock_postiter();
 
     /// Common initialization
-    void common_init();
+    void common_init() override;
 
     /**
     * Return number of ERI shell quartets computed during the JK build process.

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -16,6 +16,7 @@ list(APPEND sources
   sobasis.cc
   cartesianiter.cc
   basisset.cc
+  basewavefunction.cc
   wavefunction.cc
   irrep.cc
   fjt.cc

--- a/psi4/src/psi4/libmints/basewavefunction.cc
+++ b/psi4/src/psi4/libmints/basewavefunction.cc
@@ -1,0 +1,258 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include "basewavefunction.h"
+#include "wavefunction.h"
+
+#include "psi4/libmints/basisset.h"
+#include "psi4/libmints/mintshelper.h"
+#include "psi4/libmints/integral.h"
+#include "psi4/libmints/molecule.h"
+#include "psi4/libmints/sobasis.h"
+#include "psi4/liboptions/liboptions.h"
+#include "psi4/libpsi4util/exception.h"
+#include "psi4/libpsi4util/libpsi4util.h"
+#include "psi4/libpsi4util/process.h"
+
+#include <sstream>
+
+namespace psi {
+
+void BaseWavefunction::common_init() {
+    // Options-only / derived-class constructors may not have a basis yet (cf. Wavefunction(Options)).
+    if (!basisset_) {
+        return;
+    }
+
+    // Check the point group of the molecule. If it is not set, set it.
+    if (!molecule_->point_group()) {
+        molecule_->set_point_group(molecule_->find_point_group());
+    }
+
+    // Create an SO basis...we need the point group for this part.
+    integral_ = std::make_shared<IntegralFactory>(basisset_, basisset_, basisset_, basisset_);
+    mintshelper_ = std::make_shared<MintsHelper>(basisset_, options_);
+    sobasisset_ = std::make_shared<SOBasisSet>(basisset_, integral_);
+
+    // Obtain the dimension object to initialize the factory.
+    nsopi_ = sobasisset_->dimension();
+    nsopi_.set_name("SOs per irrep");
+
+    nirrep_ = nsopi_.n();
+
+    // Initialize arrays that hold dimensionality information
+    nmopi_ = Dimension(nirrep_, "MOs per irrep");
+    frzcpi_ = Dimension(nirrep_, "Frozen core orbitals per irrep");
+    frzvpi_ = Dimension(nirrep_, "Frozen virtual orbitals per irrep");
+
+    // Obtain memory amount from the environment
+    memory_ = Process::environment.get_memory();
+
+    nso_ = basisset_->nbf();
+    nmo_ = basisset_->nbf();
+    for (int k = 0; k < nirrep_; k++) {
+        nmopi_[k] = 0;
+    }
+
+    energy_ = 0.0;
+    efzc_ = 0.0;
+
+    // Read in the debug flag
+    debug_ = options_.get_int("DEBUG");
+    print_ = options_.get_int("PRINT");
+
+    // Determine the number of electrons in the system
+    nelectron_ = 0;
+    for (int i = 0; i < molecule_->natom(); ++i) {
+        nelectron_ += (int)molecule_->Z(i);
+    }
+    nelectron_ -= molecule_->molecular_charge();
+
+    // Make sure that the multiplicity is reasonable
+    multiplicity_ = molecule_->multiplicity();
+    if (multiplicity_ - 1 > nelectron_) {
+        std::ostringstream oss;
+        oss << "There are not enough electrons for multiplicity = " << multiplicity_ << ".\n";
+        oss << "Please check your input";
+        throw SanityCheckError(oss.str(), __FILE__, __LINE__);
+    }
+    if (multiplicity_ % 2 == nelectron_ % 2) {
+        std::ostringstream oss;
+        oss << "A multiplicity of " << multiplicity_ << " with " << nelectron_ << " electrons is impossible.\n";
+        oss << "Please check your input";
+        throw SanityCheckError(oss.str(), __FILE__, __LINE__);
+    }
+
+    // Setup dipole field perturbation information
+    perturb_h_ = options_.get_bool("PERTURB_H");
+    dipole_field_type_ = nothing;
+    std::fill(dipole_field_strength_.begin(), dipole_field_strength_.end(), 0.0);
+    if (perturb_h_) {
+        std::string perturb_with;
+        if (options_["PERTURB_WITH"].has_changed()) {
+            perturb_with = options_.get_str("PERTURB_WITH");
+            // Do checks to see what perturb_with is.
+            if (perturb_with == "DIPOLE_X") {
+                dipole_field_type_ = dipole_x;
+                dipole_field_strength_[0] = options_.get_double("PERTURB_MAGNITUDE");
+                outfile->Printf(
+                    " WARNING: the DIPOLE_X and PERTURB_MAGNITUDE keywords are deprecated."
+                    "  Use DIPOLE and the PERTURB_DIPOLE array instead.");
+            } else if (perturb_with == "DIPOLE_Y") {
+                dipole_field_type_ = dipole_y;
+                dipole_field_strength_[1] = options_.get_double("PERTURB_MAGNITUDE");
+                outfile->Printf(
+                    " WARNING: the DIPOLE_Y and PERTURB_MAGNITUDE keywords are deprecated."
+                    "  Use DIPOLE and the PERTURB_DIPOLE array instead.");
+            } else if (perturb_with == "DIPOLE_Z") {
+                dipole_field_type_ = dipole_z;
+                dipole_field_strength_[2] = options_.get_double("PERTURB_MAGNITUDE");
+                outfile->Printf(
+                    " WARNING: the DIPOLE_Z and PERTURB_MAGNITUDE keywords are deprecated."
+                    "  Use DIPOLE and the PERTURB_DIPOLE array instead.");
+            } else if (perturb_with == "DIPOLE") {
+                dipole_field_type_ = dipole;
+                if (options_["PERTURB_DIPOLE"].size() != 3)
+                    throw PSIEXCEPTION("The PERTURB dipole should have exactly three floating point numbers.");
+                for (int n = 0; n < 3; ++n) dipole_field_strength_[n] = options_["PERTURB_DIPOLE"][n].to_double();
+            } else if (perturb_with == "EMBPOT") {
+                dipole_field_type_ = embpot;
+            } else if (perturb_with == "DX") {
+                dipole_field_type_ = dx;
+            } else if (perturb_with == "SPHERE") {
+                outfile->Printf(
+                    "  WARNING: Option PERTURB_WITH=SPHERE is deprecated and may be removed as soon as v1.13.\n");
+                dipole_field_type_ = sphere;
+            } else {
+                outfile->Printf("Unknown PERTURB_WITH. Applying no perturbation.\n");
+            }
+        } else {
+            outfile->Printf("PERTURB_H is true, but PERTURB_WITH not found, applying no perturbation.\n");
+        }
+    }
+}
+
+BaseWavefunction::BaseWavefunction()
+    : options_(Process::environment.options), dipole_field_strength_{{0.0, 0.0, 0.0}}, PCM_enabled_(false) {}
+
+BaseWavefunction::BaseWavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis,
+                                   Options& options)
+    : molecule_(molecule),
+      basisset_(basis),
+      options_(options),
+      dipole_field_strength_{{0.0, 0.0, 0.0}},
+      PCM_enabled_(false) {}
+
+BaseWavefunction::BaseWavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis)
+    : molecule_(molecule),
+      basisset_(basis),
+      options_(Process::environment.options),
+      dipole_field_strength_{{0.0, 0.0, 0.0}},
+      PCM_enabled_(false) {}
+
+BaseWavefunction::BaseWavefunction(Options& options)
+    : options_(options), dipole_field_strength_{{0.0, 0.0, 0.0}}, PCM_enabled_(false) {}
+
+BaseWavefunction::~BaseWavefunction() = default;
+
+std::map<std::string, std::shared_ptr<BasisSet>> BaseWavefunction::basissets() const {
+    return mintshelper_->basissets();
+}
+
+std::shared_ptr<BasisSet> BaseWavefunction::get_basisset(std::string label) const {
+    return mintshelper_->get_basisset(label);
+}
+
+void BaseWavefunction::set_basisset(std::string label, std::shared_ptr<BasisSet> basis) {
+    return mintshelper_->set_basisset(label, basis);
+}
+
+bool BaseWavefunction::basisset_exists(std::string label) { return mintshelper_->basisset_exists(label); }
+
+void BaseWavefunction::set_frzvpi(const Dimension& frzvpi) {
+    for (int h = 0; h < nirrep_; h++) {
+        frzvpi_[h] = frzvpi[h];
+    }
+}
+
+void BaseWavefunction::set_energy(double ene) { set_scalar_variable("CURRENT ENERGY", ene); }
+
+bool BaseWavefunction::has_scalar_variable(const std::string& key) { return variables_.count(to_upper_copy(key)); }
+
+bool BaseWavefunction::has_potential_variable(const std::string& key) {
+    return potentials_.count(to_upper_copy(key));
+}
+
+double BaseWavefunction::scalar_variable(const std::string& key) {
+    std::string uc_key = to_upper_copy(key);
+
+    auto search = variables_.find(uc_key);
+    if (search != variables_.end()) {
+        return search->second;
+    } else {
+        throw PSIEXCEPTION("BaseWavefunction::scalar_variable: Requested variable " + uc_key + " was not set!\n");
+    }
+}
+
+std::shared_ptr<ExternalPotential> BaseWavefunction::potential_variable(const std::string& key) {
+    std::string uc_key = to_upper_copy(key);
+
+    auto search = potentials_.find(uc_key);
+    if (search != potentials_.end()) {
+        return search->second;
+    } else {
+        throw PSIEXCEPTION("BaseWavefunction::potential_variable: Requested variable " + uc_key + " was not set!\n");
+    }
+}
+
+void BaseWavefunction::set_scalar_variable(const std::string& key, double val) {
+    variables_[to_upper_copy(key)] = val;
+
+    if (to_upper_copy(key) == "CURRENT ENERGY") energy_ = val;
+}
+
+void BaseWavefunction::set_potential_variable(const std::string& key, std::shared_ptr<ExternalPotential> val) {
+    potentials_[to_upper_copy(key)] = val;
+}
+
+int BaseWavefunction::del_scalar_variable(const std::string& key) { return variables_.erase(to_upper_copy(key)); }
+
+int BaseWavefunction::del_potential_variable(const std::string& key) { return potentials_.erase(to_upper_copy(key)); }
+
+std::map<std::string, double> BaseWavefunction::scalar_variables() { return variables_; }
+
+std::map<std::string, std::shared_ptr<ExternalPotential>> BaseWavefunction::potential_variables() {
+    return potentials_;
+}
+
+void BaseWavefunction::set_PCM(const std::shared_ptr<PCM>& pcm) {
+    PCM_ = pcm;
+    PCM_enabled_ = true;
+}
+
+}  // namespace psi

--- a/psi4/src/psi4/libmints/basewavefunction.h
+++ b/psi4/src/psi4/libmints/basewavefunction.h
@@ -1,0 +1,303 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#ifndef _psi_src_lib_libmints_basewavefunction_h
+#define _psi_src_lib_libmints_basewavefunction_h
+
+#include "psi4/psi4-dec.h"
+#include "psi4/libmints/dimension.h"
+
+#include <array>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace psi {
+
+class Molecule;
+class BasisSet;
+class IntegralFactory;
+class MintsHelper;
+class MatrixFactory;
+class Options;
+class SOBasisSet;
+class PCM;
+class PSIO;
+class ExternalPotential;
+
+/*! \ingroup MINTS
+ *  \class BaseWavefunction
+ *  \brief Common polymorphic root for real and complex wavefunctions.
+ */
+class PSI_API BaseWavefunction {
+   protected:
+    /// Name of the wavefunction
+    std::string name_;
+
+    /// Module name for CURRENT ENERGY
+    std::string module_;
+
+    /// The ORBITAL basis
+    std::shared_ptr<BasisSet> basisset_;
+
+    /// Primary basis set for SO integrals
+    std::shared_ptr<SOBasisSet> sobasisset_;
+
+    /// Molecule that this wavefunction is run on
+    std::shared_ptr<Molecule> molecule_;
+
+    /// Options object
+    Options& options_;
+
+    // PSI file access variables
+    std::shared_ptr<PSIO> psio_;
+
+    /// Integral factory
+    std::shared_ptr<IntegralFactory> integral_;
+
+    /// MintsHelper
+    std::shared_ptr<MintsHelper> mintshelper_;
+
+    /// How much memory you have access to.
+    long int memory_;
+
+    /// Perturb the Hamiltonian?
+    int perturb_h_;
+    /// With what...
+    enum FieldType { nothing, dipole_x, dipole_y, dipole_z, dipole, embpot, dx, sphere };
+    FieldType dipole_field_type_;
+
+    /// How big of a field perturbation to apply
+    std::array<double, 3> dipole_field_strength_;
+
+    /// Debug flag
+    size_t debug_;
+    /// Print flag
+    size_t print_;
+
+    /// Total frozen core orbitals
+    int nfrzc_;
+
+    /// Number of frozen core per irrep
+    Dimension frzcpi_;
+    /// Number of frozen virtuals per irrep
+    Dimension frzvpi_;
+
+    /// Total number of electrons in the system
+    int nelectron_{0};
+    /// Spin multiplicity of the system
+    int multiplicity_{1};
+
+    /// Number of so per irrep
+    Dimension nsopi_;
+    /// Number of mo per irrep
+    Dimension nmopi_;
+
+    /// The energy associated with this wavefunction
+    double energy_;
+
+    /// Frozen-core energy associated with this wavefunction
+    double efzc_;
+
+    /// Total number of SOs
+    int nso_;
+    /// Total number of MOs
+    int nmo_;
+    /// Number of irreps
+    int nirrep_;
+
+    /// Should nuclear electrostatic potentials be available, they will be here
+    std::shared_ptr<std::vector<double>> esp_at_nuclei_;
+
+    /// If atomic point charges are available they will be here
+    std::shared_ptr<std::vector<double>> atomic_point_charges_;
+
+    /// Should natural orbital occupations be available, they will be here
+    std::vector<std::vector<std::tuple<double, int, int>>> no_occupations_;
+
+    // The external potential for the current wave function
+    std::shared_ptr<ExternalPotential> external_pot_;
+
+    // Collection of scalar variables
+    std::map<std::string, double> variables_;
+
+    // Collection of external potentials; this member variable is provisional and might be removed in the future.
+    // This member variable is currently used for passing ExternalPotential objects to the F/I-SAPT code
+    // The above defined external_pot_ member variable contains the total external potential defined for the current
+    // wave function. For F/I-SAPT, we need a set of external potential that can be assigned to either the interacting
+    // fragments or to the environment
+    // For F/I-SAPT the keys can be A, B, or C (all optionals), where A and B signify the interacting subsystem
+    // and C signify the envirnoment
+    std::map<std::string, std::shared_ptr<ExternalPotential>> potentials_;
+
+    // Polarizable continuum model
+    std::shared_ptr<PCM> PCM_;
+    /// Polarizable continuum model enabled?
+    bool PCM_enabled_;
+
+    /// Subclass-specific initialization after shared members are set.
+    /// Must be called from the derived constructor body (not the base ctor)
+    /// so virtual dispatch reaches the derived override.
+    virtual void common_init();
+
+   public:
+    BaseWavefunction();
+
+    /// Constructor for an entirely new wavefunction with an existing basis
+    BaseWavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis, Options& options);
+
+    /// Constructor for an entirely new wavefunction with an existing basis and global options
+    BaseWavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis);
+
+    /// Blank constructor for derived classes
+    BaseWavefunction(Options& options);
+
+    virtual ~BaseWavefunction();
+
+    /// Returns the molecule object that pertains to this wavefunction.
+    std::shared_ptr<Molecule> molecule() const { return molecule_; }
+    /// Returns the basis set object that pertains to this wavefunction.
+    std::shared_ptr<BasisSet> basisset() const { return basisset_; }
+
+    /// Returns the PSIO object that pertains to this wavefunction.
+    std::shared_ptr<PSIO> psio() const { return psio_; }
+    Options& options() const { return options_; }
+
+    /// An integral factory with basisset() on each center.
+    std::shared_ptr<IntegralFactory> integral() const { return integral_; }
+    /// An molecular integrals helper with basisset() on each center.
+    std::shared_ptr<MintsHelper> mintshelper() const { return mintshelper_; }
+    /// Returns the SO basis set object that pertains to this wavefunction.
+    std::shared_ptr<SOBasisSet> sobasisset() const { return sobasisset_; }
+
+    /// Getters and setters for other basis sets
+    std::map<std::string, std::shared_ptr<BasisSet>> basissets() const;
+    std::shared_ptr<BasisSet> get_basisset(std::string label) const;
+    void set_basisset(std::string label, std::shared_ptr<BasisSet> basis);
+    bool basisset_exists(std::string label);
+
+    /// Returns the print level
+    int get_print() const { return print_; }
+    // Set the print flag level
+    void set_print(size_t print) { print_ = print; }
+    // Set the debug flag level
+    void set_debug(size_t debug) { debug_ = debug; }
+
+    /// Returns the number of SOs per irrep array.
+    const Dimension& nsopi() const { return nsopi_; }
+    /// Returns the number of MOs per irrep array.
+    const Dimension& nmopi() const { return nmopi_; }
+    /// Returns the frozen core orbitals per irrep array.
+    const Dimension& frzcpi() const { return frzcpi_; }
+    /// Returns the frozen virtual orbitals per irrep array.
+    const Dimension& frzvpi() const { return frzvpi_; }
+    /// Sets the frozen virtual orbitals per irrep array.
+    void set_frzvpi(const Dimension& frzvpi);
+
+    /* Return the magnitude of the dipole perturbation strength in the x,y,z direction */
+    std::array<double, 3> get_dipole_field_strength() const { return dipole_field_strength_; }
+    FieldType get_dipole_perturbation_type() const { return dipole_field_type_; }
+
+    /// Return the number of frozen core orbitals
+    int nfrzc() const { return nfrzc_; }
+    /// Returns the number of SOs
+    int nso() const { return nso_; }
+    /// Returns the number of MOs
+    int nmo() const { return nmo_; }
+    /// Returns the number of irreps
+    int nirrep() const { return nirrep_; }
+    double energy() const { return energy_; }
+    /// Sets the energy
+    void set_energy(double ene);
+    /// Returns the frozen-core energy
+    double efzc() const { return efzc_; }
+    /// Sets the frozen-core energy
+    void set_efzc(double efzc) { efzc_ = efzc; }
+
+    /// Returns electrostatic potentials at nuclei
+    std::shared_ptr<std::vector<double>> esp_at_nuclei() const { return esp_at_nuclei_; }
+    /// Sets the electrostatic potentials at nuclei
+    void set_esp_at_nuclei(const std::shared_ptr<std::vector<double>>& nesps) { esp_at_nuclei_ = nesps; }
+
+    /// Returns the atomic point charges
+    std::shared_ptr<std::vector<double>> atomic_point_charges() const { return atomic_point_charges_; }
+    /// Sets the atomic point charges
+    void set_atomic_point_charges(const std::shared_ptr<std::vector<double>>& apcs) { atomic_point_charges_ = apcs; }
+
+    /// Returns NO occupations
+    std::vector<std::vector<std::tuple<double, int, int>>> no_occupations() const { return no_occupations_; }
+    /// Sets the NO occupations
+    void set_no_occupations(const std::vector<std::vector<std::tuple<double, int, int>>> no_ocs) {
+        no_occupations_ = no_ocs;
+    }
+
+    /// Set the wavefunction name (e.g. "RHF", "ROHF", "UHF", "CCEnergyWavefunction")
+    void set_name(const std::string& name) { name_ = name; }
+    /// Returns the wavefunction name
+    const std::string& name() const { return name_; }
+
+    /// Set the module name (e.g. "OCC", "CCENERGY", "CCT3")
+    void set_module(const std::string& module) { module_ = module; }
+    /// Returns the module name
+    const std::string& module() const { return module_; }
+
+    // Get the external potential
+    std::shared_ptr<ExternalPotential> external_pot() const { return external_pot_; }
+    // Set the external potential
+    void set_external_potential(std::shared_ptr<ExternalPotential> external) { external_pot_ = external; }
+
+    /// Get and set scalar and potential variable dictionaries
+    bool has_scalar_variable(const std::string& key);
+    // The function below is provisional and might be removed in the future
+    bool has_potential_variable(const std::string& key);
+    double scalar_variable(const std::string& key);
+    // The function below is provisional and might be removed in the future
+    std::shared_ptr<ExternalPotential> potential_variable(const std::string& key);
+    void set_scalar_variable(const std::string& key, double value);
+    // The function below is provisional and might be removed in the future
+    void set_potential_variable(const std::string& key, std::shared_ptr<ExternalPotential> value);
+    int del_scalar_variable(const std::string& key);
+    // The function below is provisional and might be removed in the future
+    int del_potential_variable(const std::string& key);
+    std::map<std::string, double> scalar_variables();
+    // The function below is provisional and might be removed in the future
+    std::map<std::string, std::shared_ptr<ExternalPotential>> potential_variables();
+
+    /// Set PCM object
+    void set_PCM(const std::shared_ptr<PCM>& pcm);
+    /// Get PCM object
+    std::shared_ptr<PCM> get_PCM() const { return PCM_; }
+    bool PCM_enabled() const { return PCM_enabled_; }
+};
+
+}  // namespace psi
+
+#endif

--- a/psi4/src/psi4/libmints/mintshelper.cc
+++ b/psi4/src/psi4/libmints/mintshelper.cc
@@ -264,7 +264,7 @@ std::shared_ptr<BasisSet> MintsHelper::basisset() const { return basisset_; }
 
 std::shared_ptr<SOBasisSet> MintsHelper::sobasisset() const { return sobasis_; }
 
-std::shared_ptr<BasisSet> MintsHelper::get_basisset(std::string label) {
+std::shared_ptr<BasisSet> MintsHelper::get_basisset(std::string label) const {
     // This may be slightly confusing, but better than changing this in 800 other places
     if (label == "ORBITAL") {
         return basisset_;
@@ -272,7 +272,7 @@ std::shared_ptr<BasisSet> MintsHelper::get_basisset(std::string label) {
         outfile->Printf("Could not find requested basisset (%s).", label.c_str());
         throw PSIEXCEPTION("MintsHelper::get_basisset: Requested basis set (" + label + ") was not set!\n");
     } else {
-        return basissets_[label];
+        return basissets_.at(label);
     }
 }
 void MintsHelper::set_basisset(std::string label, std::shared_ptr<BasisSet> basis) {
@@ -283,7 +283,7 @@ void MintsHelper::set_basisset(std::string label, std::shared_ptr<BasisSet> basi
     }
 }
 
-bool MintsHelper::basisset_exists(std::string label) {
+bool MintsHelper::basisset_exists(std::string label) const {
     if (basissets_.count(label) == 0)
         return false;
     else

--- a/psi4/src/psi4/libmints/mintshelper.h
+++ b/psi4/src/psi4/libmints/mintshelper.h
@@ -166,9 +166,9 @@ class PSI_API MintsHelper {
 
     /// Getters and setters for other basis sets
     std::map<std::string, std::shared_ptr<BasisSet>> basissets() const { return basissets_; };
-    std::shared_ptr<BasisSet> get_basisset(std::string label);
+    std::shared_ptr<BasisSet> get_basisset(std::string label) const;
     void set_basisset(std::string label, std::shared_ptr<BasisSet> basis);
-    bool basisset_exists(std::string label);
+    bool basisset_exists(std::string label) const;
 
     /// Molecular integrals (just like cints used to do)
     void integrals();

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -83,25 +83,16 @@ double bc[MAX_BC][MAX_BC];
 double fac[MAX_FAC];
 
 Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis, Options &options)
-    : options_(options),
-      basisset_(basis),
-      molecule_(molecule),
-      dipole_field_strength_{{0.0, 0.0, 0.0}},
-      PCM_enabled_(false) {
+    : BaseWavefunction(molecule, basis, options) {
     common_init();
 }
 
 Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis)
-    : options_(Process::environment.options),
-      basisset_(basis),
-      molecule_(molecule),
-      dipole_field_strength_{{0.0, 0.0, 0.0}},
-      PCM_enabled_(false) {
+    : BaseWavefunction(molecule, basis) {
     common_init();
 }
 
-Wavefunction::Wavefunction(SharedWavefunction reference_wavefunction, Options &options)
-    : options_(options), dipole_field_strength_{{0.0, 0.0, 0.0}}, PCM_enabled_(false) {
+Wavefunction::Wavefunction(SharedWavefunction reference_wavefunction, Options &options) : BaseWavefunction(options) {
     // Copy the wavefuntion then update
     shallow_copy(reference_wavefunction);
     set_reference_wavefunction(reference_wavefunction);
@@ -114,7 +105,7 @@ Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<B
                            std::map<std::string, Dimension> dimensions, std::map<std::string, int> ints,
                            std::map<std::string, std::string> strings, std::map<std::string, bool> booleans,
                            std::map<std::string, double> floats)
-    : options_(Process::environment.options), basisset_(basisset), molecule_(molecule) {
+    : BaseWavefunction(molecule, basisset, Process::environment.options) {
     // Check the point group of the molecule. If it is not set, set it.
     if (!molecule_->point_group()) {
         molecule_->set_point_group(molecule_->find_point_group());
@@ -177,8 +168,7 @@ Wavefunction::Wavefunction(std::shared_ptr<Molecule> molecule, std::shared_ptr<B
     dipole_field_strength_[2] = floats["dipole_field_z"];
 }
 
-Wavefunction::Wavefunction(Options &options)
-    : options_(options), dipole_field_strength_{{0.0, 0.0, 0.0}}, PCM_enabled_(false) {}
+Wavefunction::Wavefunction(Options &options) : BaseWavefunction(options) {}
 
 Wavefunction::~Wavefunction() {}
 
@@ -449,137 +439,32 @@ std::shared_ptr<Wavefunction> Wavefunction::c1_deep_copy(std::shared_ptr<BasisSe
 }
 
 void Wavefunction::common_init() {
+    BaseWavefunction::common_init();
+
     Wavefunction::initialize_singletons();
-    if (!basisset_) {
-        throw PSIEXCEPTION(
-            "You can't initialize a Wavefunction that doesn't "
-            "have a basis set");
-    }
-
-    // Check the point group of the molecule. If it is not set, set it.
-    if (!molecule_->point_group()) {
-        molecule_->set_point_group(molecule_->find_point_group());
-    }
-
-    // Create an SO basis...we need the point group for this part.
-    integral_ = std::make_shared<IntegralFactory>(basisset_, basisset_, basisset_, basisset_);
-    mintshelper_ = std::make_shared<MintsHelper>(basisset_, options_);
-    sobasisset_ = std::make_shared<SOBasisSet>(basisset_, integral_);
 
     auto pet = std::make_shared<PetiteList>(basisset_, integral_);
     AO2SO_ = pet->aotoso();
 
-    // Obtain the dimension object to initialize the factory.
-    nsopi_ = sobasisset_->dimension();
-    nsopi_.set_name("SOs per irrep");
-
     factory_ = std::make_shared<MatrixFactory>();
     factory_->init_with(nsopi_, nsopi_);
-
-    nirrep_ = nsopi_.n();
 
     S_ = factory_->create_shared_matrix("S");
     std::shared_ptr<OneBodySOInt> Sint(integral_->so_overlap());
     Sint->compute(S_);
 
-    // Initialize array that hold dimensionality information
-    nmopi_ = Dimension(nirrep_, "MOs per irrep");
     nalphapi_ = Dimension(nirrep_, "Alpha electrons per irrep");
     nbetapi_ = Dimension(nirrep_, "Beta electrons per irrep");
-    frzcpi_ = Dimension(nirrep_, "Frozen core orbitals per irrep");
-    frzvpi_ = Dimension(nirrep_, "Frozen virtual orbitals per irrep");
-
-    // Obtain memory amount from the environment
-    memory_ = Process::environment.get_memory();
-
-    nso_ = basisset_->nbf();
-    nmo_ = basisset_->nbf();
     for (int k = 0; k < nirrep_; k++) {
-        nmopi_[k] = 0;
         nalphapi_[k] = 0;
         nbetapi_[k] = 0;
     }
 
-    energy_ = 0.0;
-    efzc_ = 0.0;
     same_a_b_dens_ = true;
     same_a_b_orbs_ = false;
 
-    // Read in the debug flag
-    debug_ = options_.get_int("DEBUG");
-    print_ = options_.get_int("PRINT");
-
-    // Determine the number of electrons in the system
-    int nelectron = 0;
-    for (int i = 0; i < molecule_->natom(); ++i) {
-        nelectron += (int)molecule_->Z(i);
-    }
-    nelectron -= molecule_->molecular_charge();
-
-    // Make sure that the multiplicity is reasonable
-    int multiplicity = molecule_->multiplicity();
-    if (multiplicity - 1 > nelectron) {
-        std::ostringstream oss;
-        oss << "There are not enough electrons for multiplicity = " << multiplicity << ".\n";
-        oss << "Please check your input";
-        throw SanityCheckError(oss.str(), __FILE__, __LINE__);
-    }
-    if (multiplicity % 2 == nelectron % 2) {
-        std::ostringstream oss;
-        oss << "A multiplicity of " << multiplicity << " with " << nelectron << " electrons is impossible.\n";
-        oss << "Please check your input";
-        throw SanityCheckError(oss.str(), __FILE__, __LINE__);
-    }
-
-    nbeta_ = (nelectron - multiplicity + 1) / 2;
-    nalpha_ = nbeta_ + multiplicity - 1;
-
-    // Setup dipole field perturbation information
-    perturb_h_ = options_.get_bool("PERTURB_H");
-    dipole_field_type_ = nothing;
-    std::fill(dipole_field_strength_.begin(), dipole_field_strength_.end(), 0.0);
-    if (perturb_h_) {
-        std::string perturb_with;
-        if (options_["PERTURB_WITH"].has_changed()) {
-            perturb_with = options_.get_str("PERTURB_WITH");
-            // Do checks to see what perturb_with is.
-            if (perturb_with == "DIPOLE_X") {
-                dipole_field_type_ = dipole_x;
-                dipole_field_strength_[0] = options_.get_double("PERTURB_MAGNITUDE");
-                outfile->Printf(
-                    " WARNING: the DIPOLE_X and PERTURB_MAGNITUDE keywords are deprecated."
-                    "  Use DIPOLE and the PERTURB_DIPOLE array instead.");
-            } else if (perturb_with == "DIPOLE_Y") {
-                dipole_field_type_ = dipole_y;
-                dipole_field_strength_[1] = options_.get_double("PERTURB_MAGNITUDE");
-                outfile->Printf(
-                    " WARNING: the DIPOLE_Y and PERTURB_MAGNITUDE keywords are deprecated."
-                    "  Use DIPOLE and the PERTURB_DIPOLE array instead.");
-            } else if (perturb_with == "DIPOLE_Z") {
-                dipole_field_type_ = dipole_z;
-                dipole_field_strength_[2] = options_.get_double("PERTURB_MAGNITUDE");
-                outfile->Printf(
-                    " WARNING: the DIPOLE_Z and PERTURB_MAGNITUDE keywords are deprecated."
-                    "  Use DIPOLE and the PERTURB_DIPOLE array instead.");
-            } else if (perturb_with == "DIPOLE") {
-                dipole_field_type_ = dipole;
-                if (options_["PERTURB_DIPOLE"].size() != 3)
-                    throw PSIEXCEPTION("The PERTURB dipole should have exactly three floating point numbers.");
-                for (int n = 0; n < 3; ++n) dipole_field_strength_[n] = options_["PERTURB_DIPOLE"][n].to_double();
-            } else if (perturb_with == "EMBPOT") {
-                dipole_field_type_ = embpot;
-            } else if (perturb_with == "DX") {
-                dipole_field_type_ = dx;
-            } else if (perturb_with == "SPHERE") {
-                outfile->Printf("  WARNING: Option PERTURB_WITH=SPHERE is deprecated and may be removed as soon as v1.13.\n");
-                dipole_field_type_ = sphere;
-            } else {
-                outfile->Printf("Unknown PERTURB_WITH. Applying no perturbation.\n");
-            }
-        } else {
-            outfile->Printf("PERTURB_H is true, but PERTURB_WITH not found, applying no perturbation.\n");
-        }
-    }
+    nbeta_ = (nelectron_ - multiplicity_ + 1) / 2;
+    nalpha_ = nbeta_ + multiplicity_ - 1;
 
 #ifdef USING_BrianQC
     if (brianEnable) {
@@ -590,7 +475,7 @@ void Wavefunction::common_init() {
         brianInt atomCount = molecule_->nallatom();
 
         brianInt totalCharge = (brianInt)round(molecule_->molecular_charge());
-        brianInt spinMultiplicity = multiplicity;
+        brianInt spinMultiplicity = multiplicity_;
 
         std::vector<brianInt> atomicNumbers;
         std::vector<double> atomCoordinates;
@@ -676,10 +561,6 @@ void Wavefunction::common_init() {
 #endif
 }
 
-std::array<double, 3> Wavefunction::get_dipole_field_strength() const { return dipole_field_strength_; }
-
-Wavefunction::FieldType Wavefunction::get_dipole_perturbation_type() const { return dipole_field_type_; }
-
 Dimension Wavefunction::map_irreps(const Dimension &dimpi) {
     auto ps = options_.get_str("PARENT_SYMMETRY");
 
@@ -734,6 +615,12 @@ void Wavefunction::initialize_singletons() {
     done = true;
 }
 
+std::shared_ptr<Wavefunction> Wavefunction::reference_wavefunction() const { return reference_wavefunction_; }
+
+void Wavefunction::set_reference_wavefunction(const std::shared_ptr<Wavefunction> wfn) {
+    reference_wavefunction_ = wfn;
+}
+
 const Dimension Wavefunction::doccpi(bool warn_on_beta_socc) const {
     std::vector<int> docc_vec;
     for (int h = 0; h < nalphapi_.n(); h++) {
@@ -756,49 +643,11 @@ const Dimension Wavefunction::soccpi(bool warn_on_beta_socc) const {
     return socc_vec;
 }
 
-std::shared_ptr<Molecule> Wavefunction::molecule() const { return molecule_; }
-
-std::shared_ptr<PSIO> Wavefunction::psio() const { return psio_; }
-
-Options &Wavefunction::options() const { return options_; }
-
-std::shared_ptr<IntegralFactory> Wavefunction::integral() const { return integral_; }
-
-std::shared_ptr<MintsHelper> Wavefunction::mintshelper() const { return mintshelper_; }
-
-std::shared_ptr<BasisSet> Wavefunction::basisset() const { return basisset_; }
-
-std::map<std::string, std::shared_ptr<BasisSet>> Wavefunction::basissets() const { return mintshelper_->basissets(); }
-
-std::shared_ptr<BasisSet> Wavefunction::get_basisset(std::string label) { return mintshelper_->get_basisset(label); }
-
-void Wavefunction::set_basisset(std::string label, std::shared_ptr<BasisSet> basis) {
-    return mintshelper_->set_basisset(label, basis);
-}
-
-bool Wavefunction::basisset_exists(std::string label) { return mintshelper_->basisset_exists(label); }
-
-std::shared_ptr<SOBasisSet> Wavefunction::sobasisset() const { return sobasisset_; }
-
-std::shared_ptr<MatrixFactory> Wavefunction::matrix_factory() const { return factory_; }
-
-std::shared_ptr<Wavefunction> Wavefunction::reference_wavefunction() const { return reference_wavefunction_; }
-
-void Wavefunction::set_reference_wavefunction(const std::shared_ptr<Wavefunction> wfn) {
-    reference_wavefunction_ = wfn;
-}
-
 void Wavefunction::force_occpi(const Dimension &input_doccpi, const Dimension &input_soccpi) {
     nalphapi_ = input_doccpi + input_soccpi;
     nbetapi_ = input_doccpi;
     nalpha_ = nalphapi_.sum();
     nbeta_ = nbetapi_.sum();
-}
-
-void Wavefunction::set_frzvpi(const Dimension &frzvpi) {
-    for (int h = 0; h < nirrep_; h++) {
-        frzvpi_[h] = frzvpi[h];
-    }
 }
 
 SharedMatrix Wavefunction::Ca() const {
@@ -1228,8 +1077,6 @@ SharedMatrix Wavefunction::lagrangian() const { return Lagrangian_; }
 
 void Wavefunction::set_lagrangian(SharedMatrix X) { Lagrangian_ = X; }
 
-void Wavefunction::set_energy(double ene) { set_scalar_variable("CURRENT ENERGY", ene); }
-
 SharedMatrix Wavefunction::gradient() const { return gradient_; }
 
 void Wavefunction::set_gradient(SharedMatrix grad) { set_array_variable("CURRENT GRADIENT", grad); }
@@ -1239,8 +1086,6 @@ SharedMatrix Wavefunction::hessian() const { return hessian_; }
 void Wavefunction::set_hessian(SharedMatrix hess) { set_array_variable("CURRENT HESSIAN", hess); }
 
 void Wavefunction::save() const {}
-
-std::shared_ptr<ExternalPotential> Wavefunction::external_pot() const { return external_pot_; }
 
 std::shared_ptr<Vector> Wavefunction::get_esp_at_nuclei() const {
     std::shared_ptr<std::vector<double>> v = esp_at_nuclei();
@@ -1296,22 +1141,7 @@ std::vector<std::vector<std::tuple<double, int, int>>> Wavefunction::get_no_occu
     return no_occs;
 }
 
-bool Wavefunction::has_scalar_variable(const std::string &key) { return variables_.count(to_upper_copy(key)); }
-
 bool Wavefunction::has_array_variable(const std::string &key) { return arrays_.count(to_upper_copy(key)); }
-
-bool Wavefunction::has_potential_variable(const std::string &key) { return potentials_.count(to_upper_copy(key)); }
-
-double Wavefunction::scalar_variable(const std::string &key) {
-    std::string uc_key = to_upper_copy(key);
-
-    auto search = variables_.find(uc_key);
-    if (search != variables_.end()) {
-        return search->second;
-    } else {
-        throw PSIEXCEPTION("Wavefunction::scalar_variable: Requested variable " + uc_key + " was not set!\n");
-    }
-}
 
 SharedMatrix Wavefunction::array_variable(const std::string &key) {
     std::string uc_key = to_upper_copy(key);
@@ -1324,23 +1154,6 @@ SharedMatrix Wavefunction::array_variable(const std::string &key) {
     }
 }
 
-std::shared_ptr<ExternalPotential> Wavefunction::potential_variable(const std::string &key) {
-    std::string uc_key = to_upper_copy(key);
-
-    auto search = potentials_.find(uc_key);
-    if (search != potentials_.end()) {
-        return search->second;
-    } else {
-        throw PSIEXCEPTION("Wavefunction::potential_variable: Requested variable " + uc_key + " was not set!\n");
-    }
-}
-
-void Wavefunction::set_scalar_variable(const std::string &key, double val) {
-    variables_[to_upper_copy(key)] = val;
-
-    if (to_upper_copy(key) == "CURRENT ENERGY") energy_ = val;
-}
-
 void Wavefunction::set_array_variable(const std::string &key, SharedMatrix val) {
     arrays_[to_upper_copy(key)] = val->clone();
 
@@ -1348,25 +1161,6 @@ void Wavefunction::set_array_variable(const std::string &key, SharedMatrix val) 
     if (to_upper_copy(key) == "CURRENT HESSIAN") hessian_ = val->clone();
 }
 
-void Wavefunction::set_potential_variable(const std::string &key, std::shared_ptr<ExternalPotential> val) {
-    potentials_[to_upper_copy(key)] = val;
-}
-
-int Wavefunction::del_scalar_variable(const std::string &key) { return variables_.erase(to_upper_copy(key)); }
-
 int Wavefunction::del_array_variable(const std::string &key) { return arrays_.erase(to_upper_copy(key)); }
 
-int Wavefunction::del_potential_variable(const std::string &key) { return potentials_.erase(to_upper_copy(key)); }
-
-std::map<std::string, double> Wavefunction::scalar_variables() { return variables_; }
-
 std::map<std::string, SharedMatrix> Wavefunction::array_variables() { return arrays_; }
-
-std::map<std::string, std::shared_ptr<ExternalPotential>> Wavefunction::potential_variables() { return potentials_; }
-
-void Wavefunction::set_PCM(const std::shared_ptr<PCM> &pcm) {
-    PCM_ = pcm;
-    PCM_enabled_ = true;
-}
-
-std::shared_ptr<PCM> Wavefunction::get_PCM() const { return PCM_; }

--- a/psi4/src/psi4/libmints/wavefunction.h
+++ b/psi4/src/psi4/libmints/wavefunction.h
@@ -31,11 +31,10 @@
 
 #include "typedefs.h"
 #include "psi4/libpsi4util/exception.h"
-#include "psi4/libmints/dimension.h"
+#include "psi4/libmints/basewavefunction.h"
 
 #include <cstddef>
 #include <vector>
-#include <array>
 #include <memory>
 #include <map>
 
@@ -65,109 +64,26 @@ extern double fac[MAX_FAC];
 
 namespace psi {
 
-class Molecule;
-class BasisSet;
-class IntegralFactory;
-class MintsHelper;
 class Matrix;
 class Vector;
-class MatrixFactory;
-class Options;
-class SOBasisSet;
-class PCM;
-class PSIO;
 class OrbitalSpace;
-class ExternalPotential;
 
 /*! \ingroup MINTS
  *  \class Wavefunction
  *  \brief Simple wavefunction base class.
  */
-class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
+class PSI_API Wavefunction : public BaseWavefunction, public std::enable_shared_from_this<Wavefunction> {
    protected:
-    /// Name of the wavefunction
-    std::string name_;
-
-    /// Module name for CURRENT ENERGY
-    std::string module_;
-
-    /// The ORBITAL basis
-    std::shared_ptr<BasisSet> basisset_;
-
-    /// Primary basis set for SO integrals
-    std::shared_ptr<SOBasisSet> sobasisset_;
-
     /// AO2SO conversion matrix (AO in rows, SO in cols)
     SharedMatrix AO2SO_;
-
-    /// Molecule that this wavefunction is run on
-    std::shared_ptr<Molecule> molecule_;
-
-    /// Options object
-    Options& options_;
-
-    // PSI file access variables
-    std::shared_ptr<PSIO> psio_;
-
-    /// Integral factory
-    std::shared_ptr<IntegralFactory> integral_;
-
-    /// MintsHelper
-    std::shared_ptr<MintsHelper> mintshelper_;
-
-    /// Matrix factory for creating standard sized matrices
-    std::shared_ptr<MatrixFactory> factory_;
-
-    std::shared_ptr<Wavefunction> reference_wavefunction_;
-
-    /// How much memory you have access to.
-    long int memory_;
-
-    /// Perturb the Hamiltonian?
-    int perturb_h_;
-    /// With what...
-    enum FieldType { nothing, dipole_x, dipole_y, dipole_z, dipole, embpot, dx, sphere };
-    FieldType dipole_field_type_;
-    /// How big of a field perturbation to apply
-    std::array<double, 3> dipole_field_strength_;
-
-    /// Debug flag
-    size_t debug_;
-    /// Print flag
-    size_t print_;
 
     /// Total alpha and beta electrons
     int nalpha_, nbeta_;
 
-    /// Total frozen core orbitals
-    int nfrzc_;
-
-    /// Number of frozen core per irrep
-    Dimension frzcpi_;
-    /// Number of frozen virtuals per irrep
-    Dimension frzvpi_;
     /// Number of alpha electrons per irrep
     Dimension nalphapi_;
     /// Number of beta electrons per irrep
     Dimension nbetapi_;
-
-    /// Number of so per irrep
-    Dimension nsopi_;
-    /// Number of mo per irrep
-    Dimension nmopi_;
-
-    /// The energy associated with this wavefunction
-    double energy_;
-
-    /// Frozen-core energy associated with this wavefunction
-    double efzc_;
-
-    /// Total number of SOs
-    int nso_;
-    /// Total number of MOs
-    int nmo_;
-    /// Number of irreps
-    int nirrep_;
 
     /// Overlap matrix
     SharedMatrix S_;
@@ -223,27 +139,17 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     //                of which are to be returned.
     std::vector<std::vector<int>> subset_occupation(const Dimension& noccpi, const std::string& subset) const;
 
-    /// Should nuclear electrostatic potentials be available, they will be here
-    std::shared_ptr<std::vector<double>> esp_at_nuclei_;
-
     /// Should molecular orbital extents be available, they will be here
     std::vector<SharedVector> mo_extents_;
 
-    /// If atomic point charges are available they will be here
-    std::shared_ptr<std::vector<double>> atomic_point_charges_;
+    /// Matrix factory for creating standard sized matrices
+    std::shared_ptr<MatrixFactory> factory_;
 
-    /// Should natural orbital occupations be available, they will be here
-    std::vector<std::vector<std::tuple<double, int, int>>> no_occupations_;
+    std::shared_ptr<Wavefunction> reference_wavefunction_;
 
     /// Same orbs or dens
     bool same_a_b_dens_;
     bool same_a_b_orbs_;
-
-    // The external potential for the current wave function
-    std::shared_ptr<ExternalPotential> external_pot_;
-
-    // Collection of scalar variables
-    std::map<std::string, double> variables_;
 
     // Collection of Matrix variables
     // * any '<mtd> GRADIENT' is an energy derivative w.r.t. nuclear perturbations (a.u.) as a (nat, 3) Matrix
@@ -251,22 +157,7 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     //   by dipole component (3 * nat, 3) Matrix
     std::map<std::string, SharedMatrix> arrays_;
 
-    // Collection of external potentials; this member variable is provisional and might be removed in the future.
-    // This member variable is currently used for passing ExternalPotential objects to the F/I-SAPT code
-    // The above defined external_pot_ member variable contains the total external potential defined for the current
-    // wave function. For F/I-SAPT, we need a set of external potential that can be assigned to either the interacting
-    // fragments or to the environment
-    // For F/I-SAPT the keys can be A, B, or C (all optionals), where A and B signify the interacting subsystem
-    // and C signify the envirnoment
-    std::map<std::string, std::shared_ptr<ExternalPotential>> potentials_;
-
-    // Polarizable continuum model
-    bool PCM_enabled_;
-    std::shared_ptr<PCM> PCM_;
-
-   private:
-    // Wavefunction() {}
-    void common_init();
+    void common_init() override;
 
    public:
     /// Constructor for an entirely new wavefunction with an existing basis
@@ -288,6 +179,13 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
 
     /// Blank constructor for derived classes
     Wavefunction(Options& options);
+
+    /// Returns the MatrixFactory object that pertains to this wavefunction
+    std::shared_ptr<MatrixFactory> matrix_factory() const { return factory_; }
+    /// Returns the reference wavefunction
+    std::shared_ptr<Wavefunction> reference_wavefunction() const;
+    /// Sets the reference wavefunction
+    void set_reference_wavefunction(const std::shared_ptr<Wavefunction> wfn);
 
     /**
      * Copy the contents of another Wavefunction into this one.
@@ -319,7 +217,7 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
      **/
     std::shared_ptr<Wavefunction> c1_deep_copy(std::shared_ptr<BasisSet> basis);
 
-    virtual ~Wavefunction();
+    ~Wavefunction() override;
 
     /// Compute energy. Subclasses override this function to compute its energy.
     virtual double compute_energy() {
@@ -344,35 +242,6 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// with occupations mapped to the current point group
     Dimension map_irreps(const Dimension& dimpi);
 
-    /// Returns the molecule object that pertains to this wavefunction.
-    std::shared_ptr<Molecule> molecule() const;
-    std::shared_ptr<PSIO> psio() const;
-    Options& options() const;
-
-    /// An integral factory with basisset() on each center.
-    std::shared_ptr<IntegralFactory> integral() const;
-    /// An molecular integrals helper with basisset() on each center.
-    std::shared_ptr<MintsHelper> mintshelper() const;
-    /// Returns the basis set object that pertains to this wavefunction.
-    std::shared_ptr<BasisSet> basisset() const;
-    /// Returns the SO basis set object that pertains to this wavefunction.
-    std::shared_ptr<SOBasisSet> sobasisset() const;
-
-    /// Getters and setters for other basis sets
-    std::map<std::string, std::shared_ptr<BasisSet>> basissets() const;
-    std::shared_ptr<BasisSet> get_basisset(std::string label);
-    void set_basisset(std::string label, std::shared_ptr<BasisSet> basis);
-    bool basisset_exists(std::string label);
-
-    /// Returns the MatrixFactory object that pertains to this wavefunction
-    std::shared_ptr<MatrixFactory> matrix_factory() const;
-    /// Returns the reference wavefunction
-    std::shared_ptr<Wavefunction> reference_wavefunction() const;
-    /// Sets the reference wavefunction
-    void set_reference_wavefunction(const std::shared_ptr<Wavefunction> wfn);
-
-    /// Returns the print level
-    int get_print() const { return print_; }
     static void initialize_singletons();
 
     /// Returns the DOCC per irrep array. Not recommended for unrestricted code.
@@ -383,22 +252,10 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Flag `warn_on_beta_socc` triggers warning on singly occupied beta orbitals,
     /// which break assumptions made in pre-1.7 DOCC/SOCC handling.
     const Dimension soccpi(bool warn_on_beta_socc = true) const;
-    /// Returns the number of SOs per irrep array.
-    const Dimension& nsopi() const { return nsopi_; }
-    /// Returns the number of MOs per irrep array.
-    const Dimension& nmopi() const { return nmopi_; }
     /// Returns the number of alpha electrons per irrep array.
     const Dimension& nalphapi() const { return nalphapi_; }
     /// Returns the number of beta electrons per irrep array.
     const Dimension& nbetapi() const { return nbetapi_; }
-    /// Returns the frozen core orbitals per irrep array.
-    const Dimension& frzcpi() const { return frzcpi_; }
-    /// Returns the frozen virtual orbitals per irrep array.
-    const Dimension& frzvpi() const { return frzvpi_; }
-
-    /* Return the magnitude of the dipole perturbation strength in the x,y,z direction */
-    std::array<double, 3> get_dipole_field_strength() const;
-    FieldType get_dipole_perturbation_type() const;
 
     /**
      * @brief Expert specialized use only. Sets the number of doubly and singly occupied orbitals per irrep. Results in an
@@ -407,28 +264,10 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
      */
     void force_occpi(const Dimension& input_doccpi, const Dimension& input_soccpi);
 
-    /// Sets the frozen virtual orbitals per irrep array.
-    void set_frzvpi(const Dimension& frzvpi);
-
-    /// Return the number of frozen core orbitals
-    int nfrzc() const { return nfrzc_; }
     /// Return the number of alpha electrons
     int nalpha() const { return nalpha_; }
     /// Return the number of beta electrons
     int nbeta() const { return nbeta_; }
-    /// Returns the number of SOs
-    int nso() const { return nso_; }
-    /// Returns the number of MOs
-    int nmo() const { return nmo_; }
-    /// Returns the number of irreps
-    int nirrep() const { return nirrep_; }
-    double energy() const { return energy_; }
-    /// Sets the energy
-    void set_energy(double ene);
-    /// Returns the frozen-core energy
-    double efzc() const { return efzc_; }
-    /// Sets the frozen-core energy
-    void set_efzc(double efzc) { efzc_ = efzc; }
 
     /// Returns the overlap matrix
     SharedMatrix S() const { return S_; }
@@ -590,14 +429,8 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Set the Hessian for the wavefunction
     void set_hessian(SharedMatrix hess);
 
-    /// Returns electrostatic potentials at nuclei
-    std::shared_ptr<std::vector<double>> esp_at_nuclei() const { return esp_at_nuclei_; }
-
     /// Returns electrostatic potentials at nuclei in Vector form for python output
     std::shared_ptr<Vector> get_esp_at_nuclei() const;
-
-    /// Sets the electrostatic potentials at nuclei
-    void set_esp_at_nuclei(const std::shared_ptr<std::vector<double>>& nesps) { esp_at_nuclei_ = nesps; }
 
     /// Returns Molecular orbital extents
     std::vector<SharedVector> mo_extents() const { return mo_extents_; }
@@ -608,79 +441,21 @@ class PSI_API Wavefunction : public std::enable_shared_from_this<Wavefunction> {
     /// Sets molecular orbital extents
     void set_mo_extents(const std::vector<SharedVector> mo_es) { mo_extents_ = mo_es; }
 
-    /// Returns the atomic point charges
-    std::shared_ptr<std::vector<double>> atomic_point_charges() const { return atomic_point_charges_; }
     /// Returns the atomic point charges in Vector form for python output.
     SharedVector get_atomic_point_charges() const;
-
-    /// Sets the atomic point charges
-    void set_atomic_point_charges(const std::shared_ptr<std::vector<double>>& apcs) { atomic_point_charges_ = apcs; }
-
-    /// Returns NO occupations
-    std::vector<std::vector<std::tuple<double, int, int>>> no_occupations() const { return no_occupations_; }
 
     /// Returns the NO occupations in vector form for python output
     std::vector<std::vector<std::tuple<double, int, int>>> get_no_occupations() const;
 
-    /// Sets the NO occupations
-    void set_no_occupations(const std::vector<std::vector<std::tuple<double, int, int>>> no_ocs) {
-        no_occupations_ = no_ocs;
-    }
-
-    /// Set the wavefunction name (e.g. "RHF", "ROHF", "UHF", "CCEnergyWavefunction")
-    void set_name(const std::string& name) { name_ = name; }
-
-    /// Returns the wavefunction name
-    const std::string& name() const { return name_; }
-
-    /// Set the module name (e.g. "OCC", "CCENERGY", "CCT3")
-    void set_module(const std::string& module) { module_ = module; }
-
-    /// Returns the module name
-    const std::string& module() const { return module_; }
-
-    // Set the print flag level
-    void set_print(size_t print) { print_ = print; }
-
-    // Set the debug flag level
-    void set_debug(size_t debug) { debug_ = debug; }
-
     /// Save the wavefunction to checkpoint
     virtual void save() const;
 
-    // Get the external potential
-    std::shared_ptr<ExternalPotential> external_pot() const;
-
-    // Set the external potential
-    void set_external_potential(std::shared_ptr<ExternalPotential> external) { external_pot_ = external; }
-
-    /// Get and set variables, arrays, and potentials dictionaries
-    bool has_scalar_variable(const std::string& key);
+    /// Get and set array variable dictionaries
     bool has_array_variable(const std::string& key);
-    // The function below is provisional and might be removed in the future
-    bool has_potential_variable(const std::string& key);
-    double scalar_variable(const std::string& key);
     SharedMatrix array_variable(const std::string& key);
-    // The function below is provisional and might be removed in the future
-    std::shared_ptr<ExternalPotential> potential_variable(const std::string& key);
-    void set_scalar_variable(const std::string& key, double value);
     void set_array_variable(const std::string& key, SharedMatrix value);
-    // The function below is provisional and might be removed in the future
-    void set_potential_variable(const std::string& key, std::shared_ptr<ExternalPotential> value);
-    int del_scalar_variable(const std::string& key);
     int del_array_variable(const std::string& key);
-    // The function below is provisional and might be removed in the future
-    int del_potential_variable(const std::string& key);
-    std::map<std::string, double> scalar_variables();
     std::map<std::string, SharedMatrix> array_variables();
-    // The function below is provisional and might be removed in the future
-    std::map<std::string, std::shared_ptr<ExternalPotential>> potential_variables();
-
-    /// Set PCM object
-    void set_PCM(const std::shared_ptr<PCM>& pcm);
-    /// Get PCM object
-    std::shared_ptr<PCM> get_PCM() const;
-    bool PCM_enabled() const { return PCM_enabled_; }
 
     /// The below members are experimental and are designed to hold densities when the
     /// "current density" is ambiguous, e.g., non-orbital optimized methods and multi-

--- a/psi4/src/psi4/libscf_solver/CMakeLists.txt
+++ b/psi4/src/psi4/libscf_solver/CMakeLists.txt
@@ -1,4 +1,5 @@
 list(APPEND sources
+  basehf.cc
   cuhf.cc
   frac.cc
   hf.cc

--- a/psi4/src/psi4/libscf_solver/basehf.cc
+++ b/psi4/src/psi4/libscf_solver/basehf.cc
@@ -1,0 +1,60 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include "basehf.h"
+
+#include "psi4/libmints/molecule.h"
+#include "psi4/liboptions/liboptions.h"
+
+namespace psi {
+namespace scf {
+
+void BaseHF::common_init(Options& options, std::string& module, const std::shared_ptr<Molecule>& molecule,
+                         const std::array<double, 3>& dipole_field_strength) {
+    attempt_number_ = 1;
+    reset_occ_ = false;
+    sad_ = false;
+    module = "scf";
+
+    scf_type_ = options.get_str("SCF_TYPE");
+
+    energies_["Total Energy"] = 0.0;
+    energies_["-D"] = 0.0;
+
+    nuclearrep_ = molecule->nuclear_repulsion_energy(dipole_field_strength);
+    charge_ = molecule->molecular_charge();
+    multiplicity_ = molecule->multiplicity();
+
+    initialized_diis_manager_ = false;
+    MOM_performed_ = false;  // duplicated py-side (needed before iterate)
+
+    integral_threshold_ = options.get_double("INTS_TOLERANCE");
+}
+
+}  // namespace scf
+}  // namespace psi

--- a/psi4/src/psi4/libscf_solver/basehf.h
+++ b/psi4/src/psi4/libscf_solver/basehf.h
@@ -1,0 +1,213 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#ifndef psi4_libscf_solver_basehf_h
+#define psi4_libscf_solver_basehf_h
+
+#include "psi4/pybind11.h"
+
+#include <array>
+#include <map>
+#include <memory>
+#include <string>
+
+namespace psi {
+
+class Molecule;
+class Options;
+class SuperFunctional;
+class BaseJK;
+
+namespace scf {
+
+/*! \brief Mixin holding SCF-loop state shared by real (HF) and complex (CGHF) solvers.
+ *
+ *  HF / CGHF inherit this alongside Wavefunction / ComplexWavefunction so common
+ *  iteration, DIIS, MOM, and DFT-functional bookkeeping is not duplicated.
+ *
+ *  JK storage lives on the derived class (typed JK vs BaseJK/ComplexJK); BaseHF
+ *  only exposes a polymorphic accessor interface.
+ */
+class BaseHF {
+   protected:
+    /// Current Iteration
+    int iteration_;
+
+    /// Did the SCF converge?
+    bool converged_;
+
+    /// Nuclear repulsion energy
+    double nuclearrep_;
+
+    /// Reset occupations in SCF iteration?
+    bool reset_occ_;
+    /// SAD guess, non-idempotent guess density?
+    bool sad_;
+
+    /// SCF algorithm type
+    std::string scf_type_;
+
+    /// Table of energy components
+    std::map<std::string, double> energies_;
+
+    /// Are we to do MOM?
+    bool MOM_enabled_;
+    /// Are we to do excited-state MOM?
+    bool MOM_excited_;
+    /// MOM performed?
+    bool MOM_performed_;
+
+    /// DIIS manager intiialized?
+    bool initialized_diis_manager_;
+    /// DIIS manager for all SCF wavefunctions
+    py::object diis_manager_;
+
+    /// When do we start collecting vectors for DIIS
+    int diis_start_;
+    /// Are we even using DIIS?
+    int diis_enabled_;
+
+    /// Which set of iterations we're on in this computation, e.g., for stability
+    /// analysis, where we want to retry SCF without going through all of the setup
+    int attempt_number_;
+
+    /// The number of electrons
+    int nelectron_;
+
+    /// The charge of the system
+    int charge_;
+
+    /// The multiplicity of the system (specified as 2 Ms + 1)
+    int multiplicity_;
+
+    /// The value below which integrals are neglected
+    double integral_threshold_;
+
+    /// DFT variables
+    std::shared_ptr<SuperFunctional> functional_;
+
+    BaseHF() = default;
+    explicit BaseHF(std::shared_ptr<SuperFunctional> functional) : functional_(std::move(functional)) {}
+
+    /// Shared SCF bookkeeping
+    /// `module` is BaseWavefunction::module_
+    void common_init(Options& options, std::string& module, const std::shared_ptr<Molecule>& molecule,
+                     const std::array<double, 3>& dipole_field_strength);
+
+   public:
+    virtual ~BaseHF() = default;
+
+    /// Get and set current iteration
+    int iteration() const { return iteration_; }
+    void set_iteration(int iter) { iteration_ = iter; }
+
+    /// Are we even using DIIS?
+    bool diis_enabled() const { return bool(diis_enabled_); }
+    void set_diis_enabled(bool tf) { diis_enabled_ = int(tf); }
+
+    /// When do we start collecting vectors for DIIS
+    int diis_start() const { return diis_start_; }
+    void set_diis_start(int iter) { diis_start_ = iter; }
+
+    /// Are we to do excited-state MOM?
+    bool MOM_excited() const { return MOM_excited_; }
+    void set_MOM_excited(bool tf) { MOM_excited_ = tf; }
+
+    /// MOM performed?
+    bool MOM_performed() const { return MOM_performed_; }
+    void set_MOM_performed(bool tf) { MOM_performed_ = tf; }
+
+    /// Which set of iterations we're on in this computation, e.g., for stability
+    /// analysis, where we want to retry SCF without going through all of the setup
+    int attempt_number() const { return attempt_number_; }
+    void set_attempt_number(int an) { attempt_number_ = an; }
+
+    const std::string& scf_type() const { return scf_type_; }
+
+    /// The DIIS object
+    // std::shared_ptr<py::object> is probably saner, but that hits a compile error.
+    // Quite probably https://github.com/pybind/pybind11/issues/787
+    py::object& diis_manager() { return diis_manager_; }
+    void set_diis_manager(py::object& manager) { diis_manager_ = manager; }
+    bool initialized_diis_manager() const { return initialized_diis_manager_; }
+    void set_initialized_diis_manager(bool tf) { initialized_diis_manager_ = tf; }
+
+    /// The DFT Functional object (or null if it has been deleted)
+    std::shared_ptr<SuperFunctional> functional() const { return functional_; }
+
+    // Expert option to reset the occupation or not at iteration zero
+    bool reset_occ() const { return reset_occ_; }
+    void set_reset_occ(bool reset) { reset_occ_ = reset; }
+    // Expert option to toggle non-idempotent density matrix or not at iteration zero
+    bool sad() const { return sad_; }
+    void set_sad(bool sad) { sad_ = sad; }
+
+    // Energies data
+    void set_energies(std::string key, double value) { energies_[key] = value; }
+    double get_energies(std::string key) { return energies_[key]; }
+
+    /// Form core Hamiltonian
+    virtual void form_H() = 0;
+
+    /// Form the S^{1/2} orthogonalization matrix
+    virtual void form_Shalf() = 0;
+
+    /// Compute MO coefficients from the current Fock matrix
+    virtual void form_C(double shift = 0.0) = 0;
+
+    /// Compute initial MO coefficients (default calls form_C)
+    virtual void form_initial_C() { form_C(); };
+
+    /** Computes the initial energy. */
+    virtual double compute_initial_E() { return 0.0; }
+
+    /// Compute energy for the iteration.
+    virtual double compute_E() { return 0.0; }
+
+    /// Form the density matrix from the current orbitals
+    virtual void form_D() = 0;
+
+    /// Form the Kohn-Sham potential matrix from the current density
+    virtual void form_V() = 0;
+
+    /// Form the Fock matrix
+    virtual void form_F() = 0;
+
+    /// Form the initial Fock matrix (default calls form_F)
+    virtual void form_initial_F() { form_F(); };
+
+    /// Form the G (J-K) matrix
+    virtual void form_G() = 0;
+
+    virtual void print_orbitals() = 0;
+};
+
+}  // namespace scf
+}  // namespace psi
+
+#endif

--- a/psi4/src/psi4/libscf_solver/hf.cc
+++ b/psi4/src/psi4/libscf_solver/hf.cc
@@ -87,7 +87,7 @@ namespace psi {
 namespace scf {
 
 HF::HF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> func, Options& options, std::shared_ptr<PSIO> psio)
-    : Wavefunction(options), functional_(func) {
+    : Wavefunction(options), BaseHF(func) {
     shallow_copy(ref_wfn);
     psio_ = psio;
     common_init();
@@ -96,18 +96,11 @@ HF::HF(SharedWavefunction ref_wfn, std::shared_ptr<SuperFunctional> func, Option
 HF::~HF() {}
 
 void HF::common_init() {
-    attempt_number_ = 1;
-    reset_occ_ = false;
-    sad_ = false;
-    module_ = "scf";
+    BaseHF::common_init(options_, module_, molecule_, dipole_field_strength_);
     frac_performed_ = false;
 
     // This quantity is needed fairly soon
     nirrep_ = factory_->nirrep();
-
-    integral_threshold_ = options_.get_double("INTS_TOLERANCE");
-
-    scf_type_ = options_.get_str("SCF_TYPE");
 
     H_ = factory_->create_matrix("One-electron Hamiltonian");
     X_ = factory_->create_matrix("X");
@@ -119,8 +112,6 @@ void HF::common_init() {
         nsopi_[h] = dimpi[h];
         nso_ += nsopi_[h];
     }
-
-    energies_["Total Energy"] = 0.0;
 
     // Read in DOCC and SOCC from memory
     input_docc_ = false;
@@ -205,10 +196,6 @@ void HF::common_init() {
         }
     }
 
-    // Set additional information
-    nuclearrep_ = molecule_->nuclear_repulsion_energy(dipole_field_strength_);
-    charge_ = molecule_->molecular_charge();
-    multiplicity_ = molecule_->multiplicity();
     nelectron_ = nbeta_ + nalpha_;
 
     // Copy data for storage
@@ -252,17 +239,12 @@ void HF::common_init() {
     // How much stuff shall we echo to the user?
     if (options_["PRINT"].has_changed()) print_ = options_.get_int("PRINT");
 
-    initialized_diis_manager_ = false;
-
-    MOM_performed_ = false;  // duplicated py-side (needed before iterate)
-
     if (print_) {
         print_header();
     }
 
     // -D is zero by default
     set_scalar_variable("-D Energy", 0.0);  // no-autodoc
-    energies_["-D"] = 0.0;
 
     // CPHF info
     cphf_nfock_builds_ = 0;
@@ -406,6 +388,13 @@ void HF::set_jk(std::shared_ptr<JK> jk) {
     }
 
     jk_ = jk;
+}
+
+std::shared_ptr<JK> HF::build_jk(size_t memory) const {
+    const bool do_wK = this->functional()->is_x_lrc();
+    auto jk = JK::build_JK(get_basisset("ORBITAL"), get_basisset("DF_BASIS_SCF"),
+                           Process::environment.options, do_wK, memory);
+    return jk;
 }
 
 void HF::semicanonicalize() { throw PSIEXCEPTION("This type of wavefunction cannot be semicanonicalized!"); }

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -50,7 +50,7 @@ class DIISManager;
 class PSIO;
 namespace scf {
 
-class HF : public Wavefunction, public BaseHF {
+class HF : public BaseHF, public Wavefunction {
    protected:
     // Prefer BaseHF's copies over BaseWavefunction's for these names.
     using BaseHF::nelectron_;

--- a/psi4/src/psi4/libscf_solver/hf.h
+++ b/psi4/src/psi4/libscf_solver/hf.h
@@ -35,7 +35,7 @@
 #include "psi4/libmints/vector3.h"
 #include "psi4/psi4-dec.h"
 
-#include "psi4/pybind11.h"
+#include "psi4/libscf_solver/basehf.h"
 
 namespace psi {
 using PerturbedPotentialFunction = std::function<SharedMatrix(SharedMatrix)>;
@@ -50,8 +50,12 @@ class DIISManager;
 class PSIO;
 namespace scf {
 
-class HF : public Wavefunction {
+class HF : public Wavefunction, public BaseHF {
    protected:
+    // Prefer BaseHF's copies over BaseWavefunction's for these names.
+    using BaseHF::nelectron_;
+    using BaseHF::multiplicity_;
+
     /// The kinetic energy matrix
     SharedMatrix T_;
     /// The 1e potential energy matrix
@@ -83,21 +87,9 @@ class HF : public Wavefunction {
     // Q: right now, thresholds are removed from Wfn since only appear once, py-side.
     //    should we instead store here the E & D to which SCF was converged?
 
-    /// Table of energy components
-    std::map<std::string, double> energies_;
-
     /// Basis list for SAD
     std::vector<std::shared_ptr<BasisSet>> sad_basissets_;
     std::vector<std::shared_ptr<BasisSet>> sad_fitting_basissets_;
-
-    /// Current Iteration
-    int iteration_;
-
-    /// Did the SCF converge?
-    bool converged_;
-
-    /// Nuclear repulsion energy
-    double nuclearrep_;
 
     /// DOCC vector from input (if found)
     bool input_docc_;
@@ -113,30 +105,13 @@ class HF : public Wavefunction {
     Dimension original_nbetapi_;
     int original_nalpha_;
     int original_nbeta_;
-    // Reset occupations in SCF iteration?
-    bool reset_occ_;
-    // SAD guess, non-idempotent guess density?
-    bool sad_;
 
     /// Mapping arrays
     int* so2symblk_;
     int* so2index_;
 
-    /// SCF algorithm type
-    std::string scf_type_;
-
-    /// The value below which integrals are neglected
-    double integral_threshold_;
-
     /// The soon to be ubiquitous JK object
     std::shared_ptr<JK> jk_;
-
-    /// Are we to do MOM?
-    bool MOM_enabled_;
-    /// Are we to do excited-state MOM?
-    bool MOM_excited_;
-    /// MOM performed?
-    bool MOM_performed_;
 
     /// Frac started? (Same thing as frac_performed_)
     bool frac_performed_;
@@ -144,25 +119,12 @@ class HF : public Wavefunction {
     SharedMatrix unscaled_Ca_;
     SharedMatrix unscaled_Cb_;
 
-    /// DIIS manager intiialized?
-    bool initialized_diis_manager_;
-    /// DIIS manager for all SCF wavefunctions
-    py::object diis_manager_;
-
-    /// When do we start collecting vectors for DIIS
-    int diis_start_;
-    /// Are we even using DIIS?
-    int diis_enabled_;
-
     // parameters for hard-sphere potentials
     double radius_;     // radius of spherical potential
     double thickness_;  // thickness of spherical barrier
     int r_points_;      // number of radial integration points
     int theta_points_;  // number of colatitude integration points
     int phi_points_;    // number of azimuthal integration points
-
-    /// DFT variables
-    std::shared_ptr<SuperFunctional> functional_;
 
     // CPHF info
     int cphf_nfock_builds_;
@@ -175,7 +137,7 @@ class HF : public Wavefunction {
     void print_occupation();
 
     /// Common initializer
-    void common_init();
+    void common_init() override;
     /// Part of the common initializer that runs after subclass specific tasks
     void subclass_init();
     /// Construct the DFT potential.
@@ -196,19 +158,6 @@ class HF : public Wavefunction {
 
     /// Prints the orbitals energies and symmetries (helper method)
     void print_orbital_pairs(const char* header, std::vector<std::pair<double, std::pair<std::string, int>>> orbs);
-
-    /// Which set of iterations we're on in this computation, e.g., for stability
-    /// analysis, where we want to retry SCF without going through all of the setup
-    int attempt_number_;
-
-    /// The number of electrons
-    int nelectron_;
-
-    /// The charge of the system
-    int charge_;
-
-    /// The multiplicity of the system (specified as 2 Ms + 1)
-    int multiplicity_;
 
     /// SAD Guess and propagation
     virtual void compute_SAD_guess(bool natorb);
@@ -232,18 +181,6 @@ class HF : public Wavefunction {
 
     ~HF() override;
 
-    /// Get and set current iteration
-    int iteration() const { return iteration_; }
-    void set_iteration(int iter) { iteration_ = iter; }
-
-    /// Are we even using DIIS?
-    bool diis_enabled() const { return bool(diis_enabled_); }
-    void set_diis_enabled(bool tf) { diis_enabled_ = int(tf); }
-
-    /// When do we start collecting vectors for DIIS
-    int diis_start() const { return diis_start_; }
-    void set_diis_start(int iter) { diis_start_ = iter; }
-
     /// Frac performed current iteration?
     bool frac_performed() const { return frac_performed_; }
     void set_frac_performed(bool tf) { frac_performed_ = tf; }
@@ -251,35 +188,17 @@ class HF : public Wavefunction {
     /// Runs the SCF using OpenOrbitalOptimizer
     virtual void openorbital_scf() { throw PSIEXCEPTION("openorbital_scf is virtual; it has not been implemented for your class"); };
 
-    /// Are we to do excited-state MOM?
-    bool MOM_excited() const { return MOM_excited_; }
-    void set_MOM_excited(bool tf) { MOM_excited_ = tf; }
-
-    /// MOM performed?
-    bool MOM_performed() const { return MOM_performed_; }
-    void set_MOM_performed(bool tf) { MOM_performed_ = tf; }
-
     // Q: MOM_started_ was ditched b/c same info as MOM_performed_
-
-    /// Which set of iterations we're on in this computation, e.g., for stability
-    /// analysis, where we want to retry SCF without going through all of the setup
-    int attempt_number() const { return attempt_number_; }
-    void set_attempt_number(int an) { attempt_number_ = an; }
 
     /// Check the stability of the wavefunction, and correct (if requested)
     /// For UHF, this is defined Python-side. The other methods should be joining it.
     virtual bool stability_analysis();
 
-    /** Computes the initial energy. */
-    virtual double compute_initial_E() { return 0.0; }
-
-    const std::string& scf_type() const { return scf_type_; }
-
     /// Check MO phases
     void check_phases();
 
     /// Prints the orbitals in arbitrary order (works with MOM)
-    void print_orbitals();
+    void print_orbitals() override;
 
     /// Prints some opening information
     void print_header();
@@ -289,22 +208,28 @@ class HF : public Wavefunction {
 
     virtual void compute_spin_contamination();
 
-    /// The DIIS object
-    // std::shared_ptr<py::object> is probably saner, but that hits a compile error.
-    // Quite probably https://github.com/pybind/pybind11/issues/787
-    py::object& diis_manager() { return diis_manager_; }
-    void set_diis_manager(py::object& manager) { diis_manager_ = manager; }
-    bool initialized_diis_manager() const { return initialized_diis_manager_; }
-    void set_initialized_diis_manager(bool tf) { initialized_diis_manager_ = tf; }
-
     /// The JK object (or null if it has been deleted)
     std::shared_ptr<JK> jk() const { return jk_; }
 
     /// Sets the internal JK object (expert)
     void set_jk(std::shared_ptr<JK> jk);
 
-    /// The DFT Functional object (or null if it has been deleted)
-    std::shared_ptr<SuperFunctional> functional() const { return functional_; }
+    /* Builds the correct JK object. This is a new function defined so that the
+    * python side no longer constructs the JK object separately from wfn.
+    * ComplexJKs should be built for ComplexWavefunctions. However, any mechanism
+    * to determine if ComplexJK is requested within JK::build_JK is smelly.
+    *   1. We could infer a ComplexJK with `REFERENCE CGHF`, but every new complex
+    *      reference would require an addition to this list.
+    *   2. We could add another option for `IS_COMPLEX`, but being a global option
+    *      anyone could change it. (not obvious what the source of truth is)
+    *   3. We could pass in the wfn directly to Build_JK and do RTTI. This works
+    *      but is awfuly smelly too *insert foghorn sound*
+    * Here, we build the correct JK via an overriden pure virtual function.
+    * Notice the const qualifier: This doesn't change `HF::jk_`. A downside
+    * to this approach is that shared ptrs are not covariant, meaning
+    * a bit more work is required to upcast JK/ComplexJK --> BaseJK.
+    */
+    std::shared_ptr<JK> build_jk(size_t memory) const;
 
     /// The DFT Potential object (or null if it has been deleted)
     /// This needs to be virtual so that subclasses can enforce their
@@ -323,7 +248,7 @@ class HF : public Wavefunction {
     void reset_occupation();
 
     /// Compute energy for the iteration.
-    virtual double compute_E();
+    double compute_E() override;
 
     /** Applies second-order convergence acceleration */
     virtual int soscf_update(double soscf_conv, int soscf_min_iter, int soscf_max_iter, bool soscf_print);
@@ -355,38 +280,38 @@ class HF : public Wavefunction {
     void frac_renormalize();
     void frac_helper();
 
-    /// Formation of H is the same regardless of RHF, ROHF, UHF
-    // Temporarily converting to virtual function for testing embedding
-    // potentials.  TDC, 5/23/12.
-    virtual void form_H();
+    /// Form core Hamiltonian
+    void form_H() override;
+
+    /// Form the S^{1/2} orthogonalization matrix
+    void form_Shalf() override;
+
+    /// Compute MO coefficients from the current Fock matrix
+    void form_C(double shift = 0.0) override;
+
+    /// Compute initial MO coefficients (default calls form_C)
+    void form_initial_C() override { form_C(); }
+
+    /// Form the density matrix from the current orbitals
+    void form_D() override;
+
+    /// Form the Kohn-Sham potential matrix from the current density
+    void form_V() override;
+
+    /// Form the Fock matrix
+    void form_F() override;
+
+    /// Form the initial Fock matrix (default calls form_F)
+    void form_initial_F() override { form_F(); }
+
+    /// Form the G (J-K) matrix
+    void form_G() override;
 
     /// Do any needed integral JK setup
     virtual void initialize_gtfock_jk();
 
-    /// Formation of S^+1/2 and S^-1/2 are the same
-    void form_Shalf();
-
     /// Form the guess (guarantees C, D, and E)
     virtual void guess();
-
-    /// Compute the MO coefficients (C_) using level shift
-    virtual void form_C(double shift = 0.0);
-    /** Computes the initial MO coefficients (default is to call form_C) */
-    virtual void form_initial_C() { form_C(); }
-
-    /// Computes the density matrix (D_)
-    virtual void form_D();
-
-    /// Computes the density matrix (V_)
-    virtual void form_V();
-
-    /** Computes the Fock matrix */
-    virtual void form_F();
-    /** Computes the initial Fock matrix (default is to call form_F) */
-    virtual void form_initial_F() { form_F(); }
-
-    /** Forms the G matrix */
-    virtual void form_G();
 
     /** Form X'(FDS - SDF)X (for DIIS) **/
     virtual SharedMatrix form_FDSmSDF(SharedMatrix Fso, SharedMatrix Dso);
@@ -414,22 +339,11 @@ class HF : public Wavefunction {
     void guess_Ca(SharedMatrix Ca) { guess_Ca_ = Ca; }
     void guess_Cb(SharedMatrix Cb) { guess_Cb_ = Cb; }
 
-    // Expert option to reset the occuption or not at iteration zero
-    bool reset_occ() const { return reset_occ_; }
-    void set_reset_occ(bool reset) { reset_occ_ = reset; }
-    // Expert option to toggle non-idempotent density matrix or not at iteration zero
-    bool sad() const { return sad_; }
-    void set_sad(bool sad) { sad_ = sad; }
-
     // SAD information
     void set_sad_basissets(std::vector<std::shared_ptr<BasisSet>> basis_vec) { sad_basissets_ = basis_vec; }
     void set_sad_fitting_basissets(std::vector<std::shared_ptr<BasisSet>> basis_vec) {
         sad_fitting_basissets_ = basis_vec;
     }
-
-    // Energies data
-    void set_energies(std::string key, double value) { energies_[key] = value; }
-    double get_energies(std::string key) { return energies_[key]; }
 
     // External potentials
     void clear_external_potentials() { external_potentials_.clear(); }

--- a/tests/pytests/test_basewavefunction.py
+++ b/tests/pytests/test_basewavefunction.py
@@ -1,0 +1,113 @@
+import pytest
+import numpy as np
+
+import psi4
+from addons import uusing
+from os.path import isfile
+
+pytestmark = [pytest.mark.psi, pytest.mark.api, pytest.mark.quick]
+
+
+@pytest.fixture
+def h2o_sto3g():
+    mol = psi4.geometry("""
+        O
+        H 1 1.0
+        H 1 1.0 2 101.5
+        symmetry c1
+    """)
+    psi4.set_options({"basis": "sto-3g"})
+    basis = psi4.core.BasisSet.build(mol, "BASIS", psi4.core.get_global_option("BASIS"))
+    return mol, basis
+
+
+@pytest.mark.parametrize("cls_str", [
+    "Wavefunction",
+    pytest.param("ComplexWavefunction", marks=pytest.mark.xfail)
+])
+def test_basewavefunction_constructors(cls_str, h2o_sto3g):
+    """Tests constructors for wavefunctions derived from BaseWavefunction."""
+    cls = getattr(psi4.core, cls_str)
+    mol, basis = h2o_sto3g
+    options = psi4.core.get_options()
+
+    wfn_mol_basis = cls(mol, basis)
+    assert isinstance(wfn_mol_basis, psi4.core.BaseWavefunction)
+    assert isinstance(wfn_mol_basis, cls)
+
+    wfn_mol_basis_opts = cls(mol, basis, options)
+    assert isinstance(wfn_mol_basis_opts, psi4.core.BaseWavefunction)
+    assert isinstance(wfn_mol_basis_opts, cls)
+
+    assert wfn_mol_basis.molecule().natom() == mol.natom()
+    assert wfn_mol_basis.basisset().nbf() == basis.nbf()
+    assert wfn_mol_basis_opts.molecule().natom() == mol.natom()
+    assert wfn_mol_basis_opts.basisset().nbf() == basis.nbf()
+
+
+@uusing("einsums")
+@pytest.mark.xfail(
+    condition=(not hasattr(psi4.core, "ComplexWavefunction")),
+    reason="You must have psi4.core.ComplexWavefunction to run ComplexWavefunction pytests."
+)
+def test_complexwavefunction_to_from_file(h2o_sto3g):
+    """ComplexWavefunction.to_file / from_file round-trip including ComplexMatrix (C1)."""
+    mol, basis = h2o_sto3g
+    nbf = basis.nbf()
+
+    rng = np.random.default_rng(0)
+    C_ref = rng.normal(size=(nbf, nbf)) + 1.0j * rng.normal(size=(nbf, nbf))
+    D_ref = rng.normal(size=(nbf, nbf)) + 1.0j * rng.normal(size=(nbf, nbf))
+    # Hermitize density-like matrix for realism
+    D_ref = 0.5 * (D_ref + D_ref.conj().T)
+    F_ref = rng.normal(size=(nbf, nbf)) + 1.0j * rng.normal(size=(nbf, nbf))
+    H_ref = rng.normal(size=(nbf, nbf))
+    S_ref = np.eye(nbf, dtype=np.complex128)
+    eps_ref = rng.normal(size=(nbf,))
+
+    wfn = psi4.core.ComplexWavefunction(mol, basis)
+    wfn.set_name("TEST-CWFN")
+    wfn.set_module("pytest")
+    wfn.set_energy(-1.23456789)
+    wfn.set_variable("CURRENT ENERGY", -1.23456789)
+    wfn.set_variable("MY SCALAR", 42.0)
+    wfn.set_C(psi4.core.ComplexMatrix.from_array(C_ref, name="C"))
+    wfn.set_D(psi4.core.ComplexMatrix.from_array(D_ref, name="D"))
+    wfn.set_F(psi4.core.ComplexMatrix.from_array(F_ref, name="F"))
+    wfn.set_H(psi4.core.ComplexMatrix.from_array(H_ref, name="H"))
+    wfn.set_S(psi4.core.ComplexMatrix.from_array(S_ref, name="S"))
+    wfn.set_epsilon(psi4.core.Vector.from_array(eps_ref, name="epsilon"))
+    wfn.set_array_variable("TEST ARR", psi4.core.ComplexMatrix.from_array(D_ref, name="TEST ARR"))
+
+    wfn.to_file("pytest_cwfn")
+    assert isfile("pytest_cwfn.npy")
+
+    wfn_dict = wfn.to_file()
+    np.testing.assert_allclose(wfn_dict["matrix"]["C"], C_ref)
+    np.testing.assert_allclose(wfn_dict["matrix"]["D"], D_ref)
+    np.testing.assert_allclose(wfn_dict["matrix"]["F"], F_ref)
+    np.testing.assert_allclose(wfn_dict["matrix"]["H"], H_ref)
+    np.testing.assert_allclose(wfn_dict["matrix"]["S"], S_ref)
+    np.testing.assert_allclose(wfn_dict["vector"]["epsilon"], eps_ref)
+    np.testing.assert_allclose(wfn_dict["matrixarr"]["TEST ARR"], D_ref)
+
+    wfn_disk = psi4.core.ComplexWavefunction.from_file("pytest_cwfn")
+    wfn_mem = psi4.core.ComplexWavefunction.from_file(wfn_dict)
+
+    for restored in (wfn_disk, wfn_mem):
+        assert isinstance(restored, psi4.core.ComplexWavefunction)
+        assert restored.name() == "TEST-CWFN"
+        assert restored.module() == "pytest"
+        assert restored.energy() == pytest.approx(-1.23456789)
+        assert restored.scalar_variable("MY SCALAR") == pytest.approx(42.0)
+        assert restored.molecule().natom() == mol.natom()
+        assert restored.basisset().nbf() == nbf
+        assert restored.nelec() == wfn.nelec()
+        assert restored.nirrep() == 1
+        np.testing.assert_allclose(restored.C().to_array(), C_ref)
+        np.testing.assert_allclose(restored.D().to_array(), D_ref)
+        np.testing.assert_allclose(restored.F().to_array(), F_ref)
+        np.testing.assert_allclose(restored.H().to_array(), H_ref)
+        np.testing.assert_allclose(restored.S().to_array(), S_ref)
+        np.testing.assert_allclose(restored.epsilon().to_array(), eps_ref)
+        np.testing.assert_allclose(restored.array_variable("TEST ARR").to_array(), D_ref)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This is the second layer of the PR stack adding support for complex wavefunctions in Psi4. It adds the pybinds for `BaseHF`, `BaseWavefunction` and `BaseJK`. Many methods in `python_helpers.py` were pulled up to `BaseWavefunction`. A significant amount of docstrings and type hints were updated accordingly. This changes *who* builds JK, not *how* JK is built.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user. This is destined for the release notes. May be empty. -->
*None*
## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance." Target audience is code reviewers and other devs skimming PRs. Should be more technical than user notes. Should never be empty. -->
- [x] `_core_wavefunction_build` was edited for the future addition of ComplexWavefunction. Like other methods in `python_helpers.py`, it is now monkeypatched to `BaseWavefunction`. Since it gets inherited by `Wavefunction` and `ComplexWavefunction`, it is now a classmethod so it can access the class of the caller.
- [x] `_core_wavefunction_variables` likewise anticipates `ComplexMatrix` type, thus the guard for `_qcvar_reshape_get` which is not implemented for `ComplexMatrix`.
- [x] JK is now built by HF/CGHF, thus the conversion from `_build_jk(self, memory)` to `self.build_jk(memory)`.
> One significant refactor is to let HF/CGHF make their own JK objects with `build_jk`, rather than building JK directly in python. JK knows nothing about the type of wavefunction that's using it, and it shouldn't! This doesn't change functionality, or how you supply a custom JK, it just simplifies the python code.
> 
> One solution I tried was to have a `std::shared_ptr<BaseJK>` object as private member in `BaseHF`. This would have been a nice solution if `shared_ptr` was a covariant type, or we used a regular pointer / reference. This is because the JK getter `virtual BaseJK* BaseHF::jk()` could be overridden to return a more specific type: `ComplexJK* CGHF::jk() override` and `JK* HF::jk() override`, respectively.
>   
> I understand there are workarounds to this problem, but many of them require changing code in classes derived from HF, which goes against one of my golden rules. On one hand, BaseHF has no JK-like members, and a small amount of code is duplicated: complex and real versions of JK getter/setter/builder. On the other, you get simpler python code and identical functionality in return. I think that's a fair balance.
- [x] Monkeypatched `scf_initialize`, `scf_compute_energy`, etc. are now added to `BaseHF` so they get inherited by CGHF later. This requires the MRO for `HF` to put `BaseHF` before `Wavefunction`.
- [x] Added pytests for BaseWavefunction ctors that xfails when `ComplexMatrix` is not an attribute of `psi4.core`. This will be removed later, but helps me keep track of things.
## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation, bug-seeking, code generation, docs, etc.). No restrictions, but a person should be submitting the PR and (as usual) be ready to answer questions about it. -->
- [x] AI was used significantly to write unit tests and docstrings.
- [x] AI was used occasionally to fix bugs.
## Checklist
- [x] Tests added for any new features
- [x] ~~Docstring or narrative docs/sphinxman/source updated.~~ \[*NB: I have documentation planned for one of the last layers*\]
## Status
- [x] Ready for review
## Stack Directory
1. [Base classes in C++](https://github.com/psi4/psi4/pull/3487)
2. Base classes in Python
3. [ComplexMatrix](https://github.com/psi4/psi4/pull/3489)
4. ~~ComplexDirectJK~~
5. ~~ComplexWavefunction in C++~~
6. ~~ComplexWavefunction in Python~~
7. ~~guess_C~~
8. ~~CGHF~~
9. ~~Documentation~~
10. ~~Stability Analysis~~