### PR TITLE
Dimension deprecation: use new `dpd_init` in `libtrans`

### DIFF
--- a/psi4/src/psi4/libtrans/integraltransform.cc
+++ b/psi4/src/psi4/libtrans/integraltransform.cc
@@ -275,7 +275,7 @@ void IntegralTransform::initialize() {
     cacheFiles_ = init_int_array(PSIO_MAXUNIT);
     cacheList_ = init_int_matrix(numIndexArrays, numIndexArrays);
     int currentActiveDPD = psi::dpd_default;
-    dpd_init(myDPDNum_, nirreps_, memory_, 0, cacheFiles_, cacheList_, nullptr, numSpaces, spaceArray_);
+    dpd_init(myDPDNum_, nirreps_, memory_, 0, cacheFiles_, cacheList_, nullptr, spaceArray_);
 
     // We have to redefine the MO coefficients for a UHF-like treatment
     if (transformationType_ == TransformationType::SemiCanonical) {
@@ -325,8 +325,8 @@ IntegralTransform::~IntegralTransform() {
     }
 
     for(int i = 0; i < spaceArray_.size(); i++) {
-        if(spaceArray_[i] != nullptr) {
-            delete[] spaceArray_[i];
+        if(spaceArray_[i].second != nullptr) {
+            delete[] spaceArray_[i].second;
         }
     }
 }

--- a/psi4/src/psi4/libtrans/integraltransform.h
+++ b/psi4/src/psi4/libtrans/integraltransform.h
@@ -287,11 +287,11 @@ class PSI_API IntegralTransform {
     // The unique orbital spaces involved in this transformation
     std::vector<char> spacesUsed_;
     // A list of the arrays to pass into libDPD
-    std::vector<int *> spaceArray_;
+    std::vector<std::pair<Dimension, int *>> spaceArray_;
     // The alpha orbitals per irrep for each space
-    std::map<char, int *> aOrbsPI_;
+    std::map<char, Dimension> aOrbsPI_;
     // The beta orbitals per irrep for each space
-    std::map<char, int *> bOrbsPI_;
+    std::map<char, Dimension> bOrbsPI_;
     // The alpha MO coefficients for all unique spaces needed
     std::map<char, SharedMatrix> aMOCoefficients_;
     // The beta MO coefficients for all unique spaces needed

--- a/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
@@ -99,7 +99,7 @@ void IntegralTransform::process_spaces() {
 
     for (space = uniqueSpaces_.begin(); space != uniqueSpaces_.end(); ++space) {
         std::shared_ptr<MOSpace> moSpace = *space;
-        int *aOrbsPI = new int[nirreps_];
+        Dimension aOrbsPI(nirreps_, "aOrbsPI");
         int *aIndex;
         int *aOrbSym;
 
@@ -115,8 +115,8 @@ void IntegralTransform::process_spaces() {
         if (moSpace->label() == MOSPACE_FZC) {
             // This is the frozen occupied space
             int numAOcc = 0, aOccCount = 0;
+            aOrbsPI = frzcpi_;
             for (int h = 0; h < nirreps_; ++h) {
-                aOrbsPI[h] = frzcpi_[h];
                 numAOcc += aOrbsPI[h];
             }
             aOrbSym = new int[numAOcc];
@@ -218,8 +218,8 @@ void IntegralTransform::process_spaces() {
         } else if (moSpace->label() == MOSPACE_FZV) {
             // This is the frozen virtual space
             int numAVir = 0, aVirCount = 0;
+            aOrbsPI = frzvpi_;
             for (int h = 0; h < nirreps_; ++h) {
-                aOrbsPI[h] = frzvpi_[h];
                 numAVir += aOrbsPI[h];
             }
             aOrbSym = new int[numAVir];
@@ -242,7 +242,7 @@ void IntegralTransform::process_spaces() {
             // This is the dummy single-function-per-irrep space
             aOrbSym = new int[1];
             aIndex = new int[1];
-            for (int h = 0; h < nirreps_; ++h) aOrbsPI[h] = 0;
+            aOrbsPI.zero();
             aOrbsPI[0] = 1;
             aOrbSym[0] = 0;
             aIndex[0] = 0;
@@ -254,7 +254,6 @@ void IntegralTransform::process_spaces() {
             // Figure out how many orbitals per irrep, and group all orbitals by irrep
             int nAOrbs = aorbs.size();
             aOrbSym = new int[nAOrbs];
-            ::memset(aOrbsPI, '\0', nirreps_ * sizeof(int));
             aIndex = (aindex.empty() ? 0 : new int[nAOrbs]);
             for (int h = 0, count = 0; h < nirreps_; ++h) {
                 for (int n = 0; n < nAOrbs; ++n) {
@@ -289,8 +288,7 @@ void IntegralTransform::process_spaces() {
         }
 
         spacesUsed_.push_back(toupper(moSpace->label()));
-        spaceArray_.push_back(aOrbsPI);
-        spaceArray_.push_back(aOrbSym);
+        spaceArray_.emplace_back(aOrbsPI, aOrbSym);
         aOrbsPI_[moSpace->label()] = aOrbsPI;
         aIndices_[moSpace->label()] = aIndex;
         //        if(transformationType_ == TransformationType::Restricted){
@@ -307,16 +305,15 @@ void IntegralTransform::process_spaces() {
     if (transformationType_ != TransformationType::Restricted) {
         for (space = uniqueSpaces_.begin(); space != uniqueSpaces_.end(); ++space) {
             std::shared_ptr<MOSpace> moSpace = *space;
-            int *bOrbsPI = new int[nirreps_];
-            ;
+            Dimension bOrbsPI(nirreps_, "bOrbsPI");
             int *bIndex;
             int *bOrbSym;
 
             if (moSpace->label() == MOSPACE_FZC) {
                 // This is the frozen occupied space
                 int numBOcc = 0, bOccCount = 0;
+                bOrbsPI = frzcpi_;
                 for (int h = 0; h < nirreps_; ++h) {
-                    bOrbsPI[h] = frzcpi_[h];
                     numBOcc += bOrbsPI[h];
                 }
                 bOrbSym = new int[numBOcc];
@@ -440,7 +437,6 @@ void IntegralTransform::process_spaces() {
                 int nBOrbs = borbs.size();
                 bOrbSym = new int[nBOrbs];
                 bIndex = (bindex.empty() ? 0 : new int[nBOrbs]);
-                ::memset(bOrbsPI, '\0', nirreps_ * sizeof(int));
                 for (int h = 0, count = 0; h < nirreps_; ++h) {
                     for (int n = 0; n < nBOrbs; ++n) {
                         int orb = borbs[n];
@@ -473,8 +469,7 @@ void IntegralTransform::process_spaces() {
             }
 
             spacesUsed_.push_back(tolower(moSpace->label()));
-            spaceArray_.push_back(bOrbsPI);
-            spaceArray_.push_back(bOrbSym);
+            spaceArray_.emplace_back(bOrbsPI, bOrbSym);
             bOrbsPI_[moSpace->label()] = bOrbsPI;
             bIndices_[moSpace->label()] = bIndex;
         }  // End loop over spaces
@@ -483,16 +478,9 @@ void IntegralTransform::process_spaces() {
     // End by adding the AO orbital space - this is always needed
     spacesUsed_.push_back(MOSPACE_NIL);
 
-    int *sopi_data = new int[sopi_.n()];
-
-    for(int i = 0; i < sopi_.n(); i++) {
-        sopi_data[i] = sopi_.get(i);
-    }
-
-    spaceArray_.push_back(sopi_data);
-    spaceArray_.push_back(sosym_);
-    aOrbsPI_[MOSPACE_NIL] = sopi_data;
-    bOrbsPI_[MOSPACE_NIL] = sopi_data;
+    spaceArray_.emplace_back(sopi_, sosym_);
+    aOrbsPI_[MOSPACE_NIL] = sopi_;
+    bOrbsPI_[MOSPACE_NIL] = sopi_;
 
     /* Populate the DPD indexing map.  The string class is used instead of a char*
      * because I can't be bothered to roll my own char* container with comparison
@@ -645,7 +633,7 @@ void IntegralTransform::process_eigenvectors() {
             int nBOrbs = borbs.size();
             std::string name("Alpha orbitals for space ");
             name += label;
-            Ca = std::make_shared<Matrix>(name, nirreps_, sopi_, aOrbsPI_[label]);
+            Ca = std::make_shared<Matrix>(name, sopi_, aOrbsPI_[label]);
             int mo_offsets[8];
             mo_offsets[0] = 0;
             for (int h = 1; h < nirreps_; ++h) mo_offsets[h] = mo_offsets[h - 1] + mopi_[h - 1];
@@ -664,7 +652,7 @@ void IntegralTransform::process_eigenvectors() {
             }
             if (transformationType_ != TransformationType::Restricted) {
                 name = "Beta orbitals for space " + std::string(1, label);
-                Cb = std::make_shared<Matrix>(name, nirreps_, sopi_, bOrbsPI_[label]);
+                Cb = std::make_shared<Matrix>(name, sopi_, bOrbsPI_[label]);
                 for (int h = 0; h < nirreps_; ++h) {
                     int count = 0;
                     for (int n = 0; n < nBOrbs; ++n) {

--- a/psi4/src/psi4/libtrans/integraltransform_tei_1st_half.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tei_1st_half.cc
@@ -58,10 +58,10 @@ void IntegralTransform::transform_tei_first_half(const std::shared_ptr<MOSpace> 
     SharedMatrix c2a = aMOCoefficients_[s2->label()];
     SharedMatrix c2b = bMOCoefficients_[s2->label()];
     // And the number of orbitals per irrep
-    int *aOrbsPI1 = aOrbsPI_[s1->label()];
-    int *bOrbsPI1 = bOrbsPI_[s1->label()];
-    int *aOrbsPI2 = aOrbsPI_[s2->label()];
-    int *bOrbsPI2 = bOrbsPI_[s2->label()];
+    const auto& aOrbsPI1 = aOrbsPI_[s1->label()];
+    const auto& bOrbsPI1 = bOrbsPI_[s1->label()];
+    const auto& aOrbsPI2 = aOrbsPI_[s2->label()];
+    const auto& bOrbsPI2 = bOrbsPI_[s2->label()];
 
     // Grab control of DPD for now, but store the active number to restore it later
     int currentActiveDPD = psi::dpd_default;

--- a/psi4/src/psi4/libtrans/integraltransform_tei_2nd_half.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_tei_2nd_half.cc
@@ -61,10 +61,10 @@ void IntegralTransform::transform_tei_second_half(const std::shared_ptr<MOSpace>
     SharedMatrix c4a = aMOCoefficients_[s4->label()];
     SharedMatrix c4b = bMOCoefficients_[s4->label()];
     // And the number of orbitals per irrep
-    int *aOrbsPI3 = aOrbsPI_[s3->label()];
-    int *bOrbsPI3 = bOrbsPI_[s3->label()];
-    int *aOrbsPI4 = aOrbsPI_[s4->label()];
-    int *bOrbsPI4 = bOrbsPI_[s4->label()];
+    const auto& aOrbsPI3 = aOrbsPI_[s3->label()];
+    const auto& bOrbsPI3 = bOrbsPI_[s3->label()];
+    const auto& aOrbsPI4 = aOrbsPI_[s4->label()];
+    const auto& bOrbsPI4 = bOrbsPI_[s4->label()];
     // The reindexing arrays
     int *aIndex1 = aIndices_[s1->label()];
     int *bIndex1 = bIndices_[s1->label()];


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->

> [!IMPORTANT]
> Essentially identical fixes that were done in #3358. I just missed some cases.

It appears that I missed a few cases that should have went in that PR. I think many of these misses were caused by the deprecation warnings just not being emitted by the compiler.

In this case, I strongly suspect it might be due to the use of `extern` linkage. It makes me wonder, perhaps we need a different way of deprecating functions. If the purpose of deprecation is to let plugin developers have time to adjust their code before breaking changes, they might never know. For example, `std::make_shared<Matrix>(deprecated, constructor, params)` does *not* show up as a deprecation warning for GCC (though does for clang). Maybe we could have
1. Some idempotent outfile/stdout print statement in the function body, perhaps cached until the end of the calculation so that it's the last thing printed. For example, `"Your code called the deprecated <function> at <file>:<lineno>. Bug a developer until they fix it!"`
2. `pragma message`, supported by all compilers
3. combination of the above

Something foolproof that actually applies to the people using the deprecated code, not just compiling it.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
*None*

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
*None*

## Checklist
- [x] Tests added for any new features
- [x] Docstring or narrative docs/sphinxman/source updated if needed
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
