### PR TITLE
Add workflow to manage PR labels via comments

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,13 +1,11 @@
 # How to contribute
 
 We welcome contributions from external contributors, and this document
-describes how to merge code changes into Psi4.  As of February 2016, the
-procedure for contributing code is exactly the same for the core development
-team and for external contributors.
+describes how to merge code changes into Psi4.
 
 **Working on your first Pull Request?** You can learn how from
 this *free* series [How to Contribute to an Open Source Project on
-GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github)
+GitHub](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project)
 
 ## Getting Started
 
@@ -18,17 +16,17 @@ GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on
   [clone](https://help.github.com/articles/cloning-a-repository/) your fork of
   the Psi4 repository.
 * More detailed instructions for interacting with your Psi4 fork can be found
-  [here](http://psicode.org/psi4manual/master/build_obtaining.html#faq-forkpsi4public).
-  and [here](http://psicode.org/psi4manual/master/build_obtaining.html#faq-githubworkflow).
+  [here](https://psicode.org/psi4manual/master/build_obtaining.html#faq-forkpsi4public).
+  and [here](https://psicode.org/psi4manual/master/build_obtaining.html#faq-githubworkflow).
 
 ## Making Changes
 
 * Add some really awesome code to your local fork.  It's usually a [good
-  idea](http://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)
+  idea](https://jmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)
   to make changes on a
   [branch](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/)
   with the branch name relating to the feature you are going to add.
-* When you are ready for others to examine and comment on your new feature,
+* When you are ready to see CI tests and for others to examine and comment on your new feature,
   navigate to your fork of Psi4 on GitHub and open a [pull
   request](https://help.github.com/articles/using-pull-requests/) (PR). Note that
   after you launch a PR from one of your fork's branches, all
@@ -38,18 +36,16 @@ GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on
   will be visible on the PR page.
 * If you're providing a new feature, you must add test cases and documentation.
 * When the code is ready to go, make sure you run the full or relevant portion of the
-  [test suite](http://psicode.org/psi4manual/master/build_planning.html#faq-subsettests)
+  [test suite](https://psicode.org/psi4manual/master/build_planning.html#faq-subsettests)
   on your local machine to check that nothing is broken.
-* When you're ready to be considered for merging, check the "Ready to go"
-  box on the PR page to let the Psi4 team know that the changes are complete.
-  The code will not be merged until this box is checked, the continuous
-  integration (Travis for Linux and Distelli for Mac) returns checkmarks,
+* When you're ready to be considered for merging, issue a PR comment with only `/review-ready`
+  as content to let the Psi4 team know that the changes are ready for review.
+  The code will not be merged until the continuous
+  integration (GiHub Actions and Azure DevOps) returns checkmarks,
   and multiple core developers give "Approved" reviews.
 
 # Additional Resources
 
 * [General GitHub documentation](https://help.github.com/)
-* [PR best practices](http://codeinthehole.com/writing/pull-requests-and-other-good-practices-for-teams-using-github/)
-* [A guide to contributing to software packages](http://www.contribution-guide.org)
-* [Thinkful PR example](http://www.thinkful.com/learn/github-pull-request-tutorial/#Time-to-Submit-Your-First-PR)
-
+* [PR best practices](https://codeinthehole.com/writing/pull-requests-and-other-good-practices-for-teams-using-github/)
+* [A guide to contributing to software packages](https://www.contribution-guide.org)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,10 @@
 - [ ] Docstring or narrative docs/sphinxman/source updated if needed
 - Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)
 
-## Status
-- Ready for review -- use `/review-ready` in a PR comment to add a "review-requested" label. Expect reviewers to rm this label and add "awaiting-author-contribution". Re-add label for another cycle.
-- Priority review -- use `/review-next` in a PR comment to add a "review-this-pr-of-mine-next" label to signal priority for attention. Adding will rm it from your other PRs.
-- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
+<!--
+## HOW TO GET REVIEWED!
+
+- Ready for review -- issue a PR comment with `/review-ready` as sole text to add a "review-requested" label. Expect reviewers to rm this label and add "awaiting-author-contribution". Re-add label for another cycle.
+- Priority review -- issue a PR comment with `/review-next` as sole text to add a "review-this-pr-of-mine-next" label to signal priority for attention. Adding will rm it from your other PRs.
+- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,5 +33,6 @@
 - Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)
 
 ## Status
-- [ ] Ready for review
+- Ready for review -- use `/review-ready` in a PR comment to add a "review-requested" label. Expect reviewers to rm this label and add "awaiting-author-contribution". Re-add label for another cycle.
+- Priority review -- use `/review-next` in a PR comment to add a "review-this-pr-of-mine-next" label to signal priority for attention. Adding will rm it from your other PRs.
 - Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read  #  to fetch code (actions/checkout)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   ecosystem:

--- a/.github/workflows/review-queue.yml
+++ b/.github/workflows/review-queue.yml
@@ -9,7 +9,7 @@ jobs:
     # Trigger if comment is on a PR and contains either of our slash commands
     if: |
       github.event.issue.pull_request && 
-      (contains(github.event.comment.body, '/ready') || contains(github.event.comment.body, '/review-next'))
+      (contains(github.event.comment.body, '/review-ready') || contains(github.event.comment.body, '/review-next'))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -48,30 +48,30 @@ jobs:
           QUEUE_LABEL = "review-this-pr-of-mine-next"
 
           # --- CONFIGURATION ---
-          # Add usernames here who are allowed to have up to 3 queue labels
-          VIP_USERS = ["loriab", "susilehtola", " JonathonMisiewicz"] 
+          # Add usernames here who are allowed to have up to 2 queue labels
+          EXTRA_PR_USERS = ["loriab", "susilehtola", "JonathonMisiewicz"] 
 
           current_pr = repo.get_pull(current_pr_num)
 
           # ==========================================
-          # COMMAND 1: /please-review (Unlimited use cases)
+          # COMMAND 1: /review-ready (Unlimited use cases)
           # ==========================================
-          if "/please-review" in comment_body:
-              print(f"Processing /please-review command from {commenter} on PR #{current_pr_num}")
+          if "/review-ready" in comment_body:
+              print(f"Processing /review-ready command from {commenter} on PR #{current_pr_num}")
               current_pr.add_to_labels(READY_LABEL)
               print(f"Successfully added standard '{READY_LABEL}' label.")
 
           # ==========================================
-          # COMMAND 2: /please-review-next (Strict limit queue)
+          # COMMAND 2: /review-next (Strict limit queue)
           # ==========================================
-          if "/please-review-next" in comment_body:
+          if "/review-next" in comment_body:
               # Security Check: Ensure commenter is the PR author
               if current_pr.user.login != commenter:
                   print(f"Error: {commenter} is not the author of PR #{current_pr_num}. Aborting.")
                   current_pr.create_issue_comment(f"⚠️ @{commenter} you can only use this command on your own PRs.")
                   exit(0)
 
-              max_allowed = 2 if commenter in VIP_USERS else 1
+              max_allowed = 2 if commenter in EXTRA_PR_USERS else 1
               print(f"Processing queue command from user: {commenter} (Max allowed: {max_allowed})")
 
               # Check if current PR already has the label to avoid double-counting

--- a/.github/workflows/review-queue.yml
+++ b/.github/workflows/review-queue.yml
@@ -1,0 +1,107 @@
+name: Manage PR Labels via Comments
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  manage-labels:
+    # Trigger if comment is on a PR and contains either of our slash commands
+    if: |
+      github.event.issue.pull_request && 
+      (contains(github.event.comment.body, '/ready') || contains(github.event.comment.body, '/review-next'))
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install PyGithub
+        run: pip install PyGithub
+
+      - name: Process Label Commands
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          CURRENT_PR: ${{ github.event.issue.number }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        shell: python
+        run: |
+          import os
+          from github import Github
+
+          # Initialize GitHub API client
+          g = Github(os.environ['GITHUB_TOKEN'])
+          repo = g.get_repo(os.environ['REPO'])
+          commenter = os.environ['COMMENTER']
+          current_pr_num = int(os.environ['CURRENT_PR'])
+          comment_body = os.environ['COMMENT_BODY']
+
+          # Define our labels
+          READY_LABEL = "review-requested"
+          QUEUE_LABEL = "review-this-pr-of-mine-next"
+
+          # --- CONFIGURATION ---
+          # Add usernames here who are allowed to have up to 3 queue labels
+          VIP_USERS = ["loriab", "susilehtola", " JonathonMisiewicz"] 
+
+          current_pr = repo.get_pull(current_pr_num)
+
+          # ==========================================
+          # COMMAND 1: /please-review (Unlimited use cases)
+          # ==========================================
+          if "/please-review" in comment_body:
+              print(f"Processing /please-review command from {commenter} on PR #{current_pr_num}")
+              current_pr.add_to_labels(READY_LABEL)
+              print(f"Successfully added standard '{READY_LABEL}' label.")
+
+          # ==========================================
+          # COMMAND 2: /please-review-next (Strict limit queue)
+          # ==========================================
+          if "/please-review-next" in comment_body:
+              # Security Check: Ensure commenter is the PR author
+              if current_pr.user.login != commenter:
+                  print(f"Error: {commenter} is not the author of PR #{current_pr_num}. Aborting.")
+                  current_pr.create_issue_comment(f"⚠️ @{commenter} you can only use this command on your own PRs.")
+                  exit(0)
+
+              max_allowed = 2 if commenter in VIP_USERS else 1
+              print(f"Processing queue command from user: {commenter} (Max allowed: {max_allowed})")
+
+              # Check if current PR already has the label to avoid double-counting
+              current_has_label = QUEUE_LABEL in [l.name for l in current_pr.get_labels()]
+
+              # Gather all OTHER open PRs authored by this user that have the queue label
+              user_labeled_prs = []
+              open_prs = repo.get_pulls(state='open', sort='created', direction='asc') # Oldest first
+              
+              for pr in open_prs:
+                  if pr.user.login == commenter and pr.number != current_pr_num:
+                      if QUEUE_LABEL in [l.name for l in pr.get_labels()]:
+                          user_labeled_prs.append(pr)
+
+              # Total count if we add the label to the current PR
+              current_total = len(user_labeled_prs) + (1 if not current_has_label else 0)
+
+              # Bump the oldest PR(s) if user exceeds their limit
+              while current_total > max_allowed and user_labeled_prs:
+                  bumped_pr = user_labeled_prs.pop(0) # Pops oldest PR
+                  print(f"Bumping queue label from PR #{bumped_pr.number}")
+                  
+                  bumped_pr.remove_from_labels(QUEUE_LABEL)
+                  bumped_pr.create_issue_comment(
+                      f"🔄 @{commenter} added a new review priority. This PR has been bumped off the priority list to stay within your limit of {max_allowed}."
+                  )
+                  
+                  current_total -= 1
+
+              # Add label to the current PR if it isn't there already
+              if not current_has_label:
+                  current_pr.add_to_labels(QUEUE_LABEL)
+                  print(f"Successfully added queue label to PR #{current_pr_num}")

--- a/.github/workflows/review-queue.yml
+++ b/.github/workflows/review-queue.yml
@@ -12,17 +12,17 @@ jobs:
       (contains(github.event.comment.body, '/review-ready') || contains(github.event.comment.body, '/review-next'))
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      pull-requests: read
       issues: write
 
     steps:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install PyGithub
-        run: pip install PyGithub
+        run: python -m pip install PyGithub==2.9.1
 
       - name: Process Label Commands
         env:
@@ -42,6 +42,7 @@ jobs:
           commenter = os.environ['COMMENTER']
           current_pr_num = int(os.environ['CURRENT_PR'])
           comment_body = os.environ['COMMENT_BODY']
+          command = comment_body.strip()
 
           # Define our labels
           READY_LABEL = "review-requested"
@@ -53,10 +54,18 @@ jobs:
 
           current_pr = repo.get_pull(current_pr_num)
 
+          # Commands may only be issued by the PR author.
+          if command in {"/review-ready", "/review-next"} and current_pr.user.login != commenter:
+              print(f"Error: {commenter} is not the author of PR #{current_pr_num}. Aborting.")
+              current_pr.create_issue_comment(
+                  f"⚠️ @{commenter} you can only use review commands on your own PRs."
+              )
+              exit(0)
+
           # ==========================================
           # COMMAND 1: /review-ready (Unlimited use cases)
           # ==========================================
-          if "/review-ready" in comment_body:
+          if command == "/review-ready":
               print(f"Processing /review-ready command from {commenter} on PR #{current_pr_num}")
               current_pr.add_to_labels(READY_LABEL)
               print(f"Successfully added standard '{READY_LABEL}' label.")
@@ -64,38 +73,38 @@ jobs:
           # ==========================================
           # COMMAND 2: /review-next (Strict limit queue)
           # ==========================================
-          if "/review-next" in comment_body:
-              # Security Check: Ensure commenter is the PR author
-              if current_pr.user.login != commenter:
-                  print(f"Error: {commenter} is not the author of PR #{current_pr_num}. Aborting.")
-                  current_pr.create_issue_comment(f"⚠️ @{commenter} you can only use this command on your own PRs.")
-                  exit(0)
-
+          if command == "/review-next":
               max_allowed = 2 if commenter in EXTRA_PR_USERS else 1
               print(f"Processing queue command from user: {commenter} (Max allowed: {max_allowed})")
 
-              # Check if current PR already has the label to avoid double-counting
-              current_has_label = QUEUE_LABEL in [l.name for l in current_pr.get_labels()]
+              current_has_label = QUEUE_LABEL in [l.name for l in current_pr.labels]
 
-              # Gather all OTHER open PRs authored by this user that have the queue label
-              user_labeled_prs = []
-              open_prs = repo.get_pulls(state='open', sort='created', direction='asc') # Oldest first
-              
-              for pr in open_prs:
-                  if pr.user.login == commenter and pr.number != current_pr_num:
-                      if QUEUE_LABEL in [l.name for l in pr.get_labels()]:
-                          user_labeled_prs.append(pr)
+              # Fetch only this author's open items carrying the queue label,
+              # oldest update first. The Issues API includes pull requests.
+              labeled_items = repo.get_issues(
+                  state="open",
+                  labels=[QUEUE_LABEL],
+                  creator=commenter,
+                  sort="updated",
+                  direction="asc",
+              )
 
-              # Total count if we add the label to the current PR
-              current_total = len(user_labeled_prs) + (1 if not current_has_label else 0)
+              user_labeled_prs = [
+                  item for item in labeled_items
+                  if item.number != current_pr_num and item.pull_request is not None
+              ]
 
-              # Bump the oldest PR(s) if user exceeds their limit
+              # user_labeled_prs excludes the current PR, which is part of
+              # the desired final state whether or not it is already labeled.
+              current_total = len(user_labeled_prs) + 1
+
+              # Bump the least recently updated PR(s) if over the limit.
               while current_total > max_allowed and user_labeled_prs:
-                  bumped_pr = user_labeled_prs.pop(0) # Pops oldest PR
+                  bumped_pr = user_labeled_prs.pop(0)
                   print(f"Bumping queue label from PR #{bumped_pr.number}")
                   
                   bumped_pr.remove_from_labels(QUEUE_LABEL)
-                  bumped_pr.create_issue_comment(
+                  bumped_pr.create_comment(
                       f"🔄 @{commenter} added a new review priority. This PR has been bumped off the priority list to stay within your limit of {max_allowed}."
                   )
                   


### PR DESCRIPTION
This workflow manages PR labels based on comments, allowing users to request reviews or prioritize their PRs. It includes security checks for command usage and limits the number of queued labels based on user roles.

## Description
<!-- Provide a brief description of the PR's purpose here. -->
All the PRs are great, but I feel like I'm reviewing whatever shiny thing I saw last, and I know I've lost track of what are important and ready in some PR stacks. This is an effort (with labels borrowed from c-f staged-recipes) to better see what's priority.


## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] each user can issue ~`/please-review-next`~ `/review-next` and that'll get a label (max one per user, so adding bumps it from any other PR). those who handle PRs for other can ask to be added to a 2-allowed list. this is only a starting config.
- [x] if a PR is ready for reivew, add ~`/please-review`~ `/review-ready` to mark as such. these are unlimited. when a reviewer kicks it back, they'll add `awaiting-author-response` label (EDIT: and remove `/review-ready`). when ready for re-reivew, redo ~`/please-review`~ `/review-ready`.
- [x] the "concurrency" bit is separate and is supposed to kill the Eco GHA when a newer commit is pushed to a PR. Azure does this automatically, but we've had pileups of Eco's running on the same PR where the newest (and desired) commit can't run until old Mac lanes finish. This is different from "fail-fast" that kills lanes in the same run when one fails.

## Questions
<!-- Any questions or decision points on which you need clarification
     from the Psi4 team. -->
- [ ] thoughts from reviews and reviewees?

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [x] AI usage -- AI Mode of google.com

## Checklist
- [x] ADD SOMETHING TO CONTRIBUTING.md
- [ ] Docstring or narrative docs/sphinxman/source updated if needed
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
