### PR TITLE
Dimension deprecation: `libmints` and `std::make_shared<Matrix>`

### DIFF
--- a/psi4/src/psi4/cc/ccenergy/form_df_ints.cc
+++ b/psi4/src/psi4/cc/ccenergy/form_df_ints.cc
@@ -67,7 +67,8 @@ void CCEnergyWavefunction::form_df_ints(Options &options, int **cachelist, int *
     SharedMatrix dfAOtoSO = petite.aotoso();
     const Dimension &soDim = AO2SO_->colspi();
     const Dimension &dfDim = dfAOtoSO->colspi();
-    auto symQao = std::make_shared<Matrix>(nirrep_, (const int *)dfDim, nbf2);
+    const Dimension nbf2Dim{std::vector<int>(nirrep_, nbf2)};
+    auto symQao = std::make_shared<Matrix>(dfDim, nbf2Dim);
     double **pQao = Qao->pointer();
     for (int h = 0; h < nirrep_; ++h) {
         double **pAOSO = dfAOtoSO->pointer(h);

--- a/psi4/src/psi4/cc/ccenergy/form_df_ints.cc
+++ b/psi4/src/psi4/cc/ccenergy/form_df_ints.cc
@@ -67,8 +67,7 @@ void CCEnergyWavefunction::form_df_ints(Options &options, int **cachelist, int *
     SharedMatrix dfAOtoSO = petite.aotoso();
     const Dimension &soDim = AO2SO_->colspi();
     const Dimension &dfDim = dfAOtoSO->colspi();
-    const Dimension nbf2Dim{std::vector<int>(nirrep_, nbf2)};
-    auto symQao = std::make_shared<Matrix>(dfDim, nbf2Dim);
+    auto symQao = std::make_shared<Matrix>(nirrep_, (const int *)dfDim, nbf2);
     double **pQao = Qao->pointer();
     for (int h = 0; h < nirrep_; ++h) {
         double **pAOSO = dfAOtoSO->pointer(h);

--- a/psi4/src/psi4/dct/dct_compute_RHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_RHF.cc
@@ -126,7 +126,7 @@ void DCTSolver::run_simult_dct_RHF() {
         "\n\n\t*=================================================================================*\n"
         "\t* Cycle  RMS [F, Kappa]   RMS Lambda Error   delta E        Total Energy     DIIS *\n"
         "\t*---------------------------------------------------------------------------------*\n");
-    auto tmp = std::make_shared<Matrix>("temp", nirrep_, nsopi_, nsopi_);
+    auto tmp = std::make_shared<Matrix>("temp", nsopi_, nsopi_);
     // Set up the DIIS manager
     DIISManager diisManager(maxdiis_, "DCT DIIS vectors");
 

--- a/psi4/src/psi4/dct/dct_compute_UHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_UHF.cc
@@ -363,11 +363,11 @@ void DCTSolver::run_simult_dct() {
         if (options_.get_str("DCT_TYPE") == "DF" && options_.get_str("AO_BASIS") == "NONE") {
             build_DF_tensors_UHF();
 
-            auto mo_h_A = std::make_shared<Matrix>("MO-based H Alpha", nirrep_, nmopi_, nmopi_);
+            auto mo_h_A = std::make_shared<Matrix>("MO-based H Alpha", nmopi_, nmopi_);
             mo_h_A->copy(so_h_);
             mo_h_A->transform(Ca_);
 
-            auto mo_h_B = std::make_shared<Matrix>("MO-based H Beta", nirrep_, nmopi_, nmopi_);
+            auto mo_h_B = std::make_shared<Matrix>("MO-based H Beta", nmopi_, nmopi_);
             mo_h_B->copy(so_h_);
             mo_h_B->transform(Cb_);
 
@@ -378,13 +378,13 @@ void DCTSolver::run_simult_dct() {
             moFb_->add(mo_gbarGamma_B_);
 
             // Back-transform the Fock matrix to the SO basis: F_so = (Ct)^-1 F_mo C^-1 = (C^-1)t F_mo C^-1
-            auto Ca_inverse = std::make_shared<Matrix>("Ca_ inverse", nirrep_, nmopi_, nsopi_);
+            auto Ca_inverse = std::make_shared<Matrix>("Ca_ inverse", nmopi_, nsopi_);
             Ca_inverse->copy(Ca_);
             Ca_inverse->general_invert();
             Fa_->copy(moFa_);
             Fa_->transform(Ca_inverse);
 
-            auto Cb_inverse = std::make_shared<Matrix>("Cb_ inverse", nirrep_, nmopi_, nsopi_);
+            auto Cb_inverse = std::make_shared<Matrix>("Cb_ inverse", nmopi_, nsopi_);
             Cb_inverse->copy(Cb_);
             Cb_inverse->general_invert();
             Fb_->copy(moFa_);

--- a/psi4/src/psi4/dct/dct_compute_UHF.cc
+++ b/psi4/src/psi4/dct/dct_compute_UHF.cc
@@ -261,7 +261,7 @@ int DCTSolver::run_twostep_dct_cumulant_updates() {
 }
 
 void DCTSolver::run_twostep_dct_orbital_updates() {
-    auto tmp = std::make_shared<Matrix>("temp", nirrep_, nsopi_, nsopi_);
+    auto tmp = std::make_shared<Matrix>("temp", nsopi_, nsopi_);
 
     // Set up DIIS
     DIISManager scfDiisManager(maxdiis_, "DCT DIIS Orbitals", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::InCore);
@@ -339,7 +339,7 @@ void DCTSolver::run_simult_dct() {
         "\t* Cycle  RMS [F, Kappa]   RMS Lambda Error   delta E        Total Energy     DIIS *\n"
         "\t*---------------------------------------------------------------------------------*\n");
 
-    auto tmp = std::make_shared<Matrix>("temp", nirrep_, nsopi_, nsopi_);
+    auto tmp = std::make_shared<Matrix>("temp", nsopi_, nsopi_);
     // Set up the DIIS manager
     DIISManager diisManager(maxdiis_, "DCT DIIS vectors");
     dpdbuf4 Laa, Lab, Lbb;

--- a/psi4/src/psi4/dct/dct_gradient_RHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_RHF.cc
@@ -444,7 +444,7 @@ void DCTSolver::compute_ewdm_odc_RHF() {
     /* Save the SO EWDM to the wavefunction as Lagrangian_.
      * All other EWDM processing operations are then redundant, but it's what deriv.cc:compute expects...
      */
-    Lagrangian_ = std::make_shared<Matrix>("Lagrangian matrix", nirrep_, nsopi_, nsopi_);
+    Lagrangian_ = std::make_shared<Matrix>("Lagrangian matrix", nsopi_, nsopi_);
     Lagrangian_->back_transform(aW, *Ca_);
     Lagrangian_->scale(-2.0);  // Doubling is equivalent to adding beta spin case
 

--- a/psi4/src/psi4/dct/dct_gradient_UHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_UHF.cc
@@ -3749,8 +3749,8 @@ void DCTSolver::compute_ewdm_dc() {
     /* Save the SO EWDM to the wavefunction as Lagrangian_.
      * All other EWDM processing operations are then redundant, but it's what deriv.cc:compute expects...
      */
-    Lagrangian_ = std::make_shared<Matrix>("Lagrangian matrix", nirrep_, nsopi_, nsopi_);
-    auto temp_lagrangian = std::make_shared<Matrix>("temp", nirrep_, nsopi_, nsopi_);
+    Lagrangian_ = std::make_shared<Matrix>("Lagrangian matrix", nsopi_, nsopi_);
+    auto temp_lagrangian = std::make_shared<Matrix>("temp", nsopi_, nsopi_);
     Lagrangian_->back_transform(aW, *Ca_);
     temp_lagrangian->back_transform(bW, *Cb_);
     Lagrangian_->add(temp_lagrangian);
@@ -4567,8 +4567,8 @@ void DCTSolver::compute_ewdm_odc() {
     /* Save the SO EWDM to the wavefunction as Lagrangian_.
      * All other EWDM processing operations are then redundant, but it's what deriv.cc:compute expects...
      */
-    Lagrangian_ = std::make_shared<Matrix>("Lagrangian matrix", nirrep_, nsopi_, nsopi_);
-    auto temp_lagrangian = std::make_shared<Matrix>("temp", nirrep_, nsopi_, nsopi_);
+    Lagrangian_ = std::make_shared<Matrix>("Lagrangian matrix", nsopi_, nsopi_);
+    auto temp_lagrangian = std::make_shared<Matrix>("temp", nsopi_, nsopi_);
     Lagrangian_->back_transform(aW, *Ca_);
     temp_lagrangian->back_transform(bW, *Cb_);
     Lagrangian_->add(temp_lagrangian);

--- a/psi4/src/psi4/dct/dct_gradient_UHF.cc
+++ b/psi4/src/psi4/dct/dct_gradient_UHF.cc
@@ -1357,8 +1357,8 @@ void DCTSolver::compute_orbital_response_intermediates() {
 // Returns RMS of the orbital response vector
 double DCTSolver::update_orbital_response() {
     dpdfile2 X_ia, X_ai, z_ia, zI_ai, zI_ia, r_ia;
-    auto a_ria = std::make_shared<Matrix>("MO basis Orbital Response Residual (Alpha)", nirrep_, naoccpi_, navirpi_);
-    auto b_ria = std::make_shared<Matrix>("MO basis Orbital Response Residual (Beta)", nirrep_, nboccpi_, nbvirpi_);
+    auto a_ria = std::make_shared<Matrix>("MO basis Orbital Response Residual (Alpha)", naoccpi_, navirpi_);
+    auto b_ria = std::make_shared<Matrix>("MO basis Orbital Response Residual (Beta)", nboccpi_, nbvirpi_);
 
     // Alpha spin
     global_dpd_->file2_init(&zI_ia, PSIF_DCT_DPD, 0, ID('O'), ID('V'), "zI <O|V>");

--- a/psi4/src/psi4/dct/dct_intermediates_RHF.cc
+++ b/psi4/src/psi4/dct/dct_intermediates_RHF.cc
@@ -273,7 +273,7 @@ void DCTSolver::form_density_weighted_fock_RHF() {
     a_tau_mo.set_diagonal(a_evals);
 
     // Transform the Fock matrix to NSO basis
-    auto nso_Fa = std::make_shared<Matrix>("Alpha Fock in the NSO basis", nirrep_, nmopi_, nmopi_);
+    auto nso_Fa = std::make_shared<Matrix>("Alpha Fock in the NSO basis", nmopi_, nmopi_);
 
     // Alpha spin
     nso_Fa->transform(moFa_, a_evecs);

--- a/psi4/src/psi4/dct/dct_intermediates_UHF.cc
+++ b/psi4/src/psi4/dct/dct_intermediates_UHF.cc
@@ -534,8 +534,8 @@ void DCTSolver::form_density_weighted_fock() {
     b_tau_mo.set_diagonal(b_evals);
 
     // Transform the Fock matrix to NSO basis
-    auto nso_Fa = std::make_shared<Matrix>("Alpha Fock in the NSO basis", nirrep_, nmopi_, nmopi_);
-    auto nso_Fb = std::make_shared<Matrix>("Beta Fock in the NSO basis", nirrep_, nmopi_, nmopi_);
+    auto nso_Fa = std::make_shared<Matrix>("Alpha Fock in the NSO basis", nmopi_, nmopi_);
+    auto nso_Fb = std::make_shared<Matrix>("Beta Fock in the NSO basis", nmopi_, nmopi_);
 
     // Alpha spin
     nso_Fa->transform(moFa_, a_evecs);

--- a/psi4/src/psi4/dct/dct_memory.cc
+++ b/psi4/src/psi4/dct/dct_memory.cc
@@ -138,12 +138,12 @@ void DCTSolver::init() {
 
     // Quadratically-convergent algorithm or orbital-optimized methods
     if (options_.get_str("ALGORITHM") == "QC" || orbital_optimized_) {
-        orbital_gradient_a_ = std::make_shared<Matrix>("MO basis Orbital Gradient (Alpha)", nirrep_, nmopi_, nmopi_);
-        orbital_gradient_b_ = std::make_shared<Matrix>("MO basis Orbital Gradient (Beta)", nirrep_, nmopi_, nmopi_);
+        orbital_gradient_a_ = std::make_shared<Matrix>("MO basis Orbital Gradient (Alpha)", nmopi_, nmopi_);
+        orbital_gradient_b_ = std::make_shared<Matrix>("MO basis Orbital Gradient (Beta)", nmopi_, nmopi_);
         Xtotal_a_ = std::make_shared<Matrix>("Generator of the orbital rotations w.r.t. reference orbitals (Alpha)",
-                                             nirrep_, nmopi_, nmopi_);
+                                             nmopi_, nmopi_);
         Xtotal_b_ = std::make_shared<Matrix>("Generator of the orbital rotations w.r.t. reference orbitals (Beta)",
-                                             nirrep_, nmopi_, nmopi_);
+                                             nmopi_, nmopi_);
     }
 
     if (options_.get_str("ALGORITHM") == "QC") {

--- a/psi4/src/psi4/dct/dct_qc.cc
+++ b/psi4/src/psi4/dct/dct_qc.cc
@@ -266,8 +266,8 @@ void DCTSolver::compute_orbital_gradient() {
 
     // Initialize the idempotent contribution to the OPDM (Kappa)
     if (!orbital_optimized_) {
-        auto full_kappa_a = std::make_shared<Matrix>("MO basis Full Kappa (Alpha)", nirrep_, nmopi_, nmopi_);
-        auto full_kappa_b = std::make_shared<Matrix>("MO basis Full Kappa (Beta)", nirrep_, nmopi_, nmopi_);
+        auto full_kappa_a = std::make_shared<Matrix>("MO basis Full Kappa (Alpha)", nmopi_, nmopi_);
+        auto full_kappa_b = std::make_shared<Matrix>("MO basis Full Kappa (Beta)", nmopi_, nmopi_);
         // Compute Kappa in the MO basis
         for (int h = 0; h < nirrep_; ++h) {
             for (int i = 0; i < naoccpi_[h]; ++i) {

--- a/psi4/src/psi4/dct/dct_tau_RHF.cc
+++ b/psi4/src/psi4/dct/dct_tau_RHF.cc
@@ -180,8 +180,8 @@ void DCTSolver::build_tau_R() {
         aocc_tau_.zero();
         avir_tau_.zero();
         // Diagonalize and take a square root
-        auto aocc_evecs = std::make_shared<Matrix>("Eigenvectors (Alpha Occupied)", nirrep_, naoccpi_, naoccpi_);
-        auto avir_evecs = std::make_shared<Matrix>("Eigenvectors (Alpha Virtual)", nirrep_, navirpi_, navirpi_);
+        auto aocc_evecs = std::make_shared<Matrix>("Eigenvectors (Alpha Occupied)", naoccpi_, naoccpi_);
+        auto avir_evecs = std::make_shared<Matrix>("Eigenvectors (Alpha Virtual)", navirpi_, navirpi_);
         auto aocc_evals = std::make_shared<Vector>("Eigenvalues (Alpha Occupied)", naoccpi_);
         auto avir_evals = std::make_shared<Vector>("Eigenvalues (Alpha Virtual)", navirpi_);
         aocc_tau_old.diagonalize(aocc_evecs, aocc_evals);

--- a/psi4/src/psi4/dct/dct_tau_UHF.cc
+++ b/psi4/src/psi4/dct/dct_tau_UHF.cc
@@ -813,10 +813,10 @@ void DCTSolver::build_tau_U() {
         bocc_tau_.zero();
         bvir_tau_.zero();
         // Diagonalize and take a square root
-        auto aocc_evecs = std::make_shared<Matrix>("Eigenvectors (Alpha Occupied)", nirrep_, naoccpi_, naoccpi_);
-        auto bocc_evecs = std::make_shared<Matrix>("Eigenvectors (Beta Occupied)", nirrep_, nboccpi_, nboccpi_);
-        auto avir_evecs = std::make_shared<Matrix>("Eigenvectors (Alpha Virtual)", nirrep_, navirpi_, navirpi_);
-        auto bvir_evecs = std::make_shared<Matrix>("Eigenvectors (Beta Virtual)", nirrep_, nbvirpi_, nbvirpi_);
+        auto aocc_evecs = std::make_shared<Matrix>("Eigenvectors (Alpha Occupied)", naoccpi_, naoccpi_);
+        auto bocc_evecs = std::make_shared<Matrix>("Eigenvectors (Beta Occupied)", nboccpi_, nboccpi_);
+        auto avir_evecs = std::make_shared<Matrix>("Eigenvectors (Alpha Virtual)", navirpi_, navirpi_);
+        auto bvir_evecs = std::make_shared<Matrix>("Eigenvectors (Beta Virtual)", nbvirpi_, nbvirpi_);
         auto aocc_evals = std::make_shared<Vector>("Eigenvalues (Alpha Occupied)", naoccpi_);
         auto bocc_evals = std::make_shared<Vector>("Eigenvalues (Beta Occupied)", nboccpi_);
         auto avir_evals = std::make_shared<Vector>("Eigenvalues (Alpha Virtual)", navirpi_);

--- a/psi4/src/psi4/dct/dct_tau_UHF.cc
+++ b/psi4/src/psi4/dct/dct_tau_UHF.cc
@@ -601,8 +601,8 @@ void DCTSolver::transform_tau_U() {
 void DCTSolver::print_opdm() {
     // Obtain natural occupancies
     // Form one-particle density matrix
-    auto a_opdm = std::make_shared<Matrix>("MO basis OPDM (Alpha)", nirrep_, nmopi_, nmopi_);
-    auto b_opdm = std::make_shared<Matrix>("MO basis OPDM (Beta)", nirrep_, nmopi_, nmopi_);
+    auto a_opdm = std::make_shared<Matrix>("MO basis OPDM (Alpha)", nmopi_, nmopi_);
+    auto b_opdm = std::make_shared<Matrix>("MO basis OPDM (Beta)", nmopi_, nmopi_);
 
     // Alpha spin
     for (int h = 0; h < nirrep_; ++h) {
@@ -641,8 +641,8 @@ void DCTSolver::print_opdm() {
     }
 
     // Diagonalize OPDM to obtain NOs
-    auto aevecs = std::make_shared<Matrix>("Eigenvectors (Alpha)", nirrep_, nmopi_, nmopi_);
-    auto bevecs = std::make_shared<Matrix>("Eigenvectors (Beta)", nirrep_, nmopi_, nmopi_);
+    auto aevecs = std::make_shared<Matrix>("Eigenvectors (Alpha)", nmopi_, nmopi_);
+    auto bevecs = std::make_shared<Matrix>("Eigenvectors (Beta)", nmopi_, nmopi_);
     auto aevals = std::make_shared<Vector>("Eigenvalues (Alpha)", nmopi_);
     auto bevals = std::make_shared<Vector>("Eigenvalues (Beta)", nmopi_);
 
@@ -699,15 +699,14 @@ void DCTSolver::build_tau_U() {
 
     // Iteratively compute the exact Tau
 
-    auto aocc_tau_old = std::make_shared<Matrix>("MO basis Tau (Alpha Occupied, old)", nirrep_, naoccpi_, naoccpi_);
-    auto bocc_tau_old = std::make_shared<Matrix>("MO basis Tau (Beta Occupied, old)", nirrep_, nboccpi_, nboccpi_);
-    auto avir_tau_old = std::make_shared<Matrix>("MO basis Tau (Alpha Virtual, old)", nirrep_, navirpi_, navirpi_);
-    auto bvir_tau_old = std::make_shared<Matrix>("MO basis Tau (Beta Virtual, old)", nirrep_, nbvirpi_, nbvirpi_);
-    auto aocc_d =
-        std::make_shared<Matrix>("Non-idempotency of OPDM (Alpha Occupied, old)", nirrep_, naoccpi_, naoccpi_);
-    auto bocc_d = std::make_shared<Matrix>("Non-idempotency of OPDM (Beta Occupied, old)", nirrep_, nboccpi_, nboccpi_);
-    auto avir_d = std::make_shared<Matrix>("Non-idempotency of OPDM (Alpha Virtual, old)", nirrep_, navirpi_, navirpi_);
-    auto bvir_d = std::make_shared<Matrix>("Non-idempotency of OPDM (Beta Virtual, old)", nirrep_, nbvirpi_, nbvirpi_);
+    auto aocc_tau_old = std::make_shared<Matrix>("MO basis Tau (Alpha Occupied, old)", naoccpi_, naoccpi_);
+    auto bocc_tau_old = std::make_shared<Matrix>("MO basis Tau (Beta Occupied, old)", nboccpi_, nboccpi_);
+    auto avir_tau_old = std::make_shared<Matrix>("MO basis Tau (Alpha Virtual, old)", navirpi_, navirpi_);
+    auto bvir_tau_old = std::make_shared<Matrix>("MO basis Tau (Beta Virtual, old)", nbvirpi_, nbvirpi_);
+    auto aocc_d = std::make_shared<Matrix>("Non-idempotency of OPDM (Alpha Occupied, old)", naoccpi_, naoccpi_);
+    auto bocc_d = std::make_shared<Matrix>("Non-idempotency of OPDM (Beta Occupied, old)", nboccpi_, nboccpi_);
+    auto avir_d = std::make_shared<Matrix>("Non-idempotency of OPDM (Alpha Virtual, old)", navirpi_, navirpi_);
+    auto bvir_d = std::make_shared<Matrix>("Non-idempotency of OPDM (Beta Virtual, old)", nbvirpi_, nbvirpi_);
 
     bool converged = false;
     bool failed = false;
@@ -725,10 +724,10 @@ void DCTSolver::build_tau_U() {
         diisManager.set_vector_size(&aocc_tau_, &bocc_tau_, &avir_tau_, &bvir_tau_);
     }
 
-    auto aocc_r = std::make_shared<Matrix>("Residual (Alpha Occupied)", nirrep_, naoccpi_, naoccpi_);
-    auto bocc_r = std::make_shared<Matrix>("Residual (Beta Occupied)", nirrep_, nboccpi_, nboccpi_);
-    auto avir_r = std::make_shared<Matrix>("Residual (Alpha Virtual)", nirrep_, navirpi_, navirpi_);
-    auto bvir_r = std::make_shared<Matrix>("Residual (Beta Virtual)", nirrep_, nbvirpi_, nbvirpi_);
+    auto aocc_r = std::make_shared<Matrix>("Residual (Alpha Occupied)", naoccpi_, naoccpi_);
+    auto bocc_r = std::make_shared<Matrix>("Residual (Beta Occupied)", nboccpi_, nboccpi_);
+    auto avir_r = std::make_shared<Matrix>("Residual (Alpha Virtual)", navirpi_, navirpi_);
+    auto bvir_r = std::make_shared<Matrix>("Residual (Beta Virtual)", nbvirpi_, nbvirpi_);
 
     while (!converged && !failed) {
         std::string diisString;

--- a/psi4/src/psi4/dct/dct_triples.cc
+++ b/psi4/src/psi4/dct/dct_triples.cc
@@ -138,8 +138,8 @@ void DCTSolver::dump_semicanonical() {
     }
 
     // Diagonalize F0 to get transformation matrix to semicanonical basis
-    auto a_evecs = std::make_shared<Matrix>("F0 Eigenvectors (Alpha)", nirrep_, nmopi_, nmopi_);
-    auto b_evecs = std::make_shared<Matrix>("F0 Eigenvectors (Beta)", nirrep_, nmopi_, nmopi_);
+    auto a_evecs = std::make_shared<Matrix>("F0 Eigenvectors (Alpha)", nmopi_, nmopi_);
+    auto b_evecs = std::make_shared<Matrix>("F0 Eigenvectors (Beta)", nmopi_, nmopi_);
     auto a_evals = std::make_shared<Vector>("F0 Eigenvalues (Alpha)", nmopi_);
     auto b_evals = std::make_shared<Vector>("F0 Eigenvalues (Beta)", nmopi_);
 

--- a/psi4/src/psi4/detci/ciwave.cc
+++ b/psi4/src/psi4/detci/ciwave.cc
@@ -263,13 +263,13 @@ SharedMatrix CIWavefunction::get_orbitals(const std::string& orbital_name) {
 
     orbital_locations(orbital_name, start, end);
 
-    auto* spread = new int[nirrep_];
+    auto spread = std::vector<int>(nirrep_);
     for (int h = 0; h < nirrep_; h++) {
         spread[h] = end[h] - start[h];
     }
 
     /// Fill desired orbitals
-    auto retC = std::make_shared<Matrix>("C " + orbital_name, nirrep_, nsopi_, spread);
+    auto retC = std::make_shared<Matrix>("C " + orbital_name, nsopi_, spread);
     for (int h = 0; h < nirrep_; h++) {
         for (int i = start[h], pos = 0; i < end[h]; i++, pos++) {
             C_DCOPY(nsopi_[h], &Ca_->pointer(h)[0][i], nmopi_[h], &retC->pointer(h)[0][pos], spread[h]);
@@ -279,7 +279,6 @@ SharedMatrix CIWavefunction::get_orbitals(const std::string& orbital_name) {
     /// Cleanup
     delete[] start;
     delete[] end;
-    delete[] spread;
 
     return retC;
 }

--- a/psi4/src/psi4/detci/opdm.cc
+++ b/psi4/src/psi4/detci/opdm.cc
@@ -141,9 +141,9 @@ void CIWavefunction::form_opdm() {
     // Figure out which OPDM should be current
     if (Parameters_->opdm_ave) {
         Dimension act_dim = get_dimension("ACT");
-        opdm_a_ = std::make_shared<Matrix>("MO-basis Alpha OPDM", nirrep_, act_dim, act_dim);
-        opdm_b_ = std::make_shared<Matrix>("MO-basis Beta OPDM", nirrep_, act_dim, act_dim);
-        opdm_ = std::make_shared<Matrix>("MO-basis OPDM", nirrep_, act_dim, act_dim);
+        opdm_a_ = std::make_shared<Matrix>("MO-basis Alpha OPDM", act_dim, act_dim);
+        opdm_b_ = std::make_shared<Matrix>("MO-basis Beta OPDM", act_dim, act_dim);
+        opdm_ = std::make_shared<Matrix>("MO-basis OPDM", act_dim, act_dim);
 
         for (int i = 0; i < Parameters_->average_num; i++) {
             int croot = Parameters_->average_states[i];
@@ -445,15 +445,15 @@ std::vector<std::vector<SharedMatrix> > CIWavefunction::opdm(SharedCIVector Ivec
 
         std::stringstream opdm_name;
         opdm_name << "MO-basis Alpha OPDM <" << Iroot << "| Etu |" << Jroot << ">";
-        auto new_OPDM_a = std::make_shared<Matrix>(opdm_name.str(), nirrep_, act_dim, act_dim);
+        auto new_OPDM_a = std::make_shared<Matrix>(opdm_name.str(), act_dim, act_dim);
 
         opdm_name.str(std::string());
         opdm_name << "MO-basis Beta OPDM <" << Iroot << "| Etu |" << Jroot << ">";
-        auto new_OPDM_b = std::make_shared<Matrix>(opdm_name.str(), nirrep_, act_dim, act_dim);
+        auto new_OPDM_b = std::make_shared<Matrix>(opdm_name.str(), act_dim, act_dim);
 
         opdm_name.str(std::string());
         opdm_name << "MO-basis OPDM <" << Iroot << "| Etu |" << Jroot << ">";
-        auto new_OPDM = std::make_shared<Matrix>(opdm_name.str(), nirrep_, act_dim, act_dim);
+        auto new_OPDM = std::make_shared<Matrix>(opdm_name.str(), act_dim, act_dim);
 
         int offset = 0;
         for (int h = 0; h < nirrep_; h++) {

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -70,7 +70,8 @@ void DFMP2::compute_opdm_and_nos(const SharedMatrix Dnosym, SharedMatrix Dso, Sh
     AO_c1NO->gemm(false, false, 1.0, AO_c1MO, c1MO_c1NO, 0.0);
     // Reapply the symmetry to the AO dimension
     auto AO_SO = reference_wavefunction_->aotoso();
-    auto SO_c1NO = std::make_shared<Matrix>(nirrep_, (const int*)nsopi_, nmo_);
+    Dimension nmo_filled_pi{std::vector<int>(nirrep_, nmo_)};
+    auto SO_c1NO = std::make_shared<Matrix>(nsopi_, nmo_filled_pi);
     SO_c1NO->set_name("SO to C1 NO");
     for (int h = 0; h < nirrep_; ++h) {
         int so_h = nsopi_[h];
@@ -120,7 +121,7 @@ void DFMP2::compute_opdm_and_nos(const SharedMatrix Dnosym, SharedMatrix Dso, Sh
     //
     // Now we're finished with the MO(c1)->NO(c1) matrix, use it as scratch for diag(NO occ)
     c1MO_c1NO->set_diagonal(occ_c1);
-    auto temp = std::make_shared<Matrix>(nirrep_, (const int*)nsopi_, nmo_);
+    auto temp = std::make_shared<Matrix>(nsopi_, nmo_filled_pi);
     for (int h = 0; h < nirrep_; ++h) {
         int so_h = nsopi_[h];
         if (so_h) {

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -70,8 +70,7 @@ void DFMP2::compute_opdm_and_nos(const SharedMatrix Dnosym, SharedMatrix Dso, Sh
     AO_c1NO->gemm(false, false, 1.0, AO_c1MO, c1MO_c1NO, 0.0);
     // Reapply the symmetry to the AO dimension
     auto AO_SO = reference_wavefunction_->aotoso();
-    Dimension nmo_filled_pi{std::vector<int>(nirrep_, nmo_)};
-    auto SO_c1NO = std::make_shared<Matrix>(nsopi_, nmo_filled_pi);
+    auto SO_c1NO = std::make_shared<Matrix>(nirrep_, (const int*)nsopi_, nmo_);
     SO_c1NO->set_name("SO to C1 NO");
     for (int h = 0; h < nirrep_; ++h) {
         int so_h = nsopi_[h];
@@ -121,7 +120,7 @@ void DFMP2::compute_opdm_and_nos(const SharedMatrix Dnosym, SharedMatrix Dso, Sh
     //
     // Now we're finished with the MO(c1)->NO(c1) matrix, use it as scratch for diag(NO occ)
     c1MO_c1NO->set_diagonal(occ_c1);
-    auto temp = std::make_shared<Matrix>(nsopi_, nmo_filled_pi);
+    auto temp = std::make_shared<Matrix>(nirrep_, (const int*)nsopi_, nmo_);
     for (int h = 0; h < nirrep_; ++h) {
         int so_h = nsopi_[h];
         if (so_h) {

--- a/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
+++ b/psi4/src/psi4/fnocc/frozen_natural_orbitals.cc
@@ -265,7 +265,7 @@ void FrozenNO::ComputeNaturalOrbitals() {
 
     // diagonalize virtual-virtual block of opdm
     int symmetry = Ca_->symmetry();
-    auto D = std::make_shared<Matrix>("Dab", nirrep_, aVirOrbsPI, aVirOrbsPI, symmetry);
+    auto D = std::make_shared<Matrix>("Dab", aVirOrbsPI, aVirOrbsPI, symmetry);
 
     global_dpd_->file2_init(&Dab, PSIF_LIBTRANS_DPD, 0, 1, 1, "Dab");
     global_dpd_->file2_mat_init(&Dab);
@@ -286,12 +286,12 @@ void FrozenNO::ComputeNaturalOrbitals() {
     psio->close(PSIF_LIBTRANS_DPD, 1);
     ints.reset();
 
-    auto eigvec = std::make_shared<Matrix>("Dab eigenvectors", nirrep_, aVirOrbsPI, aVirOrbsPI, symmetry);
+    auto eigvec = std::make_shared<Matrix>("Dab eigenvectors", aVirOrbsPI, aVirOrbsPI, symmetry);
     auto eigval = std::make_shared<Vector>("Dab eigenvalues", aVirOrbsPI);
     D->diagonalize(eigvec, eigval, descending);
 
     // overwrite ao/mo C matrix with ao/no transformation
-    auto temp = std::make_shared<Matrix>("temp", nirrep_, nsopi_, aVirOrbsPI, symmetry);
+    auto temp = std::make_shared<Matrix>("temp", nsopi_, aVirOrbsPI, symmetry);
     for (int h = 0; h < nirrep_; h++) {
         int v = aVirOrbsPI[h];
 
@@ -411,7 +411,7 @@ void FrozenNO::ComputeNaturalOrbitals() {
 
     // transform Fock matrix to truncated NO basis
 
-    auto Fab = std::make_shared<Matrix>("Fab(NO)", nirrep_, newVirOrbsPI, newVirOrbsPI, symmetry);
+    auto Fab = std::make_shared<Matrix>("Fab(NO)", newVirOrbsPI, newVirOrbsPI, symmetry);
     for (int h = 0; h < nirrep_; h++) {
         int o = nalphapi_[h];
         int vnew = newVirOrbsPI[h];
@@ -431,7 +431,7 @@ void FrozenNO::ComputeNaturalOrbitals() {
     }
 
     // semicanonicalize orbitals:
-    auto eigvecF = std::make_shared<Matrix>("Fab eigenvectors", nirrep_, newVirOrbsPI, newVirOrbsPI, symmetry);
+    auto eigvecF = std::make_shared<Matrix>("Fab eigenvectors", newVirOrbsPI, newVirOrbsPI, symmetry);
     auto eigvalF = std::make_shared<Vector>("Fab eigenvalues", newVirOrbsPI);
     Fab->diagonalize(eigvecF, eigvalF);
 

--- a/psi4/src/psi4/libmints/factory.cc
+++ b/psi4/src/psi4/libmints/factory.cc
@@ -105,24 +105,24 @@ int MatrixFactory::ncol(int h) const { return colspi_[h]; }
 int MatrixFactory::norb() const { return nso_; }
 
 /// Returns a new Matrix object with default dimensions
-std::unique_ptr<Matrix> MatrixFactory::create_matrix(int symmetry) { return std::make_unique<Matrix>(nirrep_, rowspi_, colspi_, symmetry); }
+std::unique_ptr<Matrix> MatrixFactory::create_matrix(int symmetry) { return std::make_unique<Matrix>(rowspi_, colspi_, symmetry); }
 
 /// Returns a new Matrix object with default dimensions
-SharedMatrix MatrixFactory::create_shared_matrix() const { return std::make_shared<Matrix>(nirrep_, rowspi_, colspi_); }
+SharedMatrix MatrixFactory::create_shared_matrix() const { return std::make_shared<Matrix>(rowspi_, colspi_); }
 
 void MatrixFactory::create_matrix(Matrix& mat, int symmetry) { mat.init(rowspi_, colspi_, "", symmetry); }
 
 /// Returns a new Matrix object named name with default dimensions
 std::unique_ptr<Matrix> MatrixFactory::create_matrix(std::string name, int symmetry) {
-    return std::make_unique<Matrix>(name, nirrep_, rowspi_, colspi_, symmetry);
+    return std::make_unique<Matrix>(name, rowspi_, colspi_, symmetry);
 }
 
 SharedMatrix MatrixFactory::create_shared_matrix(const std::string& name) const {
-    return std::make_shared<Matrix>(name, nirrep_, rowspi_, colspi_);
+    return std::make_shared<Matrix>(name, rowspi_, colspi_);
 }
 
 SharedMatrix MatrixFactory::create_shared_matrix(const std::string& name, int symmetry) const {
-    return std::make_shared<Matrix>(name, nirrep_, rowspi_, colspi_, symmetry);
+    return std::make_shared<Matrix>(name, rowspi_, colspi_, symmetry);
 }
 
 SharedMatrix MatrixFactory::create_shared_matrix(const std::string& name, int rows, int cols) const {

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -1107,7 +1107,7 @@ double Matrix::trace() {
 }
 
 SharedMatrix Matrix::transpose() const {
-    auto temp = std::make_shared<Matrix>(name_, nirrep_, colspi_, rowspi_, symmetry_);
+    auto temp = std::make_shared<Matrix>(name_, colspi_, rowspi_, symmetry_);
 
     if (symmetry_) {
         for (int rowsym = 0; rowsym < nirrep_; ++rowsym) {
@@ -2122,7 +2122,7 @@ void Matrix::pivoted_cholesky(double tol, std::vector<std::vector<int>> &pivot, 
     Dimension zero(nirrep_);
 
     if (upper) {
-        auto U = std::make_shared<Matrix>("Cholesky decomposed matrix", nirrep_, rowspi_, nchol);
+        auto U = std::make_shared<Matrix>("Cholesky decomposed matrix", rowspi_, nchol);
         U->zero();
         for (int h = 0; h < nirrep_; ++h) {
             for (int m = 0; m < rowspi_[h]; ++m) {
@@ -2135,7 +2135,7 @@ void Matrix::pivoted_cholesky(double tol, std::vector<std::vector<int>> &pivot, 
         // Switch to the properly sized matrix
         *this = *U;
     } else {
-        auto L = std::make_shared<Matrix>("Cholesky decomposed matrix", nirrep_, rowspi_, nchol);
+        auto L = std::make_shared<Matrix>("Cholesky decomposed matrix", rowspi_, nchol);
         L->zero();
         for (int h = 0; h < nirrep_; ++h) {
             for (int m = 0; m < rowspi_[h]; ++m) {
@@ -2156,7 +2156,7 @@ SharedMatrix Matrix::partial_cholesky_factorize(double delta, bool throw_if_nega
     }
 
     // Temporary cholesky factor (full memory)
-    auto K = std::make_shared<Matrix>("L Temp", nirrep_, rowspi_, rowspi_);
+    auto K = std::make_shared<Matrix>("L Temp", rowspi_, rowspi_);
 
     // Significant Cholesky columns per irrep
     std::vector<int> sigpi(nirrep_, 0);
@@ -2232,7 +2232,7 @@ SharedMatrix Matrix::partial_cholesky_factorize(double delta, bool throw_if_nega
     }
 
     // Copy out to properly sized array
-    auto L = std::make_shared<Matrix>("Partial Cholesky Factor", nirrep_, rowspi_, sigpi.data());
+    auto L = std::make_shared<Matrix>("Partial Cholesky Factor", rowspi_, sigpi);
 
     // K->print();
     // L->print();
@@ -2717,7 +2717,8 @@ void Matrix::apply_symmetry(const SharedMatrix &a, const SharedMatrix &transform
     }
 
     // Create temporary matrix of proper size.
-    Matrix temp(nirrep(), a->nrow(), transformer->colspi());
+    std::vector<int> rowspi = {a->nrow()};
+    Matrix temp(rowspi, transformer->colspi());
 
     char ta = 'n';
     char tb = 'n';
@@ -2775,7 +2776,7 @@ void Matrix::remove_symmetry(const SharedMatrix &a, const SharedMatrix &SO2AO) {
     zero();
 
     // Create temporary matrix of proper size.
-    Matrix temp(SO2AO->nirrep(), a->rowspi(), SO2AO->colspi());
+    Matrix temp(a->rowspi(), SO2AO->colspi());
 
     char ta = 'n';
     char tb = 'n';
@@ -3442,7 +3443,7 @@ SharedMatrix horzcat(const std::vector<SharedMatrix> &mats) {
         colspi += mats[a]->colspi();
     }
 
-    auto cat = std::make_shared<Matrix>("", nirrep, mats[0]->rowspi(), colspi);
+    auto cat = std::make_shared<Matrix>("", mats[0]->rowspi(), colspi);
 
     for (int h = 0; h < nirrep; ++h) {
         if (mats[0]->rowspi()[h] == 0 || colspi[h] == 0) continue;
@@ -3488,7 +3489,7 @@ SharedMatrix vertcat(const std::vector<SharedMatrix> &mats) {
         rowspi += mats[a]->rowspi();
     }
 
-    auto cat = std::make_shared<Matrix>("", nirrep, rowspi, mats[0]->colspi());
+    auto cat = std::make_shared<Matrix>("", rowspi, mats[0]->colspi());
 
     for (int h = 0; h < nirrep; ++h) {
         if (mats[0]->colspi()[h] == 0 || rowspi[h] == 0) continue;

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -2717,8 +2717,7 @@ void Matrix::apply_symmetry(const SharedMatrix &a, const SharedMatrix &transform
     }
 
     // Create temporary matrix of proper size.
-    std::vector<int> rowspi = {a->nrow()};
-    Matrix temp(rowspi, transformer->colspi());
+    Matrix temp(nirrep(), a->nrow(), transformer->colspi());
 
     char ta = 'n';
     char tb = 'n';

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -416,7 +416,7 @@ SharedMatrix Prop::Dt_mo(bool total) {
 }
 std::pair<SharedMatrix, SharedVector> Prop::Na_mo() {
     SharedMatrix D = Da_mo();
-    auto C = std::make_shared<Matrix>("Na_mo", D->nirrep(), D->rowspi(), D->rowspi());
+    auto C = std::make_shared<Matrix>("Na_mo", D->rowspi(), D->rowspi());
     auto O = std::make_shared<Vector>("Alpha Occupation", D->rowspi());
 
     D->diagonalize(C, O, descending);
@@ -427,7 +427,7 @@ std::pair<SharedMatrix, SharedVector> Prop::Nb_mo() {
     if (same_dens_) throw PSIEXCEPTION("Wavefunction is restricted, asking for Nb makes no sense");
 
     SharedMatrix D = Db_mo();
-    auto C = std::make_shared<Matrix>("Nb_mo", D->nirrep(), D->rowspi(), D->rowspi());
+    auto C = std::make_shared<Matrix>("Nb_mo", D->rowspi(), D->rowspi());
     auto O = std::make_shared<Vector>("Beta Occupation", D->rowspi());
 
     D->diagonalize(C, O, descending);
@@ -439,7 +439,7 @@ std::pair<SharedMatrix, SharedVector> Prop::Na_so() {
     SharedMatrix N = pair.first;
     std::shared_ptr<Vector> O = pair.second;
 
-    auto N2 = std::make_shared<Matrix>("Na_so", Ca_so_->nirrep(), Ca_so_->rowspi(), Ca_so_->colspi());
+    auto N2 = std::make_shared<Matrix>("Na_so", Ca_so_->rowspi(), Ca_so_->colspi());
 
     for (int h = 0; h < N->nirrep(); h++) {
         int nmo = Ca_so_->colspi()[h];
@@ -462,7 +462,7 @@ std::pair<SharedMatrix, SharedVector> Prop::Nb_so() {
     SharedMatrix N = pair.first;
     std::shared_ptr<Vector> O = pair.second;
 
-    auto N2 = std::make_shared<Matrix>("Nb_so", Cb_so_->nirrep(), Cb_so_->rowspi(), Cb_so_->colspi());
+    auto N2 = std::make_shared<Matrix>("Nb_so", Cb_so_->rowspi(), Cb_so_->colspi());
 
     for (int h = 0; h < N->nirrep(); h++) {
         int nmo = Cb_so_->colspi()[h];
@@ -576,7 +576,7 @@ std::pair<SharedMatrix, SharedVector> Prop::Nb_ao() {
 }
 std::pair<SharedMatrix, SharedVector> Prop::Nt_mo() {
     SharedMatrix D = Dt_mo();
-    auto C = std::make_shared<Matrix>("Nt_mo", D->nirrep(), D->rowspi(), D->rowspi());
+    auto C = std::make_shared<Matrix>("Nt_mo", D->rowspi(), D->rowspi());
     auto O = std::make_shared<Vector>("Total Occupation", D->rowspi());
 
     D->diagonalize(C, O, descending);
@@ -588,7 +588,7 @@ std::pair<SharedMatrix, SharedVector> Prop::Nt_so() {
     SharedMatrix N = pair.first;
     std::shared_ptr<Vector> O = pair.second;
 
-    auto N2 = std::make_shared<Matrix>("Nt_so", Cb_so_->nirrep(), Cb_so_->rowspi(), Cb_so_->colspi());
+    auto N2 = std::make_shared<Matrix>("Nt_so", Cb_so_->rowspi(), Cb_so_->colspi());
 
     for (int h = 0; h < N->nirrep(); h++) {
         int nmo = Cb_so_->colspi()[h];

--- a/psi4/src/psi4/libmints/wavefunction.cc
+++ b/psi4/src/psi4/libmints/wavefunction.cc
@@ -1052,8 +1052,8 @@ SharedMatrix Wavefunction::basis_projection(SharedMatrix C_A, Dimension noccpi, 
     auto pet = std::make_shared<PetiteList>(new_basis, newfactory);
     SharedMatrix AO2USO(pet->aotoso());
 
-    auto SAB = std::make_shared<Matrix>("S_AB", C_A->nirrep(), C_A->rowspi(), AO2USO->colspi());
-    auto SBB = std::make_shared<Matrix>("S_BB", C_A->nirrep(), AO2USO->colspi(), AO2USO->colspi());
+    auto SAB = std::make_shared<Matrix>("S_AB", C_A->rowspi(), AO2USO->colspi());
+    auto SBB = std::make_shared<Matrix>("S_BB", AO2USO->colspi(), AO2USO->colspi());
 
     intAB->compute(SAB);
     intBB->compute(SBB);
@@ -1070,7 +1070,7 @@ SharedMatrix Wavefunction::basis_projection(SharedMatrix C_A, Dimension noccpi, 
     pet.reset();
 
     // Constrained to the same symmetry at the moment, we can relax this soon
-    auto C_B = std::make_shared<Matrix>("C_B", C_A->nirrep(), AO2USO->colspi(), noccpi);
+    auto C_B = std::make_shared<Matrix>("C_B", AO2USO->colspi(), noccpi);
 
     // Block over irreps (soon united irreps)
     for (int h = 0; h < C_A->nirrep(); h++) {

--- a/psi4/src/psi4/occ/coord_grad.cc
+++ b/psi4/src/psi4/occ/coord_grad.cc
@@ -94,7 +94,7 @@ void OCCWave::dump_pdms() {
             alpha_pitzer_to_corr[alpha_corr_to_pitzer[n]] = n;
         }
 
-        Lagrangian_ = std::make_shared<Matrix>("Lagrangian matrix", nirrep_, nsopi_, nsopi_);
+        Lagrangian_ = std::make_shared<Matrix>("Lagrangian matrix", nsopi_, nsopi_);
         Lagrangian_->back_transform(*GFock, *Ca_);
 
         auto *aocc_qt = new int[nooA];
@@ -263,8 +263,8 @@ void OCCWave::dump_pdms() {
             beta_pitzer_to_corr[beta_corr_to_pitzer[n]] = n;
         }
 
-        Lagrangian_ = std::make_shared<Matrix>("Lagrangian matrix", nirrep_, nsopi_, nsopi_);
-        auto temp_lagrangian = std::make_shared<Matrix>("temp", nirrep_, nsopi_, nsopi_);
+        Lagrangian_ = std::make_shared<Matrix>("Lagrangian matrix", nsopi_, nsopi_);
+        auto temp_lagrangian = std::make_shared<Matrix>("temp", nsopi_, nsopi_);
         Lagrangian_->back_transform(*GFockA, *Ca_);
         temp_lagrangian->back_transform(*GFockB, *Cb_);
         Lagrangian_->add(temp_lagrangian);

--- a/psi4/src/psi4/occ/ekt_ea.cc
+++ b/psi4/src/psi4/occ/ekt_ea.cc
@@ -41,13 +41,13 @@ namespace occwave {
 void OCCWave::ekt_ea() {
     // outfile->Printf("\n ekt_ea is starting... \n");
 
-    auto GFock_copyA = std::make_shared<Matrix>("Alpha GF copy", nirrep_, nmopi_, nmopi_);
-    auto g1symm_copyA = std::make_shared<Matrix>("Alpha OPDM copy", nirrep_, nmopi_, nmopi_);
-    auto GFock_copyB = std::make_shared<Matrix>("Beta GF copy", nirrep_, nmopi_, nmopi_);
-    auto g1symm_copyB = std::make_shared<Matrix>("Alpha OPDM copy", nirrep_, nmopi_, nmopi_);
-    G1tilde = std::make_shared<Matrix>("MO-basis 1-G1", nirrep_, nmopi_, nmopi_);
-    G1tildeA = std::make_shared<Matrix>("MO-basis Alpha 1-G1", nirrep_, nmopi_, nmopi_);
-    G1tildeB = std::make_shared<Matrix>("MO-basis Beta 1-G1", nirrep_, nmopi_, nmopi_);
+    auto GFock_copyA = std::make_shared<Matrix>("Alpha GF copy", nmopi_, nmopi_);
+    auto g1symm_copyA = std::make_shared<Matrix>("Alpha OPDM copy", nmopi_, nmopi_);
+    auto GFock_copyB = std::make_shared<Matrix>("Beta GF copy", nmopi_, nmopi_);
+    auto g1symm_copyB = std::make_shared<Matrix>("Alpha OPDM copy", nmopi_, nmopi_);
+    G1tilde = std::make_shared<Matrix>("MO-basis 1-G1", nmopi_, nmopi_);
+    G1tildeA = std::make_shared<Matrix>("MO-basis Alpha 1-G1", nmopi_, nmopi_);
+    G1tildeB = std::make_shared<Matrix>("MO-basis Beta 1-G1", nmopi_, nmopi_);
 
     // Make sure  GFM is symmetric
     if (ekt_ip_ == "FALSE") {
@@ -128,13 +128,13 @@ void OCCWave::ekt_ea() {
     //========================= RHF =============================================================
     //===========================================================================================
     // Memory allocation
-    auto GFock_primeA = std::make_shared<Matrix>("Alpha GF prime", nirrep_, nmopi_, nmopi_);
-    auto g1HalfA = std::make_shared<Matrix>("g^-1/2", nirrep_, nmopi_, nmopi_);
-    auto UvecA = std::make_shared<Matrix>("UvecA", nirrep_, nmopi_, nmopi_);
-    auto Uvec_primeA = std::make_shared<Matrix>("Uvec_primeA", nirrep_, nmopi_, nmopi_);
-    auto PSA = std::make_shared<Matrix>("Alpha pole strength matrix", nirrep_, nmopi_, nmopi_);
-    auto gc_transA = std::make_shared<Matrix>("Alpha C'*g", nirrep_, nmopi_, nmopi_);
-    auto tempA = std::make_shared<Matrix>("Alpha temp", nirrep_, nmopi_, nmopi_);
+    auto GFock_primeA = std::make_shared<Matrix>("Alpha GF prime", nmopi_, nmopi_);
+    auto g1HalfA = std::make_shared<Matrix>("g^-1/2", nmopi_, nmopi_);
+    auto UvecA = std::make_shared<Matrix>("UvecA", nmopi_, nmopi_);
+    auto Uvec_primeA = std::make_shared<Matrix>("Uvec_primeA", nmopi_, nmopi_);
+    auto PSA = std::make_shared<Matrix>("Alpha pole strength matrix", nmopi_, nmopi_);
+    auto gc_transA = std::make_shared<Matrix>("Alpha C'*g", nmopi_, nmopi_);
+    auto tempA = std::make_shared<Matrix>("Alpha temp", nmopi_, nmopi_);
     Vector Diag_g1A("Diag OO-block OPDM", nmopi_);
     Vector ps_vecA("alpha pole strength vector", nmopi_);
     Vector eorbA("eorbA", nmopi_);
@@ -315,13 +315,13 @@ void OCCWave::ekt_ea() {
     //===========================================================================================
     if (reference_ == "UNRESTRICTED") {
         // Memory allocation
-        auto GFock_primeB = std::make_shared<Matrix>("Beta OO-block GF prime", nirrep_, nmopi_, nmopi_);
-        auto g1HalfB = std::make_shared<Matrix>("g^-1/2", nirrep_, nmopi_, nmopi_);
-        auto UvecB = std::make_shared<Matrix>("UvecB", nirrep_, nmopi_, nmopi_);
-        auto Uvec_primeB = std::make_shared<Matrix>("Uvec_primeB", nirrep_, nmopi_, nmopi_);
-        auto PSB = std::make_shared<Matrix>("Beta pole strength matrix", nirrep_, nmopi_, nmopi_);
-        auto gc_transB = std::make_shared<Matrix>("Beta C'*g", nirrep_, nmopi_, nmopi_);
-        auto tempB = std::make_shared<Matrix>("Beta temp", nirrep_, nmopi_, nmopi_);
+        auto GFock_primeB = std::make_shared<Matrix>("Beta OO-block GF prime", nmopi_, nmopi_);
+        auto g1HalfB = std::make_shared<Matrix>("g^-1/2", nmopi_, nmopi_);
+        auto UvecB = std::make_shared<Matrix>("UvecB", nmopi_, nmopi_);
+        auto Uvec_primeB = std::make_shared<Matrix>("Uvec_primeB", nmopi_, nmopi_);
+        auto PSB = std::make_shared<Matrix>("Beta pole strength matrix", nmopi_, nmopi_);
+        auto gc_transB = std::make_shared<Matrix>("Beta C'*g", nmopi_, nmopi_);
+        auto tempB = std::make_shared<Matrix>("Beta temp", nmopi_, nmopi_);
         Vector Diag_g1B("DiagA OO-block OPDM", nmopi_);
         Vector ps_vecB("Beta pole strength vector", nmopi_);
         auto eorbB = std::make_shared<Vector>("eorbB", nmopi_);

--- a/psi4/src/psi4/occ/ekt_ip.cc
+++ b/psi4/src/psi4/occ/ekt_ip.cc
@@ -44,15 +44,15 @@ void OCCWave::ekt_ip() {
     //========================= RHF =============================================================
     //===========================================================================================
     // Memory allocation
-    auto GFock_primeA = std::make_shared<Matrix>("Alpha GF prime", nirrep_, nmopi_, nmopi_);
-    auto GFock_copyA = std::make_shared<Matrix>("Alpha GF copy", nirrep_, nmopi_, nmopi_);
-    auto g1symm_copyA = std::make_shared<Matrix>("Alpha OPDM copy", nirrep_, nmopi_, nmopi_);
-    auto g1HalfA = std::make_shared<Matrix>("g^-1/2", nirrep_, nmopi_, nmopi_);
-    auto UvecA = std::make_shared<Matrix>("UvecA", nirrep_, nmopi_, nmopi_);
-    auto Uvec_primeA = std::make_shared<Matrix>("Uvec_primeA", nirrep_, nmopi_, nmopi_);
-    auto PSA = std::make_shared<Matrix>("Alpha pole strength matrix", nirrep_, nmopi_, nmopi_);
-    auto gc_transA = std::make_shared<Matrix>("Alpha C'*g", nirrep_, nmopi_, nmopi_);
-    auto tempA = std::make_shared<Matrix>("Alpha temp", nirrep_, nmopi_, nmopi_);
+    auto GFock_primeA = std::make_shared<Matrix>("Alpha GF prime", nmopi_, nmopi_);
+    auto GFock_copyA = std::make_shared<Matrix>("Alpha GF copy", nmopi_, nmopi_);
+    auto g1symm_copyA = std::make_shared<Matrix>("Alpha OPDM copy", nmopi_, nmopi_);
+    auto g1HalfA = std::make_shared<Matrix>("g^-1/2", nmopi_, nmopi_);
+    auto UvecA = std::make_shared<Matrix>("UvecA", nmopi_, nmopi_);
+    auto Uvec_primeA = std::make_shared<Matrix>("Uvec_primeA", nmopi_, nmopi_);
+    auto PSA = std::make_shared<Matrix>("Alpha pole strength matrix", nmopi_, nmopi_);
+    auto gc_transA = std::make_shared<Matrix>("Alpha C'*g", nmopi_, nmopi_);
+    auto tempA = std::make_shared<Matrix>("Alpha temp", nmopi_, nmopi_);
     Vector Diag_g1A("Diag OO-block OPDM", nmopi_);
     Vector ps_vecA("alpha pole strength vector", nmopi_);
     auto eorbA = std::make_shared<Vector>("eorbA", nmopi_);
@@ -259,15 +259,15 @@ void OCCWave::ekt_ip() {
     //===========================================================================================
     if (reference_ == "UNRESTRICTED") {
         // Memory allocation
-        auto GFock_primeB = std::make_shared<Matrix>("Beta OO-block GF prime", nirrep_, nmopi_, nmopi_);
-        auto GFock_copyB = std::make_shared<Matrix>("Beta GF copy", nirrep_, nmopi_, nmopi_);
-        auto g1symm_copyB = std::make_shared<Matrix>("Alpha OPDM copy", nirrep_, nmopi_, nmopi_);
-        auto g1HalfB = std::make_shared<Matrix>("g^-1/2", nirrep_, nmopi_, nmopi_);
-        auto UvecB = std::make_shared<Matrix>("UvecB", nirrep_, nmopi_, nmopi_);
-        auto Uvec_primeB = std::make_shared<Matrix>("Uvec_primeB", nirrep_, nmopi_, nmopi_);
-        auto PSB = std::make_shared<Matrix>("Beta pole strength matrix", nirrep_, nmopi_, nmopi_);
-        auto gc_transB = std::make_shared<Matrix>("Beta C'*g", nirrep_, nmopi_, nmopi_);
-        auto tempB = std::make_shared<Matrix>("Beta temp", nirrep_, nmopi_, nmopi_);
+        auto GFock_primeB = std::make_shared<Matrix>("Beta OO-block GF prime", nmopi_, nmopi_);
+        auto GFock_copyB = std::make_shared<Matrix>("Beta GF copy", nmopi_, nmopi_);
+        auto g1symm_copyB = std::make_shared<Matrix>("Alpha OPDM copy", nmopi_, nmopi_);
+        auto g1HalfB = std::make_shared<Matrix>("g^-1/2", nmopi_, nmopi_);
+        auto UvecB = std::make_shared<Matrix>("UvecB", nmopi_, nmopi_);
+        auto Uvec_primeB = std::make_shared<Matrix>("Uvec_primeB", nmopi_, nmopi_);
+        auto PSB = std::make_shared<Matrix>("Beta pole strength matrix", nmopi_, nmopi_);
+        auto gc_transB = std::make_shared<Matrix>("Beta C'*g", nmopi_, nmopi_);
+        auto tempB = std::make_shared<Matrix>("Beta temp", nmopi_, nmopi_);
         Vector Diag_g1B("DiagA OO-block OPDM", nmopi_);
         Vector ps_vecB("Beta pole strength vector", nmopi_);
         auto eorbB = std::make_shared<Vector>("eorbB", nmopi_);

--- a/psi4/src/psi4/occ/get_moinfo.cc
+++ b/psi4/src/psi4/occ/get_moinfo.cc
@@ -635,8 +635,8 @@ void OCCWave::get_moinfo() {
         // read orbital coefficients from reference
         Ca_ = SharedMatrix(reference_wavefunction_->Ca());
         Cb_ = SharedMatrix(reference_wavefunction_->Cb());
-        auto Ca_ref = std::make_shared<Matrix>("Ref alpha MO coefficients", nirrep_, nsopi_, nmopi_);
-        auto Cb_ref = std::make_shared<Matrix>("Ref beta MO coefficients", nirrep_, nsopi_, nmopi_);
+        auto Ca_ref = std::make_shared<Matrix>("Ref alpha MO coefficients", nsopi_, nmopi_);
+        auto Cb_ref = std::make_shared<Matrix>("Ref beta MO coefficients", nsopi_, nmopi_);
 
         // read orbital coefficients from external files
         if (read_mo_coeff == "TRUE") {

--- a/psi4/src/psi4/occ/get_moinfo.cc
+++ b/psi4/src/psi4/occ/get_moinfo.cc
@@ -331,7 +331,7 @@ void OCCWave::get_moinfo() {
         /********************************************************************************************/
         // read orbital coefficients from reference
         Ca_ = SharedMatrix(reference_wavefunction_->Ca());
-        auto Ca_ref = std::make_shared<Matrix>("Ref alpha MO coefficients", nirrep_, nsopi_, nmopi_);
+        auto Ca_ref = std::make_shared<Matrix>("Ref alpha MO coefficients", nsopi_, nmopi_);
 
         // read orbital coefficients from external files
         if (read_mo_coeff == "TRUE") {

--- a/psi4/src/psi4/occ/gfock_ea.cc
+++ b/psi4/src/psi4/occ/gfock_ea.cc
@@ -356,8 +356,8 @@ void OCCWave::gfock_ea() {
     //===========================================================================================
     else if (reference_ == "UNRESTRICTED") {
         // Initialize
-        FtildeA = std::make_shared<Matrix>("MO-basis Alpha GFM-EA", nirrep_, nmopi_, nmopi_);
-        FtildeB = std::make_shared<Matrix>("MO-basis Beta GFM-EA", nirrep_, nmopi_, nmopi_);
+        FtildeA = std::make_shared<Matrix>("MO-basis Alpha GFM-EA", nmopi_, nmopi_);
+        FtildeB = std::make_shared<Matrix>("MO-basis Beta GFM-EA", nmopi_, nmopi_);
         FtildeA->zero();
         FtildeB->zero();
         FtildeA->add(HmoA);

--- a/psi4/src/psi4/occ/gfock_ea.cc
+++ b/psi4/src/psi4/occ/gfock_ea.cc
@@ -45,7 +45,7 @@ void OCCWave::gfock_ea() {
     //===========================================================================================
     if (reference_ == "RESTRICTED") {
         // Initialize
-        Ftilde = std::make_shared<Matrix>("MO-basis GFM-EA", nirrep_, nmopi_, nmopi_);
+        Ftilde = std::make_shared<Matrix>("MO-basis GFM-EA", nmopi_, nmopi_);
         Ftilde->zero();
         Ftilde->add(HmoA);
         Ftilde->scale(2.0);

--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -200,17 +200,17 @@ void OCCWave::common_init() {
 
     if (reference_ == "RESTRICTED") {
         // Memory allocation
-        HmoA = std::make_shared<Matrix>("MO-basis alpha one-electron ints", nirrep_, nmopi_, nmopi_);
-        FockA = std::make_shared<Matrix>("MO-basis alpha Fock matrix", nirrep_, nmopi_, nmopi_);
-        gamma1corr = std::make_shared<Matrix>("MO-basis alpha correlation OPDM", nirrep_, nmopi_, nmopi_);
-        g1symm = std::make_shared<Matrix>("MO-basis alpha OPDM", nirrep_, nmopi_, nmopi_);
-        GFock = std::make_shared<Matrix>("MO-basis alpha generalized Fock matrix", nirrep_, nmopi_, nmopi_);
-        UorbA = std::make_shared<Matrix>("Alpha MO rotation matrix", nirrep_, nmopi_, nmopi_);
-        KorbA = std::make_shared<Matrix>("K alpha MO rotation", nirrep_, nmopi_, nmopi_);
-        HG1 = std::make_shared<Matrix>("h*g1symm", nirrep_, nmopi_, nmopi_);
-        WorbA = std::make_shared<Matrix>("Alpha MO gradient matrix", nirrep_, nmopi_, nmopi_);
-        GooA = std::make_shared<Matrix>("Alpha Goo intermediate", nirrep_, aoccpiA, aoccpiA);
-        GvvA = std::make_shared<Matrix>("Alpha Gvv intermediate", nirrep_, avirtpiA, avirtpiA);
+        HmoA = std::make_shared<Matrix>("MO-basis alpha one-electron ints", nmopi_, nmopi_);
+        FockA = std::make_shared<Matrix>("MO-basis alpha Fock matrix", nmopi_, nmopi_);
+        gamma1corr = std::make_shared<Matrix>("MO-basis alpha correlation OPDM", nmopi_, nmopi_);
+        g1symm = std::make_shared<Matrix>("MO-basis alpha OPDM", nmopi_, nmopi_);
+        GFock = std::make_shared<Matrix>("MO-basis alpha generalized Fock matrix", nmopi_, nmopi_);
+        UorbA = std::make_shared<Matrix>("Alpha MO rotation matrix", nmopi_, nmopi_);
+        KorbA = std::make_shared<Matrix>("K alpha MO rotation", nmopi_, nmopi_);
+        HG1 = std::make_shared<Matrix>("h*g1symm", nmopi_, nmopi_);
+        WorbA = std::make_shared<Matrix>("Alpha MO gradient matrix", nmopi_, nmopi_);
+        GooA = std::make_shared<Matrix>("Alpha Goo intermediate", aoccpiA, aoccpiA);
+        GvvA = std::make_shared<Matrix>("Alpha Gvv intermediate", avirtpiA, avirtpiA);
 
         Molecule &mol = *reference_wavefunction_->molecule().get();
         CharacterTable ct = mol.point_group()->char_table();
@@ -300,33 +300,33 @@ void OCCWave::common_init() {
 
     else if (reference_ == "UNRESTRICTED") {
         // Memory allocation
-        HmoA = std::make_shared<Matrix>("MO-basis alpha one-electron ints", nirrep_, nmopi_, nmopi_);
-        HmoB = std::make_shared<Matrix>("MO-basis beta one-electron ints", nirrep_, nmopi_, nmopi_);
-        FockA = std::make_shared<Matrix>("MO-basis alpha Fock matrix", nirrep_, nmopi_, nmopi_);
-        FockB = std::make_shared<Matrix>("MO-basis beta Fock matrix", nirrep_, nmopi_, nmopi_);
-        gamma1corrA = std::make_shared<Matrix>("MO-basis alpha correlation OPDM", nirrep_, nmopi_, nmopi_);
-        gamma1corrB = std::make_shared<Matrix>("MO-basis beta correlation OPDM", nirrep_, nmopi_, nmopi_);
-        g1symmA = std::make_shared<Matrix>("MO-basis alpha OPDM", nirrep_, nmopi_, nmopi_);
-        g1symmB = std::make_shared<Matrix>("MO-basis beta OPDM", nirrep_, nmopi_, nmopi_);
-        GFockA = std::make_shared<Matrix>("MO-basis alpha generalized Fock matrix", nirrep_, nmopi_, nmopi_);
-        GFockB = std::make_shared<Matrix>("MO-basis beta generalized Fock matrix", nirrep_, nmopi_, nmopi_);
-        UorbA = std::make_shared<Matrix>("Alpha MO rotation matrix", nirrep_, nmopi_, nmopi_);
-        UorbB = std::make_shared<Matrix>("Beta MO rotation matrix", nirrep_, nmopi_, nmopi_);
-        KorbA = std::make_shared<Matrix>("K alpha MO rotation", nirrep_, nmopi_, nmopi_);
-        KorbB = std::make_shared<Matrix>("K beta MO rotation", nirrep_, nmopi_, nmopi_);
-        HG1A = std::make_shared<Matrix>("Alpha h*g1symm", nirrep_, nmopi_, nmopi_);
-        HG1B = std::make_shared<Matrix>("Beta h*g1symm", nirrep_, nmopi_, nmopi_);
-        WorbA = std::make_shared<Matrix>("Alpha MO gradient matrix", nirrep_, nmopi_, nmopi_);
-        WorbB = std::make_shared<Matrix>("Beta MO gradient matrix", nirrep_, nmopi_, nmopi_);
-        GooA = std::make_shared<Matrix>("Alpha Goo intermediate", nirrep_, aoccpiA, aoccpiA);
-        GooB = std::make_shared<Matrix>("Beta Goo intermediate", nirrep_, aoccpiB, aoccpiB);
-        GvvA = std::make_shared<Matrix>("Alpha Gvv intermediate", nirrep_, avirtpiA, avirtpiA);
-        GvvB = std::make_shared<Matrix>("Beta Gvv intermediate", nirrep_, avirtpiB, avirtpiB);
+        HmoA = std::make_shared<Matrix>("MO-basis alpha one-electron ints", nmopi_, nmopi_);
+        HmoB = std::make_shared<Matrix>("MO-basis beta one-electron ints", nmopi_, nmopi_);
+        FockA = std::make_shared<Matrix>("MO-basis alpha Fock matrix", nmopi_, nmopi_);
+        FockB = std::make_shared<Matrix>("MO-basis beta Fock matrix", nmopi_, nmopi_);
+        gamma1corrA = std::make_shared<Matrix>("MO-basis alpha correlation OPDM", nmopi_, nmopi_);
+        gamma1corrB = std::make_shared<Matrix>("MO-basis beta correlation OPDM", nmopi_, nmopi_);
+        g1symmA = std::make_shared<Matrix>("MO-basis alpha OPDM", nmopi_, nmopi_);
+        g1symmB = std::make_shared<Matrix>("MO-basis beta OPDM", nmopi_, nmopi_);
+        GFockA = std::make_shared<Matrix>("MO-basis alpha generalized Fock matrix", nmopi_, nmopi_);
+        GFockB = std::make_shared<Matrix>("MO-basis beta generalized Fock matrix", nmopi_, nmopi_);
+        UorbA = std::make_shared<Matrix>("Alpha MO rotation matrix", nmopi_, nmopi_);
+        UorbB = std::make_shared<Matrix>("Beta MO rotation matrix", nmopi_, nmopi_);
+        KorbA = std::make_shared<Matrix>("K alpha MO rotation", nmopi_, nmopi_);
+        KorbB = std::make_shared<Matrix>("K beta MO rotation", nmopi_, nmopi_);
+        HG1A = std::make_shared<Matrix>("Alpha h*g1symm", nmopi_, nmopi_);
+        HG1B = std::make_shared<Matrix>("Beta h*g1symm", nmopi_, nmopi_);
+        WorbA = std::make_shared<Matrix>("Alpha MO gradient matrix", nmopi_, nmopi_);
+        WorbB = std::make_shared<Matrix>("Beta MO gradient matrix", nmopi_, nmopi_);
+        GooA = std::make_shared<Matrix>("Alpha Goo intermediate", aoccpiA, aoccpiA);
+        GooB = std::make_shared<Matrix>("Beta Goo intermediate", aoccpiB, aoccpiB);
+        GvvA = std::make_shared<Matrix>("Alpha Gvv intermediate", avirtpiA, avirtpiA);
+        GvvB = std::make_shared<Matrix>("Beta Gvv intermediate", avirtpiB, avirtpiB);
 
         // ROHF-MP2
         if (reference == "ROHF" && orb_opt_ == "FALSE" && wfn_type_ == "OMP2") {
-            t1A = std::make_shared<Matrix>("t_I^A", nirrep_, aoccpiA, avirtpiA);
-            t1B = std::make_shared<Matrix>("t_i^a", nirrep_, aoccpiB, avirtpiB);
+            t1A = std::make_shared<Matrix>("t_I^A", aoccpiA, avirtpiA);
+            t1B = std::make_shared<Matrix>("t_i^a", aoccpiB, avirtpiB);
         }
 
         Molecule &mol = *reference_wavefunction_->molecule().get();
@@ -508,7 +508,7 @@ void OCCWave::nbo() {
     outfile->Printf("\n Diagonalizing one-particle response density matrix... \n");
     outfile->Printf("\n");
 
-    auto Udum = std::make_shared<Matrix>("Udum", nirrep_, nmopi_, nmopi_);
+    auto Udum = std::make_shared<Matrix>("Udum", nmopi_, nmopi_);
     auto diag = std::make_shared<Vector>("Natural orbital occupation numbers", nmopi_);
 
     // Diagonalizing Alpha-OPDM

--- a/psi4/src/psi4/occ/semi_canonic.cc
+++ b/psi4/src/psi4/occ/semi_canonic.cc
@@ -40,10 +40,10 @@ void OCCWave::semi_canonic() {
     // tell other functions that orbitals are already semi canonical.
     orbs_already_sc = 1;
 
-    auto UooA = std::make_shared<Matrix>(nirrep_, occpiA, occpiA);
-    auto UvvA = std::make_shared<Matrix>(nirrep_, virtpiA, virtpiA);
-    auto FockooA = std::make_shared<Matrix>(nirrep_, occpiA, occpiA);
-    auto FockvvA = std::make_shared<Matrix>(nirrep_, virtpiA, virtpiA);
+    auto UooA = std::make_shared<Matrix>(occpiA, occpiA);
+    auto UvvA = std::make_shared<Matrix>(virtpiA, virtpiA);
+    auto FockooA = std::make_shared<Matrix>(occpiA, occpiA);
+    auto FockvvA = std::make_shared<Matrix>(virtpiA, virtpiA);
     Vector eigooA(occpiA);
     Vector eigvvA(virtpiA);
 
@@ -154,7 +154,7 @@ void OCCWave::semi_canonic() {
     }
 
     // Get new MOs
-    Ca_new = std::make_shared<Matrix>("New alpha MO coefficients", nirrep_, nsopi_, nmopi_);
+    Ca_new = std::make_shared<Matrix>("New alpha MO coefficients", nsopi_, nmopi_);
     Ca_new->zero();
     Ca_new->gemm(false, false, 1.0, Ca_, UorbA, 0.0);
     Ca_->zero();
@@ -173,10 +173,10 @@ void OCCWave::semi_canonic() {
 
     // UHF REFERENCE
     if (reference_ == "UNRESTRICTED") {
-        auto UooB = std::make_shared<Matrix>(nirrep_, occpiB, occpiB);
-        auto UvvB = std::make_shared<Matrix>(nirrep_, virtpiB, virtpiB);
-        auto FockooB = std::make_shared<Matrix>(nirrep_, occpiB, occpiB);
-        auto FockvvB = std::make_shared<Matrix>(nirrep_, virtpiB, virtpiB);
+        auto UooB = std::make_shared<Matrix>(occpiB, occpiB);
+        auto UvvB = std::make_shared<Matrix>(virtpiB, virtpiB);
+        auto FockooB = std::make_shared<Matrix>(occpiB, occpiB);
+        auto FockvvB = std::make_shared<Matrix>(virtpiB, virtpiB);
         Vector eigooB(occpiB);
         Vector eigvvB(virtpiB);
 
@@ -285,7 +285,7 @@ void OCCWave::semi_canonic() {
         }
 
         // Get new MOs
-        Cb_new = std::make_shared<Matrix>("New beta MO coefficients", nirrep_, nsopi_, nmopi_);
+        Cb_new = std::make_shared<Matrix>("New beta MO coefficients", nsopi_, nmopi_);
         Cb_new->zero();
         Cb_new->gemm(false, false, 1.0, Cb_, UorbB, 0.0);
         Cb_->zero();

--- a/psi4/src/psi4/occ/update_mo.cc
+++ b/psi4/src/psi4/occ/update_mo.cc
@@ -39,7 +39,7 @@ void OCCWave::update_mo_spincase(const SpinType spin) {
     const auto& kappa_bar = kappa_bar_[spin];
 
     // Form the linearized orbital rotation matrix, K, from the amplitudes, kappa_bar
-    auto Korb = std::make_shared<Matrix>("K MO rotation", nirrep_, nmopi_, nmopi_);
+    auto Korb = std::make_shared<Matrix>("K MO rotation", nmopi_, nmopi_);
     const auto idpS = idp_dimensions_[spin].sum();
     const auto& idprowS = idprow_[spin];
     const auto& idpcolS = idpcol_[spin];
@@ -54,7 +54,7 @@ void OCCWave::update_mo_spincase(const SpinType spin) {
     }
 
     // Approximate orbital rotation matrix U = exp(K) by I + K + K^2/2.
-    auto Uorb = std::make_shared<Matrix>("MO rotation matrix", nirrep_, nmopi_, nmopi_);
+    auto Uorb = std::make_shared<Matrix>("MO rotation matrix", nmopi_, nmopi_);
     Uorb->identity();
     Uorb->add(Korb);
     auto Ksqr = linalg::doublet(Korb, Korb);

--- a/psi4/src/psi4/occ/z_vector.cc
+++ b/psi4/src/psi4/occ/z_vector.cc
@@ -458,8 +458,8 @@ void OCCWave::z_vector() {
         }
 
         // Build Zmatrix
-        ZmatA = std::make_shared<Matrix>("Alpha Z-Matrix", nirrep_, nmopi_, nmopi_);
-        ZmatB = std::make_shared<Matrix>("Beta Z-Matrix", nirrep_, nmopi_, nmopi_);
+        ZmatA = std::make_shared<Matrix>("Alpha Z-Matrix", nmopi_, nmopi_);
+        ZmatB = std::make_shared<Matrix>("Beta Z-Matrix", nmopi_, nmopi_);
         for (int x = 0; x < nidpA; x++) {
             int a = idprowA[x];
             int i = idpcolA[x];

--- a/psi4/src/psi4/occ/z_vector.cc
+++ b/psi4/src/psi4/occ/z_vector.cc
@@ -159,7 +159,7 @@ void OCCWave::z_vector() {
         if (print_ > 2) zvectorA->print();
 
         // Build Zmatrix
-        ZmatA = std::make_shared<Matrix>("Alpha Z-Matrix", nirrep_, nmopi_, nmopi_);
+        ZmatA = std::make_shared<Matrix>("Alpha Z-Matrix", nmopi_, nmopi_);
         for (int x = 0; x < nidpA; x++) {
             int a = idprowA[x];
             int i = idpcolA[x];


### PR DESCRIPTION
## Description

Again, finishing up the cast-to-pointer operator deprecation for Dimension. There are many cases in `std::make_shared<Matrix>` that do not show up without `-Wsystem-headers` for GCC. Waiting to fix libmints until #3354 was merged.

The last remaining cases are in some code that calls `ras_set3` but that's going to have to wait until #3208 

\*\*\* Submitting PR successfully. Buy a developer (me) a beer! \*\*\*

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] The majority of these cases happen because the presence of `nirreps_` in the Matrix constructor causes the compiler to call the ctors with `const int*` which induces the deprecated cast-to-pointer operation. Removing `nirreps_` solves this problem.
- [x] ~~There were a handful of interesting cases. Some Matrix ctors use a combination of pointer for rows and int for cols and vice versa. To replicate this behavior I used 1. the std::vector fill ctor and 2. the implicit `std::vector<int>` to `Dimension` conversion within the Matrix ctor. For example:~~
```diff
     const int nbf2 = nbf_ * nbf_;
     ...
     const Dimension &dfDim = dfAOtoSO->colspi();
-    auto symQao = std::make_shared<Matrix>(nirrep_, (const int *)dfDim, nbf2);
+    const Dimension nbf2Dim{std::vector<int>(nirrep_, nbf2)};
+    auto symQao = std::make_shared<Matrix>(dfDim, nbf2Dim);
```
<mark>EDIT:</mark> I actually updated the Matrix ctors so these "interesting cases" were reverted to be updated in a different PR. The only edits now are removing `nirreps_` from Matrix ctors. 

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [x] None

## Checklist
- [x] Tests added for any new features
- [x] Docstring or narrative docs/sphinxman/source updated if needed
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
