### PR TITLE
Update matrix includes and Eigen for faster builds

### DIFF
--- a/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccdensity/get_moinfo.cc
@@ -40,7 +40,6 @@
 #include "psi4/libmints/dimension.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libmints/molecule.h"
-#include "psi4/libmints/matrix.h"
 #include "MOInfo.h"
 #include "Params.h"
 #include "Frozen.h"

--- a/psi4/src/psi4/cc/cclambda/cclambda.cc
+++ b/psi4/src/psi4/cc/cclambda/cclambda.cc
@@ -49,8 +49,6 @@
 #include "psi4/libqt/qt.h"
 #include "psi4/psi4-dec.h"
 #include "psi4/libmints/wavefunction.h"
-#include "psi4/libmints/matrix.h"
-
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/psi4/src/psi4/cc/ccresponse/MOInfo.h
+++ b/psi4/src/psi4/cc/ccresponse/MOInfo.h
@@ -36,7 +36,8 @@
 
 #include <string>
 #include <vector>
-#include "psi4/libmints/matrix.h"
+#include "psi4/libmints/dimension.h"
+#include "psi4/libmints/typedefs.h"
 
 namespace psi {
 namespace ccresponse {

--- a/psi4/src/psi4/cc/ccresponse/get_moinfo.cc
+++ b/psi4/src/psi4/cc/ccresponse/get_moinfo.cc
@@ -39,7 +39,6 @@
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/basisset.h"
-#include "psi4/libmints/matrix.h"
 #include "psi4/psi4-dec.h"
 #include "MOInfo.h"
 #include "Params.h"

--- a/psi4/src/psi4/cc/ccresponse/sort_pert.cc
+++ b/psi4/src/psi4/cc/ccresponse/sort_pert.cc
@@ -33,6 +33,7 @@
 #include <cstdio>
 #include <cstring>
 #include "psi4/libdpd/dpd.h"
+#include "psi4/libmints/matrix.h"
 #include "MOInfo.h"
 #include "Params.h"
 #include "Local.h"

--- a/psi4/src/psi4/detci/params.cc
+++ b/psi4/src/psi4/detci/params.cc
@@ -40,7 +40,6 @@
 
 #include "psi4/libmints/pointgrp.h"
 #include "psi4/libmints/molecule.h"
-#include "psi4/libmints/matrix.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsio/psio.h"

--- a/psi4/src/psi4/dlpno/dlpno.h
+++ b/psi4/src/psi4/dlpno/dlpno.h
@@ -32,7 +32,7 @@
 #include "sparse.h"
 
 #include "psi4/libmints/wavefunction.h"
-#include "psi4/libmints/matrix.h"
+#include "psi4/libmints/typedefs.h"
 #include "psi4/libmints/vector.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsio/psio.h"

--- a/psi4/src/psi4/f12/mp2.cc
+++ b/psi4/src/psi4/f12/mp2.cc
@@ -34,7 +34,6 @@
 
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/dimension.h"
-#include "psi4/libmints/matrix.h"
 #include "psi4/libmints/mintshelper.h"
 
 #include <Einsums/TensorAlgebra.hpp>

--- a/psi4/src/psi4/fnocc/coupled_pair.cc
+++ b/psi4/src/psi4/fnocc/coupled_pair.cc
@@ -39,7 +39,6 @@
 #include "psi4/lib3index/3index.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libmints/basisset.h"
-#include "psi4/libmints/matrix.h"
 #include "psi4/libmints/vector.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libpsi4util/process.h"

--- a/psi4/src/psi4/fnocc/df_cc_residual.cc
+++ b/psi4/src/psi4/fnocc/df_cc_residual.cc
@@ -31,7 +31,6 @@
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libmints/vector.h"
-#include "psi4/libmints/matrix.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libqt/qt.h"

--- a/psi4/src/psi4/fnocc/linear.cc
+++ b/psi4/src/psi4/fnocc/linear.cc
@@ -27,8 +27,6 @@
  */
 
 #include "psi4/libmints/wavefunction.h"
-
-#include "psi4/libmints/matrix.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/psifiles.h"
 #include "psi4/libqt/qt.h"

--- a/psi4/src/psi4/fnocc/mp2.cc
+++ b/psi4/src/psi4/fnocc/mp2.cc
@@ -28,7 +28,6 @@
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libmints/vector.h"
-#include "psi4/libmints/matrix.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libtrans/mospace.h"

--- a/psi4/src/psi4/fnocc/quadratic.cc
+++ b/psi4/src/psi4/fnocc/quadratic.cc
@@ -28,7 +28,6 @@
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libmints/vector.h"
-#include "psi4/libmints/matrix.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsio/psio.hpp"

--- a/psi4/src/psi4/libdiis/diismanager.h
+++ b/psi4/src/psi4/libdiis/diismanager.h
@@ -29,11 +29,11 @@
 #ifndef _PSI_SRC_LIB_LIBDIIS_DIISMANAGER_H_
 #define _PSI_SRC_LIB_LIBDIIS_DIISMANAGER_H_
 
+#include <string>
 #include <vector>
 #include <map>
 
 #include "psi4/pragma.h"
-#include "psi4/libmints/matrix.h"
 
 #include "psi4/pybind11.h"
 

--- a/psi4/src/psi4/libfock/snLinK.cc
+++ b/psi4/src/psi4/libfock/snLinK.cc
@@ -35,7 +35,9 @@
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/electrostatic.h"
 #include "psi4/libmints/mintshelper.h"
+#include "psi4/libmints/matrix_eigen.h"
 #include "psi4/libmints/molecule.h"
+#include "psi4/libmints/pointgrp.h"
 #include "psi4/libmints/integral.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/lib3index/dftensor.h"
@@ -462,13 +464,13 @@ void snLinK::build_G_component(std::vector<std::shared_ptr<Matrix>>& D, std::vec
     for (int iD = 0; iD != D.size(); ++iD) {
         timer_on("snLinK: Transform D");
 
-        auto Did_eigen = D[iD]->eigen_map();    
-        auto Kid_eigen = K[iD]->eigen_map();    
+        auto Did_eigen = linalg::eigen_map(*D[iD]);
+        auto Kid_eigen = linalg::eigen_map(*K[iD]);
        
         // need to reorder Psi4 density matrix to CCA ordering if in spherical harmonics
         if (do_reorder) {
             auto permutation_matrix_val = permutation_matrix_.value();
-            auto D_eigen_permute = D[iD]->eigen_map();
+            auto D_eigen_permute = linalg::eigen_map(*D[iD]);
             D_eigen_permute = permutation_matrix_val * D_eigen_permute * permutation_matrix_val.transpose();
         }
             
@@ -481,7 +483,7 @@ void snLinK::build_G_component(std::vector<std::shared_ptr<Matrix>>& D, std::vec
         } else {
             D_buffer = D[iD];
         }
-        auto D_buffer_eigen = D_buffer->eigen_map();    
+        auto D_buffer_eigen = linalg::eigen_map(*D_buffer);
         
         timer_off("snLinK: Transform D");
         
@@ -490,7 +492,7 @@ void snLinK::build_G_component(std::vector<std::shared_ptr<Matrix>>& D, std::vec
         // need to reorder Psi4 exchange matrix to CCA ordering if in spherical harmonics
         if (do_reorder) { 
             auto permutation_matrix_val = permutation_matrix_.value();
-            auto K_eigen_permute = K[iD]->eigen_map();
+            auto K_eigen_permute = linalg::eigen_map(*K[iD]);
             K_eigen_permute = permutation_matrix_val * K_eigen_permute * permutation_matrix_val.transpose();
         }
             
@@ -503,7 +505,7 @@ void snLinK::build_G_component(std::vector<std::shared_ptr<Matrix>>& D, std::vec
         } else {
             K_buffer = K[iD];
         }
-        auto K_buffer_eigen = K_buffer->eigen_map(); 
+        auto K_buffer_eigen = linalg::eigen_map(*K_buffer);
         
         timer_off("snLinK: Transform K");
         
@@ -536,10 +538,10 @@ void snLinK::build_G_component(std::vector<std::shared_ptr<Matrix>>& D, std::vec
         timer_on("snLinK: Back-transform D and K");
         if (do_reorder) {
             auto permutation_matrix_val = permutation_matrix_.value();
-            auto D_eigen_permute = D[iD]->eigen_map();
+            auto D_eigen_permute = linalg::eigen_map(*D[iD]);
             D_eigen_permute = permutation_matrix_val.transpose() * D_eigen_permute * permutation_matrix_val; 
 
-            auto K_eigen_permute = K[iD]->eigen_map();
+            auto K_eigen_permute = linalg::eigen_map(*K[iD]);
             K_eigen_permute = permutation_matrix_val.transpose() * K_eigen_permute * permutation_matrix_val; 
         }
         timer_off("snLinK: Back-transform D and K");

--- a/psi4/src/psi4/libfock/solver.cc
+++ b/psi4/src/psi4/libfock/solver.cc
@@ -39,7 +39,6 @@
 #include "psi4/libqt/qt.h"
 #include "psi4/psi4-dec.h"
 #include "psi4/libmints/vector.h"
-#include "psi4/libmints/matrix.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsi4util/process.h"
 

--- a/psi4/src/psi4/libmints/CMakeLists.txt
+++ b/psi4/src/psi4/libmints/CMakeLists.txt
@@ -38,6 +38,7 @@ list(APPEND sources
   numinthelper.cc
   coordentry.cc
   matrix.cc
+  matrix_eigen.cc
   gshell.cc
   integraliter.cc
   pointgrp.cc

--- a/psi4/src/psi4/libmints/matrix.cc
+++ b/psi4/src/psi4/libmints/matrix.cc
@@ -401,43 +401,6 @@ void Matrix::copy(const Matrix &cp) { copy(&cp); }
 
 void Matrix::copy(const SharedMatrix &cp) { copy(cp.get()); }
 
-// produces an Eigen::Map object mapping to the matrix data buffer
-// of a matrix with a single irrep
-Eigen::Map<Eigen::MatrixXd> Matrix::eigen_map() {
-    // this function only works with matrices with a single irrep
-    if (nirrep() != 1) {
-        std::string message = "Matrix::eigen_map() called, but matrix only has one irrep! ";
-        message += "Use Matrix::eigen_maps() instead.";
-
-        throw PSIEXCEPTION(message);
-    }
-
-    // create Eigen matrix "map" using Psi4 matrix data array directly
-    return std::move(
-        Eigen::Map<Eigen::MatrixXd>(
-            get_pointer(), nrow(), ncol()
-        )
-    );
-}
-
-// produces Eigen::Maps object mapping to the matrix data buffer
-// of a matrix with multiple irreps
-// NOTE: this impl for mapping Psi4 matrices to Eigen maps
-// is currently experimental, as it is unused in the code
-// currently
-std::vector<Eigen::Map<Eigen::MatrixXd>> Matrix::eigen_maps() {
-    std::vector<Eigen::Map<Eigen::MatrixXd>> eigen_maps;
-    eigen_maps.reserve(nirrep());
-
-    // create Eigen matrix "map"s for each irrep,
-    // using Psi4 matrix data array directly
-    for (int h = 0; h != nirrep(); ++h) {
-        eigen_maps.emplace_back(get_pointer(h), rowdim(h), coldim(h));
-    }
-
-    return eigen_maps;
-}
-
 #ifdef USING_OpenOrbitalOptimizer
 arma::mat Matrix::to_armadillo_matrix(int h) {
     int nc = coldim(h);

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -36,7 +36,6 @@
 
 #include "dimension.h"
 
-#include <eigen3/Eigen/Core>
 #ifdef USING_OpenOrbitalOptimizer
 #ifdef USING_LAPACK_MKL
 #include <mkl.h>
@@ -291,9 +290,6 @@ class PSI_API Matrix : public std::enable_shared_from_this<Matrix> {
     void copy(const Matrix* cp);
     /** @} */
 
-    /// returns an Eigen::Map object to the underlying matrix data buffer
-    Eigen::Map<Eigen::MatrixXd> eigen_map();
-    std::vector<Eigen::Map<Eigen::MatrixXd>> eigen_maps();
     /// Returns an Armadillo matrix
     arma::mat to_armadillo_matrix(int h=0);
     /// Copies data from an Armadillo matrix

--- a/psi4/src/psi4/libmints/matrix.h
+++ b/psi4/src/psi4/libmints/matrix.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <memory>

--- a/psi4/src/psi4/libmints/matrix_eigen.cc
+++ b/psi4/src/psi4/libmints/matrix_eigen.cc
@@ -1,0 +1,56 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include "psi4/libmints/matrix_eigen.h"
+
+namespace psi {
+namespace linalg {
+
+Eigen::Map<Eigen::MatrixXd> eigen_map(Matrix& matrix) {
+    if (matrix.nirrep() != 1) {
+        std::string message = "linalg::eigen_map() called, but matrix only has one irrep! ";
+        message += "Use linalg::eigen_maps() instead.";
+        throw PSIEXCEPTION(message);
+    }
+
+    return Eigen::Map<Eigen::MatrixXd>(matrix.get_pointer(), matrix.nrow(), matrix.ncol());
+}
+
+std::vector<Eigen::Map<Eigen::MatrixXd>> eigen_maps(Matrix& matrix) {
+    std::vector<Eigen::Map<Eigen::MatrixXd>> maps;
+    maps.reserve(matrix.nirrep());
+
+    for (int h = 0; h != matrix.nirrep(); ++h) {
+        maps.emplace_back(matrix.get_pointer(h), matrix.rowdim(h), matrix.coldim(h));
+    }
+
+    return maps;
+}
+
+}  // namespace linalg
+}  // namespace psi

--- a/psi4/src/psi4/libmints/matrix_eigen.h
+++ b/psi4/src/psi4/libmints/matrix_eigen.h
@@ -1,0 +1,45 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with Psi4; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#pragma once
+
+#include "psi4/libmints/matrix.h"
+
+#include <eigen3/Eigen/Core>
+
+namespace psi {
+namespace linalg {
+
+/// Map a single-irrep Psi4 Matrix onto its underlying data.
+PSI_API Eigen::Map<Eigen::MatrixXd> eigen_map(Matrix& matrix);
+
+/// Map each irrep block of a Psi4 Matrix onto its underlying data.
+PSI_API std::vector<Eigen::Map<Eigen::MatrixXd>> eigen_maps(Matrix& matrix);
+
+}  // namespace linalg
+}  // namespace psi

--- a/psi4/src/psi4/libmints/sobasis.cc
+++ b/psi4/src/psi4/libmints/sobasis.cc
@@ -33,8 +33,6 @@
 #include "basisset.h"
 #include "gshell.h"
 #include "dimension.h"
-
-#include "matrix.h"
 #include "psi4/psi4-dec.h"
 #include <cstdio>
 #include "psi4/libpsi4util/PsiOutStream.h"

--- a/psi4/src/psi4/libqt/reorder_qt.cc
+++ b/psi4/src/psi4/libqt/reorder_qt.cc
@@ -34,7 +34,6 @@
 */
 
 #include "psi4/libciomr/libciomr.h"
-#include "psi4/libmints/matrix.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"

--- a/psi4/src/psi4/libtrans/fcidump_helper.cc
+++ b/psi4/src/psi4/libtrans/fcidump_helper.cc
@@ -39,7 +39,6 @@
 
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libdpd/dpd.h"
-#include "psi4/libmints/matrix.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libpsio/psio.hpp"

--- a/psi4/src/psi4/psimrcc/transform_block.cc
+++ b/psi4/src/psi4/psimrcc/transform_block.cc
@@ -51,7 +51,6 @@
 
 #include "algebra_interface.h"
 #include "blas.h"
-#include "matrix.h"
 #include "index.h"
 #include "transform.h"
 

--- a/psi4/src/psi4/psimrcc/transform_presort.cc
+++ b/psi4/src/psi4/psimrcc/transform_presort.cc
@@ -53,7 +53,6 @@
 
 #include "algebra_interface.h"
 #include "blas.h"
-#include "matrix.h"
 #include "index.h"
 #include "transform.h"
 

--- a/psi4/src/psi4/scfgrad/jk_grad.cc
+++ b/psi4/src/psi4/scfgrad/jk_grad.cc
@@ -38,7 +38,6 @@
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/integral.h"
-#include "psi4/libmints/matrix.h"
 #include "psi4/libmints/mintshelper.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/vector.h"


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
From the previous work on removing unused includes, I said that a different approach was needed. I came to this conclusion because GCC shows that for most files, a majority of compilation is spent on parsing. \[This is honestly surprising to me since I would assume optimizations or conversion to IR or machine code would be longer.\] This step involves making the AST, which should be smaller when fewer headers are included. After removing nearly 2.5k unused includes I found a 3%, albeit statistically insignificant, reduction in build times. This insignificant effect is likely because the preprocessor removed redundant includes, and few real changes were made. Unlike #3456, this actually does tip the needle.

**Note:** By "compile-only", I mean the sum of all compilation steps for each TU. That does not include linking, for example. I also mean non-unity builds, which is how I benchmarked build times unless otherwise stated. "compile-only" improvements apply most directly to a serial, non-unity build. In practice, unity builds and imperfect parallelism mean that common build configurations do not see the same improvements in wall time.

> [!NOTE]
> Bottom line: Combined with other improvements outside this PR, I was able to get -37% compile-only times (1.6x faster!) with minimal API changes. That translates to a real wall time reduction of -11% for unity builds compared to master. For this PR, l measured a compile-only reduction of -15%, and a wall-time reduction of approximately -8%. 

As stated previously, the majority of build time is spent parsing. To find out where improvements could be made, I started by running some analysis.
1. I used the `compile_commands.json` file of a non-unity build to find a TUs compile command.
2. For each TU, I ran `clang++ -fsyntax-only -ftime-trace` which produces a JSON file. From that, you can extract how long parsing took for each header in that TU.
3. For each header measured, I produced a cost by summing the time spent parsing that header over all TUs. Thus, one should be able to reduce build times by reducing how long it takes to parse the header or reducing the number of times it is parsed.
4. For the highest cost headers, the next thing to do is just look at the data and figure out a plan of action. This can involve adjusting how this header is included in other files, or adjusting the header itself. This PR does both for `matrix.h`.

Some headers like `diismanager.h` didn't need `matrix.h` at all so it was just deleted. Some headers only need Matrix to be forward declared, so I could just swap to `typedefs.h`. Others just needed a refactor like `ccdensity/MOInfo.h` (different PR).

`matrix.h` was the most costly header. By looking at the timings for includes of `matrix.h`, I found that only 2% of the time spent parsing `matrix.h` was on the real body. The largest portion of time was spent parsing Eigen/Core and its friends. This PR shuffles things around for Eigen, putting it in its own header and source file to be included by the only real user of Eigen: `snLinK.cc`.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] `Matrix::eigen_map[s]()` member methods have been moved to free methods `linalg::eigen_map[s](Matrix&)`.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Creates `matrix_eigen.h` and `matrix_eigen.cc` to allow for the removal of the `<eigen3/Eigen/Core>` include from `matrix.h`.

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [x] AI wrote scripts automating the include analysis. AI was also used to automate builds, measur times, and report back on a separate computer.

## Checklist
- [x] Tests added for any new features
- [x] Docstring or narrative docs/sphinxman/source updated if needed
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
