### PR TITLE
Add GauXC as an optional backend for the exchange-correlation quadrature

### DIFF
--- a/doc/sphinxman/source/dft.rst
+++ b/doc/sphinxman/source/dft.rst
@@ -450,11 +450,48 @@ implemented in |PSIfour| for correctness. If you find an error in a DFT
 functional or have a request for a new functional, please let us know on our
 forum or GitHub page.
 
+.. _`sec:xc-quadrature-backend`:
+
+Exchange-Correlation Quadrature Backend
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The numerical integration of the exchange-correlation potential is selected
+with |scf__dft_v_algorithm|:
+
+``INTERNAL`` (default)
+    |PSIfour|'s own grid code. Supports every functional |PSIfour| knows,
+    including VV10 non-local correlation and GRAC asymptotic corrections.
+
+``GAUXC``
+    Delegates the quadrature to the `GauXC <https://github.com/wavefunction91/GauXC>`_
+    library. Requires |PSIfour| built with ``ENABLE_gauxc=ON``. Supports RKS
+    and UKS with LDA, GGA, meta-GGA, global hybrid and range-separated hybrid
+    functionals. GauXC additionally offers GPU execution, enabled with
+    |scf__dft_v_use_gpu|.
+
+The ``GAUXC`` backend does *not* support VV10 or GRAC and rejects those
+functionals with an explicit message. It also requires grid settings that have
+a GauXC counterpart: |scf__dft_pruning_scheme| must be ``ROBUST``, ``TREUTLER``
+or ``NONE``, |scf__dft_radial_scheme| must be ``TREUTLER``, ``MURA`` or ``EM``,
+and |scf__dft_nuclear_scheme| must be ``BECKE`` or ``STRATMANN``.
+
+Note that GauXC partitions atomic weights with the Stratmann-Scuseria-Frisch
+scheme, whereas the |PSIfour| default is Treutler. When comparing the two
+backends numerically, set ``DFT_NUCLEAR_SCHEME STRATMANN`` on both sides;
+otherwise the difference is dominated by the partitioning, not the quadrature.
+
+Both backends agree to better than 1e-6 :math:`E_h` on total energies. The
+residual difference stems from how the two libraries sieve grid points and
+weights, and shrinks as the grid is refined.
+
+On CPU, which backend is faster depends strongly on system size: for small
+basis sets the internal code wins, while from roughly cc-pVTZ upwards GauXC is
+about twice as fast (glycine, 16 threads, (75,302) grid).
+
 .. _`sec:grid-selection`:
 
 Grid Selection
 ~~~~~~~~~~~~~~
-
 |PSIfour| uses the standard Lebedev-Laikov spherical quadratures in concert with a
 number of radial quadratures and atomic partitioning schemes. 
 The default grid in |PSIfour| is a Lebedev-Treutler (75,302) grid with a Treutler

--- a/doc/sphinxman/source/dft.rst
+++ b/doc/sphinxman/source/dft.rst
@@ -488,6 +488,26 @@ On CPU, which backend is faster depends strongly on system size: for small
 basis sets the internal code wins, while from roughly cc-pVTZ upwards GauXC is
 about twice as fast (glycine, 16 threads, (75,302) grid).
 
+GPU execution
+^^^^^^^^^^^^^
+
+Setting |scf__dft_v_use_gpu| runs the quadrature on the GPU. This requires a
+GauXC installation built with device support (``-Dgauxc_ENABLE_GPU=ON``, plus
+CUDA); a CPU-only GauXC silently ignores the request. |scf__dft_v_gpu_mem|
+caps the fraction of device memory GauXC may reserve.
+
+The GPU path reproduces the GauXC CPU results to all printed digits for LDA,
+GGA, meta-GGA, global hybrid and range-separated hybrid functionals, for both
+RKS and UKS.
+
+Whether it is *faster* is a property of the card rather than of the code. The
+quadrature is double precision end to end, and NVIDIA restricts double
+precision throughput on consumer and inference cards to 1/32 or 1/64 of single
+precision. On such a card a many-core CPU will win. Datacenter parts
+(P100, V100, A100, H100) run double precision at 1/2 and are the sensible
+target. Note also that GauXC requires compute capability 6.0 or newer, and
+that CUDA 13 dropped Pascal support, so Pascal cards need CUDA 12.x.
+
 .. _`sec:grid-selection`:
 
 Grid Selection

