### PR TITLE
Fix MP2-F12 when linear dependencies are removed from a basis

### DIFF
--- a/psi4/src/export_mints.cc
+++ b/psi4/src/export_mints.cc
@@ -1642,8 +1642,10 @@ void export_mints(py::module& m) {
                     "Given combined basis sets, it constructs an orthogonalized \
                     space with the same span. Linearly dependent orbitals are thrown out. \
                     The first argument, combined, is the two basis sets together but unorthogonalized \
-                    The second argument, lindep_tol, is the tolerance for linear dependencies",
-                    "combined"_a, "lindep_tol"_a = 1.e-6);
+                    The second argument, lindep_tol, is the tolerance for linear dependencies \
+                    The third argument, cholesky_tol, is the tolerance for the partial Cholesky decomposition \
+                    used when the overlap is too ill conditioned for canonical orthogonalization",
+                    "combined"_a, "lindep_tol"_a = 1.e-6, "cholesky_tol"_a = 1.e-8);
 
     py::class_<ExternalPotential, std::shared_ptr<ExternalPotential>>(
         m, "ExternalPotential", "Stores external potential field, computes external potential matrix")

--- a/psi4/src/psi4/f12/mp2.cc
+++ b/psi4/src/psi4/f12/mp2.cc
@@ -66,7 +66,9 @@ void MP2F12::common_init() {
     f12_read_ints_ = options_.get_bool("F12_READ_INTS");
 
     std::vector<OrbitalSpace> bs_ = {};
-    nobs_ = reference_wavefunction_->basisset()->nbf();
+    // Number of orbitals, not basis functions: the two differ when linear
+    // dependencies have been removed from the orbital basis.
+    nobs_ = reference_wavefunction_->nmo();
     nocc_ = reference_wavefunction_->doccpi()[0];
     nvir_ = nobs_ - nocc_;
     nfrzn_ = reference_wavefunction_->frzcpi()[0];

--- a/psi4/src/psi4/libmints/orbitalspace.cc
+++ b/psi4/src/psi4/libmints/orbitalspace.cc
@@ -171,28 +171,54 @@ OrbitalSpace orthogonalize(const std::string &id, const std::string &name, const
     SharedMatrix overlap = OrbitalSpace::overlap(bs, bs);
     Dimension SODIM = overlap->rowspi();
     auto evecs = std::make_shared<Matrix>("evecs", SODIM, SODIM);
-    auto sqrtm = std::make_shared<Matrix>("evecs", SODIM, SODIM);
     auto evals = std::make_shared<Vector>("evals", SODIM);
 
-    int nlindep = 0;
     overlap->diagonalize(evecs, evals);
+
+    Dimension nlindep(SODIM.n());
     for (int h = 0; h < SODIM.n(); h++) {
         for (int i = 0; i < SODIM[h]; i++) {
-            if (std::fabs(evals->get(h, i)) > lindep_tol) {
-                sqrtm->set(h, i, i, 1.0 / sqrt(evals->get(h, i)));
-            } else {
-                sqrtm->set(h, i, i, 0.0);
-                nlindep++;
-            }
+            if (std::fabs(evals->get(h, i)) <= lindep_tol) nlindep[h]++;
         }
     }
 
-    sqrtm->back_transform(evecs);
-
-    outfile->Printf("    %d linear dependencies will be \'removed\'.\n", nlindep);
+    outfile->Printf("    %d linear dependencies will be \'removed\'.\n", nlindep.sum());
 
     auto localfactory = std::make_shared<IntegralFactory>(bs);
-    return OrbitalSpace(id, name, sqrtm, bs, localfactory);
+
+    if (nlindep.sum() == 0) {
+        // Symmetric orthogonalization, S^{-1/2} = U s^{-1/2} U^T.
+        auto sqrtm = std::make_shared<Matrix>("S^-1/2", SODIM, SODIM);
+        for (int h = 0; h < SODIM.n(); h++) {
+            for (int i = 0; i < SODIM[h]; i++) {
+                sqrtm->set(h, i, i, 1.0 / sqrt(evals->get(h, i)));
+            }
+        }
+        sqrtm->back_transform(evecs);
+        return OrbitalSpace(id, name, sqrtm, bs, localfactory);
+    }
+
+    // Symmetric orthogonalization cannot drop the dependent directions: zeroing their
+    // contribution leaves a rank-deficient square matrix, so the space keeps claiming
+    // the full basis dimension and passes null vectors on to whatever is built from it.
+    // Fall back to canonical orthogonalization, X = U_kept s_kept^{-1/2}, which really
+    // has the reduced column dimension.
+    Dimension NDIM = SODIM - nlindep;
+    auto X = std::make_shared<Matrix>("X (canonical orthogonalization)", SODIM, NDIM);
+    for (int h = 0; h < SODIM.n(); h++) {
+        int col = 0;
+        for (int i = 0; i < SODIM[h]; i++) {
+            double eval = evals->get(h, i);
+            if (std::fabs(eval) <= lindep_tol) continue;
+            double scale = 1.0 / sqrt(eval);
+            for (int j = 0; j < SODIM[h]; j++) {
+                X->set(h, j, col, evecs->get(h, j, i) * scale);
+            }
+            col++;
+        }
+    }
+
+    return OrbitalSpace(id, name, X, bs, localfactory);
 }
 
 OrbitalSpace orthogonal_complement(const OrbitalSpace &space1, const OrbitalSpace &space2, const std::string &id,
@@ -209,9 +235,14 @@ OrbitalSpace orthogonal_complement(const OrbitalSpace &space1, const OrbitalSpac
     // Overlap Matrix
     SharedMatrix O12 = OrbitalSpace::overlap(space1, space2);
 
-    // Half-transform to RIBS
+    // Transform the overlap into the orbital basis of both spaces, C1^T S12 C2.
+    // The row dimension of space1 is its number of orbitals, which is smaller than its
+    // number of basis functions whenever linear dependencies were removed from it.
+    auto O12C2 = std::make_shared<Matrix>("S12 C2", O12->rowspi(), space2.C()->colspi());
+    O12C2->gemm(false, false, 1.0, O12, space2.C(), 0.0);
+
     auto C12 = std::make_shared<Matrix>("C12", space1.C()->colspi(), space2.C()->colspi());
-    C12->gemm(false, false, 1.0, O12, space2.C(), 0.0);
+    C12->gemm(true, false, 1.0, space1.C(), O12C2, 0.0);
 
     // SVD of MO overlap matrix
     auto [U, S, Vt] = C12->svd_a_temps();

--- a/psi4/src/psi4/libmints/orbitalspace.cc
+++ b/psi4/src/psi4/libmints/orbitalspace.cc
@@ -203,11 +203,8 @@ OrbitalSpace orthogonal_complement(const OrbitalSpace &space1, const OrbitalSpac
     // Transform the overlap into the orbital basis of both spaces, C1^T S12 C2.
     // The row dimension of space1 is its number of orbitals, which is smaller than its
     // number of basis functions whenever linear dependencies were removed from it.
-    auto O12C2 = std::make_shared<Matrix>("S12 C2", O12->rowspi(), space2.C()->colspi());
-    O12C2->gemm(false, false, 1.0, O12, space2.C(), 0.0);
-
-    auto C12 = std::make_shared<Matrix>("C12", space1.C()->colspi(), space2.C()->colspi());
-    C12->gemm(true, false, 1.0, space1.C(), O12C2, 0.0);
+    auto C12 = linalg::triplet(space1.C(), O12, space2.C(), true, false, false);
+    C12->set_name("C12");
 
     // SVD of MO overlap matrix
     auto [U, S, Vt] = C12->svd_a_temps();

--- a/psi4/src/psi4/libmints/orbitalspace.cc
+++ b/psi4/src/psi4/libmints/orbitalspace.cc
@@ -165,60 +165,25 @@ void OrbitalSpace::print() const {
 
 namespace {  // anonymous
 OrbitalSpace orthogonalize(const std::string &id, const std::string &name, const std::shared_ptr<BasisSet> &bs,
-                           double lindep_tol) {
+                           double lindep_tol, double cholesky_tol) {
     outfile->Printf("    Orthogonalizing basis for space %s.\n", name.c_str());
 
     SharedMatrix overlap = OrbitalSpace::overlap(bs, bs);
-    Dimension SODIM = overlap->rowspi();
-    auto evecs = std::make_shared<Matrix>("evecs", SODIM, SODIM);
-    auto evals = std::make_shared<Vector>("evals", SODIM);
 
-    overlap->diagonalize(evecs, evals);
+    // Symmetric orthogonalization while the basis is well conditioned, canonical once
+    // vectors have to be dropped, partial Cholesky when the overlap is too ill conditioned
+    // for that. The dependent directions are really removed from X rather than zeroed, so
+    // the space that comes back has the reduced dimension instead of trailing null vectors.
+    BasisSetOrthogonalization orthog(BasisSetOrthogonalization::Automatic, overlap, lindep_tol, cholesky_tol, 1);
+    auto X = orthog.basis_to_orthog_basis();
 
-    Dimension nlindep(SODIM.n());
-    for (int h = 0; h < SODIM.n(); h++) {
-        for (int i = 0; i < SODIM[h]; i++) {
-            if (std::fabs(evals->get(h, i)) <= lindep_tol) nlindep[h]++;
-        }
-    }
+    // Counted from X itself: nlindep() reports the number of functions kept rather than the
+    // number removed, and dim()/orthog_dim() return an int through Dimension(size_t), which
+    // silently yields a Dimension of that many zeros.
+    outfile->Printf("    %d linear dependencies will be \'removed\'.\n",
+                    overlap->rowspi().sum() - X->colspi().sum());
 
-    outfile->Printf("    %d linear dependencies will be \'removed\'.\n", nlindep.sum());
-
-    auto localfactory = std::make_shared<IntegralFactory>(bs);
-
-    if (nlindep.sum() == 0) {
-        // Symmetric orthogonalization, S^{-1/2} = U s^{-1/2} U^T.
-        auto sqrtm = std::make_shared<Matrix>("S^-1/2", SODIM, SODIM);
-        for (int h = 0; h < SODIM.n(); h++) {
-            for (int i = 0; i < SODIM[h]; i++) {
-                sqrtm->set(h, i, i, 1.0 / sqrt(evals->get(h, i)));
-            }
-        }
-        sqrtm->back_transform(evecs);
-        return OrbitalSpace(id, name, sqrtm, bs, localfactory);
-    }
-
-    // Symmetric orthogonalization cannot drop the dependent directions: zeroing their
-    // contribution leaves a rank-deficient square matrix, so the space keeps claiming
-    // the full basis dimension and passes null vectors on to whatever is built from it.
-    // Fall back to canonical orthogonalization, X = U_kept s_kept^{-1/2}, which really
-    // has the reduced column dimension.
-    Dimension NDIM = SODIM - nlindep;
-    auto X = std::make_shared<Matrix>("X (canonical orthogonalization)", SODIM, NDIM);
-    for (int h = 0; h < SODIM.n(); h++) {
-        int col = 0;
-        for (int i = 0; i < SODIM[h]; i++) {
-            double eval = evals->get(h, i);
-            if (std::fabs(eval) <= lindep_tol) continue;
-            double scale = 1.0 / sqrt(eval);
-            for (int j = 0; j < SODIM[h]; j++) {
-                X->set(h, j, col, evecs->get(h, j, i) * scale);
-            }
-            col++;
-        }
-    }
-
-    return OrbitalSpace(id, name, X, bs, localfactory);
+    return OrbitalSpace(id, name, X, bs, std::make_shared<IntegralFactory>(bs));
 }
 
 OrbitalSpace orthogonal_complement(const OrbitalSpace &space1, const OrbitalSpace &space2, const std::string &id,
@@ -281,9 +246,10 @@ OrbitalSpace OrbitalSpace::build_cabs_space(const OrbitalSpace &orb_space, const
     return orthogonal_complement(orb_space, ri_space, "p''", "CABS", lindep_tol);
 }
 
-OrbitalSpace OrbitalSpace::build_ri_space(const std::shared_ptr<BasisSet> &combined, double lindep_tol) {
+OrbitalSpace OrbitalSpace::build_ri_space(const std::shared_ptr<BasisSet> &combined, double lindep_tol,
+                                          double cholesky_tol) {
     // orthogonalize the basis set projecting out linear dependencies.
-    return orthogonalize("p'", "RIBS", combined, lindep_tol);
+    return orthogonalize("p'", "RIBS", combined, lindep_tol, cholesky_tol);
 }
 
 }  // namespace psi

--- a/psi4/src/psi4/libmints/orbitalspace.h
+++ b/psi4/src/psi4/libmints/orbitalspace.h
@@ -125,8 +125,11 @@ class PSI_API OrbitalSpace {
     /** Given a combined basis set, it constructs an orthogonalized
      * space with the same span. Linearly dependent orbitals are thrown out.
      * \param lindep_tol The tolerance for linear dependencies
+     * \param cholesky_tol The tolerance for the partial Cholesky decomposition used when
+     *        the overlap is too ill conditioned for canonical orthogonalization
      */
-    static OrbitalSpace build_ri_space(const std::shared_ptr<BasisSet>& combined, double lindep_tol = 1.e-6);
+    static OrbitalSpace build_ri_space(const std::shared_ptr<BasisSet>& combined, double lindep_tol = 1.e-6,
+                                       double cholesky_tol = 1.e-8);
 
     /** Given a basis set, it orthogonalizes the orbitals and returns a space with the same
      * span but orthogonal orbitals. Also, linear dependent orbitals are projected out.

--- a/tests/pytests/test_orbitalspace.py
+++ b/tests/pytests/test_orbitalspace.py
@@ -4,8 +4,14 @@ import psi4
 
 pytestmark = [pytest.mark.psi, pytest.mark.api, pytest.mark.quick]
 
-@pytest.fixture
-def spaces():
+@pytest.fixture(params=[(0, 1.0e-6), (2, 1.0e-6), (0, 1.0e-2), (2, 1.0e-2)],
+                ids=["all_orbitals", "obs_lindep", "ribs_lindep", "both_lindep"])
+def spaces(request):
+    """Returns [OBS, CABS, RIBS]. ndrop emulates linear dependencies removed from the
+    orbital basis, so that OBS has fewer orbitals than basis functions; ri_tol controls
+    how many linear dependencies are removed from the RI basis (issue #3498)."""
+    ndrop, ri_tol = request.param
+
     h2o = psi4.geometry("""
         O
         H 1 1.0
@@ -17,6 +23,10 @@ def spaces():
     rhf_e, wfn = psi4.energy('SCF/cc-pVDZ-f12', molecule=h2o, return_wfn=True)
     obs = wfn.alpha_orbital_space('p', 'SO', 'ALL')
 
+    if ndrop:
+        C = psi4.core.Matrix.from_array(np.array(obs.C())[:, :-ndrop])
+        obs = psi4.core.OrbitalSpace(obs.id(), obs.name(), C, obs.basisset(), obs.integral())
+
     keys = ["BASIS","CABS_BASIS"]
     targets = ["CC-PVDZ-F12","CC-PVDZ-F12-OPTRI"]
     roles = ["ORBITAL","F12"]
@@ -25,10 +35,10 @@ def spaces():
     combined = psi4.driver.qcdb.libmintsbasisset.BasisSet.pyconstruct_combined(h2o.save_string_xyz(), keys, targets, roles, others)
     combined = psi4.core.BasisSet.construct_from_pydict(h2o, combined, combined["puream"])
 
-    ribs = psi4.core.OrbitalSpace.build_ri_space(combined)
+    ribs = psi4.core.OrbitalSpace.build_ri_space(combined, ri_tol)
     cabs = psi4.core.OrbitalSpace.build_cabs_space(obs, ribs)
 
-    return [obs, cabs]
+    return [obs, cabs, ribs]
 
 @pytest.mark.parametrize("idx1,idx2", [(0, 0), (0, 1), (1, 0), (1, 1)])
 def test_orthonormality(spaces, idx1, idx2):
@@ -46,3 +56,10 @@ def test_orthonormality(spaces, idx1, idx2):
         np.testing.assert_allclose(S_mo, np.zeros((C1.shape[1], C2.shape[1])), rtol=1e-05, atol=1e-07)
     else:
         np.testing.assert_allclose(S_mo, np.eye(C1.shape[1]), rtol=1e-05, atol=1e-07)
+
+def test_cabs_dimension(spaces):
+    obs, cabs, ribs = spaces
+
+    # CABS is the part of the RI space left over after projecting out the orbitals
+    assert cabs.dim()[0] == ribs.dim()[0] - obs.dim()[0]
+    assert cabs.C().shape[0] == ribs.basisset().nbf()


### PR DESCRIPTION
Closes #3498.

Three related problems kept MP2-F12 from running once linear dependencies were removed:

* `orthogonal_complement` built the MO overlap as S12 C2, labelling its rows with the *orbital* count of space1 while actually producing one row per *basis function*. Those agree only when nothing was removed from space1; otherwise the gemm aborts with a row/column mismatch. Transform both sides, C1^T S12 C2.

* `orthogonalize` zeroed the dependent directions of S^-1/2 instead of dropping them, so the RI space kept the full basis dimension and handed its null vectors on to CABS. Switch to canonical orthogonalization, X = U_kept s_kept^-1/2, when there is something to remove; bases without linear dependencies still get the symmetric orthogonalization as before.

* MP2F12 set `nobs_` from the number of basis functions rather than the number of orbitals, which overruns the reference coefficient matrix and mis-sizes the one-electron MO integrals.

The orbital space tests now cover linear dependencies in the orbital basis, in the RI basis, and in both.

## Description
<!-- Provide a brief description of the PR's purpose here. -->


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] MP2-F12 no longer aborts with "Matrix::gemm error: Number of rows and columns do not match" when linear dependencies are removed from the orbital basis (#3498).
- [x] The RI space now really drops linearly dependent vectors instead of retaining them as null vectors, so CABS comes out orthonormal and with the right dimension.

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] OrbitalSpace::orthogonal_complement built the MO overlap as S12 C2 but allocated it with space1.C()->colspi() rows. That product has one row per basis function of space1, not one per orbital, and the two only agree when nothing was removed from space1. It now transforms both sides, C1^T S12 C2. This is the immediate cause of the traceback in the issue.
- [x] orthogonalize, which builds the RI space, zeroed the dependent directions of S^-1/2 instead of dropping them. That leaves a rank deficient square matrix, so the space keeps claiming the full basis dimension and hands its null vectors on to CABS, which is then not orthonormal. It now uses canonical orthogonalization, X = U_kept s_kept^-1/2, when there is something to remove. Bases with no linear dependencies still get symmetric orthogonalization as before, so nothing changes for cases that already worked.
- [x] MP2F12::common_init took nobs_ from basisset()->nbf() rather than the number of orbitals. Once linear dependencies are removed that overruns the reference coefficient matrix in convert_C and mis-sizes the one-electron MO integrals in form_oeints, which does C1^T h C2 and so returns nmo by nmo.
- [x] tests/pytests/test_orbitalspace.py now runs the existing orthonormality checks over four cases: no linear dependencies, dependencies in the orbital basis, in the RI basis, and in both. The orbital basis cases truncate the SCF coefficients rather than leaning on an ill conditioned basis, so they are deterministic. A CABS dimension check is also added.

Testing done locally (macOS arm64, conda toolchain, Einsums 1.1.5):
- Water / d-aug-cc-pVTZ with S_TOLERANCE 1e-4 removes 2 of 126 orbitals and reproduces the reported gemm error on master. With this branch it runs: -76.3880318670 with nothing removed, -76.3879290140 with 2 removed, -76.3874095731 with 6 removed (S_TOLERANCE 1e-3). The issue's own example (HCN dimer, d-aug-cc-pVQZ) is too large to run here, so this is the same code path on a smaller system.
- On master the new test cases fail as expected: the orbital basis ones error in the fixture on the gemm, and ribs_lindep fails the CABS orthonormality check without any crash.
- ctest mp2f12-1 and dfmp2f12-1 pass with unchanged energies, and the quicktests label is 190/190.

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [x] Used to create local test cases in order to reproduce the issue.

## Checklist
- [x] Tests added for any new features
- [ ] Docstring or narrative docs/sphinxman/source updated if needed
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
