### PR TITLE
Matrix constructor refresh; `Dimension::operator=` deprecations

### DIFF
--- a/psi4/src/psi4/cc/ccenergy/form_df_ints.cc
+++ b/psi4/src/psi4/cc/ccenergy/form_df_ints.cc
@@ -67,7 +67,7 @@ void CCEnergyWavefunction::form_df_ints(Options &options, int **cachelist, int *
     SharedMatrix dfAOtoSO = petite.aotoso();
     const Dimension &soDim = AO2SO_->colspi();
     const Dimension &dfDim = dfAOtoSO->colspi();
-    auto symQao = std::make_shared<Matrix>(nirrep_, (const int *)dfDim, nbf2);
+    auto symQao = std::make_shared<Matrix>(dfDim, nbf2);
     double **pQao = Qao->pointer();
     for (int h = 0; h < nirrep_; ++h) {
         double **pAOSO = dfAOtoSO->pointer(h);

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -70,7 +70,7 @@ void DFMP2::compute_opdm_and_nos(const SharedMatrix Dnosym, SharedMatrix Dso, Sh
     AO_c1NO->gemm(false, false, 1.0, AO_c1MO, c1MO_c1NO, 0.0);
     // Reapply the symmetry to the AO dimension
     auto AO_SO = reference_wavefunction_->aotoso();
-    auto SO_c1NO = std::make_shared<Matrix>(nirrep_, (const int*)nsopi_, nmo_);
+    auto SO_c1NO = std::make_shared<Matrix>(nsopi_, nmo_);
     SO_c1NO->set_name("SO to C1 NO");
     for (int h = 0; h < nirrep_; ++h) {
         int so_h = nsopi_[h];
@@ -120,7 +120,7 @@ void DFMP2::compute_opdm_and_nos(const SharedMatrix Dnosym, SharedMatrix Dso, Sh
     //
     // Now we're finished with the MO(c1)->NO(c1) matrix, use it as scratch for diag(NO occ)
     c1MO_c1NO->set_diagonal(occ_c1);
-    auto temp = std::make_shared<Matrix>(nirrep_, (const int*)nsopi_, nmo_);
+    auto temp = std::make_shared<Matrix>(nsopi_, nmo_);
     for (int h = 0; h < nirrep_; ++h) {
         int so_h = nsopi_[h];
         if (so_h) {

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -63,6 +63,7 @@
 #include <regex>
 #include <tuple>
 #include <memory>
+#include <utility>
 
 // In molecule.cc
 namespace psi {
@@ -94,16 +95,18 @@ Matrix& Matrix::operator=(const Matrix &c) {
 
 Matrix::Matrix(Matrix&& m) noexcept
     : rowspi_(std::move(m.rowspi_)), colspi_(std::move(m.colspi_)), nirrep_(m.nirrep_), matrix_(m.matrix_),
-      symmetry_(m.symmetry_), name_(m.name_), numpy_shape_(std::move(m.numpy_shape_)) {
+      symmetry_(m.symmetry_), name_(std::move(m.name_)), numpy_shape_(std::move(m.numpy_shape_)) {
     // Copy pointer to data then nullify the previous pointer to prevent double free.
     m.matrix_ = nullptr;
 }
 
 Matrix& Matrix::operator=(Matrix&& m) noexcept {
+    if (this == &m) return *this;
+
     release();
     nirrep_ = m.nirrep_;
     symmetry_ = m.symmetry_;
-    name_ = m.name_;
+    name_ = std::move(m.name_);
     rowspi_ = std::move(m.rowspi_);
     colspi_ = std::move(m.colspi_);
     numpy_shape_ = std::move(m.numpy_shape_);
@@ -345,11 +348,10 @@ SharedMatrix Matrix::matrix_3d_rotation(Vector3 axis, double phi, bool Sn) {
         R(2, 1) = R(1, 2) = 2 * wy * wz;
         Matrix tmp(nrow(), 3);
         tmp.gemm(false, true, 1.0, rotated_coord, R, 0.0);
-        rotated_coord.copy(tmp);
+        rotated_coord = std::move(tmp);
     }
 
-    SharedMatrix to_return = rotated_coord.clone();
-    return to_return;
+    return std::make_shared<Matrix>(std::move(rotated_coord));
 }
 
 void Matrix::copy_to_row(int h, int row, double const *const data) {
@@ -924,7 +926,7 @@ void Matrix::symmetrize_gradient(std::shared_ptr<Molecule> molecule) {
     // Obtain atom mapping of atom * symm op to atom
     auto atom_map = compute_atom_map(molecule);
 
-    SharedMatrix ret(clone());
+    auto ret = std::make_shared<Matrix>(name_, rowspi_, colspi_, symmetry_);
     ret->zero();
     Matrix temp = *this;
 
@@ -960,7 +962,7 @@ void Matrix::symmetrize_hessian(SharedMolecule molecule) {
 
     auto atom_map = compute_atom_map(molecule);
 
-    auto symm = std::make_shared<Matrix>(clone());
+    auto symm = std::make_shared<Matrix>(name_, rowspi_, colspi_, symmetry_);
     symm->zero();
     double **pH = pointer();
     double **pS = symm->pointer();
@@ -1326,7 +1328,9 @@ void Matrix::transform(const Matrix &L, const Matrix &F, const Matrix &R) {
         gemm(true, false, 1.0, L, temp, 0.0);
     } else {
         // The dimensions of this matrix need to change, so gemm is out.
-        copy(linalg::doublet(L, temp, true, false));
+        auto result = linalg::doublet(L, temp, true, false);
+        result.set_name(name_);
+        *this = std::move(result);
     }
 }
 
@@ -1769,7 +1773,7 @@ std::tuple<SharedMatrix, SharedVector, SharedMatrix> Matrix::svd_temps() {
     auto S = std::make_shared<Vector>("S", rank);
     auto V = std::make_shared<Matrix>("V", rank, colspi_);
 
-    return std::tuple<SharedMatrix, SharedVector, SharedMatrix>(U, S, V);
+    return std::tuple<SharedMatrix, SharedVector, SharedMatrix>(std::move(U), std::move(S), std::move(V));
 }
 
 std::tuple<SharedMatrix, SharedVector, SharedMatrix> Matrix::svd_a_temps() {
@@ -1782,7 +1786,7 @@ std::tuple<SharedMatrix, SharedVector, SharedMatrix> Matrix::svd_a_temps() {
     auto U = std::make_shared<Matrix>("U", rowspi_, rowspi_);
     auto S = std::make_shared<Vector>("S", rank);
     auto V = std::make_shared<Matrix>("V", colspi_, colspi_);
-    return std::tuple<SharedMatrix, SharedVector, SharedMatrix>(U, S, V);
+    return std::tuple<SharedMatrix, SharedVector, SharedMatrix>(std::move(U), std::move(S), std::move(V));
 }
 
 void Matrix::svd(SharedMatrix &U, SharedVector &S, SharedMatrix &V) {
@@ -1890,9 +1894,9 @@ void Matrix::svd_a(SharedMatrix &U, SharedVector &S, SharedMatrix &V) {
 
 SharedMatrix Matrix::pseudoinverse(double condition, int &nremoved) {
     std::tuple<SharedMatrix, SharedVector, SharedMatrix> svd_temp = svd_temps();
-    SharedMatrix U = std::get<0>(svd_temp);
-    SharedVector S = std::get<1>(svd_temp);
-    SharedMatrix V = std::get<2>(svd_temp);
+    SharedMatrix U = std::move(std::get<0>(svd_temp));
+    SharedVector S = std::move(std::get<1>(svd_temp));
+    SharedMatrix V = std::move(std::get<2>(svd_temp));
 
     svd(U, S, V);
 
@@ -1911,7 +1915,7 @@ SharedMatrix Matrix::pseudoinverse(double condition, int &nremoved) {
         }
     }
 
-    SharedMatrix Q(clone());
+    auto Q = std::make_shared<Matrix>(name_, rowspi_, colspi_, symmetry_);
 
     for (int h = 0; h < nirrep_; h++) {
         int m = rowspi_[h];
@@ -2094,7 +2098,7 @@ void Matrix::pivoted_cholesky(double tol, std::vector<std::vector<int>> &pivot, 
             }
         }
         // Switch to the properly sized matrix
-        *this = *U;
+        *this = std::move(*U);
     } else {
         auto L = std::make_shared<Matrix>("Cholesky decomposed matrix", nirrep_, rowspi_, nchol);
         L->zero();
@@ -2107,7 +2111,7 @@ void Matrix::pivoted_cholesky(double tol, std::vector<std::vector<int>> &pivot, 
             }
         }
         // Switch to the properly sized matrix
-        *this = *L;
+        *this = std::move(*L);
     }
 }
 
@@ -2262,7 +2266,7 @@ std::pair<SharedMatrix, SharedMatrix> Matrix::partial_square_root(double delta) 
         }
     }
 
-    return std::pair<SharedMatrix, SharedMatrix>(P, N);
+    return std::pair<SharedMatrix, SharedMatrix>(std::move(P), std::move(N));
 }
 
 void Matrix::invert() {
@@ -2786,7 +2790,9 @@ void Matrix::back_transform(const Matrix &a, const Matrix &transformer) {
         gemm(false, false, 1.0, transformer, temp, 0.0);
     } else {
         // The dimensions of this matrix need to change, so gemm is out.
-        copy(linalg::doublet(transformer, temp, false, false));
+        auto result = linalg::doublet(transformer, temp, false, false);
+        result.set_name(name_);
+        *this = std::move(result);
     }
 }
 

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -75,7 +75,8 @@ Matrix::Matrix(const std::string &name, int symmetry)
     : name_(name), symmetry_(symmetry) {}
 
 Matrix::Matrix(const Matrix &c)
-    : rowspi_(c.rowspi_), colspi_(c.colspi_), nirrep_(c.nirrep_), symmetry_(c.symmetry_), name_(c.name_) {
+    : rowspi_(c.rowspi_), colspi_(c.colspi_), nirrep_(c.nirrep_), symmetry_(c.symmetry_),
+      name_(c.name_), numpy_shape_(c.numpy_shape_) {
     alloc();
     copy_from(c.matrix_);
 }
@@ -87,6 +88,7 @@ Matrix& Matrix::operator=(const Matrix &c) {
     name_ = c.name();
     rowspi_ = c.rowspi_;
     colspi_ = c.colspi_;
+    numpy_shape_ = c.numpy_shape_;
     alloc();
     copy_from(c.matrix_);
 
@@ -98,6 +100,8 @@ Matrix::Matrix(Matrix&& m) noexcept
       symmetry_(m.symmetry_), name_(std::move(m.name_)), numpy_shape_(std::move(m.numpy_shape_)) {
     // Copy pointer to data then nullify the previous pointer to prevent double free.
     m.matrix_ = nullptr;
+    // Zero out m.nirrep_ so it is left in a default state.
+    m.nirrep_ = 0;
 }
 
 Matrix& Matrix::operator=(Matrix&& m) noexcept {
@@ -114,6 +118,7 @@ Matrix& Matrix::operator=(Matrix&& m) noexcept {
     // Copy pointer to data then nullify the previous pointer to prevent double free.
     matrix_ = m.matrix_;
     m.matrix_ = nullptr;
+    m.nirrep_ = 0;
 
     return *this;
 }

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -232,6 +232,26 @@ Matrix::Matrix(const Dimension &rows, const Dimension &cols, int symmetry) {
     alloc();
 }
 
+Matrix::Matrix(const Dimension& rows, const int cols, int symmetry)
+    : Matrix("", rows, cols, symmetry) {}
+
+Matrix::Matrix(const std::string &name, const Dimension& rows, const int cols, int symmetry)
+    : nirrep_(rows.n()), rowspi_(rows), colspi_(Dimension(std::vector<int>(nirrep_, cols))), name_(name) {
+    matrix_ = nullptr;
+    symmetry_ = symmetry;
+    alloc();
+}
+
+Matrix::Matrix(const int rows, const Dimension& cols, int symmetry)
+    : Matrix("", rows, cols, symmetry) {}
+
+Matrix::Matrix(const std::string &name, const int rows, const Dimension& cols, int symmetry)
+    : nirrep_(cols.n()), rowspi_(Dimension(std::vector<int>(nirrep_, rows))), colspi_(cols), name_(name) {
+    matrix_ = nullptr;
+    symmetry_ = symmetry;
+    alloc();
+}
+
 Matrix::Matrix(dpdfile2 *inFile)
     : rowspi_(inFile->params->nirreps), colspi_(inFile->params->nirreps), name_(inFile->label) {
     global_dpd_->file2_mat_init(inFile);

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -70,20 +70,11 @@ extern int str_to_int(const std::string &s);
 
 extern double str_to_double(const std::string &s);
 
-Matrix::Matrix() {
-    matrix_ = nullptr;
-    nirrep_ = 0;
-    symmetry_ = 0;
-}
-
 Matrix::Matrix(const std::string &name, int symmetry)
-    : matrix_(nullptr), nirrep_(0), name_(name), symmetry_(symmetry) {}
+    : name_(name), symmetry_(symmetry) {}
 
-Matrix::Matrix(const Matrix &c) : rowspi_(c.rowspi_), colspi_(c.colspi_) {
-    matrix_ = nullptr;
-    nirrep_ = c.nirrep_;
-    symmetry_ = c.symmetry_;
-    name_ = c.name();
+Matrix::Matrix(const Matrix &c)
+    : rowspi_(c.rowspi_), colspi_(c.colspi_), nirrep_(c.nirrep_), symmetry_(c.symmetry_), name_(c.name_) {
     alloc();
     copy_from(c.matrix_);
 }
@@ -101,88 +92,46 @@ Matrix &Matrix::operator=(const Matrix &c) {
     return *this;
 }
 
-Matrix::Matrix(const SharedMatrix &c) : rowspi_(c->rowspi_), colspi_(c->colspi_) {
-    matrix_ = nullptr;
-    nirrep_ = c->nirrep_;
-    symmetry_ = c->symmetry_;
-    name_ = c->name();
-    alloc();
-    copy_from(c->matrix_);
-}
+Matrix::Matrix(const SharedMatrix &c)
+    : Matrix(*c) {}
 
-Matrix::Matrix(const Matrix *c) : rowspi_(c->rowspi_), colspi_(c->colspi_) {
-    matrix_ = nullptr;
-    nirrep_ = c->nirrep_;
-    symmetry_ = c->symmetry_;
-    name_ = c->name();
-    alloc();
-    copy_from(c->matrix_);
-}
+Matrix::Matrix(const Matrix *c)
+    : Matrix(*c) {}
 
 Matrix::Matrix(int l_nirreps, const int *l_rowspi, const int *l_colspi, int symmetry)
-    : rowspi_(l_nirreps), colspi_(l_nirreps) {
-    matrix_ = nullptr;
-    nirrep_ = l_nirreps;
-    symmetry_ = symmetry;
-    rowspi_ = l_rowspi;
-    colspi_ = l_colspi;
-    alloc();
-}
+    : Matrix("", l_nirreps, l_rowspi, l_colspi, symmetry) {}
 
 Matrix::Matrix(const std::string &name, int l_nirreps, const int *l_rowspi, const int *l_colspi, int symmetry)
-    : rowspi_(l_nirreps), colspi_(l_nirreps), name_(name) {
-    matrix_ = nullptr;
-    nirrep_ = l_nirreps;
-    symmetry_ = symmetry;
-    rowspi_ = l_rowspi;
-    colspi_ = l_colspi;
+    : nirrep_(l_nirreps), symmetry_(symmetry), name_(name), matrix_(nullptr),
+      rowspi_(std::vector<int>(l_rowspi, l_rowspi + l_nirreps)),
+      colspi_(std::vector<int>(l_colspi, l_colspi + l_nirreps)) {
     alloc();
 }
 
-Matrix::Matrix(const std::string &name, int rows, int cols) : rowspi_(1), colspi_(1), name_(name) {
-    matrix_ = nullptr;
-    nirrep_ = 1;
-    symmetry_ = 0;
-    rowspi_[0] = rows;
-    colspi_[0] = cols;
+Matrix::Matrix(const std::string &name, int rows, int cols)
+    : rowspi_(std::vector<int>{rows}), colspi_(std::vector<int>{cols}), name_(name),
+      nirrep_(1), symmetry_(0), matrix_(nullptr) {
     alloc();
 }
 
-Matrix::Matrix(int rows, int cols) : rowspi_(1), colspi_(1) {
-    matrix_ = nullptr;
-    nirrep_ = 1;
-    symmetry_ = 0;
-    rowspi_[0] = rows;
-    colspi_[0] = cols;
+Matrix::Matrix(int rows, int cols)
+    : Matrix("", rows, cols) {}
+
+Matrix::Matrix(int nirrep, int rows, const int *colspi)
+    : nirrep_(nirrep), matrix_(nullptr), symmetry_(0), rowspi_(std::vector<int>(nirrep, rows)),
+      colspi_(std::vector<int>(colspi, colspi + nirrep)) {
     alloc();
 }
 
-Matrix::Matrix(int nirrep, int rows, const int *colspi) : rowspi_(nirrep), colspi_(nirrep) {
-    matrix_ = nullptr;
-    symmetry_ = 0;
-    nirrep_ = nirrep;
-    for (int i = 0; i < nirrep_; ++i) {
-        rowspi_[i] = rows;
-        colspi_[i] = colspi[i];
-    }
+Matrix::Matrix(int nirrep, const int *rowspi, int cols)
+    : nirrep_(nirrep), matrix_(nullptr), symmetry_(0), colspi_(std::vector<int>(nirrep, cols)),
+      rowspi_(std::vector<int>(rowspi, rowspi + nirrep)) {
     alloc();
 }
 
-Matrix::Matrix(int nirrep, const int *rowspi, int cols) : rowspi_(nirrep), colspi_(nirrep) {
-    matrix_ = nullptr;
-    symmetry_ = 0;
-    nirrep_ = nirrep;
-    for (int i = 0; i < nirrep_; ++i) {
-        rowspi_[i] = rowspi[i];
-        colspi_[i] = cols;
-    }
-    alloc();
-}
-
-Matrix::Matrix(const std::string &name, const Dimension &rows, const Dimension &cols, int symmetry) {
-    name_ = name;
-    matrix_ = nullptr;
-    symmetry_ = symmetry;
+Matrix::Matrix(const std::string &name, const Dimension &rows, const Dimension &cols, int symmetry)
+    : name_(name), matrix_(nullptr), symmetry_(symmetry) {
+    // Oh brother, this code stinks!
 
     // This will happen in PetiteList::aotoso()
     if (rows.n() == 1) {
@@ -206,43 +155,18 @@ Matrix::Matrix(const std::string &name, const Dimension &rows, const Dimension &
     alloc();
 }
 
-Matrix::Matrix(const Dimension &rows, const Dimension &cols, int symmetry) {
-    matrix_ = nullptr;
-    symmetry_ = symmetry;
-
-    // This will happen in PetiteList::aotoso()
-    if (rows.n() == 1) {
-        nirrep_ = cols.n();
-        rowspi_ = Dimension(nirrep_);
-        colspi_ = Dimension(nirrep_);
-        for (int i = 0; i < nirrep_; ++i) {
-            rowspi_[i] = rows[0];
-            colspi_[i] = cols[i];
-        }
-    } else {
-        nirrep_ = rows.n();
-        rowspi_ = Dimension(nirrep_);
-        colspi_ = Dimension(nirrep_);
-        for (int i = 0; i < nirrep_; ++i) {
-            rowspi_[i] = rows[i];
-            colspi_[i] = cols[i];
-        }
-    }
-
-    alloc();
-}
+Matrix::Matrix(const Dimension &rows, const Dimension &cols, int symmetry)
+    : Matrix("", rows, cols, symmetry) {}
 
 Matrix::Matrix(const std::string &name, const Dimension& rows, const int cols, int symmetry)
-    : nirrep_(rows.n()), rowspi_(rows), colspi_(Dimension(std::vector<int>(nirrep_, cols))), name_(name) {
-    matrix_ = nullptr;
-    symmetry_ = symmetry;
+    : nirrep_(rows.n()), rowspi_(rows), colspi_(Dimension(std::vector<int>(nirrep_, cols))),
+      name_(name), matrix_(nullptr), symmetry_(symmetry) {
     alloc();
 }
 
 Matrix::Matrix(const std::string &name, const int rows, const Dimension& cols, int symmetry)
-    : nirrep_(cols.n()), rowspi_(Dimension(std::vector<int>(nirrep_, rows))), colspi_(cols), name_(name) {
-    matrix_ = nullptr;
-    symmetry_ = symmetry;
+    : nirrep_(cols.n()), rowspi_(Dimension(std::vector<int>(nirrep_, rows))), colspi_(cols),
+    name_(name), matrix_(nullptr), symmetry_(symmetry) {
     alloc();
 }
 

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -2737,7 +2737,7 @@ void Matrix::apply_symmetry(const SharedMatrix &a, const SharedMatrix &transform
     }
 
     // Create temporary matrix of proper size.
-    Matrix temp(nirrep(), a->nrow(), transformer->colspi());
+    Matrix temp(a->nrow(), transformer->colspi());
 
     char ta = 'n';
     char tb = 'n';

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -79,7 +79,7 @@ Matrix::Matrix(const Matrix &c)
     copy_from(c.matrix_);
 }
 
-Matrix &Matrix::operator=(const Matrix &c) {
+Matrix& Matrix::operator=(const Matrix &c) {
     release();
     nirrep_ = c.nirrep_;
     symmetry_ = c.symmetry_;
@@ -88,6 +88,29 @@ Matrix &Matrix::operator=(const Matrix &c) {
     colspi_ = c.colspi_;
     alloc();
     copy_from(c.matrix_);
+
+    return *this;
+}
+
+Matrix::Matrix(Matrix&& m) noexcept
+    : rowspi_(std::move(m.rowspi_)), colspi_(std::move(m.colspi_)), nirrep_(m.nirrep_), matrix_(m.matrix_),
+      symmetry_(m.symmetry_), name_(m.name_), numpy_shape_(std::move(m.numpy_shape_)) {
+    // Copy pointer to data then nullify the previous pointer to prevent double free.
+    m.matrix_ = nullptr;
+}
+
+Matrix& Matrix::operator=(Matrix&& m) noexcept {
+    release();
+    nirrep_ = m.nirrep_;
+    symmetry_ = m.symmetry_;
+    name_ = m.name_;
+    rowspi_ = std::move(m.rowspi_);
+    colspi_ = std::move(m.colspi_);
+    numpy_shape_ = std::move(m.numpy_shape_);
+
+    // Copy pointer to data then nullify the previous pointer to prevent double free.
+    matrix_ = m.matrix_;
+    m.matrix_ = nullptr;
 
     return *this;
 }

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -232,18 +232,12 @@ Matrix::Matrix(const Dimension &rows, const Dimension &cols, int symmetry) {
     alloc();
 }
 
-Matrix::Matrix(const Dimension& rows, const int cols, int symmetry)
-    : Matrix("", rows, cols, symmetry) {}
-
 Matrix::Matrix(const std::string &name, const Dimension& rows, const int cols, int symmetry)
     : nirrep_(rows.n()), rowspi_(rows), colspi_(Dimension(std::vector<int>(nirrep_, cols))), name_(name) {
     matrix_ = nullptr;
     symmetry_ = symmetry;
     alloc();
 }
-
-Matrix::Matrix(const int rows, const Dimension& cols, int symmetry)
-    : Matrix("", rows, cols, symmetry) {}
 
 Matrix::Matrix(const std::string &name, const int rows, const Dimension& cols, int symmetry)
     : nirrep_(cols.n()), rowspi_(Dimension(std::vector<int>(nirrep_, rows))), colspi_(cols), name_(name) {

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -137,9 +137,9 @@ void free(double** Block);
 class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
    protected:
     /// Matrix data
-    double*** matrix_;
+    double*** matrix_ = nullptr;
     /// Number of irreps
-    int nirrep_;
+    int nirrep_ = 0;
     /// Rows per irrep array. Element "h" is associated with matrix block h.
     Dimension rowspi_;
     /// Columns per irrep array. Element "h" is associated with matrix block h ^ symmetry_.
@@ -147,7 +147,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     /// Name of the matrix
     std::string name_;
     /// Symmetry of this matrix (in most cases this will be 0 [totally symmetric])
-    int symmetry_;
+    int symmetry_ = 0;
 
     /// Allocates matrix_
     void alloc();
@@ -164,7 +164,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
 
    public:
     /// Default constructor, zeros everything out
-    Matrix();
+    Matrix() = default;
     /**
      * Constructor, zeros everything out, sets name_
      *

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -173,6 +173,10 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     Matrix(const Matrix& copy);
     /// Copy assignment operator.
     Matrix& operator=(const Matrix& copy);
+    /// Move constructor.
+    Matrix(Matrix&& move) noexcept;
+    /// Move assignment operator.
+    Matrix& operator=(Matrix&& move) noexcept;
     /// Explicit \c shared_ptr copy constructor.
     explicit Matrix(const SharedMatrix& copy);
     /// Explicit pointer copy constructor.

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -75,23 +75,23 @@ enum diagonalize_order { evals_only_ascending = 0, ascending = 1, evals_only_des
 namespace linalg {
 /**
  * Horizontally concatenate matrices
- * @param mats std::vector of Matrix objects to concatenate
+ * @param mats `std::vector` of Matrix objects to concatenate
  */
 PSI_API
 SharedMatrix horzcat(const std::vector<SharedMatrix>& mats);
 
 /**
  * Vertically concatenate matrices
- * @param mats std::vector of Matrix objects to concatenate
+ * @param mats `std::vector` of Matrix objects to concatenate
  */
 PSI_API
 SharedMatrix vertcat(const std::vector<SharedMatrix>& mats);
 
-/** Simple doublet GEMM with on-the-fly allocation
- * \param A The first matrix
- * \param B The second matrix
- * \param transA Transpose the first matrix
- * \param transB Transpose the second matrix
+/** Simple doublet GEMM with on-the-fly allocation.
+ * @param A The first matrix
+ * @param B The second matrix
+ * @param transA Transpose the first matrix
+ * @param transB Transpose the second matrix
  */
 
 PSI_API
@@ -99,13 +99,13 @@ SharedMatrix doublet(const SharedMatrix& A, const SharedMatrix& B, bool transA =
 
 Matrix doublet(const Matrix& A, const Matrix& B, bool transA = false, bool transB = false);
 
-/** Simple triplet GEMM with on-the-fly allocation
- * \param A The first matrix
- * \param B The second matrix
- * \param C The third matrix
- * \param transA Transpose the first matrix
- * \param transB Transpose the second matrix
- * \param transC Transpose the third matrix
+/** Simple triplet GEMM with on-the-fly allocation.
+ * @param A The first matrix
+ * @param B The second matrix
+ * @param C The third matrix
+ * @param transA Transpose the first matrix
+ * @param transB Transpose the second matrix
+ * @param transC Transpose the third matrix
  */
 PSI_API
 SharedMatrix triplet(const SharedMatrix& A, const SharedMatrix& B, const SharedMatrix& C, bool transA = false,
@@ -114,14 +114,14 @@ SharedMatrix triplet(const SharedMatrix& A, const SharedMatrix& B, const SharedM
 Matrix triplet(const Matrix&A, const Matrix& B, const Matrix& C, bool transA = false, bool transB = false, bool transC = false);
 
 namespace detail {
-/*!
- * allocate a block matrix -- analogous to libciomr's block_matrix
+/**
+ * Allocate a block matrix -- analogous to psi::block_matrix in `libciomr`.
  */
 PSI_API
 double** matrix(int nrow, int ncol);
 
-/*!
- * free a (block) matrix -- analogous to libciomr's free_block
+/**
+ * Free a (block) matrix -- analogous to psi::free_block in `libciomr`.
  */
 PSI_API
 void free(double** Block);
@@ -132,7 +132,7 @@ void free(double** Block);
  *  \class Matrix
  *  \brief Makes using matrices just a little easier.
  *
- * Using a matrix factory makes creating these a breeze.
+ * Using a MatrixFactory makes creating these a breeze.
  */
 class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
    protected:
@@ -149,37 +149,37 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     /// Symmetry of this matrix (in most cases this will be 0 [totally symmetric])
     int symmetry_ = 0;
 
-    /// Allocates matrix_
+    /// Allocates #matrix_
     void alloc();
-    /// Release matrix_
+    /// Release #matrix_
     void release();
 
-    /// Copies data from the passed matrix to this matrix_
+    /// Copies data from the passed Matrix to `this`.
     void copy_from(double***);
 
     void print_mat(const double* const* const a, int m, int n, std::string out) const;
 
-    /// Numpy Shape
+    /// Used for converting to NumPy ndarray.
     std::vector<int> numpy_shape_;
 
    public:
-    /// Default constructor, zeros everything out
+    /// Default constructor, zeros everything out.
     Matrix() = default;
-    /**
-     * Constructor, zeros everything out, sets name_
-     *
-     * @param name Name of the matrix, used in saving and printing.
-     */
+    /// Constructor with name, zeros everything out.
+    /// @param name Name of the matrix, used in saving and printing.
+    /// @param symmetry Overall symmetry of the data.
     Matrix(const std::string& name, int symmetry = 0);
-    /// copy reference constructor
+    /// Reference copy constructor.
     Matrix(const Matrix& copy);
+    /// Copy assignment operator.
     Matrix& operator=(const Matrix& copy);
-    /// Explicit shared point copy constructor
+    /// Explicit \c shared_ptr copy constructor.
     explicit Matrix(const SharedMatrix& copy);
-    /// copy pointer constructor
+    /// Explicit pointer copy constructor.
     explicit Matrix(const Matrix* copy);
     /**
-     * Constructor, sets up the matrix
+     * Int pointer Matrix constructor without name.
+     * @deprecated Use Dimension instead of int pointers.
      *
      * @param nirrep Number of blocks.
      * @param rowspi Array of length nirreps giving row dimensionality.
@@ -188,7 +188,8 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     PSI_DEPRECATED("Matrix construction via int* is being deprecated and will be removed as soon as 1.13.")
     Matrix(int nirrep, const int* rowspi, const int* colspi, int symmetry = 0);
     /**
-     * Constructor, sets name_, and sets up the matrix
+     * Int pointer Matrix constructor with name.
+     * @deprecated Use Dimension instead of int pointers.
      *
      * @param name Name of the matrix.
      * @param nirrep Number of blocks.
@@ -198,7 +199,9 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     PSI_DEPRECATED("Matrix construction via int* is being deprecated and will be removed as soon as 1.13.")
     Matrix(const std::string& name, int nirrep, const int* rowspi, const int* colspi, int symmetry = 0);
     /**
-     * Constructor, forms non-standard matrix.
+     * @brief Int pointer Matrix constructor of non-standard form.
+     * @deprecated Use Dimension instead of int pointers.
+     *
      * @param nirrep Number of blocks.
      * @param rows Singular value. All blocks have same number of rows.
      * @param colspi Array of length nirreps. Defines blocking scheme for columns.
@@ -207,7 +210,9 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     Matrix(int nirrep, int rows, const int* colspi);
 
     /**
-     * Constructor, forms non-standard matrix.
+     * Int pointer Matrix constructor of non-standard form.
+     * @deprecated Use Dimension instead of int pointers.
+     *
      * @param nirrep Number of blocks.
      * @param rowspi Array of length nirreps. Defines blocking scheme for rows.
      * @param cols Singular value. All blocks have same number of columns.
@@ -216,16 +221,14 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     Matrix(int nirrep, const int* rowspi, int cols);
 
     /**
-     * Constructor, sets up the matrix
-     * Convenience case for 1 irrep
+     * Matrix constructor for one irrep.
      *
      * @param rows Row dimensionality.
      * @param cols Column dimensionality.
      */
     Matrix(int rows, int cols);
     /**
-     * Constructor, sets up the matrix
-     * Convenience case for 1 irrep
+     * Matrix constructor for one irrep.
      *
      * @param name Name of the matrix.
      * @param rows Row dimensionality.
@@ -244,7 +247,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     Matrix(const std::string& name, const Dimension& rows, const Dimension& cols, int symmetry = 0);
 
     /**
-     * Constructor using Dimension objects to define order and dimensionality.
+     * Matrix constructor using Dimension without name.
      *
      * @param rows Dimension object providing row information.
      * @param cols Dimension object providing column information.
@@ -253,7 +256,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     Matrix(const Dimension& rows, const Dimension& cols, int symmetry = 0);
 
     /**
-     * Constructor using Dimension objects to define order and dimensionality.
+     * Matrix constructor using Dimension with name.
      *
      * @param name Name of the matrix.
      * @param rows Dimension object providing row information.
@@ -263,7 +266,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     Matrix(const std::string& name, const Dimension& rows, const int cols, int symmetry = 0);
 
     /**
-     * Constructor using Dimension objects to define order and dimensionality.
+     * Matrix constructor using Dimension without name for non-standard shape.
      *
      * @param rows Dimension object providing row information.
      * @param cols Singular value. All blocks have same number of columns.
@@ -273,7 +276,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
         : Matrix("", rows, cols, symmetry) {};
 
     /**
-     * Constructor using Dimension objects to define order and dimensionality.
+     * Matrix constructor using Dimension with name for non-standard shape.
      *
      * @param name Name of the matrix.
      * @param rows Singular value. All blocks have same number of rows.
@@ -283,7 +286,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     Matrix(const std::string& name, const int rows, const Dimension& cols, int symmetry = 0);
 
     /**
-     * Constructor using Dimension objects to define order and dimensionality.
+     * Matrix constructor using Dimension without name for non-standard shape.
      *
      * @param rows Singular value. All blocks have same number of rows.
      * @param cols Dimension object providing column information.

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -234,20 +234,6 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     Matrix(const std::string& name, int rows, int cols);
 
     /**
-     * Contructs a Matrix from a dpdfile2
-     *
-     * @param inFile dpdfile2 object to replicate (must already be initialized).
-     */
-    Matrix(dpdfile2* inFile);
-
-    /**
-     * Contructs a Matrix from a dpdbuf4
-     *
-     * @param inBuf dpdbuf4 object to replicate (must already be initialized).
-     */
-    Matrix(dpdbuf4* inBuf);
-
-    /**
      * Constructor using Dimension objects to define order and dimensionality.
      *
      * @param name Name of the matrix.
@@ -269,15 +255,6 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     /**
      * Constructor using Dimension objects to define order and dimensionality.
      *
-     * @param rows Dimension object providing row information.
-     * @param cols Singular value. All blocks have same number of columns.
-     * @param symmetry overall symmetry of the data.
-     */
-    Matrix(const Dimension& rows, const int cols, int symmetry = 0);
-
-    /**
-     * Constructor using Dimension objects to define order and dimensionality.
-     *
      * @param name Name of the matrix.
      * @param rows Dimension object providing row information.
      * @param cols Singular value. All blocks have same number of columns.
@@ -288,12 +265,12 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     /**
      * Constructor using Dimension objects to define order and dimensionality.
      *
-     * @param name Name of the matrix.
-     * @param rows Singular value. All blocks have same number of rows.
-     * @param cols Dimension object providing column information.
+     * @param rows Dimension object providing row information.
+     * @param cols Singular value. All blocks have same number of columns.
      * @param symmetry overall symmetry of the data.
      */
-    Matrix(const int rows, const Dimension& cols, int symmetry = 0);
+    Matrix(const Dimension& rows, const int cols, int symmetry = 0)
+        : Matrix("", rows, cols, symmetry) {};
 
     /**
      * Constructor using Dimension objects to define order and dimensionality.
@@ -305,6 +282,29 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      */
     Matrix(const std::string& name, const int rows, const Dimension& cols, int symmetry = 0);
 
+    /**
+     * Constructor using Dimension objects to define order and dimensionality.
+     *
+     * @param rows Singular value. All blocks have same number of rows.
+     * @param cols Dimension object providing column information.
+     * @param symmetry overall symmetry of the data.
+     */
+    Matrix(const int rows, const Dimension& cols, int symmetry = 0)
+        : Matrix("", rows, cols, symmetry) {};
+
+    /**
+     * Contructs a Matrix from a dpdfile2
+     *
+     * @param inFile dpdfile2 object to replicate (must already be initialized).
+     */
+    Matrix(dpdfile2* inFile);
+
+    /**
+     * Contructs a Matrix from a dpdbuf4
+     *
+     * @param inBuf dpdbuf4 object to replicate (must already be initialized).
+     */
+    Matrix(dpdbuf4* inBuf);
 
     /// Destructor, frees memory
     virtual ~Matrix();

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -185,6 +185,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * @param rowspi Array of length nirreps giving row dimensionality.
      * @param colspi Array of length nirreps giving column dimensionality.
      */
+    PSI_DEPRECATED("Matrix construction via int* is being deprecated and will be removed as soon as 1.13.")
     Matrix(int nirrep, const int* rowspi, const int* colspi, int symmetry = 0);
     /**
      * Constructor, sets name_, and sets up the matrix
@@ -194,6 +195,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * @param rowspi Array of length nirreps giving row dimensionality.
      * @param colspi Array of length nirreps giving column dimensionality.
      */
+    PSI_DEPRECATED("Matrix construction via int* is being deprecated and will be removed as soon as 1.13.")
     Matrix(const std::string& name, int nirrep, const int* rowspi, const int* colspi, int symmetry = 0);
     /**
      * Constructor, forms non-standard matrix.
@@ -201,6 +203,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * @param rows Singular value. All blocks have same number of rows.
      * @param colspi Array of length nirreps. Defines blocking scheme for columns.
      */
+    PSI_DEPRECATED("Matrix construction via int* is being deprecated and will be removed as soon as 1.13.")
     Matrix(int nirrep, int rows, const int* colspi);
 
     /**
@@ -209,6 +212,7 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * @param rowspi Array of length nirreps. Defines blocking scheme for rows.
      * @param cols Singular value. All blocks have same number of columns.
      */
+    PSI_DEPRECATED("Matrix construction via int* is being deprecated and will be removed as soon as 1.13.")
     Matrix(int nirrep, const int* rowspi, int cols);
 
     /**
@@ -261,6 +265,46 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
      * @param symmetry overall symmetry of the data.
      */
     Matrix(const Dimension& rows, const Dimension& cols, int symmetry = 0);
+
+    /**
+     * Constructor using Dimension objects to define order and dimensionality.
+     *
+     * @param rows Dimension object providing row information.
+     * @param cols Singular value. All blocks have same number of columns.
+     * @param symmetry overall symmetry of the data.
+     */
+    Matrix(const Dimension& rows, const int cols, int symmetry = 0);
+
+    /**
+     * Constructor using Dimension objects to define order and dimensionality.
+     *
+     * @param name Name of the matrix.
+     * @param rows Dimension object providing row information.
+     * @param cols Singular value. All blocks have same number of columns.
+     * @param symmetry overall symmetry of the data.
+     */
+    Matrix(const std::string& name, const Dimension& rows, const int cols, int symmetry = 0);
+
+    /**
+     * Constructor using Dimension objects to define order and dimensionality.
+     *
+     * @param name Name of the matrix.
+     * @param rows Singular value. All blocks have same number of rows.
+     * @param cols Dimension object providing column information.
+     * @param symmetry overall symmetry of the data.
+     */
+    Matrix(const int rows, const Dimension& cols, int symmetry = 0);
+
+    /**
+     * Constructor using Dimension objects to define order and dimensionality.
+     *
+     * @param name Name of the matrix.
+     * @param rows Singular value. All blocks have same number of rows.
+     * @param cols Dimension object providing column information.
+     * @param symmetry overall symmetry of the data.
+     */
+    Matrix(const std::string& name, const int rows, const Dimension& cols, int symmetry = 0);
+
 
     /// Destructor, frees memory
     virtual ~Matrix();


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR updates the Matrix constructors to use more initializer lists. In general, use of initializer lists is preferred over what happens currently: the compiler is implicitly initializing the values first then setting them *again* in the ctor block. Initializer lists are faster, require less allocations, allow the compiler to optimize moves vs. copies, and allow for const classes to be initialized more easily. The last point doesn't benefit Matrix outside of copying one Matrix to another, but developers should still be used to seeing them and using them.

Based on [rule of five](https://en.cppreference.com/cpp/language/rule_of_three#Rule_of_five) and our circumstances, we will need to implement the move `Matrix(const Matrix&& other)` ctor and move assignment `operator=(const Matrix&& other)` operator since the compiler does not do this by default. A function returning `Matrix` by value (technically prvalue) may go from copies to moves due to compiler [RVO](https://en.wikipedia.org/wiki/Copy_elision#Return_value_optimization). For example, a `Matrix` may be converted to `SharedMatrix` _without_ any copy operations: `std::make_shared<Matrix>(Factory())`. The obvious benefit here is that moving is near instantaneous and essentially constant time.

This would also have benefits for code within matrix.cc. Consider the random example `Matrix::pivoted_cholesky`:
```C++
auto U = std::make_shared<Matrix>(rowspi_, nchol);
U->zero();
for (int h = 0; h < nirrep_; ++h)
    for (int m = 0; m < rowspi_[h]; ++m)
        for (int n = m; n < nchol[h]; ++n)
            U->set(h, m, n, get(h, n, m));
*this = *U;
```
The Matrix class uses the copy assignment operator here, but it should instead move. For correct behavior, just convert to an rvalue `*this = std::move(*U);`. This code would do nothing before because no explicit or implicit move assignment operator existed. So adding support for move semantics is essentially free, and gives you free performance. There are really only pros and const to this PR.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
*None*

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Deprecates Matrix ctors using `const int *` parameters.
- [x] Adds four new constructors to replace the above deprecated ctors `(const int *, const int)` --> `(const Dimension&, const int)`. These function identically, but use Dimension instead, and most of it can be done in the initializer list because `std::vector` has a handy "fill" constructor. 
- [x] Removes the `Dimension::operator=(const int * start)` lines in these ctors and replaces them with `Dimension(std::vector<int>(start, start + nirrep_))`. Since Matrix has a implicit conversion operator from `std::vector<int>` to `Dimension`, this just works without requiring any copy operations. It is somewhat similar to the previous approach, but more modern and shifts the deprecation burden away from Dimension.
- [x] The `Matrix(string, ...)` and `Matrix(...)` constructor pairs are merged by defining `Matrix(...) : Matrix("", ...) {};`. This works because the default value for `std::string` is already `""`, thus it behaves like the same ctor with a default option.
- [x] Explicit defaults were added for `matrix_`, `nirreps_` and `symmetry_`. `int` and pointer types initialize to garbage by default. This was already being explicitly set within each constructor, so this only simplifies redundant lines of code.
- [x] The now redundant default ctor `Matrix::Matrix()` was explicitly set to `= default`, again simplifying the code.
- [x] Added move semantics.
## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [x] None

## Checklist
- [x] Tests added for any new features
- [x] Docstring or narrative docs/sphinxman/source updated if needed
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review

How it feels opening 6 consecutive PRs with no user-facing changes:
![Programmer typing deviously](https://media1.tenor.com/m/GythNLlEJtYAAAAC/code-encoding.gif)