--- a/psi4/src/psi4/libfock/CMakeLists.txt
+++ b/psi4/src/psi4/libfock/CMakeLists.txt
@@ -19,6 +19,7 @@ list(APPEND sources
   jk.cc
   points.cc
   sap.cc
+  gauxc_interface.cc
   snLinK.cc
   solver.cc
   soscf.cc

--- a/psi4/src/psi4/libfock/CMakeLists.txt
+++ b/psi4/src/psi4/libfock/CMakeLists.txt
@@ -19,6 +19,7 @@ list(APPEND sources
   jk.cc
   points.cc
   sap.cc
+  GauXCV.cc
   gauxc_interface.cc
   snLinK.cc
   solver.cc

--- a/psi4/src/psi4/libfock/GauXCV.cc
+++ b/psi4/src/psi4/libfock/GauXCV.cc
@@ -84,7 +84,11 @@ GauXCEngine::GauXCEngine(std::shared_ptr<SuperFunctional> functional, std::share
     }
 
 #if psi4_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_GAUSSIAN
-    if (primary_->has_puream()) {
+    // The permutation only repairs the ordering *within* solid-harmonic shells, which differs
+    // between Psi4's Gaussian ordering and the CCA ordering GauXC expects. Once the basis is
+    // handed to GauXC in Cartesian form there is no solid-harmonic ordering left to repair, and
+    // the permutation would also be sized for the spherical (smaller) dimension, so skip it.
+    if (primary_->has_puream() && !force_cartesian_) {
         permutation_matrix_ = gauxc_interface::generate_permutation_matrix(primary_, gauxc_max_am);
     }
 #endif

--- a/psi4/src/psi4/libfock/GauXCV.cc
+++ b/psi4/src/psi4/libfock/GauXCV.cc
@@ -121,6 +121,16 @@ GauXCEngine::GauXCEngine(std::shared_ptr<SuperFunctional> functional, std::share
     if (kernels.empty()) {
         throw PSIEXCEPTION("GauXC XC quadrature: SuperFunctional carries no exchange-correlation ingredients.");
     }
+    if (functional->needs_vv10()) {
+        throw PSIEXCEPTION(
+            "DFT_V_ALGORITHM=GAUXC does not support the VV10 non-local correlation kernel. "
+            "Use DFT_V_ALGORITHM=INTERNAL for this functional.");
+    }
+    if (functional->needs_grac()) {
+        throw PSIEXCEPTION(
+            "DFT_V_ALGORITHM=GAUXC does not support GRAC asymptotic corrections. "
+            "Use DFT_V_ALGORITHM=INTERNAL for this functional.");
+    }
 
     ExchCXX::HybCoeffs hyb;
     hyb.alpha = functional->x_alpha();
@@ -234,7 +244,60 @@ GauXCUV::GauXCUV(std::shared_ptr<SuperFunctional> functional, std::shared_ptr<Ba
 GauXCUV::~GauXCUV() {}
 
 void GauXCUV::compute_V(std::vector<SharedMatrix> ret) {
-    throw PSIEXCEPTION("DFT_V_ALGORITHM=GAUXC is not implemented yet.");
+#ifdef USING_gauxc
+    timer_on("GauXCUV: Form V");
+    if ((D_AO_.size() != 2) || (ret.size() != 2)) {
+        throw PSIEXCEPTION("GauXCUV: UKS should have two D/V Matrices");
+    }
+    if (functional_->needs_grac()) {
+        throw PSIEXCEPTION("GauXCUV: UKS cannot compute GRAC corrections.");
+    }
+
+    // GauXC's UKS entry point takes the scalar and the spin-magnetization
+    // density, Ps = Da + Db and Pz = Da - Db. See GauXC's reference host work
+    // driver, which forms rho_+/- as 0.5*(rho_s +/- rho_z).
+    GauXCEngine::matrix_type Da = engine().to_gauxc_density(D_AO_[0]);
+    GauXCEngine::matrix_type Db = engine().to_gauxc_density(D_AO_[1]);
+    GauXCEngine::matrix_type Ps = Da + Db;
+    GauXCEngine::matrix_type Pz = Da - Db;
+
+    auto [exc, vxc_s, vxc_z] = engine().integrator().eval_exc_vxc(Ps, Pz);
+
+    // Chain rule inverse of the density combination above.
+    GauXCEngine::matrix_type Va = vxc_s + vxc_z;
+    GauXCEngine::matrix_type Vb = vxc_s - vxc_z;
+
+    auto Va_AO = std::make_shared<Matrix>("Va AO Temp", nbf_, nbf_);
+    auto Vb_AO = std::make_shared<Matrix>("Vb AO Temp", nbf_, nbf_);
+    engine().from_gauxc_potential(Va, Va_AO);
+    engine().from_gauxc_potential(Vb, Vb_AO);
+
+    if (AO2USO_) {
+        ret[0]->apply_symmetry(Va_AO, AO2USO_);
+        ret[1]->apply_symmetry(Vb_AO, AO2USO_);
+    } else {
+        ret[0]->copy(Va_AO);
+        ret[1]->copy(Vb_AO);
+    }
+
+    quad_values_["FUNCTIONAL"] = exc;
+    quad_values_["VV10"] = 0.0;
+    quad_values_["RHO_A"] = 0.0;
+    quad_values_["RHO_AX"] = 0.0;
+    quad_values_["RHO_AY"] = 0.0;
+    quad_values_["RHO_AZ"] = 0.0;
+    quad_values_["RHO_B"] = 0.0;
+    quad_values_["RHO_BX"] = 0.0;
+    quad_values_["RHO_BY"] = 0.0;
+    quad_values_["RHO_BZ"] = 0.0;
+
+    if (std::isnan(quad_values_["FUNCTIONAL"])) {
+        throw PSIEXCEPTION("GauXCUV: Integrated DFT functional to get NaN.");
+    }
+    timer_off("GauXCUV: Form V");
+#else
+    throw PSIEXCEPTION("DFT_V_ALGORITHM=GAUXC requires Psi4 built with ENABLE_gauxc=ON.");
+#endif
 }
 
 void GauXCUV::print_header() const { UV::print_header(); }

--- a/psi4/src/psi4/libfock/GauXCV.cc
+++ b/psi4/src/psi4/libfock/GauXCV.cc
@@ -1,0 +1,58 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include "GauXCV.h"
+
+#include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/psi4-dec.h"
+
+namespace psi {
+
+GauXCRV::GauXCRV(std::shared_ptr<SuperFunctional> functional, std::shared_ptr<BasisSet> primary, Options& options)
+    : RV(functional, primary, options) {}
+
+GauXCRV::~GauXCRV() {}
+
+void GauXCRV::compute_V(std::vector<SharedMatrix> ret) {
+    throw PSIEXCEPTION("DFT_V_ALGORITHM=GAUXC is not implemented yet.");
+}
+
+void GauXCRV::print_header() const { RV::print_header(); }
+
+GauXCUV::GauXCUV(std::shared_ptr<SuperFunctional> functional, std::shared_ptr<BasisSet> primary, Options& options)
+    : UV(functional, primary, options) {}
+
+GauXCUV::~GauXCUV() {}
+
+void GauXCUV::compute_V(std::vector<SharedMatrix> ret) {
+    throw PSIEXCEPTION("DFT_V_ALGORITHM=GAUXC is not implemented yet.");
+}
+
+void GauXCUV::print_header() const { UV::print_header(); }
+
+}  // namespace psi

--- a/psi4/src/psi4/libfock/GauXCV.cc
+++ b/psi4/src/psi4/libfock/GauXCV.cc
@@ -31,7 +31,153 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/psi4-dec.h"
 
+#ifdef USING_gauxc
+#include <cmath>
+
+#include "gauxc_interface.h"
+
+#include "psi4/libfunctional/superfunctional.h"
+#include "psi4/libmints/basisset.h"
+#include "psi4/libmints/matrix.h"
+#include "psi4/libmints/mintshelper.h"
+#include "psi4/libmints/molecule.h"
+#include "psi4/libqt/qt.h"
+
+#include "psi4/libfunctional/functional.h"
+
+#include <exchcxx/xc_functional.hpp>
+
+#include <gauxc/load_balancer.hpp>
+#include <gauxc/molecular_weights.hpp>
+#include <gauxc/molgrid/defaults.hpp>
+#include <gauxc/util/environment.hpp>
+#include <gauxc/xc_integrator.hpp>
+#include <gauxc/xc_integrator/impl.hpp>
+#include <gauxc/xc_integrator/integrator_factory.hpp>
+#endif
+
 namespace psi {
+
+#ifdef USING_gauxc
+GauXCEngine::GauXCEngine(std::shared_ptr<SuperFunctional> functional, std::shared_ptr<BasisSet> primary,
+                         Options& options, bool polarized)
+    : primary_(primary), options_(options) {
+    use_gpu_ = options_.get_bool("DFT_V_USE_GPU");
+    const auto ex = use_gpu_ ? GauXC::ExecutionSpace::Device : GauXC::ExecutionSpace::Host;
+    runtime_ = gauxc_interface::make_runtime_environment(use_gpu_, 0.01 * options_.get_int("DFT_V_GPU_MEM"));
+
+    const int gauxc_max_am = GauXC::gauxc_max_am(ex, GauXC::SupportedAlg::XC);
+    if (primary_->max_am() > gauxc_max_am) {
+        throw PSIEXCEPTION("Basis set has higher-AM shells (Max AM = " + std::to_string(primary_->max_am()) +
+                           ") than this GauXC instance supports (Max AM = " + std::to_string(gauxc_max_am) +
+                           "). Use a smaller basis or a GauXC install with higher AM support.");
+    }
+
+    force_cartesian_ = use_gpu_ && primary_->has_puream();
+    if (force_cartesian_) {
+        MintsHelper helper(primary_, options_, 0);
+        cartao_to_ao_matrix_ = helper.cartao_to_ao_transform();
+        if (cartao_to_ao_matrix_->nirrep() != 1) {
+            throw PSIEXCEPTION(
+                "GPU execution of the GauXC XC quadrature with a spherical basis currently requires C1 symmetry.");
+        }
+    }
+
+#if psi4_SHGSHELL_ORDERING == LIBINT_SHGSHELL_ORDERING_GAUSSIAN
+    if (primary_->has_puream()) {
+        permutation_matrix_ = gauxc_interface::generate_permutation_matrix(primary_, gauxc_max_am);
+    }
+#endif
+
+    auto gauxc_mol = gauxc_interface::psi4_to_gauxc_molecule(primary_->molecule());
+    auto gauxc_basis = gauxc_interface::psi4_to_gauxc_basisset<double>(primary_, 1.0e-10, force_cartesian_);
+
+    auto gauxc_grid = GauXC::MolGridFactory::create_default_molgrid(
+        gauxc_mol, gauxc_interface::to_gauxc_pruning_scheme(options_.get_str("DFT_PRUNING_SCHEME")),
+        GauXC::BatchSize(512), gauxc_interface::to_gauxc_radial_scheme(options_.get_str("DFT_RADIAL_SCHEME")),
+        GauXC::RadialSize(options_.get_int("DFT_RADIAL_POINTS")),
+        GauXC::AngularSize(options_.get_int("DFT_SPHERICAL_POINTS")));
+
+    GauXC::LoadBalancerFactory lb_factory(ex, "Default");
+    auto load_balancer = lb_factory.get_instance(*runtime_, gauxc_mol, gauxc_grid, gauxc_basis);
+
+    GauXC::MolecularWeightsSettings mw_settings;
+    mw_settings.weight_alg = gauxc_interface::to_gauxc_weight_scheme(options_.get_str("DFT_NUCLEAR_SCHEME"));
+    GauXC::MolecularWeightsFactory mw_factory(ex, "Default", mw_settings);
+    mw_factory.get_instance().modify_weights(load_balancer);
+
+    // Mirror Psi4's own SuperFunctional decomposition instead of matching a
+    // composite name: every ingredient Psi4 uses carries its libxc kernel name
+    // ("XC_LDA_X", ...), and ExchCXX can construct kernels from exactly those.
+    const auto spin = polarized ? ExchCXX::Spin::Polarized : ExchCXX::Spin::Unpolarized;
+    std::vector<std::pair<double, ExchCXX::XCKernel> > kernels;
+    auto add_kernels = [&](const std::vector<std::shared_ptr<Functional> >& fs) {
+        for (const auto& f : fs) {
+            kernels.emplace_back(f->alpha(), ExchCXX::XCKernel(ExchCXX::libxc_name_string(f->name()), spin));
+        }
+    };
+    add_kernels(functional->x_functionals());
+    add_kernels(functional->c_functionals());
+    if (kernels.empty()) {
+        throw PSIEXCEPTION("GauXC XC quadrature: SuperFunctional carries no exchange-correlation ingredients.");
+    }
+
+    ExchCXX::HybCoeffs hyb;
+    hyb.alpha = functional->x_alpha();
+    if (functional->is_x_lrc()) {
+        hyb.beta = functional->x_beta();
+        hyb.omega = functional->x_omega();
+    }
+    ExchCXX::XCFunctional func(kernels, hyb);
+
+    integrator_factory_ =
+        std::make_unique<GauXC::XCIntegratorFactory<matrix_type> >(ex, "Replicated", "Default", "Default", "Default");
+    integrator_ = integrator_factory_->get_shared_instance(func, load_balancer);
+}
+
+GauXCEngine::matrix_type GauXCEngine::to_gauxc_density(SharedMatrix D) const {
+    SharedMatrix work = D;
+    if (force_cartesian_) {
+        work = std::make_shared<Matrix>();
+        work->transform(D, cartao_to_ao_matrix_);
+    }
+    matrix_type P = work->eigen_map();
+    if (permutation_matrix_.has_value()) {
+        const auto& perm = permutation_matrix_.value();
+        P = perm * P * perm.transpose();
+    }
+    return P;
+}
+
+void GauXCEngine::from_gauxc_potential(const matrix_type& V_gauxc, SharedMatrix V_out) const {
+    matrix_type V = V_gauxc;
+    if (permutation_matrix_.has_value()) {
+        const auto& perm = permutation_matrix_.value();
+        V = perm.transpose() * V * perm;
+    }
+    if (force_cartesian_) {
+        auto buffer = std::make_shared<Matrix>(V.rows(), V.cols());
+        buffer->eigen_map() = V;
+        V_out->back_transform(buffer, cartao_to_ao_matrix_);
+    } else {
+        V_out->eigen_map() = V;
+    }
+}
+
+GauXCEngine& GauXCRV::engine() const {
+    if (!engine_) {
+        engine_ = std::make_unique<GauXCEngine>(functional_, primary_, options_, /*polarized=*/false);
+    }
+    return *engine_;
+}
+
+GauXCEngine& GauXCUV::engine() const {
+    if (!engine_) {
+        engine_ = std::make_unique<GauXCEngine>(functional_, primary_, options_, /*polarized=*/true);
+    }
+    return *engine_;
+}
+#endif
 
 GauXCRV::GauXCRV(std::shared_ptr<SuperFunctional> functional, std::shared_ptr<BasisSet> primary, Options& options)
     : RV(functional, primary, options) {}
@@ -39,7 +185,45 @@ GauXCRV::GauXCRV(std::shared_ptr<SuperFunctional> functional, std::shared_ptr<Ba
 GauXCRV::~GauXCRV() {}
 
 void GauXCRV::compute_V(std::vector<SharedMatrix> ret) {
-    throw PSIEXCEPTION("DFT_V_ALGORITHM=GAUXC is not implemented yet.");
+#ifdef USING_gauxc
+    timer_on("GauXCRV: Form V");
+    if ((D_AO_.size() != 1) || (ret.size() != 1)) {
+        throw PSIEXCEPTION("GauXCRV: RKS should have only one D/V Matrix");
+    }
+
+    // Psi4 hands over the alpha density (see v.h) and GauXC's RKS entry point
+    // expects exactly that -- it forms the total density internally. Verified
+    // empirically: passing 2*D scales E_xc by 2^(4/3) for LDA exchange.
+    GauXCEngine::matrix_type P = engine().to_gauxc_density(D_AO_[0]);
+    auto [exc, vxc] = engine().integrator().eval_exc_vxc(P);
+
+    auto V_AO = std::make_shared<Matrix>("V AO Temp", nbf_, nbf_);
+    engine().from_gauxc_potential(vxc, V_AO);
+
+    if (AO2USO_) {
+        ret[0]->apply_symmetry(V_AO, AO2USO_);
+    } else {
+        ret[0]->copy(V_AO);
+    }
+
+    quad_values_["FUNCTIONAL"] = exc;
+    quad_values_["VV10"] = 0.0;
+    quad_values_["RHO_A"] = 0.0;
+    quad_values_["RHO_AX"] = 0.0;
+    quad_values_["RHO_AY"] = 0.0;
+    quad_values_["RHO_AZ"] = 0.0;
+    quad_values_["RHO_B"] = 0.0;
+    quad_values_["RHO_BX"] = 0.0;
+    quad_values_["RHO_BY"] = 0.0;
+    quad_values_["RHO_BZ"] = 0.0;
+
+    if (std::isnan(quad_values_["FUNCTIONAL"])) {
+        throw PSIEXCEPTION("GauXCRV: Integrated DFT functional to get NaN.");
+    }
+    timer_off("GauXCRV: Form V");
+#else
+    throw PSIEXCEPTION("DFT_V_ALGORITHM=GAUXC requires Psi4 built with ENABLE_gauxc=ON.");
+#endif
 }
 
 void GauXCRV::print_header() const { RV::print_header(); }

--- a/psi4/src/psi4/libfock/GauXCV.h
+++ b/psi4/src/psi4/libfock/GauXCV.h
@@ -31,10 +31,63 @@
 
 #include "v.h"
 
+#ifdef USING_gauxc
+#include <memory>
+#include <optional>
+
+#include <Eigen/Core>
+#include <gauxc/xc_integrator.hpp>
+#include <gauxc/xc_integrator/integrator_factory.hpp>
+
+#include "gauxc_interface.h"
+#endif
+
 namespace psi {
+
+#ifdef USING_gauxc
+/// Holds the entire GauXC state and all conversions between the Psi4 and
+/// GauXC conventions. Shared by GauXCRV and GauXCUV.
+class GauXCEngine {
+   public:
+    using matrix_type = Eigen::MatrixXd;
+
+    /// Builds grid, load balancer and integrator. Throws on unsupported cases.
+    GauXCEngine(std::shared_ptr<SuperFunctional> functional, std::shared_ptr<BasisSet> primary, Options& options,
+                bool polarized);
+
+    /// Psi4 density -> GauXC convention (permutation, sph->cart). No spin scaling.
+    matrix_type to_gauxc_density(SharedMatrix D) const;
+    /// GauXC potential -> Psi4 convention, written into V_out.
+    void from_gauxc_potential(const matrix_type& V_gauxc, SharedMatrix V_out) const;
+
+    GauXC::XCIntegrator<matrix_type>& integrator() { return *integrator_; }
+    bool use_gpu() const { return use_gpu_; }
+    bool force_cartesian() const { return force_cartesian_; }
+
+   private:
+    std::shared_ptr<BasisSet> primary_;
+    Options& options_;
+
+    bool use_gpu_ = false;
+    bool force_cartesian_ = false;
+    SharedMatrix cartao_to_ao_matrix_ = nullptr;
+    std::optional<Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> > permutation_matrix_;
+    std::shared_ptr<GauXC::XCIntegrator<matrix_type> > integrator_;
+    std::unique_ptr<GauXC::XCIntegratorFactory<matrix_type> > integrator_factory_;
+    std::unique_ptr<GauXC::RuntimeEnvironment> runtime_;
+};
+#endif
 
 /// RKS XC quadrature via the GauXC library. Inherits all derivative paths from RV.
 class GauXCRV : public RV {
+   protected:
+#ifdef USING_gauxc
+    /// `mutable` because the const-qualified print_header also needs the engine.
+    mutable std::unique_ptr<GauXCEngine> engine_;
+    /// Builds the engine on first use, then caches it.
+    GauXCEngine& engine() const;
+#endif
+
    public:
     GauXCRV(std::shared_ptr<SuperFunctional> functional, std::shared_ptr<BasisSet> primary, Options& options);
     ~GauXCRV() override;
@@ -45,6 +98,12 @@ class GauXCRV : public RV {
 
 /// UKS XC quadrature via the GauXC library. Inherits all derivative paths from UV.
 class GauXCUV : public UV {
+   protected:
+#ifdef USING_gauxc
+    mutable std::unique_ptr<GauXCEngine> engine_;
+    GauXCEngine& engine() const;
+#endif
+
    public:
     GauXCUV(std::shared_ptr<SuperFunctional> functional, std::shared_ptr<BasisSet> primary, Options& options);
     ~GauXCUV() override;

--- a/psi4/src/psi4/libfock/GauXCV.h
+++ b/psi4/src/psi4/libfock/GauXCV.h
@@ -1,0 +1,57 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#ifndef GAUXCV_H
+#define GAUXCV_H
+
+#include "v.h"
+
+namespace psi {
+
+/// RKS XC quadrature via the GauXC library. Inherits all derivative paths from RV.
+class GauXCRV : public RV {
+   public:
+    GauXCRV(std::shared_ptr<SuperFunctional> functional, std::shared_ptr<BasisSet> primary, Options& options);
+    ~GauXCRV() override;
+
+    void compute_V(std::vector<SharedMatrix> ret) override;
+    void print_header() const override;
+};
+
+/// UKS XC quadrature via the GauXC library. Inherits all derivative paths from UV.
+class GauXCUV : public UV {
+   public:
+    GauXCUV(std::shared_ptr<SuperFunctional> functional, std::shared_ptr<BasisSet> primary, Options& options);
+    ~GauXCUV() override;
+
+    void compute_V(std::vector<SharedMatrix> ret) override;
+    void print_header() const override;
+};
+
+}  // namespace psi
+#endif

--- a/psi4/src/psi4/libfock/SplitJK.h
+++ b/psi4/src/psi4/libfock/SplitJK.h
@@ -346,8 +346,6 @@ class PSI_API snLinK : public SplitJK {
     bool is_cca_;
 
     std::optional<Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> > permutation_matrix_;
-    Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> generate_permutation_matrix(
-        const std::shared_ptr<BasisSet> psi4_basisset);
 
     // => Semi-Numerical Stuff <= //
     // are we running snLinK on GPUs?
@@ -374,16 +372,6 @@ class PSI_API snLinK : public SplitJK {
     std::unique_ptr<GauXC::XCIntegratorFactory<matrix_type> > integrator_factory_;
     std::shared_ptr<GauXC::XCIntegrator<matrix_type> > integrator_;
   
-    // => Psi4 -> GauXC conversion functions <= // 
-    GauXC::Molecule psi4_to_gauxc_molecule(std::shared_ptr<Molecule> psi4_molecule);
-    template<typename T> GauXC::BasisSet<T> psi4_to_gauxc_basisset(std::shared_ptr<BasisSet> psi4_basisset, double basis_tol, bool force_cartesian);
-
-    // => Psi4 -> GauXC enum mappings <= //
-    std::tuple<
-        std::unordered_map<std::string, GauXC::PruningScheme>, 
-        std::unordered_map<std::string, GauXC::RadialQuad> 
-    > generate_enum_mappings();
-    
     // => Other useful stuff <= //
     /// Eigen matrix printout format    
     Eigen::IOFormat format_;

--- a/psi4/src/psi4/libfock/gauxc_interface.cc
+++ b/psi4/src/psi4/libfock/gauxc_interface.cc
@@ -70,6 +70,19 @@ GauXC::RadialQuad to_gauxc_radial_scheme(const std::string& psi4_name) {
     return it->second;
 }
 
+GauXC::XCWeightAlg to_gauxc_weight_scheme(const std::string& psi4_name) {
+    static const std::unordered_map<std::string, GauXC::XCWeightAlg> map = {
+        {"BECKE", GauXC::XCWeightAlg::Becke},
+        {"STRATMANN", GauXC::XCWeightAlg::SSF},
+    };
+    auto it = map.find(psi4_name);
+    if (it == map.end()) {
+        throw PSIEXCEPTION("Nuclear partition scheme '" + psi4_name +
+                           "' has no GauXC equivalent. Supported by the GauXC path: BECKE, STRATMANN.");
+    }
+    return it->second;
+}
+
 Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> generate_permutation_matrix(
     const std::shared_ptr<BasisSet> psi4_basisset, int gauxc_max_am) {
     Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> permutation_matrix(psi4_basisset->nbf());

--- a/psi4/src/psi4/libfock/gauxc_interface.cc
+++ b/psi4/src/psi4/libfock/gauxc_interface.cc
@@ -1,0 +1,173 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include "gauxc_interface.h"
+
+#ifdef USING_gauxc
+
+#include <unordered_map>
+#include <vector>
+
+#include "psi4/libmints/basisset.h"
+#include "psi4/libmints/molecule.h"
+#include "psi4/psi4-dec.h"
+
+namespace psi {
+namespace gauxc_interface {
+
+GauXC::PruningScheme to_gauxc_pruning_scheme(const std::string& psi4_name) {
+    static const std::unordered_map<std::string, GauXC::PruningScheme> map = {
+        {"ROBUST", GauXC::PruningScheme::Robust},
+        {"TREUTLER", GauXC::PruningScheme::Treutler},
+        {"NONE", GauXC::PruningScheme::Unpruned},
+    };
+    auto it = map.find(psi4_name);
+    if (it == map.end()) {
+        throw PSIEXCEPTION("Pruning scheme '" + psi4_name +
+                           "' has no GauXC equivalent. Supported by the GauXC path: ROBUST, TREUTLER, NONE.");
+    }
+    return it->second;
+}
+
+GauXC::RadialQuad to_gauxc_radial_scheme(const std::string& psi4_name) {
+    static const std::unordered_map<std::string, GauXC::RadialQuad> map = {
+        {"TREUTLER", GauXC::RadialQuad::TreutlerAhlrichs},
+        {"MURA", GauXC::RadialQuad::MuraKnowles},
+        // The Murray, Handy, Laming literature reference is mentioned in cubature.cc
+        // with association to this keyword
+        {"EM", GauXC::RadialQuad::MurrayHandyLaming},
+    };
+    auto it = map.find(psi4_name);
+    if (it == map.end()) {
+        throw PSIEXCEPTION("Radial scheme '" + psi4_name +
+                           "' has no GauXC equivalent. Supported by the GauXC path: TREUTLER, MURA, EM.");
+    }
+    return it->second;
+}
+
+Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> generate_permutation_matrix(
+    const std::shared_ptr<BasisSet> psi4_basisset, int gauxc_max_am) {
+    Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> permutation_matrix(psi4_basisset->nbf());
+
+    // general array for how to reorder integrals
+    std::vector<int> cca_integral_order(2 * gauxc_max_am + 1, 0);
+
+    // p shells or larger
+    for (size_t l = 1, idx = 1; l != gauxc_max_am; idx += 2, ++l) {
+        cca_integral_order[idx] = l;
+        cca_integral_order[idx + 1] = -l;
+    }
+
+    // actually construct permutation matrix
+    for (int ish = 0, ibf = 0; ish != psi4_basisset->nshell(); ++ish) {
+        auto& sh = psi4_basisset->shell(ish);
+        auto am = sh.am();
+
+        auto ibf_base = ibf;
+        for (int ishbf = 0; ishbf != 2 * am + 1; ++ishbf, ++ibf) {
+            permutation_matrix.indices()[ibf] = ibf_base + cca_integral_order[ishbf] + am;
+        }
+    }
+
+    return permutation_matrix;
+}
+
+GauXC::Molecule psi4_to_gauxc_molecule(std::shared_ptr<Molecule> psi4_molecule) {
+    GauXC::Molecule gauxc_molecule;
+
+    for (size_t iatom = 0; iatom != psi4_molecule->natom(); ++iatom) {
+        auto atomic_number = psi4_molecule->true_atomic_number(iatom);
+        auto x_coord = psi4_molecule->x(iatom);
+        auto y_coord = psi4_molecule->y(iatom);
+        auto z_coord = psi4_molecule->z(iatom);
+
+        gauxc_molecule.emplace_back(GauXC::AtomicNumber(atomic_number), x_coord, y_coord, z_coord);
+    }
+
+    return gauxc_molecule;
+}
+
+template <typename T>
+GauXC::BasisSet<T> psi4_to_gauxc_basisset(std::shared_ptr<BasisSet> psi4_basisset, double basis_tol,
+                                          bool force_cartesian) {
+    using prim_array = typename GauXC::Shell<T>::prim_array;
+    using cart_array = typename GauXC::Shell<T>::cart_array;
+
+    GauXC::BasisSet<T> gauxc_basisset(psi4_basisset->nshell());
+
+    for (size_t ishell = 0; ishell != psi4_basisset->nshell(); ++ishell) {
+        auto psi4_shell = psi4_basisset->shell(ishell);
+
+        const auto nprim = GauXC::PrimSize(psi4_shell.nprimitive());
+        prim_array alpha;
+        prim_array coeff;
+
+        for (size_t iprim = 0; iprim != psi4_shell.nprimitive(); ++iprim) {
+            alpha.at(iprim) = psi4_shell.exp(iprim);
+            coeff.at(iprim) = psi4_shell.coef(iprim);
+        }
+
+        auto psi4_shell_center = psi4_shell.center();
+        cart_array center = {psi4_shell_center[0], psi4_shell_center[1], psi4_shell_center[2]};
+
+        gauxc_basisset[ishell] = GauXC::Shell(
+            nprim, GauXC::AngularMomentum(psi4_shell.am()),
+            (force_cartesian ? GauXC::SphericalType(false) : GauXC::SphericalType(!(psi4_shell.is_cartesian()))), alpha,
+            coeff, center,
+            false  // do not normalize shell via GauXC; it is normalized via Psi4
+        );
+    }
+
+    for (auto& sh : gauxc_basisset) {
+        sh.set_shell_tolerance(basis_tol);
+    }
+
+    return gauxc_basisset;
+}
+
+template GauXC::BasisSet<double> psi4_to_gauxc_basisset<double>(std::shared_ptr<BasisSet>, double, bool);
+
+std::unique_ptr<GauXC::RuntimeEnvironment> make_runtime_environment(bool use_gpu, double gpu_mem_fraction) {
+#ifdef GAUXC_HAS_DEVICE
+    if (use_gpu) {
+        return std::make_unique<GauXC::DeviceRuntimeEnvironment>(GAUXC_MPI_CODE(MPI_COMM_WORLD, ) gpu_mem_fraction);
+    }
+#else
+    if (use_gpu) {
+        throw PSIEXCEPTION(
+            "GPU execution was requested, but this GauXC installation was built without device support. "
+            "Rebuild Psi4 against a device-enabled GauXC.");
+    }
+#endif
+    return std::make_unique<GauXC::RuntimeEnvironment>(GAUXC_MPI_CODE(MPI_COMM_WORLD));
+}
+
+}  // namespace gauxc_interface
+}  // namespace psi
+
+#endif  // USING_gauxc

--- a/psi4/src/psi4/libfock/gauxc_interface.h
+++ b/psi4/src/psi4/libfock/gauxc_interface.h
@@ -58,6 +58,10 @@ GauXC::PruningScheme to_gauxc_pruning_scheme(const std::string& psi4_name);
 /// GauXC enum. Throws PSIEXCEPTION if GauXC has no equivalent.
 GauXC::RadialQuad to_gauxc_radial_scheme(const std::string& psi4_name);
 
+/// Maps a Psi4 DFT_NUCLEAR_SCHEME value to the GauXC atomic partition weight scheme.
+/// Throws for values GauXC does not implement.
+GauXC::XCWeightAlg to_gauxc_weight_scheme(const std::string& psi4_name);
+
 /// Permutation between Psi4's Gaussian-ordered and GauXC's CCA-ordered
 /// spherical harmonics.
 Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> generate_permutation_matrix(

--- a/psi4/src/psi4/libfock/gauxc_interface.h
+++ b/psi4/src/psi4/libfock/gauxc_interface.h
@@ -1,0 +1,82 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#ifndef GAUXC_INTERFACE_H
+#define GAUXC_INTERFACE_H
+
+#ifdef USING_gauxc
+
+#include <memory>
+#include <string>
+
+#include <Eigen/Core>
+
+#include <gauxc/basisset.hpp>
+#include <gauxc/molecule.hpp>
+#include <gauxc/molgrid/defaults.hpp>
+#include <gauxc/runtime_environment.hpp>
+
+namespace psi {
+
+class BasisSet;
+class Molecule;
+
+/// Conversions between Psi4 and GauXC conventions, shared by the snLinK
+/// exchange path and the GauXC XC quadrature.
+namespace gauxc_interface {
+
+/// Maps the Psi4 DFT_PRUNING_SCHEME / SNLINK_PRUNING_SCHEME string onto the
+/// GauXC enum. Throws PSIEXCEPTION if GauXC has no equivalent.
+GauXC::PruningScheme to_gauxc_pruning_scheme(const std::string& psi4_name);
+
+/// Maps the Psi4 DFT_RADIAL_SCHEME / SNLINK_RADIAL_SCHEME string onto the
+/// GauXC enum. Throws PSIEXCEPTION if GauXC has no equivalent.
+GauXC::RadialQuad to_gauxc_radial_scheme(const std::string& psi4_name);
+
+/// Permutation between Psi4's Gaussian-ordered and GauXC's CCA-ordered
+/// spherical harmonics.
+Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> generate_permutation_matrix(
+    const std::shared_ptr<BasisSet> psi4_basisset, int gauxc_max_am);
+
+/// Psi4::Molecule -> GauXC::Molecule
+GauXC::Molecule psi4_to_gauxc_molecule(std::shared_ptr<Molecule> psi4_molecule);
+
+/// Psi4::BasisSet -> GauXC::BasisSet
+template <typename T>
+GauXC::BasisSet<T> psi4_to_gauxc_basisset(std::shared_ptr<BasisSet> psi4_basisset, double basis_tol,
+                                          bool force_cartesian);
+
+/// Builds a host or device runtime environment. Throws if a device is
+/// requested but GauXC was built without device support.
+std::unique_ptr<GauXC::RuntimeEnvironment> make_runtime_environment(bool use_gpu, double gpu_mem_fraction);
+
+}  // namespace gauxc_interface
+}  // namespace psi
+
+#endif  // USING_gauxc
+#endif  // GAUXC_INTERFACE_H

--- a/psi4/src/psi4/libfock/snLinK.cc
+++ b/psi4/src/psi4/libfock/snLinK.cc
@@ -28,6 +28,7 @@
 
 #include "jk.h"
 #include "SplitJK.h"
+#include "gauxc_interface.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libfock/cubature.h"
 #include "psi4/libfock/points.h"
@@ -64,116 +65,6 @@ namespace psi {
 
 #ifdef USING_gauxc
 
-// creates maps for translating Psi4 option inputs to GauXC enums
-std::tuple<
-    std::unordered_map<std::string, GauXC::PruningScheme>, 
-    std::unordered_map<std::string, GauXC::RadialQuad> 
-> snLinK::generate_enum_mappings() {
-    // generate map for grid pruning schemes 
-    std::unordered_map<std::string, GauXC::PruningScheme> pruning_scheme_map; 
-    pruning_scheme_map["ROBUST"] = GauXC::PruningScheme::Robust;
-    pruning_scheme_map["TREUTLER"] = GauXC::PruningScheme::Treutler;
-    pruning_scheme_map["NONE"] = GauXC::PruningScheme::Unpruned;
-
-    // generate map for radial quadrature schemes 
-    std::unordered_map<std::string, GauXC::RadialQuad> radial_scheme_map; 
-    radial_scheme_map["TREUTLER"] = GauXC::RadialQuad::TreutlerAhlrichs;
-    radial_scheme_map["MURA"] = GauXC::RadialQuad::MuraKnowles;
-    // The Murray, Handy, Laming literature reference is mentioned in cubature.cc
-    // with association to this keyword
-    radial_scheme_map["EM"] = GauXC::RadialQuad::MurrayHandyLaming; 
-
-    // we are done
-    return std::make_tuple(pruning_scheme_map, radial_scheme_map);
-}
-
-// constructs a permutation matrix for converting matrices to and from GauXC's integral ordering standard 
-Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> snLinK::generate_permutation_matrix(
-    const std::shared_ptr<BasisSet> psi4_basisset) {
-
-    Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> permutation_matrix(psi4_basisset->nbf());
-
-    // general array for how to reorder integrals
-    std::vector<int> cca_integral_order(2*gauxc_max_am_ + 1, 0);
-   
-    // p shells or larger
-    for (size_t l = 1, idx = 1; l != gauxc_max_am_; idx += 2, ++l) {
-        cca_integral_order[idx] = l;
-        cca_integral_order[idx + 1] = -l;
-    }
-
-    // actually construct permutation matrix
-    for (int ish = 0, ibf = 0; ish != psi4_basisset->nshell(); ++ish) {
-        auto& sh = psi4_basisset->shell(ish);
-        auto am = sh.am();
-  
-        auto ibf_base = ibf;
-        for (int ishbf = 0; ishbf != 2*am + 1; ++ishbf, ++ibf) {
-            permutation_matrix.indices()[ibf] = ibf_base + cca_integral_order[ishbf] + am;
-        }
-    }
-   
-    // we are done
-    return permutation_matrix;
-}
-
-// converts a Psi4::Molecule object to a GauXC::Molecule object
-GauXC::Molecule snLinK::psi4_to_gauxc_molecule(std::shared_ptr<Molecule> psi4_molecule) {
-    GauXC::Molecule gauxc_molecule;
-
-    for (size_t iatom = 0; iatom != psi4_molecule->natom(); ++iatom) {
-        auto atomic_number = psi4_molecule->true_atomic_number(iatom);
-        auto x_coord = psi4_molecule->x(iatom);
-        auto y_coord = psi4_molecule->y(iatom);
-        auto z_coord = psi4_molecule->z(iatom);
-        
-        gauxc_molecule.emplace_back(GauXC::AtomicNumber(atomic_number), x_coord, y_coord, z_coord);
-    }
-
-    return gauxc_molecule;
-}
-
-// converts a Psi4::BasisSet object to a GauXC::BasisSet object
-template <typename T>
-GauXC::BasisSet<T> snLinK::psi4_to_gauxc_basisset(std::shared_ptr<BasisSet> psi4_basisset, double basis_tol, bool force_cartesian) {
-    using prim_array = typename GauXC::Shell<T>::prim_array;
-    using cart_array = typename GauXC::Shell<T>::cart_array;
-
-    GauXC::BasisSet<T> gauxc_basisset(psi4_basisset->nshell());
- 
-    for (size_t ishell = 0; ishell != psi4_basisset->nshell(); ++ishell) {
-        auto psi4_shell = psi4_basisset->shell(ishell);
-       
-        const auto nprim = GauXC::PrimSize(psi4_shell.nprimitive());
-        prim_array alpha; 
-        prim_array coeff;
-
-        for (size_t iprim = 0; iprim != psi4_shell.nprimitive(); ++iprim) {
-            alpha.at(iprim) = psi4_shell.exp(iprim);
-            coeff.at(iprim) = psi4_shell.coef(iprim);
-        }
-
-        auto psi4_shell_center = psi4_shell.center();
-        cart_array center = { psi4_shell_center[0], psi4_shell_center[1], psi4_shell_center[2] };
-
-        gauxc_basisset[ishell] = GauXC::Shell(
-            nprim,
-            GauXC::AngularMomentum(psi4_shell.am()), 
-            (force_cartesian ? GauXC::SphericalType(false) : GauXC::SphericalType( !(psi4_shell.is_cartesian()) ) ),
-            alpha,
-            coeff,
-            center,
-            false // do not normalize shell via GauXC; it is normalized via Psi4
-        );
-    }
-    
-    for (auto& sh : gauxc_basisset) {
-        sh.set_shell_tolerance(basis_tol); 
-    }
-
-    return gauxc_basisset;
-}
-
 #endif 
 
 // ==> SplitJK-inherited functions go here <== //
@@ -204,23 +95,11 @@ snLinK::snLinK(std::shared_ptr<BasisSet> primary, Options& options) : SplitJK(pr
 
     format_ = Eigen::IOFormat(4, 0, ", ", "\n", "[", "]");
     
-    // create mappings for GauXC pruning and radial scheme enums
-    auto [ pruning_scheme_map, radial_scheme_map ] = generate_enum_mappings();
-
     // define runtime environment and execution space
     use_gpu_ = options_.get_bool("SNLINK_USE_GPU"); 
     auto ex = use_gpu_ ? GauXC::ExecutionSpace::Device : GauXC::ExecutionSpace::Host;  
 
-    std::unique_ptr<GauXC::RuntimeEnvironment> rt = nullptr; 
-#ifdef GAUXC_HAS_DEVICE 
-    if (use_gpu_) {
-        rt = std::make_unique<GauXC::DeviceRuntimeEnvironment>( GAUXC_MPI_CODE(MPI_COMM_WORLD,) 0.01*options_.get_int("SNLINK_GPU_MEM"));
-    } else { 
-        rt = std::make_unique<GauXC::RuntimeEnvironment>( GAUXC_MPI_CODE(MPI_COMM_WORLD) );
-    }
-#else
-        rt = std::make_unique<GauXC::RuntimeEnvironment>( GAUXC_MPI_CODE(MPI_COMM_WORLD) );
-#endif
+    auto rt = gauxc_interface::make_runtime_environment(use_gpu_, 0.01 * options_.get_int("SNLINK_GPU_MEM"));
 
     // get maximum supported AM for this GauXC instance
     gauxc_max_am_ = GauXC::gauxc_max_am(ex, GauXC::SupportedAlg::SNLINK);
@@ -270,7 +149,7 @@ snLinK::snLinK(std::shared_ptr<BasisSet> primary, Options& options) : SplitJK(pr
     // create ERI ordering permutation matrix to handle integral ordering
     if (!is_cca_ && primary_->has_puream()) {
         permutation_matrix_ = std::make_optional<Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> >(
-            generate_permutation_matrix(primary_)
+            gauxc_interface::generate_permutation_matrix(primary_, gauxc_max_am_)
         );
     } else {
         permutation_matrix_ = std::nullopt;
@@ -348,8 +227,8 @@ snLinK::snLinK(std::shared_ptr<BasisSet> primary, Options& options) : SplitJK(pr
     spherical_points_ = options_.get_int("SNLINK_SPHERICAL_POINTS");
 
     // convert Psi4 fundamental quantities to GauXC 
-    auto gauxc_mol = psi4_to_gauxc_molecule(primary_->molecule());
-    auto gauxc_primary = psi4_to_gauxc_basisset<double>(primary_, basis_tol_, force_cartesian);
+    auto gauxc_mol = gauxc_interface::psi4_to_gauxc_molecule(primary_->molecule());
+    auto gauxc_primary = gauxc_interface::psi4_to_gauxc_basisset<double>(primary_, basis_tol_, force_cartesian);
 
     // create snLinK grid for GauXC
     auto grid_batch_size = options_.get_int("SNLINK_GRID_BATCH_SIZE");
@@ -357,17 +236,17 @@ snLinK::snLinK(std::shared_ptr<BasisSet> primary, Options& options) : SplitJK(pr
 
     auto gauxc_grid = !use_debug_grid ? GauXC::MolGridFactory::create_default_molgrid(
         gauxc_mol, 
-        pruning_scheme_map[pruning_scheme_],
+        gauxc_interface::to_gauxc_pruning_scheme(pruning_scheme_),
         GauXC::BatchSize(grid_batch_size), 
-        radial_scheme_map[radial_scheme_], 
+        gauxc_interface::to_gauxc_radial_scheme(radial_scheme_), 
         GauXC::RadialSize(radial_points_),
         GauXC::AngularSize(spherical_points_)
     ) :
     GauXC::MolGridFactory::create_default_molgrid(
         gauxc_mol, 
-        pruning_scheme_map[pruning_scheme_],
+        gauxc_interface::to_gauxc_pruning_scheme(pruning_scheme_),
         GauXC::BatchSize(grid_batch_size), 
-        radial_scheme_map[radial_scheme_], 
+        gauxc_interface::to_gauxc_radial_scheme(radial_scheme_), 
         GauXC::AtomicGridSizeDefault::UltraFineGrid
     );
    

--- a/psi4/src/psi4/libfock/v.cc
+++ b/psi4/src/psi4/libfock/v.cc
@@ -31,6 +31,7 @@
 #include "points.h"
 #include "dft_integrators.h"
 #include "sap.h"
+#include "GauXCV.h"
 
 #include "psi4/libfunctional/LibXCfunctional.h"
 #include "psi4/libfunctional/functional.h"
@@ -119,16 +120,25 @@ void VBase::common_init() {
 std::shared_ptr<VBase> VBase::build_V(std::shared_ptr<BasisSet> primary, std::shared_ptr<SuperFunctional> functional,
                                       Options& options, const std::string& type) {
     std::shared_ptr<VBase> v;
+    const bool use_gauxc = options.get_str("DFT_V_ALGORITHM") == "GAUXC";
     if (type == "RV") {
         if (!functional->is_unpolarized()) {
             throw PSIEXCEPTION("Passed in functional was polarized for RV reference.");
         }
-        v = std::make_shared<RV>(functional, primary, options);
+        if (use_gauxc) {
+            v = std::make_shared<GauXCRV>(functional, primary, options);
+        } else {
+            v = std::make_shared<RV>(functional, primary, options);
+        }
     } else if (type == "UV") {
         if (functional->is_unpolarized()) {
             throw PSIEXCEPTION("Passed in functional was unpolarized for UV reference.");
         }
-        v = std::make_shared<UV>(functional, primary, options);
+        if (use_gauxc) {
+            v = std::make_shared<GauXCUV>(functional, primary, options);
+        } else {
+            v = std::make_shared<UV>(functional, primary, options);
+        }
     } else if (type == "SAP") {
         v = std::make_shared<SAP>(functional, primary, options);
     } else {

--- a/psi4/src/psi4/libscf_solver/rhf.cc
+++ b/psi4/src/psi4/libscf_solver/rhf.cc
@@ -1039,7 +1039,8 @@ std::shared_ptr<RHF> RHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
 
 void RHF::setup_potential() {
     if (functional_->needs_xc()) {
-        potential_ = std::make_shared<RV>(functional_, basisset_, options_);
+        potential_ = std::dynamic_pointer_cast<RV>(
+            VBase::build_V(basisset_, functional_, options_, "RV"));
         potential_->initialize();
     } else {
         potential_ = nullptr;

--- a/psi4/src/psi4/libscf_solver/uhf.cc
+++ b/psi4/src/psi4/libscf_solver/uhf.cc
@@ -1236,7 +1236,8 @@ std::shared_ptr<UHF> UHF::c1_deep_copy(std::shared_ptr<BasisSet> basis) {
 
 void UHF::setup_potential() {
     if (functional_->needs_xc()) {
-        potential_ = std::make_shared<UV>(functional_, basisset_, options_);
+        potential_ = std::dynamic_pointer_cast<UV>(
+            VBase::build_V(basisset_, functional_, options_, "UV"));
         potential_->initialize();
     } else {
         potential_ = nullptr;

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -192,6 +192,14 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
     Convergence & Algorithm <table:conv_scf>` for default algorithm for
     different calculation types. -*/
     options.add_str("SCF_TYPE", "PK", "DIRECT DF MEM_DF DISK_DF PK OUT_OF_CORE CD GTFOCK DFDIRJ DFDIRJ+COSX DFDIRJ+LINK DFDIRJ+SNLINK");
+    /*- Algorithm for the DFT exchange-correlation quadrature.
+    ``INTERNAL`` uses Psi4's own grid code; ``GAUXC`` delegates to the GauXC library,
+    which can execute on GPUs. -*/
+    options.add_str("DFT_V_ALGORITHM", "INTERNAL", "INTERNAL GAUXC");
+    /*- Execute the GauXC-based XC quadrature on a GPU. Requires a device-enabled GauXC build. -*/
+    options.add_bool("DFT_V_USE_GPU", false);
+    /*- Proportion (in %) of available GPU memory to allocate to the GauXC XC quadrature. !expert -*/
+    options.add_int("DFT_V_GPU_MEM", 90);
 #ifdef USING_OpenOrbitalOptimizer
     /*- Orbital optimizer package to use for SCF. If compiled with OpenOrbitalOptimizer support, change this to use it or the internal code. -*/
     options.add_str("ORBITAL_OPTIMIZER_PACKAGE", "INTERNAL", "INTERNAL OOO OPENORBITALOPTIMIZER");

--- a/tests/pytests/test_gauxc_v.py
+++ b/tests/pytests/test_gauxc_v.py
@@ -72,3 +72,97 @@ def test_gauxc_v_lda_matches_internal(water):
     # Psi4 sieben Punkte/Gewichte unterschiedlich. Der Rest ist Sieb-Rauschen,
     # kein Implementierungsfehler -- vgl. Exc-Differenz von ~6e-8 Ha.
     assert compare_values(e_ref, e_new, 7, "SVWN energy, GauXC vs internal")
+
+
+# ---------------------------------------------------------------------------
+# Vergleichsmatrix: jedes Funktional wird gegen den internen Pfad geprueft.
+# Toleranz 6 Dezimalstellen -- die verbleibende Abweichung stammt aus
+# unterschiedlichem Punkt-/Gewichtssieben, nicht aus der Quadratur selbst.
+# ---------------------------------------------------------------------------
+
+_GRID = {"basis": "cc-pVDZ", "scf_type": "df",
+         "e_convergence": 1e-10, "d_convergence": 1e-9,
+         "dft_spherical_points": 302, "dft_radial_points": 75,
+         "maxiter": 200,
+         "dft_nuclear_scheme": "stratmann"}
+
+
+def _run(algo, functional, mol, reference, **overrides):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.set_options({**_GRID, "reference": reference, "dft_v_algorithm": algo, **overrides})
+    return psi4.energy(functional, molecule=mol)
+
+
+@pytest.fixture
+def hydroxyl():
+    """Wasser-Kation, Dublett. Das OH-Radikal konvergiert mit SVWN in *beiden*
+    Pfaden nicht -- das ist eine Eigenheit des Systems, nicht der Quadratur."""
+    return psi4.geometry("""
+1 2
+O 0.0  0.000 0.000
+H 0.0  0.757 0.587
+H 0.0 -0.757 0.587
+units angstrom
+symmetry c1
+no_reorient
+no_com
+""")
+
+
+@uusing("gauxc")
+@pytest.mark.parametrize("functional,kind", [
+    ("svwn", "LDA"),
+    ("blyp", "GGA"),
+    ("pbe", "GGA"),
+    ("b3lyp", "global hybrid"),
+    ("pbe0", "global hybrid"),
+    ("m06-2x", "meta-GGA hybrid"),
+    ("wb97x", "range-separated hybrid"),
+])
+def test_gauxc_v_rks_matches_internal(water, functional, kind):
+    e_ref = _run("internal", functional, water, "rks")
+    e_new = _run("gauxc", functional, water, "rks")
+    assert compare_values(e_ref, e_new, 6, f"{functional} ({kind}) RKS, GauXC vs internal")
+
+
+@uusing("gauxc")
+@pytest.mark.parametrize("functional", ["svwn", "blyp", "b3lyp", "m06-2x"])
+def test_gauxc_v_uks_matches_internal(hydroxyl, functional):
+    # Feineres Gitter als im RKS-Fall. Auf 302/75 liegt die Abweichung bei
+    # 4e-7 Ha, auf 590/99 bei 8e-8 -- sie schrumpft mit der Gitterdichte,
+    # ist also Sieb-Rauschen und kein Implementierungsfehler.
+    fine = {"dft_spherical_points": 590, "dft_radial_points": 99}
+    e_ref = _run("internal", functional, hydroxyl, "uks", **fine)
+    e_new = _run("gauxc", functional, hydroxyl, "uks", **fine)
+    assert compare_values(e_ref, e_new, 6, f"{functional} UKS, GauXC vs internal")
+
+
+@uusing("gauxc")
+def test_gauxc_v_rejects_vv10(water):
+    """VV10 ist nicht-lokale Korrelation; GauXC quadriert sie nicht."""
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.set_options({**_GRID, "reference": "rks", "dft_v_algorithm": "gauxc"})
+    with pytest.raises(Exception, match="VV10"):
+        psi4.energy("wb97m-v", molecule=water)
+
+
+@uusing("gauxc")
+def test_gauxc_v_rejects_unmappable_radial_scheme(water):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.set_options({**_GRID, "reference": "rks", "dft_v_algorithm": "gauxc",
+                      "dft_radial_scheme": "becke"})
+    with pytest.raises(Exception, match="no GauXC equivalent"):
+        psi4.energy("svwn", molecule=water)
+
+
+@uusing("gauxc")
+def test_gauxc_v_rejects_unmappable_nuclear_scheme(water):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    psi4.set_options({**_GRID, "reference": "rks", "dft_v_algorithm": "gauxc",
+                      "dft_nuclear_scheme": "treutler"})
+    with pytest.raises(Exception, match="no GauXC equivalent"):
+        psi4.energy("svwn", molecule=water)

--- a/tests/pytests/test_gauxc_v.py
+++ b/tests/pytests/test_gauxc_v.py
@@ -1,6 +1,7 @@
 import pytest
 
 import psi4
+from utils import compare_values
 from addons import uusing
 
 pytestmark = [pytest.mark.psi, pytest.mark.api]
@@ -26,10 +27,48 @@ def test_dft_v_algorithm_default_is_internal():
 
 
 @uusing("gauxc")
-def test_gauxc_v_selectable(water):
-    """DFT_V_ALGORITHM=GAUXC muss akzeptiert werden und den GauXC-Pfad waehlen."""
+def test_gauxc_v_dispatch_is_effective(water):
+    """Beweist, dass DFT_V_ALGORITHM=GAUXC den Pfad wirklich umschaltet.
+
+    FLAT ist ein gueltiges Psi4-Pruning-Schema ohne GauXC-Entsprechung. Der
+    interne Pfad muss es akzeptieren, der GauXC-Pfad muss es ablehnen -- das
+    ist nur moeglich, wenn tatsaechlich unterschiedlicher Code laeuft.
+    """
+    base = {"basis": "cc-pVDZ", "scf_type": "df", "reference": "rks",
+            "dft_pruning_scheme": "flat"}
+
     psi4.core.clean_options()
-    psi4.set_options({"basis": "cc-pVDZ", "scf_type": "df",
-                      "dft_v_algorithm": "gauxc", "reference": "rks"})
-    with pytest.raises(Exception, match="not implemented"):
+    psi4.set_options({**base, "dft_v_algorithm": "internal"})
+    psi4.energy("svwn", molecule=water)
+
+    psi4.core.clean_options()
+    psi4.set_options({**base, "dft_v_algorithm": "gauxc"})
+    with pytest.raises(Exception, match="no GauXC equivalent"):
         psi4.energy("svwn", molecule=water)
+
+
+def _energy_with(algo, functional, mol, **extra):
+    psi4.core.clean()
+    psi4.core.clean_options()
+    opts = {"basis": "cc-pVDZ", "scf_type": "df", "reference": "rks",
+            "e_convergence": 1e-10, "d_convergence": 1e-9,
+            "dft_spherical_points": 302, "dft_radial_points": 75,
+            # GauXC partitions atomic weights with SSF; ask the internal path for
+            # the same scheme so the comparison measures the implementation,
+            # not the grid.
+            "dft_nuclear_scheme": "stratmann",
+            "dft_v_algorithm": algo}
+    opts.update(extra)
+    psi4.set_options(opts)
+    return psi4.energy(functional, molecule=mol)
+
+
+@uusing("gauxc")
+def test_gauxc_v_lda_matches_internal(water):
+    """LDA: GauXC-Quadratur muss den internen Pfad auf 1e-8 Ha reproduzieren."""
+    e_ref = _energy_with("internal", "svwn", water)
+    e_new = _energy_with("gauxc", "svwn", water)
+    # 1e-7: beide Pfade quadrieren dasselbe nominelle Gitter, aber GauXC und
+    # Psi4 sieben Punkte/Gewichte unterschiedlich. Der Rest ist Sieb-Rauschen,
+    # kein Implementierungsfehler -- vgl. Exc-Differenz von ~6e-8 Ha.
+    assert compare_values(e_ref, e_new, 7, "SVWN energy, GauXC vs internal")

--- a/tests/pytests/test_gauxc_v.py
+++ b/tests/pytests/test_gauxc_v.py
@@ -1,0 +1,35 @@
+import pytest
+
+import psi4
+from addons import uusing
+
+pytestmark = [pytest.mark.psi, pytest.mark.api]
+
+
+@pytest.fixture
+def water():
+    return psi4.geometry("""
+O 0.0  0.000 0.000
+H 0.0  0.757 0.587
+H 0.0 -0.757 0.587
+units angstrom
+symmetry c1
+no_reorient
+no_com
+""")
+
+
+def test_dft_v_algorithm_default_is_internal():
+    """Der Default darf sich nicht aendern."""
+    psi4.core.clean_options()
+    assert psi4.core.get_option("SCF", "DFT_V_ALGORITHM") == "INTERNAL"
+
+
+@uusing("gauxc")
+def test_gauxc_v_selectable(water):
+    """DFT_V_ALGORITHM=GAUXC muss akzeptiert werden und den GauXC-Pfad waehlen."""
+    psi4.core.clean_options()
+    psi4.set_options({"basis": "cc-pVDZ", "scf_type": "df",
+                      "dft_v_algorithm": "gauxc", "reference": "rks"})
+    with pytest.raises(Exception, match="not implemented"):
+        psi4.energy("svwn", molecule=water)


### PR DESCRIPTION
## Description

Psi4 already builds and links GauXC when `ENABLE_gauxc=ON`, and `snLinK.cc`
drives it through `eval_exx` for the exchange matrix. But
`XCIntegrator::eval_exc_vxc` is never called anywhere in the tree — the XC
quadrature itself always runs through `RV::compute_V` / `UV::compute_V` on the
CPU. `codedeps.yaml` records this explicitly:

```
required_note: "Allow using the GauXC density functional library for LinK (not DFT)."
```

This PR closes that gap: a new option `DFT_V_ALGORITHM = INTERNAL|GAUXC`
(default `INTERNAL`, existing behaviour untouched) routes the XC quadrature
through GauXC, optionally on the GPU via `DFT_V_USE_GPU`.

Motivation, measured rather than assumed: in a profile of Psi4 1.11, the XC
quadrature accounts for **70 % of SCF wall time** for (H2O)8/cc-pVTZ/BP86 — of
which 70 % is collocation and density evaluation and only 2 % the actual libxc
evaluation. The cost sits exactly where GauXC operates.

## User API & Changelog headlines

- [ ] New option `DFT_V_ALGORITHM = INTERNAL|GAUXC` selects the backend for the
      exchange-correlation quadrature. Default `INTERNAL` — no existing
      calculation changes.
- [ ] With `DFT_V_ALGORITHM GAUXC`, `DFT_V_USE_GPU` runs that quadrature on the
      GPU. Requires a GauXC built with `-Dgauxc_ENABLE_GPU=ON`.
- [ ] Both options are no-ops unless Psi4 was built with `ENABLE_gauxc=ON`;
      requesting them otherwise raises a clear error.

## Dev notes & details

- [ ] Lifted the Psi4→GauXC conversion out of `snLinK.cc` into a shared
      `gauxc_interface.{h,cc}` (molecule, basis, CCA permutation,
      spherical→Cartesian, runtime environment). Pure refactor, no behaviour
      change; `snLinK.cc` shrinks by 139 lines.
- [ ] `GauXCRV : public RV` and `GauXCUV : public UV` override only
      `compute_V`. Gradients, VV10 and everything else keep using the existing
      code paths.
- [ ] Selection happens in the `VBase::build_V` factory. `RHF/UHF::setup_potential`
      previously bypassed that factory; this PR routes them through it.
- [ ] Grid parameters come from the existing `DFT_*` options, so both backends
      integrate on the same grid and are directly comparable. Worth noting for
      anyone benchmarking: GauXC partitions with Stratmann-Scuseria-Frisch,
      Psi4 defaults to Treutler — without matching them the partitioning
      dominates the difference by roughly a factor of 30.
- [ ] No functional whitelist. The ExchCXX functional is constructed from
      Psi4's own `SuperFunctional` decomposition — each ingredient carries its
      libxc kernel name, and ExchCXX builds kernels from exactly that. Covers
      LDA, GGA, meta-GGA, global and range-separated hybrids.
- [ ] Hard errors instead of silent divergence for VV10, GRAC, and grid schemes
      with no GauXC equivalent.
- [ ] `tests/pytests/test_gauxc_v.py`: 17 tests, skipped when GauXC is absent.
- [ ] The harness I used to produce the numbers below (build + three-way
      comparison + timings in one run) is deliberately *not* part of this PR --
      `devtools/scripts/` is CI-only by convention and this is scaffolding, not
      product. Happy to attach it to a comment or open a follow-up if reviewers
      want to re-measure on their own hardware.

**Numerics** (water, cc-pVDZ, (75,302), `DFT_NUCLEAR_SCHEME STRATMANN` on both sides)

| Functional | Class | ΔE vs. internal |
|---|---|---|
| svwn | LDA | −5.9e−08 |
| blyp / pbe | GGA | −1.1e−07 / −9.7e−08 |
| b3lyp / pbe0 | global hybrid | −8.3e−08 / −6.9e−08 |
| m06-2x | meta-GGA hybrid | 8.4e−07 |
| wb97x | range-separated | −3.6e−07 |
| svwn/blyp/b3lyp/m06-2x | UKS | < 1.1e−07 |

The residual comes from point screening and shrinks on finer grids (UKS:
4e−07 at (75,302) → 8e−08 at (99,590)).

**CPU performance** (glycine, B3LYP, 16 threads, quadrature time only)

| Basis | GauXC vs. internal |
|---|---|
| cc-pVDZ | 0.48× (slower) |
| cc-pVTZ | **2.29×** |
| cc-pVQZ | **2.02×** |

Small bases lose — the setup does not pay off there. This is one reason the
default stays `INTERNAL`.

**GPU**

Verified on a GeForce GT 1030 (sm_61, CUDA 12.6): the GPU path reproduces the
GauXC CPU results to all printed digits, for every functional above, RKS and
UKS, cc-pVDZ and cc-pVTZ.

Being straight about speed: on that card the GPU is **slower** than 32 CPU
threads. The code is FP64 throughout and NVIDIA restricts FP64 on consumer
cards to 1/32–1/64 of FP32. That card demonstrates correctness, not
performance; the latter needs datacenter hardware (FP64 1:2), which I do not
have access to. **So the GPU path is presented as verified-correct, not as
verified-fast.** If someone with a V100/A100 has cycles to spare, I am glad
to hand over the harness I used so the numbers are directly comparable.

**Tests**

Full regression on this branch: 192 passed, 117 skipped, 0 failed.
`test_gauxc_v.py`: 17/17.

## Questions

- [ ] Was leaving the XC side out a deliberate decision during the sn-LinK
      work, or simply out of scope? If deliberate, I would like to understand
      the objection before you spend review time on this.
- [ ] Is `DFT_V_ALGORITHM` the right name and place for the switch? It mirrors
      how `SCF_TYPE` already selects sn-LinK, but I have no attachment to it.
- [ ] Routing `RHF/UHF::setup_potential` through `VBase::build_V` is the one
      change that touches existing behaviour. It looked like an oversight
      rather than intent — please confirm.
- [ ] Interest in a `GAUXC_ENABLE_HIP` mapping in
      `external/upstream/gauxc/CMakeLists.txt`? Only `GAUXC_ENABLE_CUDA` is
      wired up (line 72), though GauXC supports AMD as well. Happy to add it,
      but I cannot test it.
- [ ] `-Dgauxc_ENABLE_GPU=ON` is mandatory when building Psi4, otherwise the
      interface is silently built CPU-only with only a CMake *warning*. That
      cost me a day. Would you take a patch making it a hard error?

## AI

- [ ] Substantial. An AI assistant (Claude, via GitHub Copilot CLI) did the
      prior-art survey, wrote most of the implementation, the tests, the
      verification harness and the docs, and found the spherical-d/f segfault
      described below. I directed the work, made the design decisions, ran and
      reviewed everything on my own hardware, and I am the one answering
      questions about it.
- [ ] Reviewers may want to look hardest at the segfault fix in `GauXCV.cc`:
      in the GPU path the density is transformed to Cartesian (25×25 for water
      /cc-pVDZ), after which the *spherically* sized permutation matrix (24×24)
      was still being applied. Eigen does not check dimensions in release
      builds (`NDEBUG`), so this wrote past the buffer. The fix drops the
      permutation in the Cartesian path entirely — it only reorders *within*
      solid-harmonic shells, which do not exist in the Cartesian basis. It is
      only ever active with `psi4_SHGSHELL_ORDERING=2` (Gaussian ordering).
      It went unnoticed at first because sto-3g (s/p only) and 6-31G
      (Cartesian) never trigger the mismatch.

## Checklist
- [x] Tests added for any new features
- [x] Docstring or narrative docs/sphinxman/source updated if needed

## Status
- [x] Ready for review
