### PR TITLE
Query LibXC exact-exchange parameters by default for composed functionals

### DIFF
--- a/psi4/driver/procrouting/dft/dft_builder.py
+++ b/psi4/driver/procrouting/dft/dft_builder.py
@@ -47,7 +47,7 @@ dict = {
        "X_METHOD_NAME":  {       must match a LibXC method
                  "alpha": 1.0,   coefficient for (global) GGA exchange, by default 1.0
                  "omega": 0.0,   range-separation parameter
-             "use_libxc": False  whether "x_hf" parameters should be set from LibXC values for this method
+             "use_libxc": True   read this method's exact-exchange parameters from LibXC (default True; set False to ignore them)
                  "tweak": {},    tweak the underlying functional
      },
 
@@ -339,11 +339,32 @@ def build_superfunctional_from_dictionary(func_dictionary, npoints, deriv, restr
                 x_func = core.LibXCFunctional(x_name, restricted)
                 x_params = x_funcs[x_key]
 
-                # If we're told to use libxc parameters for x_hf from this GGA, do so and set flag
-                if "use_libxc" in x_params and x_params["use_libxc"]:
-                    x_HF.update(x_func.query_libxc("XC_HYB_CAM_COEF"))
-                    x_HF["used"] = True
-                    x_func.set_alpha(1.0)
+                # By default read the exact-exchange parameters LibXC declares for this
+                # component; set "use_libxc": False to ignore them. Only act when they
+                # are actually nonzero, so a plain semilocal component paired with an
+                # explicit "x_hf" block is left untouched.
+                libxc_hf = x_func.query_libxc("XC_HYB_CAM_COEF")
+                is_hybrid = libxc_hf["ALPHA"] != 0.0 or libxc_hf["BETA"] != 0.0
+                if x_params.get("use_libxc", True):
+                    if is_hybrid:
+                        x_HF.update(libxc_hf)
+                        x_HF["used"] = True
+                        x_func.set_alpha(1.0)
+                elif is_hybrid:
+                    # Discarding the exact exchange LibXC declares silently changes the
+                    # functional, so shout -- distinguishing "semilocal only" from the
+                    # case where the definition supplies its own x_hf values instead.
+                    manual = any(k in func_dictionary.get("x_hf", {}) for k in ("alpha", "beta", "omega"))
+                    fate = ("the manual x_hf values in the definition are used instead"
+                            if manual else
+                            "only the semilocal part is used -- this is a DIFFERENT functional")
+                    core.print_out(
+                        "\n" + "!" * 72 + "\n"
+                        "!! WARNING: \"use_libxc\": False for %s ignores the exact exchange\n"
+                        "!! LibXC declares (alpha=%.6g, beta=%.6g, omega=%.6g);\n"
+                        "!! %s.\n"
+                        % (x_name, libxc_hf["ALPHA"], libxc_hf["BETA"], libxc_hf["OMEGA"], fate)
+                        + "!" * 72 + "\n\n")
 
                 if "tweak" in x_params:
                     x_func.set_tweak(x_params["tweak"], quiet=True)


### PR DESCRIPTION
Till now, it has been gloriously easy to shoot oneself in the foot when using functionals from Libxc in Psi4 directly by forgetting to add the magical `use_libxc = True` key in the functional definition. For example, calling `hyb_gga_xc_b3lyp` directly without `use_libxc = True` leads to Psi4 only using the semi-local part, which is missing the 20% of exact exchange, and ridiculously large errors in energies and properties.

This PR makes the default behavior of Psi4 sane: when using a functional from Libxc, one should always use its exact exchange parameters. The expert route to turn off exact exchange is the one that should be gated behind the extra keyword.

## AI Summary

A hybrid exchange component listed in `x_functionals` had its exact-exchange parameters read from LibXC only when the definition carried `"use_libxc": True`. That is an unsafe default — a hybrid was silently run as a pure semilocal functional.

This makes querying LibXC the default: `use_libxc` now defaults to `True`, and `"use_libxc": False` is the per-component opt-out. When an opt-out discards exact exchange that LibXC declares for the component, a prominent warning is printed, since that quietly yields a different functional — noting whether the semilocal part is used alone or the definition's manual `x_hf` values are used in its place.

The parameters are only marked used when they are actually nonzero, so a plain semilocal component paired with an explicit `x_hf` block (B2PLYP, PBE0-2, the DSD-* functionals, ...) is left untouched.

## Change

A single hunk in `dft_builder.py`:

```python
if x_params.get("use_libxc", True):
    libxc_hf = x_func.query_libxc("XC_HYB_CAM_COEF")
    if libxc_hf["ALPHA"] != 0.0 or libxc_hf["BETA"] != 0.0:
        x_HF.update(libxc_hf)
        x_HF["used"] = True
        x_func.set_alpha(1.0)
```

plus a one-line docstring correction for the `use_libxc` default.

## Compatibility

- The 21 built-in hybrids that carried `"use_libxc": True` are unchanged (the flag is now redundant but harmless).
- The 29 double-hybrids that combine a pure semilocal X component with a manual `x_hf` alpha are unchanged: the queried parameters are zero, so nothing is marked used and the `x_hf` alpha is preserved.
- Custom functionals that used a hybrid LibXC exchange component *without* the flag (relying on the old default-off) now correctly pick up its exact exchange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
