### PR TITLE
Clean up confusing is_core handling between DiskDFJK and CDJK

### DIFF
--- a/psi4/src/psi4/libfock/CDJK.cc
+++ b/psi4/src/psi4/libfock/CDJK.cc
@@ -52,7 +52,26 @@ namespace psi {
 CDJK::CDJK(std::shared_ptr<BasisSet> primary, Options& options, double cholesky_tolerance)
     : DiskDFJK(primary, primary, options), cholesky_tolerance_(cholesky_tolerance) {}
 
-void CDJK::initialize_JK_disk() { throw PSIEXCEPTION("Disk algorithm for CD JK not implemented."); }
+void CDJK::initialize_JK_disk() {
+    throw PSIEXCEPTION(
+        "CDJK::initialize_JK_disk(): internal error: the out-of-core path was selected even though CDJK::is_core() "
+        "guarantees the in-core subalgorithm. If you are seeing this, there is a bug!");
+}
+
+bool CDJK::is_core() {
+    // CD has no out-of-core algorithm, so the only meaningful subalgorithm is in-core.
+    if (subalgo_ != "AUTO" && subalgo_ != "INCORE") {
+        throw PSIEXCEPTION(
+            "Invalid SCF_SUBTYPE option in CDJK! Valid choices of SCF_SUBTYPE for Cholesky JK are AUTO and INCORE. "
+            "SCF_SUBTYPE=OUT_OF_CORE is not supported with SCF_TYPE=CD: the Cholesky JK algorithm is in-core only. Use"
+            " SCF_TYPE=DISK_DF if you need an out-of-core algorithm.");
+    }
+    // The true memory requirement cannot be known before the decomposition runs (ncholesky_ is determined by
+    // CHOLESKY_TOLERANCE), so the memory_estimate() gate used by DiskDFJK::is_core() is deliberately not applied here;
+    // a pessimistic estimate must not route CD onto the nonexistent disk path. The authoritative memory check lives in
+    // initialize_JK_core(), after ncholesky_ is known.
+    return true;
+}
 
 void CDJK::set_do_wK(const bool do_wK) {
     if (do_wK)

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -316,8 +316,8 @@ bool DiskDFJK::is_core() {
         }
     } else {
         throw PSIEXCEPTION(
-            "Invalid SCF_SUBTYPE option in DiskDFJK! Valid choices of SCF_SUBTYPE for density-fitted JK are AUTO, "
-            "INCORE, and OUT_OF_CORE.");
+            "Invalid SCF_SUBTYPE option in DiskDFJK! Valid choices of SCF_SUBTYPE for the DiskDFJK implementation of "
+            "density-fitted JK are AUTO, INCORE, and OUT_OF_CORE.");
     }
 
     return do_core;

