### PR TITLE
DF-MP2 memory checks

### DIFF
--- a/psi4/driver/driver_util.py
+++ b/psi4/driver/driver_util.py
@@ -415,7 +415,7 @@ def highest_analytic_properties_available(method: str,
             try:
                 proc["properties"][method](method, probe=True, **managed_keywords)
             except ManagedMethodError as e:
-                proc_messages[0] = e.message
+                proc_messages[0] = e.stats
                 raise MissingMethodError(_alternative_methods_message(method, "any", messages=proc_messages, proc=proc))
 
     if dertype == '(auto)':

--- a/psi4/src/psi4/dfmp2/corr_grad.cc
+++ b/psi4/src/psi4/dfmp2/corr_grad.cc
@@ -28,6 +28,9 @@
 
 #include "corr_grad.h"
 
+#include <algorithm>
+#include <sstream>
+
 #include "psi4/libqt/qt.h"
 #include "psi4/lib3index/3index.h"
 #include "psi4/libpsio/psio.hpp"
@@ -53,6 +56,26 @@ using namespace psi;
 
 namespace psi {
 namespace dfmp2 {
+
+namespace {
+
+void require_corr_grad_memory(size_t available, size_t required, const std::string& stage) {
+    if (available < required) {
+        constexpr double doubles_per_gib = 1024.0 * 1024.0 * 1024.0 / sizeof(double);
+        std::ostringstream message;
+        message << "DFCorrGrad: " << stage << " requires at least " << required / doubles_per_gib
+                << " GiB, but only " << available / doubles_per_gib << " GiB is available.";
+        throw PSIEXCEPTION(message.str());
+    }
+}
+
+size_t corr_grad_auxiliary_block_rows(size_t available, size_t row_cost, size_t max_shell, size_t naux,
+                                      const std::string& stage) {
+    require_corr_grad_memory(available, max_shell * row_cost, stage + " (one auxiliary shell)");
+    return std::min(naux, available / row_cost);
+}
+
+}  // namespace
 
 CorrGrad::CorrGrad(std::shared_ptr<MintsHelper> mints) : mints_(mints), primary_(mints->get_basisset("ORBITAL")) { common_init(); }
 CorrGrad::~CorrGrad() {}
@@ -198,10 +221,10 @@ void DFCorrGrad::build_Amn_terms() {
     row_cost += nso * (size_t)nso;
     row_cost += nso * (size_t)na;
     row_cost += na * (size_t)nlr;
-    size_t rows = memory_ / row_cost;
-    rows = (rows > naux ? naux : rows);
-    rows = (rows < maxP ? maxP : rows);
-    max_rows = (int)rows;
+    const size_t vector_memory = 2L * naux;
+    require_corr_grad_memory(memory_, vector_memory + maxP * row_cost, "Amn term formation");
+    max_rows = static_cast<int>(
+        corr_grad_auxiliary_block_rows(memory_ - vector_memory, row_cost, maxP, naux, "Amn term formation"));
 
     // => Block Sizing <= //
 
@@ -301,7 +324,7 @@ void DFCorrGrad::build_Amn_terms() {
         int np = pstop - pstart;
 
         // > Clear Integrals Register < //
-        ::memset((void*)Amnp[0], '\0', sizeof(double) * np * nso * nso);
+        ::memset((void*)Amnp[0], '\0', sizeof(double) * static_cast<size_t>(np) * nso * nso);
 
 // > Integrals < //
 #pragma omp parallel for schedule(dynamic) num_threads(df_ints_num_threads_)
@@ -465,8 +488,11 @@ void DFCorrGrad::build_AB_inv_terms() {
 void DFCorrGrad::fitting_helper(SharedMatrix J, size_t file, const std::string& label, size_t naux, size_t nij,
                                 size_t memory) {
     int max_cols;
-    size_t effective_memory = memory - 1L * naux * naux;
+    const size_t metric_memory = naux * static_cast<size_t>(naux);
+    const size_t vector_memory = 2L * naux;
     size_t col_cost = 2L * naux;
+    require_corr_grad_memory(memory, metric_memory + vector_memory + col_cost, "fitting transformation");
+    size_t effective_memory = memory - metric_memory - vector_memory;
     size_t cols = effective_memory / col_cost;
     cols = (cols > nij ? nij : cols);
     cols = (cols < 1L ? 1L : cols);
@@ -537,14 +563,16 @@ void DFCorrGrad::build_UV_terms() {
     } else {
         V->scale(2.0);
     }
-    psio_->write_entry(unit_c_, "V", (char*)Vp[0], sizeof(double) * naux * naux);
+    psio_->write_entry(unit_c_, "V", (char*)Vp[0], sizeof(double) * static_cast<size_t>(naux) * naux);
 }
 void DFCorrGrad::UV_helper(SharedMatrix V, double c, size_t file, const std::string& label, size_t naux, size_t nij,
                            size_t memory) {
     int max_rows;
-    size_t effective_memory = memory - 1L * naux * naux;
+    const size_t metric_memory = naux * static_cast<size_t>(naux);
     size_t row_cost = 2L * nij;
-    size_t rows = memory_ / row_cost;
+    require_corr_grad_memory(memory, metric_memory + row_cost, "UV formation");
+    size_t effective_memory = memory - metric_memory;
+    size_t rows = effective_memory / row_cost;
     rows = (rows > naux ? naux : rows);
     rows = (rows < 1L ? 1L : rows);
     max_rows = (int)rows;
@@ -586,7 +614,7 @@ void DFCorrGrad::build_AB_x_terms() {
 
     auto K = std::make_shared<Matrix>("K", naux, naux);
     auto Kp = K->pointer();
-    psio_->read_entry(unit_c_, "V", (char*)Kp[0], sizeof(double) * naux * naux);
+    psio_->read_entry(unit_c_, "V", (char*)Kp[0], sizeof(double) * static_cast<size_t>(naux) * naux);
 
     std::map<std::string, SharedMatrix> densities = {{"Coulomb", J}, {"Exchange", K}};
  
@@ -635,10 +663,10 @@ void DFCorrGrad::build_Amn_x_terms() {
     row_cost += nso * (size_t)nso;
     row_cost += nso * (size_t)na;
     row_cost += na * (size_t)nlr;
-    size_t rows = memory_ / row_cost;
-    rows = (rows > naux ? naux : rows);
-    rows = (rows < maxP ? maxP : rows);
-    max_rows = (int)rows;
+    const size_t vector_memory = 2L * naux;
+    require_corr_grad_memory(memory_, vector_memory + maxP * row_cost, "Amn gradient term formation");
+    max_rows = static_cast<int>(corr_grad_auxiliary_block_rows(memory_ - vector_memory, row_cost, maxP, naux,
+                                                               "Amn gradient term formation"));
 
     // => Block Sizing <= //
 

--- a/psi4/src/psi4/dfmp2/corr_grad.cc
+++ b/psi4/src/psi4/dfmp2/corr_grad.cc
@@ -29,7 +29,6 @@
 #include "corr_grad.h"
 
 #include <algorithm>
-#include <sstream>
 
 #include "psi4/libqt/qt.h"
 #include "psi4/lib3index/3index.h"
@@ -59,20 +58,11 @@ namespace dfmp2 {
 
 namespace {
 
-void require_corr_grad_memory(size_t available, size_t required, const std::string& stage) {
-    if (available < required) {
-        constexpr double doubles_per_gib = 1024.0 * 1024.0 * 1024.0 / sizeof(double);
-        std::ostringstream message;
-        message << "DFCorrGrad: " << stage << " requires at least " << required / doubles_per_gib
-                << " GiB, but only " << available / doubles_per_gib << " GiB is available.";
-        throw PSIEXCEPTION(message.str());
-    }
-}
-
-size_t corr_grad_auxiliary_block_rows(size_t available, size_t row_cost, size_t max_shell, size_t naux,
-                                      const std::string& stage) {
-    require_corr_grad_memory(available, max_shell * row_cost, stage + " (one auxiliary shell)");
-    return std::min(naux, available / row_cost);
+// Rows to block over for an array indexed by the auxiliary basis. When fewer rows fit in
+// memory than the largest auxiliary shell, DFCorrGrad has always kept the calculation going
+// at the minimum useful block size of one shell rather than erroring out on the request.
+size_t corr_grad_auxiliary_block_rows(size_t available, size_t row_cost, size_t max_shell, size_t naux) {
+    return std::max(max_shell, std::min(naux, available / row_cost));
 }
 
 }  // namespace
@@ -222,9 +212,8 @@ void DFCorrGrad::build_Amn_terms() {
     row_cost += nso * (size_t)na;
     row_cost += na * (size_t)nlr;
     const size_t vector_memory = 2L * naux;
-    require_corr_grad_memory(memory_, vector_memory + maxP * row_cost, "Amn term formation");
-    max_rows = static_cast<int>(
-        corr_grad_auxiliary_block_rows(memory_ - vector_memory, row_cost, maxP, naux, "Amn term formation"));
+    const size_t block_memory = (memory_ > vector_memory ? memory_ - vector_memory : 0L);
+    max_rows = static_cast<int>(corr_grad_auxiliary_block_rows(block_memory, row_cost, maxP, naux));
 
     // => Block Sizing <= //
 
@@ -488,11 +477,9 @@ void DFCorrGrad::build_AB_inv_terms() {
 void DFCorrGrad::fitting_helper(SharedMatrix J, size_t file, const std::string& label, size_t naux, size_t nij,
                                 size_t memory) {
     int max_cols;
-    const size_t metric_memory = naux * static_cast<size_t>(naux);
-    const size_t vector_memory = 2L * naux;
+    const size_t fixed_memory = naux * static_cast<size_t>(naux) + 2L * naux;
     size_t col_cost = 2L * naux;
-    require_corr_grad_memory(memory, metric_memory + vector_memory + col_cost, "fitting transformation");
-    size_t effective_memory = memory - metric_memory - vector_memory;
+    size_t effective_memory = (memory > fixed_memory ? memory - fixed_memory : 0L);
     size_t cols = effective_memory / col_cost;
     cols = (cols > nij ? nij : cols);
     cols = (cols < 1L ? 1L : cols);
@@ -570,8 +557,7 @@ void DFCorrGrad::UV_helper(SharedMatrix V, double c, size_t file, const std::str
     int max_rows;
     const size_t metric_memory = naux * static_cast<size_t>(naux);
     size_t row_cost = 2L * nij;
-    require_corr_grad_memory(memory, metric_memory + row_cost, "UV formation");
-    size_t effective_memory = memory - metric_memory;
+    size_t effective_memory = (memory > metric_memory ? memory - metric_memory : 0L);
     size_t rows = effective_memory / row_cost;
     rows = (rows > naux ? naux : rows);
     rows = (rows < 1L ? 1L : rows);
@@ -664,9 +650,8 @@ void DFCorrGrad::build_Amn_x_terms() {
     row_cost += nso * (size_t)na;
     row_cost += na * (size_t)nlr;
     const size_t vector_memory = 2L * naux;
-    require_corr_grad_memory(memory_, vector_memory + maxP * row_cost, "Amn gradient term formation");
-    max_rows = static_cast<int>(corr_grad_auxiliary_block_rows(memory_ - vector_memory, row_cost, maxP, naux,
-                                                               "Amn gradient term formation"));
+    const size_t block_memory = (memory_ > vector_memory ? memory_ - vector_memory : 0L);
+    max_rows = static_cast<int>(corr_grad_auxiliary_block_rows(block_memory, row_cost, maxP, naux));
 
     // => Block Sizing <= //
 

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -28,6 +28,9 @@
 
 #include "mp2.h"
 
+#include <algorithm>
+#include <sstream>
+
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -58,6 +61,26 @@
 
 namespace psi {
 namespace dfmp2 {
+
+namespace {
+
+void require_memory(size_t available, size_t required, const std::string& stage) {
+    if (available < required) {
+        constexpr double doubles_per_gib = 1024.0 * 1024.0 * 1024.0 / sizeof(double);
+        std::ostringstream message;
+        message << "DFMP2: " << stage << " requires at least " << required / doubles_per_gib
+                << " GiB, but only " << available / doubles_per_gib << " GiB is available.";
+        throw PSIEXCEPTION(message.str());
+    }
+}
+
+size_t auxiliary_block_rows(size_t available, size_t row_cost, size_t max_shell, size_t naux,
+                            const std::string& stage) {
+    require_memory(available, max_shell * row_cost, stage + " (one auxiliary shell)");
+    return std::min(naux, available / row_cost);
+}
+
+}  // namespace
 
 void DFMP2::compute_opdm_and_nos(const SharedMatrix Dnosym, SharedMatrix Dso, SharedMatrix Cno, SharedVector occ) {
     // The density matrix
@@ -400,7 +423,8 @@ SharedMatrix DFMP2::form_inverse_metric() {
         auto Jm12 = std::make_shared<Matrix>("SO Basis Fitting Inverse (Eig)", naux, naux);
         outfile->Printf("\t Will attempt to load fitting metric from file %d.\n\n", PSIF_DFSCF_BJ);
         psio_->open(PSIF_DFSCF_BJ, PSIO_OPEN_OLD);
-        psio_->read_entry(PSIF_DFSCF_BJ, "DFMP2 Jm12", (char*)Jm12->pointer()[0], sizeof(double) * naux * naux);
+        psio_->read_entry(PSIF_DFSCF_BJ, "DFMP2 Jm12", (char*)Jm12->pointer()[0],
+                          sizeof(double) * static_cast<size_t>(naux) * naux);
         psio_->close(PSIF_DFSCF_BJ, 1);
 
         timer_off("DFMP2 Metric");
@@ -417,7 +441,8 @@ SharedMatrix DFMP2::form_inverse_metric() {
         if (options_.get_str("DF_INTS_IO") == "SAVE") {
             outfile->Printf("\t Will save fitting metric to file %d.\n\n", PSIF_DFSCF_BJ);
             psio_->open(PSIF_DFSCF_BJ, PSIO_OPEN_OLD);
-            psio_->write_entry(PSIF_DFSCF_BJ, "DFMP2 Jm12", (char*)Jm12->pointer()[0], sizeof(double) * naux * naux);
+            psio_->write_entry(PSIF_DFSCF_BJ, "DFMP2 Jm12", (char*)Jm12->pointer()[0],
+                               sizeof(double) * static_cast<size_t>(naux) * naux);
             psio_->close(PSIF_DFSCF_BJ, 1);
         }
 
@@ -428,7 +453,7 @@ SharedMatrix DFMP2::form_inverse_metric() {
 }
 void DFMP2::apply_fitting(SharedMatrix Jm12, size_t file, size_t naux, size_t nia) {
     // Memory constraints
-    size_t Jmem = naux * naux;
+    size_t Jmem = naux * static_cast<size_t>(naux);
     size_t doubles = (size_t)(options_.get_double("DFMP2_MEM_FACTOR") * (memory_ / 8L));
     if (doubles < 2L * Jmem) {
         throw PSIEXCEPTION("DFMP2: More memory required for tractable disk transpose");
@@ -488,7 +513,7 @@ void DFMP2::apply_fitting(SharedMatrix Jm12, size_t file, size_t naux, size_t ni
 }
 void DFMP2::apply_fitting_grad(SharedMatrix Jm12, size_t file, size_t naux, size_t nia) {
     // Memory constraints
-    size_t Jmem = naux * naux;
+    size_t Jmem = naux * static_cast<size_t>(naux);
     size_t doubles = (size_t)(options_.get_double("DFMP2_MEM_FACTOR") * (memory_ / 8L));
     if (doubles < 2L * Jmem) {
         throw PSIEXCEPTION("DFMP2: More memory required for tractable disk transpose");
@@ -543,11 +568,9 @@ void DFMP2::apply_fitting_grad(SharedMatrix Jm12, size_t file, size_t naux, size
     psio_->close(file, 1);
 }
 void DFMP2::apply_gamma(size_t file, size_t naux, size_t nia) {
-    size_t Jmem = naux * naux;
+    size_t Jmem = naux * static_cast<size_t>(naux);
     size_t doubles = (size_t)(options_.get_double("DFMP2_MEM_FACTOR") * (memory_ / 8L));
-    if (doubles < 1L * Jmem) {
-        throw PSIEXCEPTION("DFMP2: More memory required for gamma");
-    }
+    require_memory(doubles, Jmem + 2L * naux, "gamma formation");
     size_t rem = (doubles - Jmem) / 2L;
     size_t max_nia = (rem / naux);
     max_nia = (max_nia > nia ? nia : max_nia);
@@ -607,9 +630,9 @@ void DFMP2::apply_gamma(size_t file, size_t naux, size_t nia) {
 void DFMP2::apply_G_transpose(size_t file, size_t naux, size_t nia) {
     // Memory constraints
     size_t doubles = (size_t)(options_.get_double("DFMP2_MEM_FACTOR") * (memory_ / 8L));
-    size_t max_nia = (doubles / naux);
-    max_nia = (max_nia > nia ? nia : max_nia);
-    max_nia = (max_nia < 1L ? 1L : max_nia);
+    const size_t row_cost = 2L * naux;
+    require_memory(doubles, row_cost, "G transpose");
+    size_t max_nia = std::min(nia, doubles / row_cost);
 
     // Block sizing
     std::vector<size_t> ia_starts;
@@ -624,6 +647,7 @@ void DFMP2::apply_G_transpose(size_t file, size_t naux, size_t nia) {
     // block_status(ia_starts, __FILE__,__LINE__);
 
     // Prestripe
+    require_memory(doubles, nia, "G transpose prestripe");
     psio_->open(file, PSIO_OPEN_OLD);
     psio_address next_QIA = PSIO_ZERO;
     std::vector<double> temp(nia, 0);
@@ -672,14 +696,14 @@ void DFMP2::apply_G_transpose(size_t file, size_t naux, size_t nia) {
 void DFMP2::apply_B_transpose(size_t file, size_t naux, size_t naocc, size_t navir) {
     // Memory constraints
     size_t doubles = (size_t)(options_.get_double("DFMP2_MEM_FACTOR") * (memory_ / 8L));
-    size_t rows = doubles / (1L * naocc * naux);
-    int max_A = (rows <= 0L ? 1L : rows);
-    max_A = (rows > navir ? navir : rows);
+    const size_t row_cost = naocc * naux;
+    require_memory(doubles, row_cost, "B transpose");
+    const size_t max_A = std::max<size_t>(1, std::min(navir, doubles / row_cost));
 
     // Block sizing
-    std::vector<int> a_starts;
+    std::vector<size_t> a_starts;
     a_starts.push_back(0);
-    for (int a = 0; a < navir; a += max_A) {
+    for (size_t a = 0; a < navir; a += max_A) {
         if (a + max_A >= navir) {
             a_starts.push_back(navir);
         } else {
@@ -696,14 +720,14 @@ void DFMP2::apply_B_transpose(size_t file, size_t naux, size_t naocc, size_t nav
     psio_->open(file, PSIO_OPEN_OLD);
     psio_address next_BIA = PSIO_ZERO;
     psio_address next_BAI = PSIO_ZERO;
-    for (int block = 0; block < a_starts.size() - 1; block++) {
+    for (size_t block = 0; block < a_starts.size() - 1; block++) {
         // Sizing
-        int a_start = a_starts[block];
-        int a_stop = a_starts[block + 1];
-        int na = a_stop - a_start;
+        size_t a_start = a_starts[block];
+        size_t a_stop = a_starts[block + 1];
+        size_t na = a_stop - a_start;
 
-        for (int a = 0; a < na; a++) {
-            for (int i = 0; i < naocc; i++) {
+        for (size_t a = 0; a < na; a++) {
+            for (size_t i = 0; i < naocc; i++) {
                 next_BIA = psio_get_address(PSIO_ZERO, sizeof(double) * (i * navir * naux + (a + a_start) * naux));
                 psio_->read(file, "B(ia|Q)", (char*)Biap[a * naocc + i], sizeof(double) * naux, next_BIA, &next_BIA);
             }
@@ -863,9 +887,7 @@ void RDFMP2::form_Aia() {
     size_t Aia_cost_per_row = naocc * (size_t)navir;
     size_t total_cost_per_row = Amn_cost_per_row + Ami_cost_per_row + Aia_cost_per_row;
     size_t doubles = ((size_t)(options_.get_double("DFMP2_MEM_FACTOR") * memory_ / 8L));
-    size_t max_temp = doubles / (total_cost_per_row);
-    int max_naux = (max_temp > (size_t)naux ? naux : max_temp);
-    max_naux = (max_naux < maxQ ? maxQ : max_naux);
+    int max_naux = static_cast<int>(auxiliary_block_rows(doubles, total_cost_per_row, maxQ, naux, "Aia formation"));
 
     // Block extents
     std::vector<int> block_Q_starts;
@@ -908,7 +930,7 @@ void RDFMP2::form_Aia() {
                          : ribasis_->shell(Qstop).function_index() - ribasis_->shell(Qstart).function_index());
 
         // Clear Amn for Schwarz sieve
-        ::memset((void*)Amnp[0], '\0', sizeof(double) * nrows * nso * nso);
+        ::memset((void*)Amnp[0], '\0', sizeof(double) * static_cast<size_t>(nrows) * nso * nso);
 
         // Compute TEI tensor block (A|mn)
         timer_on("DFMP2 (A|mn)");
@@ -964,7 +986,8 @@ void RDFMP2::form_Aia() {
 
         // Stripe (A|ia) out to disk
         timer_on("DFMP2 Aia Write");
-        psio_->write(PSIF_DFMP2_AIA, "A(Q|ia)", (char*)Aiap[0], sizeof(double) * nrows * naocc * navir, next_AIA,
+        psio_->write(PSIF_DFMP2_AIA, "A(Q|ia)", (char*)Aiap[0],
+                     sizeof(double) * static_cast<size_t>(nrows) * naocc * navir, next_AIA,
                      &next_AIA);
         timer_off("DFMP2 Aia Write");
     }
@@ -1127,7 +1150,9 @@ void RDFMP2::form_Pab() {
 
     // Memory
     size_t doubles = static_cast<size_t>(options_.get_double("DFMP2_MEM_FACTOR") * memory_ / 8L);
-    doubles -= static_cast<double>(navir) * static_cast<double>(navir);
+    const size_t fixed_memory = static_cast<size_t>(navir) * navir;
+    require_memory(doubles, fixed_memory + 1L, "Pab formation");
+    doubles -= fixed_memory;
     double C = -(double)doubles;
     double B = 4.0 * navir * naux;
     double A = 2.0 * navir * (double)navir;
@@ -1323,7 +1348,9 @@ void RDFMP2::form_Pij() {
 
     // Memory
     size_t doubles = static_cast<size_t>(options_.get_double("DFMP2_MEM_FACTOR") * memory_ / 8L);
-    doubles -= naocc * naocc;
+    const size_t fixed_memory = static_cast<size_t>(naocc) * naocc;
+    require_memory(doubles, fixed_memory + 1L, "Pij formation");
+    doubles -= fixed_memory;
     double C = -(double)doubles;
     double B = 2.0 * naocc * naux;
     double A = 2.0 * naocc * (double)naocc;
@@ -1496,7 +1523,7 @@ void RDFMP2::form_Amn_x_terms() {
     int nso = basisset_->nbf();
     int naocc = Caocc_->colspi()[0];
     int navir = Cavir_->colspi()[0];
-    int nia = Caocc_->colspi()[0] * Cavir_->colspi()[0];
+    size_t nia = static_cast<size_t>(Caocc_->colspi()[0]) * Cavir_->colspi()[0];
     int naux = ribasis_->nbf();
 
     // => Thread Count <= //
@@ -1531,10 +1558,7 @@ void RDFMP2::form_Amn_x_terms() {
     row_cost += nso * (size_t)nso;
     row_cost += nso * (size_t)naocc;
     row_cost += naocc * (size_t)navir;
-    size_t rows = memory / row_cost;
-    rows = (rows > naux ? naux : rows);
-    rows = (rows < maxP ? maxP : rows);
-    max_rows = (int)rows;
+    max_rows = static_cast<int>(auxiliary_block_rows(memory, row_cost, maxP, naux, "Amn gradient formation"));
 
     // => Block Sizing <= //
 
@@ -1554,8 +1578,8 @@ void RDFMP2::form_Amn_x_terms() {
 
     // => Temporary Buffers <= //
 
-    auto Gia = std::make_shared<Matrix>("Gia", max_rows, naocc * navir);
-    auto Gmi = std::make_shared<Matrix>("Gmi", max_rows, nso * naocc);
+    auto Gia = std::make_shared<Matrix>("Gia", max_rows, static_cast<size_t>(naocc) * navir);
+    auto Gmi = std::make_shared<Matrix>("Gmi", max_rows, static_cast<size_t>(nso) * naocc);
     auto Gmn = std::make_shared<Matrix>("Gmn", max_rows, nso * (size_t)nso);
 
     double** Giap = Gia->pointer();
@@ -1698,7 +1722,7 @@ void RDFMP2::form_L() {
     int nso = basisset_->nbf();
     int naocc = Caocc_->colspi()[0];
     int navir = Cavir_->colspi()[0];
-    int nia = Caocc_->colspi()[0] * Cavir_->colspi()[0];
+    size_t nia = static_cast<size_t>(Caocc_->colspi()[0]) * Cavir_->colspi()[0];
     int naux = ribasis_->nbf();
 
     // => Thread Count <= //
@@ -1724,9 +1748,10 @@ void RDFMP2::form_L() {
     // => Memory Constraints <= //
 
     size_t memory = static_cast<size_t>((options_.get_double("DFMP2_MEM_FACTOR") * memory_ / 8L));
-    memory -= static_cast<size_t>(naocc) * static_cast<size_t>(nso);
-    memory -= static_cast<size_t>(navir) * static_cast<size_t>(nso);
-    memory -= static_cast<size_t>(naocc) * static_cast<size_t>(navir);
+    const size_t fixed_memory = static_cast<size_t>(naocc) * nso + static_cast<size_t>(navir) * nso +
+                                static_cast<size_t>(naocc) * navir;
+    require_memory(memory, fixed_memory + 1L, "L intermediate fixed storage");
+    memory -= fixed_memory;
     int max_rows;
     int maxP = ribasis_->max_function_per_shell();
     size_t row_cost = 0L;
@@ -1734,10 +1759,7 @@ void RDFMP2::form_L() {
     row_cost += static_cast<size_t>(nso)   * static_cast<size_t>(naocc);
     row_cost += static_cast<size_t>(nso)   * static_cast<size_t>(navir);
     row_cost += static_cast<size_t>(naocc) * static_cast<size_t>(navir);
-    size_t rows = memory / row_cost;
-    rows = (rows > naux ? naux : rows);
-    rows = (rows < maxP ? maxP : rows);
-    max_rows = static_cast<int>(rows);
+    max_rows = static_cast<int>(auxiliary_block_rows(memory, row_cost, maxP, naux, "L intermediate formation"));
 
     // => Block Sizing <= //
 
@@ -1757,9 +1779,9 @@ void RDFMP2::form_L() {
 
     // => Temporary Buffers <= //
 
-    auto Gia = std::make_shared<Matrix>("Gia", max_rows, naocc * navir);
-    auto Gim = std::make_shared<Matrix>("Pim", max_rows, nso * naocc);
-    auto Gam = std::make_shared<Matrix>("Pam", max_rows, nso * navir);
+    auto Gia = std::make_shared<Matrix>("Gia", max_rows, static_cast<size_t>(naocc) * navir);
+    auto Gim = std::make_shared<Matrix>("Pim", max_rows, static_cast<size_t>(nso) * naocc);
+    auto Gam = std::make_shared<Matrix>("Pam", max_rows, static_cast<size_t>(nso) * navir);
     auto Gmn = std::make_shared<Matrix>("Pmn", max_rows, nso * (size_t)nso);
 
     auto Giap = Gia->pointer();
@@ -1770,7 +1792,7 @@ void RDFMP2::form_L() {
     auto Caoccp = Caocc_->pointer();
     auto Cavirp = Cavir_->pointer();
 
-    std::vector<double> temp(naocc * navir);
+    std::vector<double> temp(static_cast<size_t>(naocc) * navir);
 
     // => Targets <= //
 
@@ -1852,7 +1874,7 @@ void RDFMP2::form_L() {
 
         // Sort G_P^ia to G_P^ai
         for (int p = 0; p < np; p++) {
-            ::memcpy((void*)temp.data(), (void*)Giap[p], sizeof(double) * naocc * navir);
+            ::memcpy((void*)temp.data(), (void*)Giap[p], sizeof(double) * static_cast<size_t>(naocc) * navir);
             for (int i = 0; i < naocc; i++) {
                 C_DCOPY(navir, &temp[i * navir], 1, &Giap[p][i], naocc);
             }
@@ -2684,9 +2706,8 @@ void UDFMP2::form_Aia() {
     size_t Aia_cost_per_row = naocc * (size_t)navir;
     size_t total_cost_per_row = Amn_cost_per_row + Ami_cost_per_row + Aia_cost_per_row;
     size_t doubles = ((size_t)(options_.get_double("DFMP2_MEM_FACTOR") * memory_ / 8L));
-    size_t max_temp = doubles / (total_cost_per_row);
-    int max_naux = (max_temp > (size_t)naux ? naux : max_temp);
-    max_naux = (max_naux < maxQ ? maxQ : max_naux);
+    int max_naux =
+        static_cast<int>(auxiliary_block_rows(doubles, total_cost_per_row, maxQ, naux, "unrestricted Aia formation"));
 
     // Block extents
     std::vector<int> block_Q_starts;
@@ -2733,7 +2754,7 @@ void UDFMP2::form_Aia() {
                          : ribasis_->shell(Qstop).function_index() - ribasis_->shell(Qstart).function_index());
 
         // Clear Amn for Schwarz sieve
-        ::memset((void*)Amnp[0], '\0', sizeof(double) * nrows * nso * nso);
+        ::memset((void*)Amnp[0], '\0', sizeof(double) * static_cast<size_t>(nrows) * nso * nso);
 
         // Compute TEI tensor block (A|mn)
         timer_on("DFMP2 (A|mn)");

--- a/psi4/src/psi4/dfmp2/mp2.cc
+++ b/psi4/src/psi4/dfmp2/mp2.cc
@@ -74,10 +74,11 @@ void require_memory(size_t available, size_t required, const std::string& stage)
     }
 }
 
-size_t auxiliary_block_rows(size_t available, size_t row_cost, size_t max_shell, size_t naux,
-                            const std::string& stage) {
-    require_memory(available, max_shell * row_cost, stage + " (one auxiliary shell)");
-    return std::min(naux, available / row_cost);
+// Rows to block over for an array indexed by the auxiliary basis. When fewer rows fit in
+// memory than the largest auxiliary shell, DFMP2 has always kept the calculation going at the
+// minimum useful block size of one shell rather than erroring out on the requested memory.
+size_t auxiliary_block_rows(size_t available, size_t row_cost, size_t max_shell, size_t naux) {
+    return std::max(max_shell, std::min(naux, available / row_cost));
 }
 
 }  // namespace
@@ -570,7 +571,7 @@ void DFMP2::apply_fitting_grad(SharedMatrix Jm12, size_t file, size_t naux, size
 void DFMP2::apply_gamma(size_t file, size_t naux, size_t nia) {
     size_t Jmem = naux * static_cast<size_t>(naux);
     size_t doubles = (size_t)(options_.get_double("DFMP2_MEM_FACTOR") * (memory_ / 8L));
-    require_memory(doubles, Jmem + 2L * naux, "gamma formation");
+    require_memory(doubles, Jmem, "gamma formation");
     size_t rem = (doubles - Jmem) / 2L;
     size_t max_nia = (rem / naux);
     max_nia = (max_nia > nia ? nia : max_nia);
@@ -631,8 +632,7 @@ void DFMP2::apply_G_transpose(size_t file, size_t naux, size_t nia) {
     // Memory constraints
     size_t doubles = (size_t)(options_.get_double("DFMP2_MEM_FACTOR") * (memory_ / 8L));
     const size_t row_cost = 2L * naux;
-    require_memory(doubles, row_cost, "G transpose");
-    size_t max_nia = std::min(nia, doubles / row_cost);
+    size_t max_nia = std::max<size_t>(1, std::min(nia, doubles / row_cost));
 
     // Block sizing
     std::vector<size_t> ia_starts;
@@ -647,7 +647,6 @@ void DFMP2::apply_G_transpose(size_t file, size_t naux, size_t nia) {
     // block_status(ia_starts, __FILE__,__LINE__);
 
     // Prestripe
-    require_memory(doubles, nia, "G transpose prestripe");
     psio_->open(file, PSIO_OPEN_OLD);
     psio_address next_QIA = PSIO_ZERO;
     std::vector<double> temp(nia, 0);
@@ -697,7 +696,6 @@ void DFMP2::apply_B_transpose(size_t file, size_t naux, size_t naocc, size_t nav
     // Memory constraints
     size_t doubles = (size_t)(options_.get_double("DFMP2_MEM_FACTOR") * (memory_ / 8L));
     const size_t row_cost = naocc * naux;
-    require_memory(doubles, row_cost, "B transpose");
     const size_t max_A = std::max<size_t>(1, std::min(navir, doubles / row_cost));
 
     // Block sizing
@@ -887,7 +885,7 @@ void RDFMP2::form_Aia() {
     size_t Aia_cost_per_row = naocc * (size_t)navir;
     size_t total_cost_per_row = Amn_cost_per_row + Ami_cost_per_row + Aia_cost_per_row;
     size_t doubles = ((size_t)(options_.get_double("DFMP2_MEM_FACTOR") * memory_ / 8L));
-    int max_naux = static_cast<int>(auxiliary_block_rows(doubles, total_cost_per_row, maxQ, naux, "Aia formation"));
+    int max_naux = static_cast<int>(auxiliary_block_rows(doubles, total_cost_per_row, maxQ, naux));
 
     // Block extents
     std::vector<int> block_Q_starts;
@@ -1558,7 +1556,7 @@ void RDFMP2::form_Amn_x_terms() {
     row_cost += nso * (size_t)nso;
     row_cost += nso * (size_t)naocc;
     row_cost += naocc * (size_t)navir;
-    max_rows = static_cast<int>(auxiliary_block_rows(memory, row_cost, maxP, naux, "Amn gradient formation"));
+    max_rows = static_cast<int>(auxiliary_block_rows(memory, row_cost, maxP, naux));
 
     // => Block Sizing <= //
 
@@ -1750,8 +1748,7 @@ void RDFMP2::form_L() {
     size_t memory = static_cast<size_t>((options_.get_double("DFMP2_MEM_FACTOR") * memory_ / 8L));
     const size_t fixed_memory = static_cast<size_t>(naocc) * nso + static_cast<size_t>(navir) * nso +
                                 static_cast<size_t>(naocc) * navir;
-    require_memory(memory, fixed_memory + 1L, "L intermediate fixed storage");
-    memory -= fixed_memory;
+    memory = (memory > fixed_memory ? memory - fixed_memory : 0L);
     int max_rows;
     int maxP = ribasis_->max_function_per_shell();
     size_t row_cost = 0L;
@@ -1759,7 +1756,7 @@ void RDFMP2::form_L() {
     row_cost += static_cast<size_t>(nso)   * static_cast<size_t>(naocc);
     row_cost += static_cast<size_t>(nso)   * static_cast<size_t>(navir);
     row_cost += static_cast<size_t>(naocc) * static_cast<size_t>(navir);
-    max_rows = static_cast<int>(auxiliary_block_rows(memory, row_cost, maxP, naux, "L intermediate formation"));
+    max_rows = static_cast<int>(auxiliary_block_rows(memory, row_cost, maxP, naux));
 
     // => Block Sizing <= //
 
@@ -2706,8 +2703,7 @@ void UDFMP2::form_Aia() {
     size_t Aia_cost_per_row = naocc * (size_t)navir;
     size_t total_cost_per_row = Amn_cost_per_row + Ami_cost_per_row + Aia_cost_per_row;
     size_t doubles = ((size_t)(options_.get_double("DFMP2_MEM_FACTOR") * memory_ / 8L));
-    int max_naux =
-        static_cast<int>(auxiliary_block_rows(doubles, total_cost_per_row, maxQ, naux, "unrestricted Aia formation"));
+    int max_naux = static_cast<int>(auxiliary_block_rows(doubles, total_cost_per_row, maxQ, naux));
 
     // Block extents
     std::vector<int> block_Q_starts;

--- a/psi4/src/psi4/dfocc/manager.cc
+++ b/psi4/src/psi4/dfocc/manager.cc
@@ -26,8 +26,12 @@
  * @END LICENSE
  */
 
+#include <algorithm>
 #include <cmath>
+#include <iomanip>
+#include <sstream>
 #include "psi4/libciomr/libciomr.h"
+#include "psi4/libmints/basisset.h"
 #include "psi4/libqt/qt.h"
 #include "psi4/libpsi4util/process.h"
 #include "dfocc.h"
@@ -361,6 +365,94 @@ void DFOCC::omp2_manager() {
 void DFOCC::mp2_manager() {
     time4grad = 0;     // means i will not compute the gradient
     mo_optimized = 0;  // means MOs are not optimized
+
+    // This implementation is entirely in-core. Estimate each sequential stage's
+    // peak before the first large allocation rather than merely printing the
+    // amplitude cost after the integral transformation has completed.
+    nQ = get_basisset("DF_BASIS_CC")->nbf();
+    const bool transform_all =
+        !(dertype == "NONE" && oeprop_ == "FALSE" && ekt_ip_ == "FALSE" && comput_s2_ == "FALSE" && qchf_ == "FALSE");
+    if (transform_all) nQ_ref = get_basisset("DF_BASIS_SCF")->nbf();
+
+    const long double bytes_per_double = sizeof(double);
+    const long double nso = nso_;
+    const long double cc_ao = nQ * nso * nso * bytes_per_double;
+    const long double cc_metric = nQ * static_cast<long double>(nQ) * bytes_per_double;
+    const long double cc_ao_build = 2.0L * cc_ao + cc_metric;
+
+    const int max_nocc = reference_ == "RESTRICTED" ? noccA : std::max(noccA, noccB);
+    const int max_nvir = reference_ == "RESTRICTED" ? nvirA : std::max(nvirA, nvirB);
+    const int max_navir = reference_ == "RESTRICTED" ? navirA : std::max(navirA, navirB);
+    const long double cc_active_vv =
+        nQ * static_cast<long double>(max_navir) * max_navir * bytes_per_double;
+    const long double cc_ov = nQ * static_cast<long double>(max_nocc) * max_nvir * bytes_per_double;
+    const long double cc_direct_transform =
+        std::max({2.0L * cc_ao, cc_ao + nQ * nso * max_nvir * bytes_per_double + cc_ov,
+                  cc_ao + 2.0L * cc_ov + cc_metric});
+    const long double cc_full_transform =
+        cc_ao + nQ * nso * max_nvir * bytes_per_double +
+        nQ * static_cast<long double>(max_nvir) * max_nvir * bytes_per_double;
+    const long double cc_transform =
+        std::max(cc_ao_build, transform_all ? cc_full_transform : cc_direct_transform);
+
+    long double ref_transform = 0.0L;
+    if (transform_all) {
+        const long double ref_ao = nQ_ref * nso * nso * bytes_per_double;
+        const long double ref_metric = nQ_ref * static_cast<long double>(nQ_ref) * bytes_per_double;
+        const long double ref_ao_build = 3.0L * ref_ao + ref_metric;
+        const long double ref_mo_transform =
+            ref_ao + nQ_ref * nso * max_nvir * bytes_per_double +
+            nQ_ref * static_cast<long double>(max_nvir) * max_nvir * bytes_per_double;
+        ref_transform = std::max(ref_ao_build, ref_mo_transform);
+    }
+
+    const long double amp_aa =
+        naoccA * static_cast<long double>(naoccA) * navirA * static_cast<long double>(navirA) * bytes_per_double;
+    long double largest_amp = amp_aa;
+    if (reference_ == "UNRESTRICTED") {
+        const long double amp_ab =
+            naoccA * static_cast<long double>(naoccB) * navirA * static_cast<long double>(navirB) * bytes_per_double;
+        const long double amp_bb =
+            naoccB * static_cast<long double>(naoccB) * navirB * static_cast<long double>(navirB) * bytes_per_double;
+        largest_amp = std::max({amp_aa, amp_ab, amp_bb});
+    }
+    const int amplitude_copies = reference_ == "UNRESTRICTED" && dertype == "FIRST" ? 4 : 3;
+    const long double amplitude_peak = amplitude_copies * largest_amp;
+    const long double required_bytes = std::max({cc_transform, ref_transform, amplitude_peak});
+    const long double available_bytes = Process::environment.get_memory();
+    const long double mib = 1024.0L * 1024.0L;
+    const long double gib = 1024.0L * mib;
+
+    memory = Process::environment.get_memory();
+    memory_mb = static_cast<double>(available_bytes / mib);
+    cost_df = static_cast<double>(cc_transform / mib);
+    cost_amp = static_cast<double>(amplitude_peak / mib);
+    outfile->Printf("\n\tDFOCC MP2 in-core memory requirements:\n");
+    outfile->Printf("\tAvailable memory [GiB]                 : %12.4f\n",
+                    static_cast<double>(available_bytes / gib));
+    outfile->Printf("\tB-CC (Q|mu nu) [GiB]                  : %12.4f\n", static_cast<double>(cc_ao / gib));
+    outfile->Printf("\tB-CC (Q|ab), largest spin [GiB]       : %12.4f\n",
+                    static_cast<double>(cc_active_vv / gib));
+    outfile->Printf("\tDF-CC integral build/transform [GiB]   : %12.4f\n",
+                    static_cast<double>(cc_transform / gib));
+    if (transform_all)
+        outfile->Printf("\tDF-SCF integral build/transform [GiB]  : %12.4f\n",
+                        static_cast<double>(ref_transform / gib));
+    outfile->Printf("\tAmplitude/density (%d tensors) [GiB]   : %12.4f\n", amplitude_copies,
+                    static_cast<double>(amplitude_peak / gib));
+    outfile->Printf("\tEstimated minimum peak [GiB]           : %12.4f\n",
+                    static_cast<double>(required_bytes / gib));
+
+    if (required_bytes > available_bytes) {
+        std::ostringstream message;
+        message << "The current " << (reference_ == "RESTRICTED" ? "restricted" : "unrestricted")
+                << " DFOCC MP2 " << (dertype == "FIRST" ? "gradient" : "energy")
+                << " algorithm is in-core and requires at least " << std::fixed << std::setprecision(1)
+                << required_bytes / gib << " GiB, but only " << available_bytes / gib
+                << " GiB is available. Use a memory-blocked MP2 implementation or increase available memory.";
+        throw PSIEXCEPTION(message.str());
+    }
+
     timer_on("DF CC Integrals");
     df_corr();
     if (dertype == "NONE" && oeprop_ == "FALSE" && ekt_ip_ == "FALSE" && comput_s2_ == "FALSE" && qchf_ == "FALSE") {
@@ -386,89 +478,6 @@ void DFOCC::mp2_manager() {
     outfile->Printf("\tNumber of basis functions in the DF-CC basis: %3d\n", nQ);
 
     timer_off("DF CC Integrals");
-
-    if (reference_ == "RESTRICTED") {
-        // mem for amplitudes
-        cost_ampAA = 0.0;
-        cost_ampAA = (long long int)naocc2AA * (long long int)nvir2AA;
-        cost_ampAA /= 1024.0 * 1024.0;
-        cost_ampAA *= sizeof(double);
-        cost_amp = 3.0 * cost_ampAA;
-        memory = Process::environment.get_memory();
-        memory_mb = (double)memory / (1024.0 * 1024.0);
-        outfile->Printf("\n\tAvailable memory                      : %9.2lf MB \n", memory_mb);
-        outfile->Printf("\tMinimum required memory for amplitudes: %9.2lf MB \n", cost_amp);
-
-        // memory requirements
-        /*
-        // DF-HF B(Q,mn)
-        cost_ampAA = 0;
-        cost_ampAA = nQ_ref * nso2_;
-        cost_ampAA /= 1024.0 * 1024.0;
-        cost_ampAA *= sizeof(double);
-        outfile->Printf("\n\tMemory requirement for B-HF (Q|mu nu) : %9.2lf MB \n", cost_ampAA);
-
-        // DF-HF B(Q,ab)
-        cost_ampAA = 0;
-        cost_ampAA = nQ_ref * nvir2AA;
-        cost_ampAA /= 1024.0 * 1024.0;
-        cost_ampAA *= sizeof(double);
-        outfile->Printf("\tMemory requirement for B-HF (Q|ab)    : %9.2lf MB \n", cost_ampAA);
-
-        // Cost of Integral transform for DF-HF B(Q,ab)
-        cost_ampAA = 0.0;
-        cost_ampAA = nQ_ref * nso2_;
-        cost_ampAA += nQ_ref * navirA * navirA;
-        cost_ampAA += nQ_ref * nso_ * navirA;
-        cost_ampAA /= 1024.0 * 1024.0;
-        cost_ampAA *= sizeof(double);
-        outfile->Printf("\tMemory requirement for DF-HF int trans: %9.2lf MB \n", cost_ampAA);
-        */
-
-        // DF-CC B(Q,mn)
-        cost_ampAA = 0.0;
-        cost_ampAA = (long long int)nQ * (long long int)nso2_;
-        cost_ampAA /= 1024.0 * 1024.0;
-        cost_ampAA *= sizeof(double);
-        outfile->Printf("\tMemory requirement for B-CC (Q|mu nu) : %9.2lf MB \n", cost_ampAA);
-
-        // DF-CC B(Q,ab)
-        cost_ampAA = 0.0;
-        cost_ampAA = (long long int)nQ * (long long int)navirA * (long long int)navirA;
-        cost_ampAA /= 1024.0 * 1024.0;
-        cost_ampAA *= sizeof(double);
-        outfile->Printf("\tMemory requirement for B-CC (Q|ab)    : %9.2lf MB \n", cost_ampAA);
-
-        // Cost of Integral transform for DF-CC B(Q,ab)
-        cost_ampAA = 0.0;
-        cost_ampAA = (long long int)nQ * (long long int)nso2_;
-        cost_ampAA += (long long int)nQ * (long long int)navirA * (long long int)navirA;
-        cost_ampAA += (long long int)nQ * (long long int)nso_ * (long long int)navirA;
-        cost_ampAA /= 1024.0 * 1024.0;
-        cost_ampAA *= sizeof(double);
-        outfile->Printf("\tMemory requirement for DF-CC int trans: %9.2lf MB \n", cost_ampAA);
-    }  // end if (reference_ == "RESTRICTED")
-
-    else if (reference_ == "UNRESTRICTED") {
-        // memory requirements
-        cost_ampAA = 0.0;
-        cost_ampAA = (long long int)naocc2AA * (long long int)nvir2AA;
-        cost_ampAA /= 1024.0 * 1024.0;
-        cost_ampAA *= sizeof(double);
-        cost_ampBB = (long long int)naocc2BB * (long long int)nvir2BB;
-        cost_ampBB /= 1024.0 * 1024.0;
-        cost_ampBB *= sizeof(double);
-        cost_ampAB = (long long int)naocc2AB * (long long int)nvir2AB;
-        cost_ampAB /= 1024.0 * 1024.0;
-        cost_ampAB *= sizeof(double);
-        cost_amp = MAX0(cost_ampAA, cost_ampBB);
-        cost_amp = MAX0(cost_amp, cost_ampAB);
-        cost_amp = 3.0 * cost_amp;
-        memory = Process::environment.get_memory();
-        memory_mb = (double)memory / (1024.0 * 1024.0);
-        outfile->Printf("\n\tAvailable memory                      : %9.2lf MB \n", memory_mb);
-        outfile->Printf("\tMinimum required memory for amplitudes: %9.2lf MB \n", cost_amp);
-    }  // end else if (reference_ == "UNRESTRICTED")
 
     // QCHF
     if (qchf_ == "TRUE") qchf();

--- a/psi4/src/psi4/dfocc/manager.cc
+++ b/psi4/src/psi4/dfocc/manager.cc
@@ -372,6 +372,9 @@ void DFOCC::mp2_manager() {
     nQ = get_basisset("DF_BASIS_CC")->nbf();
     const bool transform_all =
         !(dertype == "NONE" && oeprop_ == "FALSE" && ekt_ip_ == "FALSE" && comput_s2_ == "FALSE" && qchf_ == "FALSE");
+    // mp2_manager() only runs with orb_opt_ == "FALSE", so this one flag is both
+    // trans_corr()'s all-orbital-vs-active branch and omp2_tpdm()'s guard.
+    const bool form_densities = dertype == "FIRST" || oeprop_ == "TRUE" || ekt_ip_ == "TRUE";
     if (transform_all) nQ_ref = get_basisset("DF_BASIS_SCF")->nbf();
 
     const long double bytes_per_double = sizeof(double);
@@ -381,17 +384,29 @@ void DFOCC::mp2_manager() {
     const long double cc_ao_build = 2.0L * cc_ao + cc_metric;
 
     const int max_nocc = reference_ == "RESTRICTED" ? noccA : std::max(noccA, noccB);
+    const int max_naocc = reference_ == "RESTRICTED" ? naoccA : std::max(naoccA, naoccB);
     const int max_nvir = reference_ == "RESTRICTED" ? nvirA : std::max(nvirA, nvirB);
     const int max_navir = reference_ == "RESTRICTED" ? navirA : std::max(navirA, navirB);
     const long double cc_active_vv =
         nQ * static_cast<long double>(max_navir) * max_navir * bytes_per_double;
-    const long double cc_ov = nQ * static_cast<long double>(max_nocc) * max_nvir * bytes_per_double;
+    const long double cc_active_ov =
+        nQ * static_cast<long double>(max_naocc) * max_navir * bytes_per_double;
+    // Direct MP2 forms only the active B(Q|IA), inside b_so(), where B(Q|mn) and J^-1/2 are
+    // both still resident alongside (Q|mA) and (Q|IA). The following (Q|IA)+(Q|IA) step is
+    // smaller because nso >= naocc, and the AO build is covered by cc_ao_build below.
     const long double cc_direct_transform =
-        std::max({2.0L * cc_ao, cc_ao + nQ * nso * max_nvir * bytes_per_double + cc_ov,
-                  cc_ao + 2.0L * cc_ov + cc_metric});
+        cc_ao + cc_metric + nQ * nso * max_navir * bytes_per_double + cc_active_ov;
+    // Every MO transform stage holds B(Q|mn) plus a half-transformed (Q|m x) and a fully
+    // transformed (Q|x y). The (Q|ov) stage is dominated by whichever of oo/vv is larger,
+    // so only those two need comparing -- oo wins whenever there are more occ than vir.
+    auto transform_stage = [&](long double ao, int naux, int n) {
+        return ao + naux * nso * n * bytes_per_double + naux * static_cast<long double>(n) * n * bytes_per_double;
+    };
+    // trans_corr() transforms all orbitals for the density path and actives otherwise.
+    const int tr_nocc = form_densities ? max_nocc : max_naocc;
+    const int tr_nvir = form_densities ? max_nvir : max_navir;
     const long double cc_full_transform =
-        cc_ao + nQ * nso * max_nvir * bytes_per_double +
-        nQ * static_cast<long double>(max_nvir) * max_nvir * bytes_per_double;
+        std::max(transform_stage(cc_ao, nQ, tr_nocc), transform_stage(cc_ao, nQ, tr_nvir));
     const long double cc_transform =
         std::max(cc_ao_build, transform_all ? cc_full_transform : cc_direct_transform);
 
@@ -400,9 +415,9 @@ void DFOCC::mp2_manager() {
         const long double ref_ao = nQ_ref * nso * nso * bytes_per_double;
         const long double ref_metric = nQ_ref * static_cast<long double>(nQ_ref) * bytes_per_double;
         const long double ref_ao_build = 3.0L * ref_ao + ref_metric;
+        // trans_ref() has no active-only variant; it always transforms all orbitals.
         const long double ref_mo_transform =
-            ref_ao + nQ_ref * nso * max_nvir * bytes_per_double +
-            nQ_ref * static_cast<long double>(max_nvir) * max_nvir * bytes_per_double;
+            std::max(transform_stage(ref_ao, nQ_ref, max_nocc), transform_stage(ref_ao, nQ_ref, max_nvir));
         ref_transform = std::max(ref_ao_build, ref_mo_transform);
     }
 
@@ -416,7 +431,10 @@ void DFOCC::mp2_manager() {
             naoccB * static_cast<long double>(naoccB) * navirB * static_cast<long double>(navirB) * bytes_per_double;
         largest_amp = std::max({amp_aa, amp_ab, amp_bb});
     }
-    const int amplitude_copies = reference_ == "UNRESTRICTED" && dertype == "FIRST" ? 4 : 3;
+    // Restricted energies hold T, K and U at once. Unrestricted ones work a spin block at a
+    // time and never hold more than two of them; the unrelaxed-density path (omp2_tpdm, which
+    // sorts a freshly built T2 while U is live) adds two more.
+    const int amplitude_copies = reference_ == "RESTRICTED" ? 3 : (form_densities ? 4 : 2);
     const long double amplitude_peak = amplitude_copies * largest_amp;
     const long double required_bytes = std::max({cc_transform, ref_transform, amplitude_peak});
     const long double available_bytes = Process::environment.get_memory();
@@ -424,23 +442,22 @@ void DFOCC::mp2_manager() {
     const long double gib = 1024.0L * mib;
 
     memory = Process::environment.get_memory();
-    memory_mb = static_cast<double>(available_bytes / mib);
-    cost_df = static_cast<double>(cc_transform / mib);
-    cost_amp = static_cast<double>(amplitude_peak / mib);
+    std::ostringstream amplitude_label;
+    amplitude_label << "Amplitude/density (" << amplitude_copies << " tensors)";
     outfile->Printf("\n\tDFOCC MP2 in-core memory requirements:\n");
-    outfile->Printf("\tAvailable memory [GiB]                 : %12.4f\n",
-                    static_cast<double>(available_bytes / gib));
-    outfile->Printf("\tB-CC (Q|mu nu) [GiB]                  : %12.4f\n", static_cast<double>(cc_ao / gib));
-    outfile->Printf("\tB-CC (Q|ab), largest spin [GiB]       : %12.4f\n",
-                    static_cast<double>(cc_active_vv / gib));
-    outfile->Printf("\tDF-CC integral build/transform [GiB]   : %12.4f\n",
+    outfile->Printf("\t%-37s: %12.3f [GiB]\n", "Available memory", static_cast<double>(available_bytes / gib));
+    outfile->Printf("\t%-37s: %12.3f [GiB]\n", "B-CC (Q|mu nu)", static_cast<double>(cc_ao / gib));
+    if (transform_all)
+        outfile->Printf("\t%-37s: %12.3f [GiB]\n", "B-CC (Q|ab), largest spin",
+                        static_cast<double>(cc_active_vv / gib));
+    outfile->Printf("\t%-37s: %12.3f [GiB]\n", "DF-CC integral build/transform",
                     static_cast<double>(cc_transform / gib));
     if (transform_all)
-        outfile->Printf("\tDF-SCF integral build/transform [GiB]  : %12.4f\n",
+        outfile->Printf("\t%-37s: %12.3f [GiB]\n", "DF-SCF integral build/transform",
                         static_cast<double>(ref_transform / gib));
-    outfile->Printf("\tAmplitude/density (%d tensors) [GiB]   : %12.4f\n", amplitude_copies,
+    outfile->Printf("\t%-37s: %12.3f [GiB]\n", amplitude_label.str().c_str(),
                     static_cast<double>(amplitude_peak / gib));
-    outfile->Printf("\tEstimated minimum peak [GiB]           : %12.4f\n",
+    outfile->Printf("\t%-37s: %12.3f [GiB]\n", "Estimated minimum peak (lower bound)",
                     static_cast<double>(required_bytes / gib));
 
     if (required_bytes > available_bytes) {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->


## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] dfocc stops and prints memory usage rather than proceeding when it knows it's going to require terabytes of memory for a df-mp2 energy or gradient

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->

  Two related pieces of memory work on the DF-MP2 paths, plus one driver fix.

  `dfocc`'s MP2 code is entirely in-core, but its only memory reporting ran *after*
  the integral transformation had already allocated. A calculation too large for the
  requested memory would print its costs and then die in `std::bad_alloc` — or, worse,
  take the machine down with it. This PR estimates each sequential stage's peak up
  front and stops with a diagnosable error before the first large allocation.

  `dfmp2` gets the integer-overflow and block-sizing bugs found while auditing the
  same class of code in `libdfmp2`.

  4 files, +207 / −151.

  ## dfocc: up-front memory estimate for DF-MP2

  `DFOCC::mp2_manager()` now estimates, before `df_corr()`, the peak of every stage it
  will run, and throws with the shortfall if the request can't cover the largest one.
  The stages are sequential and each frees before the next, so the requirement is the
  max over stages, not the sum:

  | stage | resident at peak |
  |---|---|
  | DF-CC AO build (`b_so`) | `Ap` + `Bp` + `J^-1/2` |
  | DF-CC transform, direct MP2 (`b_so`) | `B(Q\|mn)` + `J^-1/2` + `(Q\|mA)` + `(Q\|IA)` |
  | DF-CC transform, full (`b_oo`/`b_ov`/`b_vv`) | `B(Q\|mn)` + `(Q\|m x)` + `(Q\|x y)` |
  | DF-SCF AO build (`b_so_ref`) | `bQso` + `Ap` + `Bp` + `J^-1/2` |
  | DF-SCF transform (`trans_ref`) | as above, `nQ_ref` |
  | amplitudes | 3 restricted / 2 unrestricted energy / 4 density path |

  Output, printed before anything large is allocated:

  ```
        DFOCC MP2 in-core memory requirements:
        Available memory                     :        0.466 [GiB]
        B-CC (Q|mu nu)                       :        0.004 [GiB]
        DF-CC integral build/transform       :        0.007 [GiB]
        Amplitude/density (3 tensors)        :        0.001 [GiB]
        Estimated minimum peak (lower bound) :        0.007 [GiB]
  ```

  and on failure:

  ```
  The current restricted DFOCC MP2 energy algorithm is in-core and requires at
  least 4.2 GiB, but only 0.5 GiB is available. Use a memory-blocked MP2
  implementation or increase available memory.
  ```

  Details worth a reviewer's eye:

  - The AO build is 2 AO-sized blocks for DF-CC (`b_so` frees `Ap` before making
    `bQso`) but 3 for DF-SCF (`b_so_ref` allocates `bQso` up front). The estimate
    distinguishes them.
  - The full transform compares the `oo` and `vv` stages. `vv` alone under-sizes any
    case with more occupied than virtual orbitals. The `ov` stage needs no separate
    term: `nocc > nvir` makes both its factors smaller than `oo`'s, `nocc <= nvir`
    smaller than `vv`'s.
  - `trans_corr()` transforms all orbitals only on the density path and actives
    otherwise. Since `mp2_manager()` only runs with `orb_opt_ == FALSE`, one flag is
    both that branch and `omp2_tpdm()`'s guard, so it drives the dimension choice and
    the amplitude count together.
  - Amplitude counts are per-path rather than a single constant: restricted holds `T`,
    `K` and `U` at once; unrestricted energies work a spin block at a time and never
    hold more than two; the density path adds `omp2_tpdm`'s live `U`. Overestimating
    here refuses calculations that would have run.

  ## dfmp2: overflow and block-sizing fixes

  Genuine bugs:

  - **`apply_B_transpose` could hang.** `max_A = (rows <= 0 ? 1 : rows)` was
    immediately overwritten by `max_A = (rows > navir ? navir : rows)`, so `max_A`
    could reach 0 and the block-sizing loop `for (a = 0; a < navir; a += max_A)` would
    never terminate.
  - **`UV_helper` sized its blocks from the wrong variable** — the member `memory_`
    rather than the `memory` parameter it was passed.
  - **Unsigned underflow** in `form_Pab`, `form_Pij`, `form_L`, `fitting_helper` and
    `UV_helper`: subtracting fixed storage from `size_t` memory could wrap to an
    enormous value and sail past the function's own "Not enough memory" throw with a
    garbage block size.
  - **`int` overflow** in size computations that exceed 2^31 for large systems:
    `naux * naux` in the `Jm12` and `V` PSIO entries, `nrows * nso * nso`,
    `np * nso * nso` and `nrows * naocc * navir`, and `naocc * navir` for `nia` and
    the `Gia`/`Gmi`/`Gam` allocations. `apply_B_transpose`'s block loops moved to
    `size_t` throughout.
  - **`apply_G_transpose` under-costed its rows** at `naux` when it allocates two
    buffers per row; now `2 * naux`.

  #### driver: unmasked error message (this is trivial)

  `highest_analytic_properties_available()` passed `e.message` (a string) to
  `_alternative_methods_message()`, which indexes its argument as the stats dict —
  what every call site in `highest_analytic_derivative_available()` passes. A real
  `MissingMethodError` surfaced as `TypeError: string indices must be integers, not
  'str'`, hiding the cause.

  ```
  molecule { 0 2
  O
  H 1 0.97
  }
  set { basis cc-pvdz
        reference uhf
        mp2_type df }
  properties('mp2', properties=['dipole'])
  ```

  now reports that MP2 properties are unavailable for UHF/DF, with the conditions and
  the capabilities-table link.

  ## Two design decisions

  **1. Where to error, and where to keep going.** DFMP2's block-sizing clamps
  (`rows = (rows < maxP ? maxP : rows)`, `max_nia = (max_nia < 1 ? 1 : max_nia)`) look
  like clamps in the wrong direction — they let the code exceed the user's memory
  request. They're deliberate: proceed at the minimum useful block size rather than
  refuse to run. Per discussion in this PR, `mp2.cc` and `corr_grad.cc` keep that
  behavior everywhere, and `require_memory` throws only where the original threw, at
  the original's threshold. The underflow guards above are the exception, and only
  because the original *intended* to throw there and the wrap prevented it.

  **2. The dfocc estimate is a lower bound, deliberately.** It omits contributions it
  can't cheaply bound, and it compares against total requested memory rather than what
  is free — the SCF wavefunction is already resident. So it catches the clearly
  impossible and does not promise the calculation will fit. The label says so.

  ## Verification

  `dfmp2-grad1` through `-grad5`, `dfomp2-1/2`, `dfomp2-grad1/2`, `dfmp2-1/2` and
  `scf5` pass. Additionally checked by hand:

  - DF-MP2 gradient at 12 MB still runs (no regression from the clamp behavior).
  - Water/cc-pVQZ at 30 MB throws the new dfocc error before allocating.
  - Printed values hand-verified against the formulas for water/cc-pVTZ (frozen core)
    and benzene/STO-3G, the latter chosen for `nocc` (21) > `nvir` (15) so the `oo`
    stage is the one that binds.
  - Amplitude counts confirmed per path: RHF energy 3, UHF energy 2, UHF EKT-IP 4,
    UHF gradient 4.

<!--
  ## Open items

  - The dfocc estimate's gradient path was verified through `omp2_tpdm`; the tensors
    held by `prepare4grad`'s callees (`separable_tpdm`, `gfock_*`, `z_vector_pcg`,
    `effective_pdm_gfm`) were not exhaustively traced. They appear to work in 3- and
    2-index quantities, so they are unlikely to set the peak, but this is unproven.
  - Pre-existing and untouched: `mp2_manager` splits on `qchf_` inconsistently — the
    integral branch includes `qchf_ == "FALSE"`, the amplitude branch does not, so
    `qchf_ true` reaches `mp2_direct()` without `fock()` having run.
  - Pre-existing and untouched: with the driver error message now rendering, its "Or
    did you mean?" suffix lists ~110 candidates, because `find_approximate_string_matches`
    matches every `mp<N>`.
-->

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [x] Diagnosed by AI and rechecked by another AI

## Checklist
- [ ] Tests added for any new features
- [ ] Docstring or narrative docs/sphinxman/source updated if needed
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
