### PR TITLE
libpsio: return the unit filename as a std::string

### DIFF
--- a/psi4/src/psi4/libpsio/change_namespace.cc
+++ b/psi4/src/psi4/libpsio/change_namespace.cc
@@ -32,8 +32,7 @@
  */
 
 #include <cstdio>
-#include <cstdlib>
-#include <cstring>
+#include <string>
 #include "psi4/pragma.h"
 #include <memory>
 #include "psi4/libpsio/psio.h"
@@ -42,34 +41,16 @@
 namespace psi {
 
 void PSIO::change_file_namespace(size_t unit, const std::string& ns1, const std::string& ns2) {
-    char *old_name, *new_name, *old_fullpath, *new_fullpath;
-    _default_psio_lib_->get_filename(unit, &old_name, true);
-    _default_psio_lib_->get_filename(unit, &new_name, true);
-    std::string tpath = PSIOManager::shared_object()->get_file_path(unit);
-    const char* path = tpath.c_str();
+    // The bare file name (prefix plus PID), without any namespace suffix.
+    const std::string name = _default_psio_lib_->get_filename(unit, true);
+    const std::string path = PSIOManager::shared_object()->get_file_path(unit);
+    const std::string unit_suffix = "." + std::to_string(unit);
 
-    old_fullpath = (char*)malloc((strlen(path) + strlen(old_name) + 80) * sizeof(char));
-    new_fullpath = (char*)malloc((strlen(path) + strlen(new_name) + 80) * sizeof(char));
+    const std::string old_fullpath = path + name + (ns1.empty() ? "" : "." + ns1) + unit_suffix;
+    const std::string new_fullpath = path + name + (ns2.empty() ? "" : "." + ns2) + unit_suffix;
 
-    if (ns1 == "") {
-        sprintf(old_fullpath, "%s%s.%zu", path, old_name, unit);
-    } else {
-        sprintf(old_fullpath, "%s%s.%s.%zu", path, old_name, ns1.c_str(), unit);
-    }
-    if (ns2 == "") {
-        sprintf(new_fullpath, "%s%s.%zu", path, new_name, unit);
-    } else {
-        sprintf(new_fullpath, "%s%s.%s.%zu", path, new_name, ns2.c_str(), unit);
-    }
-
-    // printf("%s\n",old_fullpath);
-    // printf("%s\n",new_fullpath);
-
-    PSIOManager::shared_object()->move_file(std::string(old_fullpath), std::string(new_fullpath));
-    ::rename(old_fullpath, new_fullpath);
-
-    free(old_fullpath);
-    free(new_fullpath);
+    PSIOManager::shared_object()->move_file(old_fullpath, new_fullpath);
+    ::rename(old_fullpath.c_str(), new_fullpath.c_str());
 }
 
 }  // namespace psi

--- a/psi4/src/psi4/libpsio/get_filename.cc
+++ b/psi4/src/psi4/libpsio/get_filename.cc
@@ -31,48 +31,23 @@
  \ingroup PSIO
  */
 
-#include <cstdio>
 #include <cstdlib>