--- a/psi4/src/psi4/libfock/DiskDFJK.cc
+++ b/psi4/src/psi4/libfock/DiskDFJK.cc
@@ -166,7 +166,9 @@ SharedVector DiskDFJK::iaia(SharedMatrix Ci, SharedMatrix Ca) {
     E_left_ = std::make_shared<Matrix>("E_left", nso, maxrows * nocc);
     E_right_ = std::make_shared<Matrix>("E_right", nvir, maxrows * nocc);
 
-    // Disk overhead
+    // Disk overhead. Note: this re-evaluates the (virtual) is_core() rather than using the
+    // is_core_ flag cached by preiterations(); the two agree unless memory_ or subalgo_
+    // changed in between.
     psio_address addr = PSIO_ZERO;
     if (!is_core()) {
         Qmn_ = std::make_shared<Matrix>("(Q|mn) Block", maxrows, num_nm);
@@ -288,7 +290,7 @@ void DiskDFJK::print_header() const {
     }
 }
 bool DiskDFJK::is_core() {
-    auto do_core = is_core_;
+    bool do_core = false;
 
     // determine do_core either automatically...
     if (subalgo_ == "AUTO") {
@@ -313,7 +315,9 @@ bool DiskDFJK::is_core() {
             do_core = true;
         }
     } else {
-        throw PSIEXCEPTION("Invalid SCF_SUBTYPE option! The choices for SCF_SUBTYPE are AUTO, INCORE, and OUT_OF_CORE.");
+        throw PSIEXCEPTION(
+            "Invalid SCF_SUBTYPE option in DiskDFJK! Valid choices of SCF_SUBTYPE for density-fitted JK are AUTO, "
+            "INCORE, and OUT_OF_CORE.");
     }
 
     return do_core;
@@ -452,7 +456,8 @@ void DiskDFJK::preiterations() {
         }
     }
 
-    // Core or disk?
+    // Core or disk? Virtual dispatch: CDJK overrides is_core() to validate SCF_SUBTYPE and force the in-core
+    // subalgorithm, so the disk branches below are DF-only.
     is_core_ = is_core();
 
     if (is_core_)

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -956,7 +956,13 @@ class PSI_API DiskDFJK : public JK {
     /// Common initialization
     void common_init();
 
-    bool is_core();
+    /// @brief Determine if we should perform the JK build in-memory (aka. in-core), considering the amount of memory
+    /// required vs. available, and honoring SCF_SUBTYPE. If no, an altarnative, disk-based subalgorithm may be used.
+    /// Virtual so subclasses with a restricted set of subalgorithms (e.g. CDJK, which has no out-of-core path)
+    /// participate in the decision made by preiterations() and iaia().
+    /// @return True if the JK build is to proceed in-memory, false if disk-IO is required.
+    virtual bool is_core();
+
     size_t memory_temp() const;
     int max_rows() const;
     int max_nocc() const;
@@ -1065,10 +1071,16 @@ class PSI_API CDJK : public DiskDFJK {
 
     // => Required Algorithm-Specific Methods <= //
 
-    virtual bool is_core() { return true; }
+    
+    /// @brief CD has no out-of-core algorithm: validates SCF_SUBTYPE, then forces in-core.
+    /// @return Always true.
+    bool is_core() override;
 
     // => J and K <= //
     void initialize_JK_core() override;
+
+    /// @brief Unreachable by construction: CDJK::is_core() either returns true or throws, so DiskDFJK::preiterations()
+    /// can never select the disk path for a CDJK object.
     void initialize_JK_disk() override;
     void manage_JK_core() override;
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Currently CDJK declares `virtual bool is_core()`, which hides DiskDFJK's `is_core()` instead of overriding it.
This has several negative effects, primarily that CDJK's `is_core()` is not the one getting called when it really should be.

Since CDJK does not implement its own `preiterations()` and `iaia()`, calls to these functions on a CDJK object lead to the parent implementations running (`DiskDFJK::preiterations()` and `DiskDFJK::iaia()`, respectively). But since CDJK does not override `is_core()`, when `DiskDFJK::preiterations()` and `DiskDFJK::iaia()` runs, they call `DiskDFJK::is_core()`, which might select the out-of-core algo and return false. As CDJK only supports incore, mayhem ensues.

This PR switches `is_core()` from hiding to overriding its parent counterpart.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] C++ API change: `DiskDFJK::is_core()` is now marked as virtual
- [x] C++ API change: `CDJK::is_core()` now overrides `DiskDFJK::is_core()` instead of hiding it. `CDJK::is_core()` now throws if SCF_SUBTYPE is neither AUTO or INCORE.
- [x] SCF_SUBTYPE=CD with SCF_SUBTYPE=AUTO previously failed with 'Disk algorithm for CD JK not implemented.', if the a sufficiently pessimistic memory estimate was obtained, which was bad UX. It now proceeds to the decomposition and either succeeds or fails with the authoritative 'Not enough memory for CD.' check.
- [x] SCF_SUBTYPE=CD with SCF_SUBTYPE=OUT_OF_CORE previously failed with a misleading message, it now fails immediately with an explanation and suggested alternatives.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] `DiskDFJK::is_core()` is now marked as virtual so that it can be overridden by CDJK.
- [x] `virtual bool is_core() { return true; }` for CDJK is now `bool is_core() override;` with a body that throws if an unsupported SCF_SUBTYPE is requested.
- [x] The dead initial read of the cached `is_core_` flag in `DiskDFJK::is_core()` is removed (every branch overwrote it).
- [x] Comments and docstrings are added or expanded where relevant.
- [x] Some PSIEXCEPTION messages were improved
- [x] `CDJK::initialize_JK_disk()` should now be unreachable

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [x] LLMs were used to write the initial version of this patch, which was then manually applied and refined in the process. The initial version of the PR description was generated by LLMs, which was then manually rewritten.

## Checklist
- [x] No new features
- [x] Docstrings and comments in the source files were added/updated
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
