### PR TITLE
libpsio: factor out unit-filename generation (on #3452)

### DIFF
--- a/psi4/src/psi4/libpsio/filescfg.cc
+++ b/psi4/src/psi4/libpsio/filescfg.cc
@@ -65,7 +65,7 @@ void PSIO::filecfg_kwd(const char* kwdgrp, const char* kwd, int unit, const char
     files_keywords_[fkwd] = kwdval;
 }
 
-const std::string& PSIO::filecfg_kwd(const char* kwdgrp, const char* kwd, int unit) {
+const std::string& PSIO::filecfg_kwd(const char* kwdgrp, const char* kwd, int unit) const {
     static std::string nullstr;
 
     const std::string fkwd = fullkwd(kwdgrp, kwd, unit);

--- a/psi4/src/psi4/libpsio/get_filename.cc
+++ b/psi4/src/psi4/libpsio/get_filename.cc
@@ -40,7 +40,7 @@
 
 namespace psi {
 
-void PSIO::get_filename(size_t unit, char **name, bool remove_namespace) {
+void PSIO::get_filename(size_t unit, char **name, bool remove_namespace) const {
     std::string kval;
     std::string dot(".");
     std::string ns = dot + pid_;

--- a/psi4/src/psi4/libpsio/getpid.cc
+++ b/psi4/src/psi4/libpsio/getpid.cc
@@ -49,7 +49,7 @@
 
 namespace psi {
 
-std::string PSIO::getpid() {
+std::string PSIO::getpid() const {
     std::stringstream ss;
 
     if (psi::restart_id.empty()) {

--- a/psi4/src/psi4/libpsio/open.cc
+++ b/psi4/src/psi4/libpsio/open.cc
@@ -41,8 +41,15 @@
 #include "psi4/psi4-dec.h"
 namespace psi {
 
-void PSIO::open(size_t unit, int status) {
+std::string PSIO::get_unit_filename(size_t unit) const {
     char *name;
+    get_filename(unit, &name);
+    std::string full_path = PSIOManager::shared_object()->get_file_path(unit) + name + "." + std::to_string(unit);
+    free(name);
+    return full_path;
+}
+
+void PSIO::open(size_t unit, int status) {
     psio_ud* this_unit;
 
     /* check for too large unit */
@@ -53,32 +60,21 @@ void PSIO::open(size_t unit, int status) {
     /* Check to see if this unit is already open */
     if (this_unit->vol.stream != -1) psio_error(unit, PSIO_ERROR_REOPEN);
 
-    /* Get the file name prefix */
-    get_filename(unit, &name);
-
     /* Build the file name and open the file */
-    {
-        std::string spath = PSIOManager::shared_object()->get_file_path(unit);
-        const char* path = spath.c_str();
+    this_unit->vol.path = strdup(get_unit_filename(unit).c_str());
 
-        char* fullpath = (char*)malloc((strlen(path) + strlen(name) + 80) * sizeof(char));
-        sprintf(fullpath, "%s%s.%zu", path, name, unit);
-        this_unit->vol.path = strdup(fullpath);
-        free(fullpath);
+    /* Register the file */
+    PSIOManager::shared_object()->open_file(std::string(this_unit->vol.path), unit);
 
-        /* Register the file */
-        PSIOManager::shared_object()->open_file(std::string(this_unit->vol.path), unit);
+    /* Now open the file */
+    if (status == PSIO_OPEN_OLD) {
+        this_unit->vol.stream = SYSTEM_OPEN(this_unit->vol.path, PSIO_OPEN_OLD_FLAGS, PERMISSION_MODE);
+    } else if (status == PSIO_OPEN_NEW) {
+        this_unit->vol.stream = SYSTEM_OPEN(this_unit->vol.path, PSIO_OPEN_NEW_FLAGS, PERMISSION_MODE);
+    } else
+        psio_error(unit, PSIO_ERROR_OSTAT);
 
-        /* Now open the file */
-        if (status == PSIO_OPEN_OLD) {
-            this_unit->vol.stream = SYSTEM_OPEN(this_unit->vol.path, PSIO_OPEN_OLD_FLAGS, PERMISSION_MODE);
-        } else if (status == PSIO_OPEN_NEW) {
-            this_unit->vol.stream = SYSTEM_OPEN(this_unit->vol.path, PSIO_OPEN_NEW_FLAGS, PERMISSION_MODE);
-        } else
-            psio_error(unit, PSIO_ERROR_OSTAT);
-
-        if (this_unit->vol.stream == -1) psio_error(unit, PSIO_ERROR_OPEN);
-    }
+    if (this_unit->vol.stream == -1) psio_error(unit, PSIO_ERROR_OPEN);
 
     if (status == PSIO_OPEN_OLD)
         tocread(unit);
@@ -89,14 +85,11 @@ void PSIO::open(size_t unit, int status) {
         wt_toclen(unit, 0);
     } else
         psio_error(unit, PSIO_ERROR_OSTAT);
-
-    free(name);
 }
 
 // Mirrors PSIO::open() but just check to see if the file is there
 // status needs is assumed PSIO_OPEN_OLD if this is called
-bool PSIO::exists(size_t unit) {
-    char *name;
+bool PSIO::exists(size_t unit) const {
     psio_ud* this_unit;
 
     if (unit > PSIO_MAXUNIT) psio_error(unit, PSIO_ERROR_MAXUNIT);
@@ -106,23 +99,14 @@ bool PSIO::exists(size_t unit) {
     /* If the unit is already open, the file exists */
     if (this_unit->vol.stream != -1) return (true);
 
-    /* Get the file name prefix */
-    get_filename(unit, &name);
-
     /* Build the file name and test whether it can be opened */
-    std::string spath = PSIOManager::shared_object()->get_file_path(unit);
-    const char* path = spath.c_str();
+    std::string full_path = get_unit_filename(unit);
 
-    char* fullpath = (char*)malloc((strlen(path) + strlen(name) + 80) * sizeof(char));
-    sprintf(fullpath, "%s%s.%zu", path, name, unit);
-
-    int stream = SYSTEM_OPEN(fullpath, O_RDWR);
+    int stream = SYSTEM_OPEN(full_path.c_str(), O_RDWR);
     const bool file_exists = (stream != -1);
     /* and close it again, if opening worked */
     if (stream != -1) SYSTEM_CLOSE(stream);
 
-    free(fullpath);
-    free(name);
     return (file_exists);
 }
 

--- a/psi4/src/psi4/libpsio/open_check.cc
+++ b/psi4/src/psi4/libpsio/open_check.cc
@@ -38,7 +38,7 @@
 
 namespace psi {
 
-int PSIO::open_check(size_t unit) {
+int PSIO::open_check(size_t unit) const {
     psio_ud *this_unit;
 
     this_unit = &(psio_unit[unit]);

--- a/psi4/src/psi4/libpsio/psio.hpp
+++ b/psi4/src/psi4/libpsio/psio.hpp
@@ -32,7 +32,6 @@
 #include <string>
 #include <map>
 #include <set>
-#include <queue>
 #include <memory>
 
 #include "psi4/libpsio/config.h"
@@ -197,7 +196,7 @@ class PSI_API PSIO {
     ~PSIO();
 
     /// return 1 if activated
-    int state() { return state_; }
+    int state() const { return state_; }
     /**
        set keyword kwd describing some aspect of configuration of PSIO file unit
        to value kwdval. kwdgrp specifies the keyword group (useful values are: "DEFAULT", "PSI", and the name of
@@ -210,24 +209,24 @@ class PSI_API PSIO {
        */
     void filecfg_kwd(const char *kwdgrp, const char *kwd, int unit, const char *kwdval);
     /// returns the keyword value. If not defined, returns empty string.
-    const std::string &filecfg_kwd(const char *kwdgrp, const char *kwd, int unit);
+    const std::string &filecfg_kwd(const char *kwdgrp, const char *kwd, int unit) const;
 
     /// moves a file from old_unit to new_unit
     void rename_file(size_t old_unit, size_t new_unit);
 
     /// check if a psi unit already exists or not
-    bool exists(size_t unit);
+    bool exists(size_t unit) const;
     /// open unit. status can be PSIO_OPEN_OLD (if existing file is to be opened) or PSIO_OPEN_NEW if new file should be
     /// open
     void open(size_t unit, int status);
     /// close unit. if keep == 0, will remove the file, else keep it
     void close(size_t unit, int keep);
     /// lookup process id
-    std::string getpid();
+    std::string getpid() const;
     /// sync up the object to the file on disk by closing and opening the file, if necessary
     void rehash(size_t unit);
     /// return 1 if unit is open
-    int open_check(size_t unit);
+    int open_check(size_t unit) const;
     /** Reads data from within a TOC entry from a PSI file.
      **
      **  \param unit   = The PSI unit number used to identify the file to all
@@ -311,7 +310,7 @@ class PSI_API PSIO {
     size_t rd_toclen(size_t unit);          // Read the length of the TOC for a given unit directly from the file.
 
     /// grab the filename of unit and strdup into name.
-    void get_filename(size_t unit, char **name, bool remove_namespace = false);
+    void get_filename(size_t unit, char **name, bool remove_namespace = false) const;
 
     /// delete a specific TOC entry (only deletes entry, not data)
     bool tocdel(size_t unit, const char *key);
@@ -340,7 +339,10 @@ class PSI_API PSIO {
     /// return the last TOC entry
     psio_tocentry *toclast(size_t unit);
 
-    size_t toclen(size_t unit);  // Compute the length of the TOC for a given unit using the in-core TOC list.
+    /// Compose the full on-disk path for a unit: <path><name>.<unit>.
+    std::string get_unit_filename(size_t unit) const;
+
+    size_t toclen(size_t unit) const;  // Compute the length of the TOC for a given unit using the in-core TOC list.
     void wt_toclen(size_t unit, size_t toclen);  // Write the length of the TOC for a given unit directly to the file.
 
     /// Read the table of contents for file number 'unit'.

--- a/psi4/src/psi4/libpsio/toclen.cc
+++ b/psi4/src/psi4/libpsio/toclen.cc
@@ -43,7 +43,7 @@ namespace psi {
 /// @brief Compute the length of the TOC for a given unit using the in-core TOC list
 /// @param unit : file unit number
 /// @return length of the TOC for a given unit
-size_t PSIO::toclen(const size_t unit) {
+size_t PSIO::toclen(const size_t unit) const {
     size_t len = 0;
     psio_tocentry *this_entry = psio_unit[unit].toc;
 


### PR DESCRIPTION
## Description

Follow-up cleanup from #3514 (item 3), now that #3452 is merged.

`PSIO::open()` and `PSIO::exists()` each rebuilt the on-disk filename with the same `get_filename` + `PSIOManager::get_file_path` + `malloc`/`sprintf`/`strdup`/`free` sequence. This factors it into a single private helper `PSIO::get_unit_filename(unit)` that composes the path with `std::string` (`<path><name>.<unit>`), removing the duplication and the manual C-string juggling on the file-open path. Behaviour is unchanged.

## User API & Changelog headlines
- No user-facing change (internal refactor).

## Dev notes & details
- New private member `std::string PSIO::get_unit_filename(size_t unit)` composes `<path><name>.<unit>` via `std::string`.
- `PSIO::open()` and `PSIO::exists()` call it instead of each re-implementing the same path construction with `malloc`/`sprintf`/`strdup`/`free`.
- Pure refactor: no behavioural change on the file-open/exists paths.

## Questions
- None.

## AI
- Refactor drafted with Claude Code (identifying the duplicated path-construction, extracting the helper); reviewed and verified by me.

## Checklist
- [x] Tests added for any new features — n/a (no new feature; covered by existing `psio_roundtrip` test)
- [x] Docstring or narrative docs/sphinxman/source updated if needed — n/a

## Status
- [x] Ready for review

---

Verified: the `psio_roundtrip` standalone test passes (4/4), and a normal SCF (which round-trips PSIO to disk) gives the expected energy.