-#include <cstring>
+#include <string>
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/psi4-dec.h"
 
 namespace psi {
 
-void PSIO::get_filename(size_t unit, char **name, bool remove_namespace) const {
-    std::string kval;
-    std::string dot(".");
-    std::string ns = dot + pid_;
-    ns += (default_namespace_ == "" || remove_namespace) ? "" : dot + default_namespace_;
-    // std::string path = PSIOManager::shared_object()->get_file_path(unit);
-    // printf("%s %s: %d\n", path.c_str(), ns.c_str(), unit);
-    //*name = strdup((path + ns).c_str());
-    // return;
+std::string PSIO::get_filename(size_t unit, bool remove_namespace) const {
+    std::string ns = "." + pid_;
+    if (!(default_namespace_.empty() || remove_namespace)) ns += "." + default_namespace_;
 
-    kval = filecfg_kwd("PSI", "NAME", unit);
-    if (!kval.empty()) {
-        kval = kval + ns;
-        *name = strdup(kval.c_str());
-        return;
-    }
-    kval = filecfg_kwd("PSI", "NAME", -1);
-    if (!kval.empty()) {
-        kval = kval + ns;
-        *name = strdup(kval.c_str());
-        return;
-    }
-    kval = filecfg_kwd("DEFAULT", "NAME", unit);
-    if (!kval.empty()) {
-        kval = kval + ns;
-        *name = strdup(kval.c_str());
-        return;
-    }
-    kval = filecfg_kwd("DEFAULT", "NAME", -1);
-    if (!kval.empty()) {
-        kval = kval + ns;
-        *name = strdup(kval.c_str());
-        return;
+    for (const char *kwdgrp : {"PSI", "DEFAULT"}) {
+        for (int u : {static_cast<int>(unit), -1}) {
+            const std::string &kval = filecfg_kwd(kwdgrp, "NAME", u);
+            if (!kval.empty()) return kval + ns;
+        }
     }
 
     // assume that the default has been provided already

--- a/psi4/src/psi4/libpsio/open.cc
+++ b/psi4/src/psi4/libpsio/open.cc
@@ -42,11 +42,7 @@
 namespace psi {
 
 std::string PSIO::get_unit_filename(size_t unit) const {
-    char *name;
-    get_filename(unit, &name);
-    std::string full_path = PSIOManager::shared_object()->get_file_path(unit) + name + "." + std::to_string(unit);
-    free(name);
-    return full_path;
+    return PSIOManager::shared_object()->get_file_path(unit) + get_filename(unit) + "." + std::to_string(unit);
 }
 
 void PSIO::open(size_t unit, int status) {

--- a/psi4/src/psi4/libpsio/psio.hpp
+++ b/psi4/src/psi4/libpsio/psio.hpp
@@ -309,8 +309,8 @@ class PSI_API PSIO {
     void rewind_toclen(const size_t unit);  // Seek the stream of the file backing a unit to its beginning.
     size_t rd_toclen(size_t unit);          // Read the length of the TOC for a given unit directly from the file.
 
-    /// grab the filename of unit and strdup into name.
-    void get_filename(size_t unit, char **name, bool remove_namespace = false) const;
+    /// Return the filename of a unit (the file-name prefix plus namespace suffix, without path or unit number).
+    std::string get_filename(size_t unit, bool remove_namespace = false) const;
 
     /// delete a specific TOC entry (only deletes entry, not data)
     bool tocdel(size_t unit, const char *key);

--- a/psi4/src/psi4/libpsio/rename_file.cc
+++ b/psi4/src/psi4/libpsio/rename_file.cc
@@ -32,8 +32,6 @@
  */
 
 #include <cstdio>
-#include <cstring>
-#include <cstdlib>
 #include <string>
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"
@@ -41,32 +39,12 @@
 namespace psi {
 
 void PSIO::rename_file(size_t old_unit, size_t new_unit) {
-    char *old_name, *new_name;
-    /* Get the file name prefix */
-    get_filename(old_unit, &old_name);
-    get_filename(new_unit, &new_name);
+    const std::string old_full_path = get_unit_filename(old_unit);
+    const std::string new_full_path = get_unit_filename(new_unit);
 
-    /* Get the path */
-    std::string sold_path = PSIOManager::shared_object()->get_file_path(old_unit).c_str();
-    std::string snew_path = PSIOManager::shared_object()->get_file_path(new_unit).c_str();
-    const char* old_path = sold_path.c_str();
-    const char* new_path = snew_path.c_str();
-
-    /* build the full path */
-    char* old_full_path = (char*)malloc((strlen(old_path) + strlen(old_name) + 80) * sizeof(char));
-    char* new_full_path = (char*)malloc((strlen(new_path) + strlen(new_name) + 80) * sizeof(char));
-
-    sprintf(old_full_path, "%s%s.%zu", old_path, old_name, old_unit);
-    sprintf(new_full_path, "%s%s.%zu", new_path, new_name, new_unit);
-
-  /* move the file */
-    remove(new_full_path); // On Windows, if the new path exist, it has to be remove, otherwise "rename" fails
-    rename(old_full_path, new_full_path);
-
-    free(old_name);
-    free(new_name);
-    free(old_full_path);
-    free(new_full_path);
+    // On Windows, if the new path exists it has to be removed first, otherwise "rename" fails.
+    remove(new_full_path.c_str());
+    rename(old_full_path.c_str(), new_full_path.c_str());
 }
 
 }  // namespace psi


### PR DESCRIPTION
## Description

`PSIO::get_filename()` returned its result the old way: a `char **` out-param, `strdup`'d by the callee, `free`'d by every caller. A reviewer on #3515 called the convention horrible, which it is — three of the four call sites existed only to allocate a buffer, copy into it and release it again. It now returns a `std::string`.

```c++
-    void get_filename(size_t unit, char **name, bool remove_namespace = false) const;
+    std::string get_filename(size_t unit, bool remove_namespace = false) const;
```

The three callers compose paths with `std::string` instead of `malloc`/`sprintf`/`free`, and `rename_file()` drops its own path assembly in favour of the `get_unit_filename()` helper #3515 factored out — the two were building the same string by different means.

**Net −70 lines**, no behaviour change: the composed paths are byte-identical. `get_filename` is used nowhere outside `libpsio`, so nothing else sees the signature change.

## Rebased and reduced

This PR previously carried the whole of #3514 item 2 and was stacked on #3452 → #3515 → #3516. #3452 and #3515 have merged, and the other two thirds are **superseded by #3540**, which reimplements libpsio's I/O core on [libspill](https://github.com/ReLibQC/libspill):

| previously in this PR | status |
| --- | --- |
| `psio_unit` / `psio_readlen` / `psio_writlen` → `std::vector` | dropped — #3540 deletes the array outright rather than converting it |
| `psio_ud::path` → `std::string` | dropped — `psio_vol` and `psio_ud` go with it |
| **`get_filename()` → `std::string`** | **kept — this PR** |

Once libspill owns the file handle and the on-disk layout, the per-unit descriptor has nothing left to describe, so modernizing it is effort spent on something about to be removed. `get_filename.cc` is a file that port *keeps*, so this half stands on its own and no longer depends on anything unmerged.

One difference from the earlier revision worth flagging: it had dropped `const` from `get_filename()` and `get_unit_filename()`, both of which are `const` on master. That is preserved here.

## Checklist
- [x] Tests added for any new features — n/a, no behaviour change; covered by the existing `psio_roundtrip` test
- [ ] Docstring or narrative docs updated if needed — n/a

## Status
- [x] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
