### PR TITLE
Restricted Open-Shell DLPNO-CCSD(T) (Under Development)

### DIFF
--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -810,6 +810,11 @@ Bibliography
    *J. Chem. Phys.* **148**, 011101 (2018).
    https://doi.org/10.1063/1.5011798
 
+.. [Guo:2020:024116]
+   Y. Guo, C. Riplinger, D. G. Liakos, U. Becker, M. Saitow, and F. Neese,
+   *J. Chem. Phys.* **152**, 024116 (2020).
+   https://doi.org/10.1063/1.5127550
+
 .. [Jiang:2024:082502]
    A. Jiang, Z. Glick, D. Poole, J. M. Turney, C. D. Sherrill, and H. F. Schaefer III,
    *J. Chem. Phys.* **161**, 082502 (2024).

--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -815,6 +815,21 @@ Bibliography
    *J. Chem. Phys.* **161**, 082502 (2024).
    https://doi.org/10.1063/5.0219963
 
+.. [Neese:2006:10213]
+   F. Neese,
+   *J. Am. Chem. Soc.* **128**, 10213-10222 (2006).
+   https://doi.org/10.1021/ja061798a
+
+.. [Hansen:2011:214102]
+   A. Hansen, D. G. Liakos, and F. Neese,
+   *J. Chem. Phys.* **135**, 214102 (2011).
+   https://doi.org/10.1063/1.3663855
+
+.. [Szabo:2021:2886]
+   P. B. Szabó, J. Csóka, M. Kállay, and P. R. Nagy,
+   *J. Chem. Theory Comput.* **17**, 2886-2905 (2021).
+   https://doi.org/10.1021/acs.jctc.1c00093
+
 .. [Pak:2025:094110]
    "Fast simulation of soft x-ray near-edge spectra using a relativistic state-interaction approach"
    S. Pak, M. A. Dada, N. Govind and D. R. Nascimento,
@@ -832,4 +847,3 @@ Bibliography
    E. Aprà, E. J. Bylaska, W. A. de Jong, et. al.,
    *J. Chem. Phys.* **152**, 184102 (2020)
    https://doi.org/10.1063/5.0004997
-

--- a/doc/sphinxman/source/dlpnocc.rst
+++ b/doc/sphinxman/source/dlpnocc.rst
@@ -103,13 +103,16 @@ An example input file for a DLPNO-CCSD(T) computation is::
 Open-Shell References and UHF-to-QRO Transformation
 ----------------------------------------------------
 
-``DLPNO-CCSD`` supports high-spin ``ROHF`` references.  When ``REFERENCE UHF``
-is requested, |PSIfour| first constructs a common set of quasi-restricted
-orbitals (QROs) and then invokes the restricted open-shell DLPNO-CCSD solver.
+``DLPNO-CCSD`` and ``DLPNO-CCSD(T)`` support high-spin ``ROHF`` references.
+When ``REFERENCE UHF`` is requested for DLPNO-CCSD, |PSIfour| first constructs
+a common set of quasi-restricted orbitals (QROs) and then invokes the restricted
+open-shell DLPNO-CCSD solver.
 The QRO construction follows Neese [Neese:2006:10213]_ and the open-shell
 local-correlation formulation of Hansen, Liakos, and Neese
 [Hansen:2011:214102]_.  Related restricted-orbital open-shell local-correlation
-considerations are discussed by Szabó *et al.* [Szabo:2021:2886]_.
+considerations are discussed by Szabó *et al.* [Szabo:2021:2886]_.  The
+spin-resolved semicanonical and iterative triples corrections follow the
+open-shell DLPNO-(T0/T) formulation of Guo *et al.* [Guo:2020:024116]_.
 
 The spin-summed UHF density is diagonalized to obtain unrestricted natural
 orbitals.  The first :math:`N_\beta` orbitals define the doubly occupied space,
@@ -187,7 +190,8 @@ Practical Advice
 
 * DLPNO-CCSD is available for closed-shell RHF, high-spin ROHF, and high-spin
   UHF references transformed to QROs.  The perturbative triples correction is
-  presently available only for closed-shell RHF computations.
+  available for closed-shell RHF and high-spin ROHF computations; the UHF-to-QRO
+  route is presently available only for DLPNO-CCSD.
 
 Computation Size Limits
 -----------------------

--- a/doc/sphinxman/source/dlpnocc.rst
+++ b/doc/sphinxman/source/dlpnocc.rst
@@ -100,6 +100,44 @@ An example input file for a DLPNO-CCSD(T) computation is::
    
    energy('dlpno-ccsd(t)') # dlpno-ccsd(t0) for the semicanonical (T0) computation
 
+Open-Shell References and UHF-to-QRO Transformation
+----------------------------------------------------
+
+``DLPNO-CCSD`` supports high-spin ``ROHF`` references.  When ``REFERENCE UHF``
+is requested, |PSIfour| first constructs a common set of quasi-restricted
+orbitals (QROs) and then invokes the restricted open-shell DLPNO-CCSD solver.
+The QRO construction follows Neese [Neese:2006:10213]_ and the open-shell
+local-correlation formulation of Hansen, Liakos, and Neese
+[Hansen:2011:214102]_.  Related restricted-orbital open-shell local-correlation
+considerations are discussed by Szabó *et al.* [Szabo:2021:2886]_.
+
+The spin-summed UHF density is diagonalized to obtain unrestricted natural
+orbitals.  The first :math:`N_\beta` orbitals define the doubly occupied space,
+the next :math:`N_\alpha-N_\beta` define the singly occupied space, and the
+remainder define the external space.  These three spaces are separately
+semicanonicalized with :math:`F^\beta`,
+:math:`(F^\alpha+F^\beta)/2`, and :math:`F^\alpha`, respectively.  Rotations
+between occupation classes are not permitted.
+
+The resulting restricted high-spin determinant is not an optimized ROHF
+determinant.  Therefore, occupied--virtual Fock elements and their singles
+contributions are retained.  Its spin-resolved Fock matrices and determinant
+energy are rebuilt from the QRO densities.  Energy variables follow
+
+.. math::
+
+   E_\text{DLPNO-CCSD}=E_\text{QRO reference}+E_\text{CCSD correlation}.
+
+``SCF TOTAL ENERGY`` remains the energy of the input UHF calculation for
+provenance, while ``QRO REFERENCE ENERGY`` and ``CURRENT REFERENCE ENERGY``
+contain the determinant energy used by the correlation calculation.  A
+broken-symmetry UHF singlet cannot be represented by this high-spin restricted
+formalism and is rejected; a collapsed closed-shell UHF reference is allowed.
+At present, the UHF-to-QRO route is available for ``DLPNO-CCSD`` only.
+
+This implementation was developed from published equations and native
+|PSIfour| infrastructure.  No ORCA source code was used.
+
 PNO Convergence Settings
 ------------------------
 
@@ -147,7 +185,9 @@ Practical Advice
 
 * Note that DLPNO does not yet have molecular point group symmetry implemented and will run in C1 symmetry.
 
-* At this time, DLPNO-CCSD/(T) is only available for closed-shell RHF computations.
+* DLPNO-CCSD is available for closed-shell RHF, high-spin ROHF, and high-spin
+  UHF references transformed to QROs.  The perturbative triples correction is
+  presently available only for closed-shell RHF computations.
 
 Computation Size Limits
 -----------------------

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -4621,7 +4621,7 @@ def run_dlpnoccsd(name, **kwargs):
         raise ValidationError("""  DLPNO-CCSD does not make use of molecular symmetry: """
                               """reference wavefunction must be C1.\n""")
     
-    if core.get_global_option('REFERENCE') != "RHF":
+    if core.get_global_option('REFERENCE') == "UHF":
         raise ValidationError("DLPNO-CCSD is not available for %s references.",
                               core.get_global_option('REFERENCE'))
     

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -4681,8 +4681,8 @@ def run_dlpnoccsd_t(name, **kwargs):
         raise ValidationError("""  DLPNO-CCSD(T) does not make use of molecular symmetry: """
                               """reference wavefunction must be C1.\n""")
     
-    if core.get_global_option('REFERENCE') != "RHF":
-        raise ValidationError("DLPNO-CCSD(T) is not available for %s references.",
+    if core.get_global_option('REFERENCE') not in ["RHF", "ROHF"]:
+        raise ValidationError("DLPNO-CCSD(T) is not available for %s references." %
                               core.get_global_option('REFERENCE'))
     
     core.tstart()

--- a/psi4/driver/procrouting/proc.py
+++ b/psi4/driver/procrouting/proc.py
@@ -4621,10 +4621,6 @@ def run_dlpnoccsd(name, **kwargs):
         raise ValidationError("""  DLPNO-CCSD does not make use of molecular symmetry: """
                               """reference wavefunction must be C1.\n""")
     
-    if core.get_global_option('REFERENCE') == "UHF":
-        raise ValidationError("DLPNO-CCSD is not available for %s references.",
-                              core.get_global_option('REFERENCE'))
-    
     core.tstart()
     core.print_out('\n')
     p4util.banner('DLPNO-CCSD')

--- a/psi4/src/psi4/dlpno/CMakeLists.txt
+++ b/psi4/src/psi4/dlpno/CMakeLists.txt
@@ -3,6 +3,7 @@ list(APPEND sources
   mp2.cc
   ccsd.cc
   triples.cc
+  ro_triples.cc
   wrapper.cc
   sparse.cc
   )

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -3096,11 +3096,17 @@ void RO_DLPNOCCSD::print_header() {
     const int nsomo = nalpha_ - nbeta_;
 
     outfile->Printf("   --------------------------------------------------\n");
-    outfile->Printf("          ROHF T1-Transformed DLPNO-CCSD            \n");
+    outfile->Printf("     Restricted Open-Shell T1-Transformed DLPNO-CCSD\n");
     outfile->Printf("                    by Andy Jiang                    \n");
     outfile->Printf("       Closed-shell engine: DOI 10.1063/5.0219963   \n");
     outfile->Printf("   --------------------------------------------------\n\n");
-    outfile->Printf("  Reference                    : ROHF\n");
+    outfile->Printf("  Reference                    : %s\n",
+                    qro_reference_ ? "UHF -> QRO" : "ROHF");
+    if (qro_reference_) {
+        outfile->Printf("  Correlation reference energy : QRO determinant\n");
+        outfile->Printf("  Input UHF SCF energy          : %20.12f\n", input_scf_energy_);
+        outfile->Printf("  QRO reference energy          : %20.12f\n", reference_energy_);
+    }
     outfile->Printf("  PNO selector                 : spin-independent SROMP2\n");
     outfile->Printf("  SOMO treatment               : appended to every pair space\n");
     outfile->Printf("  DLPNO convergence            : %s\n\n",
@@ -3191,17 +3197,20 @@ void RO_DLPNOCCSD::print_results() {
 
     const double e_corr =
         e_lccsd_ + de_weak_ + de_lmp2_eliminated_ + de_pno_total_ + de_dipole_;
-    const double e_total = variables_["SCF TOTAL ENERGY"] + e_corr;
+    const double e_total = reference_energy_ + e_corr;
 
     outfile->Printf("  \n");
-    outfile->Printf("  Total ROHF-DLPNO-CCSD Correlation Energy: %16.12f \n", e_corr);
+    outfile->Printf("  Total Restricted-Open-Shell DLPNO-CCSD Correlation Energy: %16.12f \n", e_corr);
     outfile->Printf("    Strong-Pair RCCSD Contribution:         %16.12f \n", e_lccsd_);
     outfile->Printf("    SROLMP2 Weak-Pair Contribution:         %16.12f \n", de_weak_);
     outfile->Printf("    Semicanonical SROMP2 Correction:        %16.12f \n",
                     de_lmp2_eliminated_);
-    outfile->Printf("    ROHF Dipole-Pair Correction:            %16.12f \n", de_dipole_);
+    outfile->Printf("    Open-Shell Dipole-Pair Correction:       %16.12f \n", de_dipole_);
     outfile->Printf("    PNO Truncation Correction:              %16.12f \n", de_pno_total_);
-    outfile->Printf("\n\n  @Total ROHF-DLPNO-CCSD Energy: %16.12f \n", e_total);
+    outfile->Printf("\n\n  @Total Restricted-Open-Shell DLPNO-CCSD Energy: %16.12f \n", e_total);
+    if (qro_reference_)
+        outfile->Printf("    (QRO reference %16.12f + correlation %16.12f)\n",
+                        reference_energy_, e_corr);
     outfile->Printf("    *** Spin-adapted and SOMO-safe. A thousand hallelujahs!!! \n\n");
 }
 
@@ -3607,14 +3616,14 @@ std::vector<double> RO_DLPNOCCSD::compute_semicanonical_sromp2_pair_energies(boo
     const int nbocc = nbeta_ - nfrzc();
     const int n_lmo_pairs = ij_to_i_j_.size();
     const std::array<SharedMatrix, 2> F_lmo_spin = {
-        linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_lmo_, true, false, false),
-        linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_lmo_, true, false, false)};
+        linalg::triplet(C_lmo_, F_reference_a_, C_lmo_, true, false, false),
+        linalg::triplet(C_lmo_, F_reference_b_, C_lmo_, true, false, false)};
     const std::array<SharedMatrix, 2> F_pao_spin = {
-        linalg::triplet(C_pao_, reference_wavefunction_->Fa(), C_pao_, true, false, false),
-        linalg::triplet(C_pao_, reference_wavefunction_->Fb(), C_pao_, true, false, false)};
+        linalg::triplet(C_pao_, F_reference_a_, C_pao_, true, false, false),
+        linalg::triplet(C_pao_, F_reference_b_, C_pao_, true, false, false)};
     const std::array<SharedMatrix, 2> F_lmo_pao_spin = {
-        linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_pao_, true, false, false),
-        linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_pao_, true, false, false)};
+        linalg::triplet(C_lmo_, F_reference_a_, C_pao_, true, false, false),
+        linalg::triplet(C_lmo_, F_reference_b_, C_pao_, true, false, false)};
 
     if (print_header) {
         outfile->Printf("\n  ==> Spin-Restricted Open-Shell Semicanonical MP2 Pair Prescreening <==\n\n");
@@ -3728,14 +3737,14 @@ std::vector<double> RO_DLPNOCCSD::update_sromp2_pair_energies() {
     const int nbocc = nbeta_ - nfrzc();
     const int n_lmo_pairs = ij_to_i_j_.size();
     const std::array<SharedMatrix, 2> F_lmo_spin = {
-        linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_lmo_, true, false, false),
-        linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_lmo_, true, false, false)};
+        linalg::triplet(C_lmo_, F_reference_a_, C_lmo_, true, false, false),
+        linalg::triplet(C_lmo_, F_reference_b_, C_lmo_, true, false, false)};
     const std::array<SharedMatrix, 2> F_pao_spin = {
-        linalg::triplet(C_pao_, reference_wavefunction_->Fa(), C_pao_, true, false, false),
-        linalg::triplet(C_pao_, reference_wavefunction_->Fb(), C_pao_, true, false, false)};
+        linalg::triplet(C_pao_, F_reference_a_, C_pao_, true, false, false),
+        linalg::triplet(C_pao_, F_reference_b_, C_pao_, true, false, false)};
     const std::array<SharedMatrix, 2> F_lmo_pao_spin = {
-        linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_pao_, true, false, false),
-        linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_pao_, true, false, false)};
+        linalg::triplet(C_lmo_, F_reference_a_, C_pao_, true, false, false),
+        linalg::triplet(C_lmo_, F_reference_b_, C_pao_, true, false, false)};
     for (auto& block : sromp2_pair_energies_) block.assign(n_lmo_pairs, 0.0);
     std::vector<double> e_ijs(n_lmo_pairs, 0.0);
 
@@ -4023,7 +4032,7 @@ void RO_DLPNOCCSD::extend_virtual_by_somo() {
     C_pao_ = C_pao_new;
     // Recompute S_pao and F_pao
     S_pao_ = linalg::triplet(C_pao_, reference_wavefunction_->S(), C_pao_, true, false, false);
-    F_pao_ = linalg::triplet(C_pao_, reference_wavefunction_->Fa(), C_pao_, true, false, false);
+    F_pao_ = linalg::triplet(C_pao_, F_reference_a_, C_pao_, true, false, false);
 
 #pragma omp parallel for
     for (int ij = 0; ij < n_lmo_pairs; ++ij) {
@@ -4374,8 +4383,8 @@ void RO_DLPNOCCSD::t1_fock_spin() {
     constexpr std::array<SpinCase, 2> spins = {SpinCase::Alpha, SpinCase::Beta};
 
     std::array<SharedMatrix, 2> F_lmo_pao_spin = {
-        linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_pao_, true, false, false),
-        linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_pao_, true, false, false)};
+        linalg::triplet(C_lmo_, F_reference_a_, C_pao_, true, false, false),
+        linalg::triplet(C_lmo_, F_reference_b_, C_pao_, true, false, false)};
 
     // The bars denote dressing over contracted indices.  The Coulomb part
     // contains alpha + beta T1 density; exchange is same-spin only.
@@ -5575,11 +5584,11 @@ void RO_DLPNOCCSD::lccsd_iterations() {
     std::array<SharedMatrix, 2> F_lmo_spin;
     std::array<std::vector<SharedMatrix>, 2> Fia_energy_spin;
 
-    F_lmo_a_ = linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_lmo_, true, false, false);
-    F_lmo_b_ = linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_lmo_, true, false, false);
+    F_lmo_a_ = linalg::triplet(C_lmo_, F_reference_a_, C_lmo_, true, false, false);
+    F_lmo_b_ = linalg::triplet(C_lmo_, F_reference_b_, C_lmo_, true, false, false);
 
-    F_pao_a_ = linalg::triplet(C_pao_, reference_wavefunction_->Fa(), C_pao_, true, false, false);
-    F_pao_b_ = linalg::triplet(C_pao_, reference_wavefunction_->Fb(), C_pao_, true, false, false);
+    F_pao_a_ = linalg::triplet(C_pao_, F_reference_a_, C_pao_, true, false, false);
+    F_pao_b_ = linalg::triplet(C_pao_, F_reference_b_, C_pao_, true, false, false);
 
     F_lmo_spin[static_cast<int>(SpinCase::Alpha)] = F_lmo_a_;
     F_lmo_spin[static_cast<int>(SpinCase::Beta)] = F_lmo_b_;
@@ -5587,8 +5596,8 @@ void RO_DLPNOCCSD::lccsd_iterations() {
     // Bare f(ia) blocks for the spin-resolved CCSD energy.  These vanish in
     // the canonical closed-shell limit, but not for a general ROHF reference.
     std::array<SharedMatrix, 2> F_lmo_pao_spin = {
-        linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_pao_, true, false, false),
-        linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_pao_, true, false, false)};
+        linalg::triplet(C_lmo_, F_reference_a_, C_pao_, true, false, false),
+        linalg::triplet(C_lmo_, F_reference_b_, C_pao_, true, false, false)};
     for (SpinCase sigma : {SpinCase::Alpha, SpinCase::Beta}) {
         Fia_energy_spin[static_cast<int>(sigma)].resize(naocc);
     }
@@ -5982,6 +5991,7 @@ void RO_DLPNOCCSD::lccsd_iterations() {
 double RO_DLPNOCCSD::compute_dlpno_ccsd_energy() {
     timer_on("DLPNO-CCSD");
 
+    prepare_reference();
     print_header();
 
     timer_on("Setup Orbitals");
@@ -5990,8 +6000,8 @@ double RO_DLPNOCCSD::compute_dlpno_ccsd_energy() {
     // SROMP2/PNO-RCCSD uses one spin-free Fock operator for the common
     // spatial selector amplitudes and PNOs.  The actual RCCSD equations and
     // Jacobi denominators below continue to use F^alpha and F^beta.
-    auto F_spin_free_ao = reference_wavefunction_->Fa()->clone();
-    F_spin_free_ao->add(reference_wavefunction_->Fb());
+    auto F_spin_free_ao = F_reference_a_->clone();
+    F_spin_free_ao->add(F_reference_b_);
     F_spin_free_ao->scale(0.5);
     F_lmo_ = linalg::triplet(C_lmo_, F_spin_free_ao, C_lmo_, true, false, false);
     F_pao_ = linalg::triplet(C_pao_, F_spin_free_ao, C_pao_, true, false, false);
@@ -6002,8 +6012,6 @@ double RO_DLPNOCCSD::compute_dlpno_ccsd_energy() {
     compute_overlap_ints();
     timer_off("Overlap Ints");
 
-    /* TODO: Update this function to account for alpha and beta spin cases
-    (This function currently assumes nalpha = ndocc, but nalpha > ndocc in ROHF) */
     timer_on("Dipole Ints");
     compute_dipole_ints();
     timer_off("Dipole Ints");
@@ -6054,10 +6062,11 @@ double RO_DLPNOCCSD::compute_dlpno_ccsd_energy() {
     timer_off("Refined Pair Prescreening");
 
     // Set variables from LMP2
-    double e_scf = variables_["SCF TOTAL ENERGY"];
+    const double e_reference = reference_energy_;
     double e_lmp2_corr = e_lmp2_ + de_lmp2_eliminated_ + de_dipole_ + de_pno_total_;
-    double e_lmp2_total = e_scf + e_lmp2_corr;
+    double e_lmp2_total = e_reference + e_lmp2_corr;
 
+    set_scalar_variable("CURRENT REFERENCE ENERGY", e_reference);
     set_scalar_variable("MP2 CORRELATION ENERGY", e_lmp2_corr);
     set_scalar_variable("CURRENT CORRELATION ENERGY", e_lmp2_corr);
     set_scalar_variable("MP2 TOTAL ENERGY", e_lmp2_total);
@@ -6069,7 +6078,8 @@ double RO_DLPNOCCSD::compute_dlpno_ccsd_energy() {
     outfile->Printf("    Semicanonical MP2 Correction:     %16.12f \n", de_lmp2_eliminated_);
     outfile->Printf("    Dipole Correction:                %16.12f \n", de_dipole_);
     outfile->Printf("    PNO Truncation Correction:        %16.12f \n", de_pno_total_);
-    outfile->Printf("\n\n  @Total DLPNO-MP2 Energy: %16.12f \n", variables_["SCF TOTAL ENERGY"] + e_lmp2_ + de_lmp2_eliminated_ + de_pno_total_ + de_dipole_);
+    outfile->Printf("\n\n  @Total DLPNO-MP2 Energy: %16.12f \n",
+                    e_reference + e_lmp2_ + de_lmp2_eliminated_ + de_pno_total_ + de_dipole_);
     outfile->Printf("\n   * WARNING: This answer will likely vary from one obtained by a energy('dlpno-mp2') call");
     outfile->Printf("\n                due to lack of a semi-canonical MP2 prescreening step in DLPNO-MP2, as well");
     outfile->Printf("\n                as slightly tighter cutoffs utilized to increase accuracy in the context of CC!!!\n\n");
@@ -6113,8 +6123,9 @@ double RO_DLPNOCCSD::compute_dlpno_ccsd_energy() {
     timer_off("DLPNO-CCSD");
 
     double e_ccsd_corr = e_lccsd_ + de_weak_ + de_lmp2_eliminated_ + de_dipole_ + de_pno_total_;
-    double e_ccsd_total = e_scf + e_ccsd_corr;
+    double e_ccsd_total = e_reference + e_ccsd_corr;
 
+    set_scalar_variable("CURRENT REFERENCE ENERGY", e_reference);
     set_scalar_variable("CCSD CORRELATION ENERGY", e_ccsd_corr);
     set_scalar_variable("CURRENT CORRELATION ENERGY", e_ccsd_corr);
     set_scalar_variable("CCSD TOTAL ENERGY", e_ccsd_total);

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -4448,62 +4448,6 @@ std::array<RO_DLPNOCCSD::SpinPairMatrixBlocks, 2> RO_DLPNOCCSD::compute_delta() 
     return {std::move(delta), std::move(delta_bar)};
 }
 
-std::array<std::vector<SharedMatrix>, 2> RO_DLPNOCCSD::compute_Fbc_double_tilde() {
-
-    const int n_lmo_pairs = ij_to_i_j_.size();
-    const int nbocc = nbeta_ - nfrzc();
-
-    std::array<std::vector<SharedMatrix>, 2> F_bc_double_tilde;
-
-    constexpr std::array<SpinCase, 2> singles_spin_cases = { SpinCase::Alpha, SpinCase::Beta };
-    F_bc_double_tilde[static_cast<int>(SpinCase::Alpha)].resize(n_lmo_pairs);
-    F_bc_double_tilde[static_cast<int>(SpinCase::Beta)].resize(n_lmo_pairs);
-
-#pragma omp parallel for schedule(dynamic, 1)
-    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
-        auto &[i, j] = ij_to_i_j_[ij];
-        const int ji = ij_to_ji_[ij];
-
-        int nlmo_ij = lmopair_to_lmos_[ij].size();
-
-        if (i > j) continue;
-
-        for (SpinCase sigma : singles_spin_cases) {
-            const int s = static_cast<int>(sigma);
-            F_bc_double_tilde[s][ij] = Fab_tilde_spin_[s][ij]->clone();
-
-            for (SpinCase gamma : singles_spin_cases) {
-                for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
-                    int k = lmopair_to_lmos_[ij][k_ij];
-                    if (sigma == SpinCase::Beta && k >= nbocc) continue;
-
-                    for (int l_ij = 0; l_ij < nlmo_ij; ++l_ij) {
-                        int l = lmopair_to_lmos_[ij][l_ij];
-                        if (gamma == SpinCase::Beta && l >= nbocc) continue;
-                        int kl = i_j_to_ij_[k][l];
-                        if (kl == -1) continue;
-
-                        auto S_ij_kl_s = S_PNO(ij, kl)->clone();
-                        matrix_spin_enforcer_vv(S_ij_kl_s, sigma);
-
-                        auto T_iajb_s_g = T_iajb_spin_helper(kl, sigma, gamma);
-                        auto F_bc_double_tilde_temp = linalg::doublet(T_iajb_s_g, K_iajb_[kl], false, true); // (b, d) (c, d) -> (b, c)
-                        F_bc_double_tilde[s][ij]->subtract(linalg::triplet(S_ij_kl_s, F_bc_double_tilde_temp, S_ij_kl_s, false, false, true));
-                    } // end l_ij
-                } // end k_ij
-
-            } // end gamma
-
-            // Probably not necessary, since enforcing spin on overlap matrices takes care of this
-            matrix_spin_enforcer_vv(F_bc_double_tilde[s][ij], sigma);
-            if (i != j) F_bc_double_tilde[s][ji] = F_bc_double_tilde[s][ij];
-        } // end sigma
-
-    } // end ij
-
-    return F_bc_double_tilde;
-}
-
 std::array<SharedMatrix, 2> RO_DLPNOCCSD::compute_Fki_double_tilde() {
 
     int n_lmo_pairs = ij_to_i_j_.size();
@@ -4724,7 +4668,6 @@ void RO_DLPNOCCSD::compute_R_ia(
 void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_iajb, std::array<std::vector<SharedMatrix>, 3> &Rn_iajb) {
 
     int n_lmo_pairs = ij_to_i_j_.size();
-    int naocc = nalpha_ - nfrzc();
     int nbocc = nbeta_ - nfrzc();
 
     auto beta_ijkl = compute_beta();
@@ -4732,7 +4675,6 @@ void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_ia
     auto delta_terms = compute_delta();
     auto& delta_jk = delta_terms[0];
     auto& delta_bar_jk = delta_terms[1];
-    auto F_bc_double_tilde = compute_Fbc_double_tilde();
     auto F_ki_double_tilde = compute_Fki_double_tilde();
 
     constexpr std::array<SpinCase, 2> singles_spin_cases = { SpinCase::Alpha, SpinCase::Beta };
@@ -4763,6 +4705,117 @@ void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_ia
 
         auto qma_ij = QIA_PNO(ij);
         auto qab_ij = QAB_PNO(ij);
+
+        /*
+         * The beta*T2 term (Eq. 21) and F_bc'' (used in Eq. 22) are the only
+         * ROHF doubles terms that require general S(PNO_kl, PNO_ij)
+         * overlaps.  Group them so LOW_MEMORY_OVERLAP can use the same
+         * semi-direct algorithm as the RHF implementation: construct one
+         * extended-PAO-by-PNO_ij overlap, then transform only the rows needed
+         * by each kl pair.  This avoids rebuilding the PAO overlap for every
+         * spin block and every contraction.
+         */
+        std::array<SharedMatrix, 3> B_ij_spin;
+        for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+            const int ds = static_cast<int>(double_sigma);
+            B_ij_spin[ds] = std::make_shared<Matrix>(n_pno_[ij], n_pno_[ij]);
+            B_ij_spin[ds]->zero();
+        }
+
+        std::array<SharedMatrix, 2> F_bc_double_tilde_ij;
+        for (SpinCase sigma : singles_spin_cases) {
+            const int s = static_cast<int>(sigma);
+            F_bc_double_tilde_ij[s] = Fab_tilde_spin_[s][ij]->clone();
+        }
+
+        SharedMatrix S_ij;
+        std::vector<int> pair_ext_domain;
+        if (low_memory_overlap_) {
+            for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
+                const int k = lmopair_to_lmos_[ij][k_ij];
+                for (int l_ij = 0; l_ij < nlmo_ij; ++l_ij) {
+                    const int l = lmopair_to_lmos_[ij][l_ij];
+                    const int kl = i_j_to_ij_[k][l];
+                    if (kl == -1 || n_pno_[kl] == 0) continue;
+                    pair_ext_domain = merge_lists(pair_ext_domain, lmopair_to_paos_[kl]);
+                }
+            }
+
+            if (!pair_ext_domain.empty()) {
+                S_ij = submatrix_rows_and_cols(
+                    *S_pao_, pair_ext_domain, lmopair_to_paos_[ij]);
+                S_ij = linalg::doublet(S_ij, X_pno_[ij], false, false);
+            }
+        }
+
+        for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
+            const int k = lmopair_to_lmos_[ij][k_ij];
+            for (int l_ij = 0; l_ij < nlmo_ij; ++l_ij) {
+                const int l = lmopair_to_lmos_[ij][l_ij];
+                const int kl = i_j_to_ij_[k][l];
+                if (kl == -1 || n_pno_[kl] == 0) continue;
+
+                SharedMatrix S_kl_ij;
+                if (low_memory_overlap_) {
+                    auto S_kl_ij_pao = submatrix_rows(
+                        *S_ij, index_list(pair_ext_domain, lmopair_to_paos_[kl]));
+                    S_kl_ij = linalg::doublet(
+                        X_pno_[kl], S_kl_ij_pao, true, false);
+                } else {
+                    S_kl_ij = S_PNO(kl, ij);
+                }
+
+                std::array<SharedMatrix, 2> S_kl_ij_spin;
+                for (SpinCase sigma : singles_spin_cases) {
+                    const int s = static_cast<int>(sigma);
+                    S_kl_ij_spin[s] = S_kl_ij->clone();
+                    matrix_spin_enforcer_vv(S_kl_ij_spin[s], sigma);
+                }
+
+                // Eq. 21: B_ij(s1,s2) += beta_kl^ij T_kl(s1,s2).
+                for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+                    const int ds = static_cast<int>(double_sigma);
+                    const std::pair<SpinCase, SpinCase> spin_pair =
+                        get_spin_pair(double_sigma);
+                    const SpinCase sigma1 = spin_pair.first;
+                    const SpinCase sigma2 = spin_pair.second;
+                    const int s1 = static_cast<int>(sigma1);
+                    const int s2 = static_cast<int>(sigma2);
+
+                    if (sigma1 == SpinCase::Beta && k >= nbocc) continue;
+                    if (sigma2 == SpinCase::Beta && l >= nbocc) continue;
+
+                    auto T_kl = linalg::triplet(
+                        S_kl_ij_spin[s1], T_iajb_spin_[ds][kl],
+                        S_kl_ij_spin[s2], true, false, false);
+                    T_kl->scale((*beta_ijkl[ds][ij])(k_ij, l_ij));
+                    B_ij_spin[ds]->add(T_kl);
+                }
+
+                // Eq. 17: F_bc''(sigma) -=
+                // sum_gamma u_kl(sigma,gamma) K_kl, projected to PNO_ij.
+                for (SpinCase sigma : singles_spin_cases) {
+                    if (sigma == SpinCase::Beta && k >= nbocc) continue;
+                    const int s = static_cast<int>(sigma);
+
+                    for (SpinCase gamma : singles_spin_cases) {
+                        if (gamma == SpinCase::Beta && l >= nbocc) continue;
+
+                        auto T_kl_s_g = T_iajb_spin_helper(kl, sigma, gamma);
+                        auto F_bc_temp = linalg::doublet(
+                            T_kl_s_g, K_iajb_[kl], false, true);
+                        F_bc_double_tilde_ij[s]->subtract(linalg::triplet(
+                            S_kl_ij_spin[s], F_bc_temp, S_kl_ij_spin[s],
+                            true, false, false));
+                    }
+                }
+            }
+        }
+
+        for (SpinCase sigma : singles_spin_cases) {
+            const int s = static_cast<int>(sigma);
+            matrix_spin_enforcer_vv(F_bc_double_tilde_ij[s], sigma);
+        }
 
         for (DoubleSpinCase double_sigma : doubles_spin_cases) {
             auto [sigma1, sigma2] = get_spin_pair(double_sigma);
@@ -4800,34 +4853,15 @@ void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_ia
                 R_iajb[ds][ij]->add(linalg::triplet(Qab_t1_s1, T_ij, Qab_t1_s2, false, false, true)); // (a, c) (c, d) (b, d)
             } // end for
 
-            // Jiang and Toth Eq. 21
-            for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
-                int k = lmopair_to_lmos_[ij][k_ij];
-                if (sigma1 == SpinCase::Beta && k >= nbocc) continue;
-
-                for (int l_ij = 0; l_ij < nlmo_ij; ++l_ij) {
-                    int l = lmopair_to_lmos_[ij][l_ij];
-                    int kl = i_j_to_ij_[k][l];
-                    if (kl == -1) continue;
-
-                    if (sigma2 == SpinCase::Beta && l >= nbocc) continue;
-
-                    auto S_ij_kl_s1 = S_PNO(ij, kl)->clone();
-                    matrix_spin_enforcer_vv(S_ij_kl_s1, sigma1);
-                    auto S_ij_kl_s2 = S_PNO(ij, kl)->clone();
-                    matrix_spin_enforcer_vv(S_ij_kl_s2, sigma2);
-                    auto T_kl = T_iajb_spin_[ds][kl]->clone();
-
-                    T_kl = linalg::triplet(S_ij_kl_s1, T_kl, S_ij_kl_s2, false, false, true);
-                    T_kl->scale((*beta_ijkl[static_cast<int>(double_sigma)][ij])(k_ij, l_ij));
-
-                    R_iajb[ds][ij]->add(T_kl);
-                } // end for
-            } // end for
+            // Jiang and Toth Eq. 21 (formed with F_bc'' above so both terms
+            // share the semi-direct PNO overlaps).
+            R_iajb[ds][ij]->add(B_ij_spin[ds]);
 
             // Jiang and Toth Eq. 22
-            R_iajb[ds][ij]->add(linalg::doublet(T_ij, F_bc_double_tilde[s2][ij], false, true));
-            R_iajb[ds][ij]->add(linalg::doublet(F_bc_double_tilde[s1][ij], T_ij, false, false));
+            R_iajb[ds][ij]->add(linalg::doublet(
+                T_ij, F_bc_double_tilde_ij[s2], false, true));
+            R_iajb[ds][ij]->add(linalg::doublet(
+                F_bc_double_tilde_ij[s1], T_ij, false, false));
 
             // Jiang and Toth Eq. 23
             for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -5127,7 +5127,12 @@ void RO_DLPNOCCSD::lccsd_iterations() {
 
     for (DoubleSpinCase double_sigma : doubles_spin_cases) {
         const int ds = static_cast<int>(double_sigma);
-        const auto [sigma1, sigma2] = get_spin_pair(double_sigma);
+        // NOTE: plain variables, not a structured binding.  These names are read inside the
+        // `omp parallel for` below, and clang cannot capture structured bindings in an OpenMP
+        // region.  (Elsewhere the binding is declared *inside* the loop body, which is fine.)
+        const std::pair<SpinCase, SpinCase> spin_pair = get_spin_pair(double_sigma);
+        const SpinCase sigma1 = spin_pair.first;
+        const SpinCase sigma2 = spin_pair.second;
         const int s1 = static_cast<int>(sigma1);
         const int s2 = static_cast<int>(sigma2);
         R_iajb_spin[ds].clear();

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -3306,24 +3306,26 @@ void RO_DLPNOCCSD::matrix_spin_enforcer_qv(SharedMatrix &X, const SpinCase &sigm
 }
 
 void RO_DLPNOCCSD::matrix_spin_enforcer_oo(SharedMatrix &X, const int &ij, const SpinCase &sigma) {
-    const int n_lmo_pairs = ij_to_i_j_.size();
-    const int naocc = nalpha_ - nfrzc();
+    matrix_spin_enforcer_oo(X, ij, sigma, sigma);
+}
+
+void RO_DLPNOCCSD::matrix_spin_enforcer_oo(SharedMatrix &X, const int &ij,
+                                            const SpinCase &row_sigma,
+                                            const SpinCase &col_sigma) {
     const int nbocc = nbeta_ - nfrzc();
-    const int nsomo = naocc - nbocc;
 
-    // Do nothing in alpha case, all occupied indices are valid
-    if (sigma == SpinCase::Alpha) return;
-
-    // Zero out occupied indices greater than nbocc (they are not occupied in beta case)
-    if (sigma == SpinCase::Beta) {
+    // Rows and columns can carry different spins (for example, beta_ijkl in
+    // an alpha-beta block).  Project each occupied index independently.
+    if (row_sigma == SpinCase::Beta) {
         for (int k_ij = 0; k_ij < X->rowspi(0); ++k_ij) {
-            int k = lmopair_to_lmos_[ij][k_ij];
-            for (int l_ij = 0; l_ij < X->colspi(0); ++l_ij) {
-                int l = lmopair_to_lmos_[ij][l_ij];
-                if (k >= nbocc || l >= nbocc) (*X)(k_ij, l_ij) = 0.0;
-            }
-        } // end for
-    } // end if
+            if (lmopair_to_lmos_[ij][k_ij] >= nbocc) X->zero_row(0, k_ij);
+        }
+    }
+    if (col_sigma == SpinCase::Beta) {
+        for (int l_ij = 0; l_ij < X->colspi(0); ++l_ij) {
+            if (lmopair_to_lmos_[ij][l_ij] >= nbocc) X->zero_column(0, l_ij);
+        }
+    }
 }
 
 void RO_DLPNOCCSD::matrix_spin_enforcer_vv(SharedMatrix &X, const SpinCase &sigma) {
@@ -3426,6 +3428,11 @@ void RO_DLPNOCCSD::t1_ints_spin() {
                     }
                 }
             }
+            // The T1 addition above is formed from the common spatial QIA
+            // tensor and can repopulate SOMO columns that are not occupied
+            // beta orbitals.  Reapply the occupied projector to the complete
+            // transformed tensor, not only to its bare QKI contribution.
+            matrix_spin_enforcer_qo(i_Qk_t1_spin_[s][ij], ij, sigma);
 
             // Eq. 3: B~(Q,ai) = B(Q,ai) - t(k,a) B~(Q,ki)
             //                         + B(Q,ab) t(i,b).
@@ -3769,6 +3776,11 @@ std::array<std::vector<SharedMatrix>, 3> RO_DLPNOCCSD::compute_beta() {
                 beta_temp->scale(prefactor);
                 beta_ijkl[ds][ij]->add(beta_temp);
             }
+
+            // beta_ijkl carries an occupied sigma1 row and occupied sigma2
+            // column.  The bare QIA factors are spatial tensors, so the T2
+            // contribution must be projected explicitly in mixed-spin cases.
+            matrix_spin_enforcer_oo(beta_ijkl[ds][ij], ij, sigma1, sigma2);
         }
     }
 
@@ -4666,6 +4678,14 @@ void RO_DLPNOCCSD::lccsd_iterations() {
             linalg::triplet(X_pno_[ij], F_pao_ij_a, X_pno_[ij], true, false, false);
         F_pno_spin_[static_cast<int>(SpinCase::Beta)][ij] =
             linalg::triplet(X_pno_[ij], F_pao_ij_b, X_pno_[ij], true, false, false);
+
+        // These are spin-labelled virtual-virtual blocks, even though both
+        // are stored in the common augmented PNO space.  Keep the forbidden
+        // alpha/SOMO rows and columns identically zero at their source.
+        matrix_spin_enforcer_vv(F_pno_spin_[static_cast<int>(SpinCase::Alpha)][ij],
+                                SpinCase::Alpha);
+        matrix_spin_enforcer_vv(F_pno_spin_[static_cast<int>(SpinCase::Beta)][ij],
+                                SpinCase::Beta);
     }
 
     outfile->Printf("\n  ==> Restricted Open Shell Local CCSD <==\n\n");

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -3089,6 +3089,507 @@ void DLPNOCCSD::print_results() {
 RO_DLPNOCCSD::RO_DLPNOCCSD(SharedWavefunction ref_wfn, Options& options) : DLPNOCCSD(ref_wfn, options) {}
 RO_DLPNOCCSD::~RO_DLPNOCCSD() {}
 
+void RO_DLPNOCCSD::print_header() {
+    const int nbf = basisset_->nbf();
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = nalpha_ - nbeta_;
+
+    outfile->Printf("   --------------------------------------------------\n");
+    outfile->Printf("          ROHF T1-Transformed DLPNO-CCSD            \n");
+    outfile->Printf("                    by Andy Jiang                    \n");
+    outfile->Printf("       Closed-shell engine: DOI 10.1063/5.0219963   \n");
+    outfile->Printf("   --------------------------------------------------\n\n");
+    outfile->Printf("  Reference                    : ROHF\n");
+    outfile->Printf("  PNO selector                 : spin-independent SROMP2\n");
+    outfile->Printf("  SOMO treatment               : appended to every pair space\n");
+    outfile->Printf("  DLPNO convergence            : %s\n\n",
+                    options_.get_str("PNO_CONVERGENCE").c_str());
+
+    outfile->Printf("  Detailed DLPNO thresholds and cutoffs:\n");
+    outfile->Printf("    T_CUT_PNO        = %6.4e \n", T_CUT_PNO_);
+    outfile->Printf("    T_DIAG_SCALE     = %6.4e \n", T_CUT_PNO_DIAG_SCALE_);
+    outfile->Printf("    T_CORE_SCALE     = %6.4e \n", T_CUT_PNO_CORE_SCALE_);
+    outfile->Printf("    T_CUT_TRACE      = %6.4e \n", T_CUT_TRACE_);
+    outfile->Printf("    T_CUT_ENERGY     = %6.4e \n", T_CUT_ENERGY_);
+    outfile->Printf("    T_CUT_PAIRS      = %6.4e \n", T_CUT_PAIRS_);
+    outfile->Printf("    T_CUT_PAIRS_MP2  = %6.4e \n", T_CUT_PAIRS_MP2_);
+    outfile->Printf("    T_CUT_PRE        = %6.4e \n", T_CUT_PRE_);
+    outfile->Printf("    T_CUT_DO_PRE     = %6.4e \n", options_.get_double("T_CUT_DO_PRE"));
+    outfile->Printf("    T_CUT_MKN        = %6.4e \n", T_CUT_MKN_);
+    outfile->Printf("    T_CUT_PNO_MP2    = %6.4e \n", T_CUT_PNO_MP2_);
+    outfile->Printf("    T_CUT_TRACE_MP2  = %6.4e \n", T_CUT_TRACE_MP2_);
+    outfile->Printf("    T_CUT_ENERGY_MP2 = %6.4e \n", T_CUT_ENERGY_MP2_);
+    outfile->Printf("    T_CUT_DO         = %6.4e \n", T_CUT_DO_);
+    outfile->Printf("    T_CUT_DO_IJ      = %6.4e \n", options_.get_double("T_CUT_DO_IJ"));
+    outfile->Printf("    T_CUT_DO_UV      = %6.4e \n", options_.get_double("T_CUT_DO_UV"));
+    outfile->Printf("    T_CUT_CLMO       = %6.4e \n", options_.get_double("T_CUT_CLMO"));
+    outfile->Printf("    T_CUT_CPAO       = %6.4e \n", options_.get_double("T_CUT_CPAO"));
+    outfile->Printf("    S_CUT            = %6.4e \n", options_.get_double("S_CUT"));
+    outfile->Printf("    F_CUT            = %6.4e \n", options_.get_double("F_CUT"));
+    outfile->Printf("    INTS_TOL (AO)    = %6.4e \n", options_.get_double("DLPNO_AO_INTS_TOL"));
+    outfile->Printf("    MIN_PNOS         = %6d   \n\n", options_.get_int("MIN_PNOS"));
+
+    outfile->Printf("  ==> ROHF Orbital-Space Information <==\n\n");
+    outfile->Printf("   -----------------------------------------------------------------------------\n");
+    outfile->Printf("    NBF  NFRZC  ACT-A  ACT-B  DOCC  SOMO  VIRT-A  VIRT-B  NAUX\n");
+    outfile->Printf("   -----------------------------------------------------------------------------\n");
+    outfile->Printf("   %4d  %5d  %5d  %5d  %4d  %4d  %6d  %6d  %4d\n",
+                    nbf, nfrzc(), naocc, nbocc, nbeta_, nsomo,
+                    nbf - nalpha_, nbf - nbeta_, ribasis_->nbf());
+    outfile->Printf("   -----------------------------------------------------------------------------\n\n");
+}
+
+void RO_DLPNOCCSD::print_results() {
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = naocc - nbocc;
+    const int n_active_electrons = naocc + nbocc;
+    double t1diag_norm = 0.0;
+
+    // This is the standard Psi4 ROHF T1 diagnostic expressed in the common
+    // SOMO-augmented diagonal-pair PNO spaces.  For DOCC -> external
+    // excitations the spin-adapted combination is t(alpha) + t(beta).
+    // DOCC -> SOMO and SOMO -> external excitations are the two allowed
+    // semi-internal sectors and carry the conventional factor of two.
+#pragma omp parallel for reduction(+ : t1diag_norm)
+    for (int i = 0; i < naocc; ++i) {
+        const int ii = i_j_to_ij_[i][i];
+        const int n_external = n_pno_[ii] - nsomo;
+
+        if (i < nbocc) {
+            for (int a = 0; a < n_external; ++a) {
+                const double t_spin_adapted =
+                    (*T_ia_spin_[static_cast<int>(SpinCase::Alpha)][i])(a, 0) +
+                    (*T_ia_spin_[static_cast<int>(SpinCase::Beta)][i])(a, 0);
+                t1diag_norm += t_spin_adapted * t_spin_adapted;
+            }
+            for (int a = n_external; a < n_pno_[ii]; ++a) {
+                const double t_beta =
+                    (*T_ia_spin_[static_cast<int>(SpinCase::Beta)][i])(a, 0);
+                t1diag_norm += 2.0 * t_beta * t_beta;
+            }
+        } else {
+            for (int a = 0; a < n_external; ++a) {
+                const double t_alpha =
+                    (*T_ia_spin_[static_cast<int>(SpinCase::Alpha)][i])(a, 0);
+                t1diag_norm += 2.0 * t_alpha * t_alpha;
+            }
+        }
+    }
+
+    const double t1diag = (n_active_electrons > 0)
+                              ? 0.5 * std::sqrt(t1diag_norm / n_active_electrons)
+                              : 0.0;
+    outfile->Printf("\n  ROHF T1 Diagnostic: %8.8f \n", t1diag);
+    if (t1diag > 0.02) {
+        outfile->Printf(
+            "    WARNING: ROHF T1 Diagnostic is greater than 0.02; "
+            "CCSD results may be unreliable!\n");
+    }
+    set_scalar_variable("CC T1 DIAGNOSTIC", t1diag);
+
+    const double e_corr =
+        e_lccsd_ + de_weak_ + de_lmp2_eliminated_ + de_pno_total_ + de_dipole_;
+    const double e_total = variables_["SCF TOTAL ENERGY"] + e_corr;
+
+    outfile->Printf("  \n");
+    outfile->Printf("  Total ROHF-DLPNO-CCSD Correlation Energy: %16.12f \n", e_corr);
+    outfile->Printf("    Strong-Pair RCCSD Contribution:         %16.12f \n", e_lccsd_);
+    outfile->Printf("    SROLMP2 Weak-Pair Contribution:         %16.12f \n", de_weak_);
+    outfile->Printf("    Semicanonical SROMP2 Correction:        %16.12f \n",
+                    de_lmp2_eliminated_);
+    outfile->Printf("    ROHF Dipole-Pair Correction:            %16.12f \n", de_dipole_);
+    outfile->Printf("    PNO Truncation Correction:              %16.12f \n", de_pno_total_);
+    outfile->Printf("\n\n  @Total ROHF-DLPNO-CCSD Energy: %16.12f \n", e_total);
+    outfile->Printf("    *** Spin-adapted and SOMO-safe. A thousand hallelujahs!!! \n\n");
+}
+
+void RO_DLPNOCCSD::estimate_memory() {
+    const int naocc = nalpha_ - nfrzc();
+    const int n_lmo_pairs = ij_to_i_j_.size();
+
+    // The cached inexpensive overlaps are required in both modes.  The
+    // expensive S(ij,kl) blocks are stored only in the high-memory mode; in
+    // low-memory mode the general overlaps are formed one target pair at a
+    // time and are included in the per-thread buffer estimate below.
+    size_t low_overlap_memory = 0;
+    size_t high_overlap_memory = 0;
+#pragma omp parallel for schedule(dynamic, 1) reduction(+ : low_overlap_memory, high_overlap_memory)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        const int i = ij_to_i_j_[ij].first;
+        const int j = ij_to_i_j_[ij].second;
+        const int nlmo_ij = lmopair_to_lmos_[ij].size();
+        const size_t npno_ij = n_pno_[ij];
+
+        for (int k = 0; k < naocc; ++k) {
+            const int kj = i_j_to_ij_[k][j];
+            if (kj != -1) {
+                const size_t words = npno_ij * static_cast<size_t>(n_pno_[kj]);
+                high_overlap_memory += words;
+                low_overlap_memory += words;
+            }
+
+            if (i <= j && lmopair_to_lmos_dense_[ij][k] != -1) {
+                const int kk = i_j_to_ij_[k][k];
+                const size_t words = npno_ij * static_cast<size_t>(n_pno_[kk]);
+                high_overlap_memory += words;
+                low_overlap_memory += words;
+            }
+        }
+
+        if (i <= j) {
+            for (int mn_ij = 0; mn_ij < nlmo_ij * nlmo_ij; ++mn_ij) {
+                const int m_ij = mn_ij / nlmo_ij;
+                const int n_ij = mn_ij % nlmo_ij;
+                const int m = lmopair_to_lmos_[ij][m_ij];
+                const int n = lmopair_to_lmos_[ij][n_ij];
+                const int mn = i_j_to_ij_[m][n];
+                if (i == m || i == n || j == m || j == n || m == n) continue;
+                if (mn == -1 || m_ij > n_ij) continue;
+                high_overlap_memory += npno_ij * static_cast<size_t>(n_pno_[mn]);
+            }
+        }
+    }
+
+    // Spin-independent integral storage inherited from the RHF engine.
+    size_t spatial_ov = 0;
+    size_t spatial_vv = 0;
+    size_t spatial_vv_non_proj = 0;
+    size_t spatial_vvv = 0;
+    size_t spatial_qo = 0;
+    size_t spatial_qv = 0;
+    size_t spatial_qov = 0;
+    size_t spatial_qvv = 0;
+
+    // Persistent spin-resolved quantities used by the ROHF iterations.
+    size_t ro_t2_amplitudes = 0;
+    size_t ro_t2_residuals = 0;
+    size_t ro_fock_pair_storage = 0;
+    size_t ro_projected_singles = 0;
+    size_t ro_transformed_df = 0;
+    size_t ro_single_storage = 0;
+    size_t ro_pair_vector_storage = 0;
+    size_t srolmp2_cache = 0;
+    size_t diis_vector_words = 0;
+    size_t diagonal_pno_words = 0;
+
+    // Iteration-wide intermediates.  beta, gamma, delta, and delta-bar are
+    // alive together during compute_R_iajb().
+    size_t ro_residual_intermediates = 0;
+    size_t ro_fock_intermediates = 0;
+
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        const int i = ij_to_i_j_[ij].first;
+        const int j = ij_to_i_j_[ij].second;
+        const size_t naux_ij = lmopair_to_ribfs_[ij].size();
+        const size_t nlmo_ij = lmopair_to_lmos_[ij].size();
+        const size_t npno_ij = n_pno_[ij];
+        const size_t ov_words = nlmo_ij * npno_ij;
+        const size_t vv_words = npno_ij * npno_ij;
+        const bool is_strong_pair = i_j_to_ij_strong_[i][j] != -1;
+
+        // K_mibj, J_ijmb, L_mibj and K_iajb, T_iajb, Tt_iajb, L_iajb.
+        spatial_ov += 3 * ov_words;
+        spatial_vv += 4 * vv_words;
+        spatial_vvv += npno_ij * vv_words;
+
+        // Three RCCSD amplitudes plus the three fixed SROLMP2 copies.
+        ro_t2_amplitudes += 6 * vv_words;
+        srolmp2_cache += 3 * vv_words;
+        // R and Rn for AA, AB, and BB.
+        ro_t2_residuals += 6 * vv_words;
+        // F_pno(alpha/beta) is allocated for every ordered pair.
+        ro_fock_pair_storage += 2 * vv_words;
+        // Projected T1(alpha/beta), and transformed Qk/Qa(alpha/beta).
+        ro_projected_singles += 2 * ov_words;
+        ro_transformed_df += 2 * naux_ij * (nlmo_ij + npno_ij);
+        // Fkc_tilde(alpha/beta), one PNO vector per ordered pair.
+        ro_pair_vector_storage += 2 * npno_ij;
+
+        // DIIS extrapolates two singles and three doubles blocks.
+        diis_vector_words += 3 * vv_words;
+
+        // beta(AA/AB/BB), gamma(AA/AB/BA/BB), and both delta families.
+        ro_residual_intermediates += 3 * nlmo_ij * nlmo_ij;
+        ro_residual_intermediates += 12 * vv_words;
+
+        if (i == j) {
+            // T1, R1, Fai_tilde, and the bare Fia energy block, each for A/B.
+            diagonal_pno_words += npno_ij;
+            ro_single_storage += 8 * npno_ij;
+            diis_vector_words += 2 * npno_ij;
+        }
+
+        if (i <= j) {
+            // Fab_tilde(alpha/beta) is shared by ij and ji.
+            ro_fock_pair_storage += 2 * vv_words;
+            // Fkc_bar and Fab_bar for both spins coexist while t1_fock_spin runs.
+            ro_fock_intermediates += 2 * (ov_words + vv_words);
+        }
+
+        if (!is_strong_pair) continue;
+
+        for (size_t k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
+            const int k = lmopair_to_lmos_[ij][k_ij];
+            const int jk = i_j_to_ij_[j][k];
+            if (jk == -1) continue;
+            spatial_vv_non_proj += 2 * npno_ij * static_cast<size_t>(n_pno_[jk]);
+        }
+
+        spatial_qo += 2 * naux_ij * nlmo_ij;
+        spatial_qv += 2 * naux_ij * npno_ij;
+        if (i <= j) {
+            spatial_qov += naux_ij * ov_words;
+            spatial_qvv += naux_ij * vv_words;
+        }
+    }
+
+    // Global spin Fock matrices retained by lccsd_iterations(): Fa/Fb in the
+    // LMO and PAO bases, and the two bare LMO-PAO energy blocks.
+    const size_t npao_global = C_pao_->colspi(0);
+    const size_t global_spin_fock_storage =
+        2 * (static_cast<size_t>(naocc) * static_cast<size_t>(naocc) +
+             npao_global * npao_global +
+             static_cast<size_t>(naocc) * npao_global);
+
+    // Two persistent transformed occupied blocks and two temporary
+    // twice-transformed blocks in the residual build.
+    const size_t occupied_fock_storage =
+        2 * static_cast<size_t>(naocc) * static_cast<size_t>(naocc);
+    // t1_fock_spin() forms an additional pair of LMO-PAO Fock matrices.
+    ro_fock_intermediates +=
+        2 * static_cast<size_t>(naocc) * npao_global;
+    ro_fock_intermediates += occupied_fock_storage;
+    ro_residual_intermediates += occupied_fock_storage;
+
+    int nthreads = 1;
+#ifdef _OPENMP
+    nthreads = Process::environment.get_n_threads();
+#endif
+
+    // Thread buffers for integral transformation and for the ROHF residual.
+    size_t eri_thread_buffer = 0;
+    size_t q_iteration_thread_buffer = 0;
+    size_t high_overlap_thread_buffer = 0;
+    size_t low_overlap_thread_buffer = 0;
+
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        const int i = ij_to_i_j_[ij].first;
+        const int j = ij_to_i_j_[ij].second;
+        const size_t naux_ij = lmopair_to_ribfs_[ij].size();
+        const size_t nlmo_ij = lmopair_to_lmos_[ij].size();
+        const size_t npno_ij = n_pno_[ij];
+
+        std::vector<int> integral_ext_domain = lmopair_to_paos_[ij];
+        for (size_t k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
+            const int k = lmopair_to_lmos_[ij][k_ij];
+            integral_ext_domain = merge_lists(integral_ext_domain, lmo_to_paos_[k]);
+        }
+        const size_t npao_ext_ij = integral_ext_domain.size();
+
+        size_t eri_buffer = naux_ij * npao_ext_ij * (nlmo_ij + npno_ij);
+        eri_buffer += naux_ij * npno_ij * (nlmo_ij + npno_ij);
+        eri_thread_buffer = std::max(eri_thread_buffer, eri_buffer);
+
+        const size_t q_buffer =
+            2 * naux_ij * npno_ij * (nlmo_ij + npno_ij);
+        q_iteration_thread_buffer = std::max(q_iteration_thread_buffer, q_buffer);
+
+        if (i_j_to_ij_strong_[i][j] == -1) continue;
+
+        std::vector<int> pair_ext_domain;
+        size_t max_npao_kl = 0;
+        size_t max_npno_kl = 0;
+        for (size_t k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
+            const int k = lmopair_to_lmos_[ij][k_ij];
+            for (size_t l_ij = 0; l_ij < nlmo_ij; ++l_ij) {
+                const int l = lmopair_to_lmos_[ij][l_ij];
+                const int kl = i_j_to_ij_[k][l];
+                if (kl == -1 || n_pno_[kl] == 0) continue;
+                pair_ext_domain = merge_lists(pair_ext_domain, lmopair_to_paos_[kl]);
+                max_npao_kl = std::max(max_npao_kl, lmopair_to_paos_[kl].size());
+                max_npno_kl = std::max(max_npno_kl, static_cast<size_t>(n_pno_[kl]));
+            }
+        }
+
+        // B(AA/AB/BB), Fbc''(A/B), spin-masked rectangular overlaps, and
+        // the largest pair-projection temporaries alive in the grouped block.
+        const size_t grouped_pair_buffer =
+            7 * npno_ij * npno_ij + 4 * max_npno_kl * npno_ij +
+            2 * max_npno_kl * max_npno_kl;
+        high_overlap_thread_buffer =
+            std::max(high_overlap_thread_buffer, grouped_pair_buffer);
+
+        const size_t semidirect_extra =
+            pair_ext_domain.size() * npno_ij + max_npao_kl * npno_ij;
+        low_overlap_thread_buffer =
+            std::max(low_overlap_thread_buffer, grouped_pair_buffer + semidirect_extra);
+    }
+
+    low_memory_overlap_ = options_.get_bool("LOW_MEMORY_OVERLAP");
+    write_qia_pno_ = options_.get_bool("WRITE_QIA_PNO");
+    write_qab_pno_ = options_.get_bool("WRITE_QAB_PNO");
+    if (write_qia_pno_) spatial_qov = 0;
+    if (write_qab_pno_) spatial_qvv = 0;
+
+    const size_t total_df_memory = qij_memory_ + qia_memory_ + qab_memory_;
+    const size_t ro_fixed_storage =
+        ro_t2_amplitudes + ro_t2_residuals + ro_fock_pair_storage +
+        ro_projected_singles + ro_transformed_df + ro_single_storage +
+        ro_pair_vector_storage + global_spin_fock_storage +
+        occupied_fock_storage +
+        2 * static_cast<size_t>(nthreads) * diagonal_pno_words;
+
+    const int diis_max_vecs = std::max(0, options_.get_int("DIIS_MAX_VECS"));
+    const size_t diis_history =
+        2 * static_cast<size_t>(diis_max_vecs) * diis_vector_words;
+    const size_t flattened_diis_buffers = 2 * diis_vector_words;
+
+    auto spatial_pno_memory = [&]() {
+        return spatial_ov + spatial_vv + spatial_vv_non_proj + spatial_vvv +
+               spatial_qo + spatial_qv + spatial_qov + spatial_qvv;
+    };
+    auto overlap_memory = [&]() {
+        return low_memory_overlap_ ? low_overlap_memory : high_overlap_memory;
+    };
+    auto iteration_thread_buffer = [&]() {
+        return q_iteration_thread_buffer +
+               (low_memory_overlap_ ? low_overlap_thread_buffer
+                                    : high_overlap_thread_buffer);
+    };
+    auto transient_iteration_memory = [&]() {
+        const size_t fock_peak =
+            ro_fock_intermediates + q_iteration_thread_buffer * nthreads;
+        const size_t residual_peak =
+            ro_residual_intermediates + iteration_thread_buffer() * nthreads;
+        return std::max({fock_peak, residual_peak, flattened_diis_buffers});
+    };
+    auto memory_integrals = [&]() {
+        // The SROLMP2 cache already exists while the augmented PNO integrals
+        // are transformed; count it conservatively at the augmented rank.
+        return total_df_memory + spatial_pno_memory() + srolmp2_cache +
+               eri_thread_buffer * nthreads;
+    };
+    auto memory_ccsd = [&]() {
+        return total_df_memory + spatial_pno_memory() + overlap_memory() +
+               ro_fixed_storage + diis_history + transient_iteration_memory();
+    };
+
+    constexpr double doubles_to_gb = 1.0e-9 * sizeof(double);
+    constexpr double bytes_to_gb = 1.0e-9;
+
+    auto print_estimate = [&](bool updated) {
+        outfile->Printf("  ==> %sROHF-DLPNO-CCSD Memory Requirements <== \n\n",
+                        updated ? "(Updated) " : "");
+        outfile->Printf("    *** Spin-Independent Spatial Quantities ***\n");
+        outfile->Printf("    (q | i j) [AUX, LMO]          : %8.3f [GB]\n",
+                        qij_memory_ * doubles_to_gb);
+        outfile->Printf("    (q | i a) [AUX, LMO, PAO]     : %8.3f [GB]\n",
+                        qia_memory_ * doubles_to_gb);
+        outfile->Printf("    (q | a b) [AUX, PAO]          : %8.3f [GB]\n",
+                        qab_memory_ * doubles_to_gb);
+        outfile->Printf("    (k_{ij}, c_{ij}) integrals    : %8.3f [GB]\n",
+                        spatial_ov * doubles_to_gb);
+        outfile->Printf("    (a_{ij}, b_{ij}) integrals    : %8.3f [GB]\n",
+                        spatial_vv * doubles_to_gb);
+        outfile->Printf("    Non-projected two-ext. ERIs   : %8.3f [GB]\n",
+                        spatial_vv_non_proj * doubles_to_gb);
+        outfile->Printf("    Three-external ERIs           : %8.3f [GB]\n",
+                        spatial_vvv * doubles_to_gb);
+        outfile->Printf("    Spatial DF PNO tensors        : %8.3f [GB]\n\n",
+                        (spatial_qo + spatial_qv + spatial_qov + spatial_qvv) *
+                            doubles_to_gb);
+
+        outfile->Printf("    *** ROHF Spin-Resolved Iteration Quantities ***\n");
+        outfile->Printf("    RCCSD + SROLMP2 T2 blocks     : %8.3f [GB]\n",
+                        ro_t2_amplitudes * doubles_to_gb);
+        outfile->Printf("    R2 and non-symmetric R2       : %8.3f [GB]\n",
+                        ro_t2_residuals * doubles_to_gb);
+        outfile->Printf("    Spin Fock pair blocks         : %8.3f [GB]\n",
+                        ro_fock_pair_storage * doubles_to_gb);
+        outfile->Printf("    Global spin Fock blocks       : %8.3f [GB]\n",
+                        global_spin_fock_storage * doubles_to_gb);
+        outfile->Printf("    Projected spin T1 blocks      : %8.3f [GB]\n",
+                        ro_projected_singles * doubles_to_gb);
+        outfile->Printf("    T1-transformed spin DF blocks : %8.3f [GB]\n",
+                        ro_transformed_df * doubles_to_gb);
+        outfile->Printf("    PNO overlaps                  : %8.3f [GB]\n",
+                        overlap_memory() * doubles_to_gb);
+        outfile->Printf("    DIIS history (maximum)        : %8.3f [GB]\n\n",
+                        diis_history * doubles_to_gb);
+
+        outfile->Printf("    Maximum ERI buffer per thread : %8.3f [GB]\n",
+                        eri_thread_buffer * doubles_to_gb);
+        outfile->Printf("    Maximum CC buffer per thread  : %8.3f [GB]\n",
+                        iteration_thread_buffer() * doubles_to_gb);
+        outfile->Printf("    Total Memory Required (ERIs)  : %8.3f [GB]\n",
+                        memory_integrals() * doubles_to_gb);
+        outfile->Printf("    Total Memory Required (RCCSD) : %8.3f [GB]\n",
+                        memory_ccsd() * doubles_to_gb);
+        outfile->Printf("    Total Memory Given            : %8.3f [GB]\n\n",
+                        memory_ * bytes_to_gb);
+    };
+
+    print_estimate(false);
+
+    auto memory_exceeded = [&]() {
+        return std::max(memory_ccsd(), memory_integrals()) * sizeof(double) >
+               0.9 * memory_;
+    };
+    bool memory_changed = false;
+
+    if (toggle_memory_ && !low_memory_overlap_ && memory_exceeded()) {
+        const size_t high_memory_requirement =
+            std::max(memory_ccsd(), memory_integrals());
+        low_memory_overlap_ = true;
+        const size_t low_memory_requirement =
+            std::max(memory_ccsd(), memory_integrals());
+        if (low_memory_requirement < high_memory_requirement) {
+            outfile->Printf("  Required memory exceeds 90%% of available memory.\n");
+            outfile->Printf(
+                "    Switching to semi-direct low-memory PNO overlaps...\n\n");
+            memory_changed = true;
+        } else {
+            // For very small pair spaces, the semi-direct per-thread buffer
+            // can exceed the stored general-overlap blocks.
+            low_memory_overlap_ = false;
+        }
+    }
+
+    if (toggle_memory_ && !write_qia_pno_ && memory_exceeded()) {
+        outfile->Printf("  Required memory still exceeds 90%% of available memory.\n");
+        outfile->Printf("    Writing (Q_{ij}|m_{ij} a_{ij}) tensors to disk...\n\n");
+        write_qia_pno_ = true;
+        spatial_qov = 0;
+        memory_changed = true;
+    }
+
+    if (toggle_memory_ && !write_qab_pno_ && memory_exceeded()) {
+        outfile->Printf("  Required memory still exceeds 90%% of available memory.\n");
+        outfile->Printf("    Writing (Q_{ij}|a_{ij} b_{ij}) tensors to disk...\n\n");
+        write_qab_pno_ = true;
+        spatial_qvv = 0;
+        memory_changed = true;
+    }
+
+    if (memory_changed) print_estimate(true);
+
+    if (toggle_memory_ && memory_exceeded()) {
+        throw PSIEXCEPTION(
+            "Too little memory given for the spin-resolved ROHF-DLPNO-CCSD algorithm!");
+    }
+
+    outfile->Printf("    Using %s-memory PNO overlap algorithm...\n\n",
+                    low_memory_overlap_ ? "semi-direct low" : "high");
+    outfile->Printf("    %s (Q_{ij}|m_{ij} a_{ij}) tensors %s.\n",
+                    write_qia_pno_ ? "Writing" : "Keeping",
+                    write_qia_pno_ ? "to disk" : "in RAM");
+    outfile->Printf("    %s (Q_{ij}|a_{ij} b_{ij}) tensors %s.\n\n",
+                    write_qab_pno_ ? "Writing" : "Keeping",
+                    write_qab_pno_ ? "to disk" : "in RAM");
+}
+
 std::vector<double> RO_DLPNOCCSD::compute_semicanonical_sromp2_pair_energies(bool print_header) {
     /*
      * The selector amplitudes deliberately have the same spatial form as
@@ -4762,7 +5263,12 @@ void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_ia
                     S_kl_ij = linalg::doublet(
                         X_pno_[kl], S_kl_ij_pao, true, false);
                 } else {
-                    S_kl_ij = S_PNO(kl, ij);
+                    // The high-memory cache is organized by the target ij
+                    // domain.  Request that orientation and transpose it so
+                    // this grouped contraction uses the same S_kl_ij shape
+                    // as the semi-direct path without falling back to an
+                    // uncached PAO transformation from the kl side.
+                    S_kl_ij = S_PNO(ij, kl)->transpose();
                 }
 
                 std::array<SharedMatrix, 2> S_kl_ij_spin;
@@ -5602,7 +6108,7 @@ double RO_DLPNOCCSD::compute_dlpno_ccsd_energy() {
     // Bye bye (Q_ij | a_ij b_ij) integrals. You won't be missed
     psio_->close(PSIF_DLPNO_QAB_PNO, 0);
 
-    // print_results();
+    print_results();
 
     timer_off("DLPNO-CCSD");
 

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -3097,8 +3097,6 @@ void RO_DLPNOCCSD::extend_virtual_by_somo() {
     int nsomo = nalpha_ - nbeta_;
 
     // Update PAO transformation matrix
-    auto C_aocc = reference_wavefunction_->Ca_subset("AO", "ACTIVE_OCC");
-    auto eps_aocc = reference_wavefunction_->epsilon_a_subset("AO", "ACTIVE_OCC");
     auto C_pao_new = std::make_shared<Matrix>(nbf, nbf + nsomo);
 
 #pragma omp parallel for
@@ -3110,7 +3108,10 @@ void RO_DLPNOCCSD::extend_virtual_by_somo() {
 
         // Block with SOMOs
         for (int v = nbf; v < nbf + nsomo; ++v) {
-            C_pao_new->set(u, v, C_aocc->get(u, nbocc + (v-nbf)));
+            // Append the same separately localized SOMOs used in C_lmo_.
+            // Using canonical SOMOs here would give the occupied and beta-
+            // virtual copies different rotations within the SOMO space.
+            C_pao_new->set(u, v, C_lmo_->get(u, nbocc + (v-nbf)));
         } // end for
     } // end for
 
@@ -3149,7 +3150,7 @@ void RO_DLPNOCCSD::extend_virtual_by_somo() {
         } // end for
 
         for (int t = 0; t < nsomo; ++t) {
-            e_pno_new->set(npno_ij + t, eps_aocc->get(nbocc + t));
+            e_pno_new->set(npno_ij + t, F_lmo_->get(nbocc + t, nbocc + t));
         } // end for
 
         X_pno_[ij] = X_pno_new;

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -1823,7 +1823,8 @@ void DLPNOCCSD::t1_fock() {
         // Partially dress Fia and Fab (Jiang Eq. 99 and 101)
         // \overline{F}_{kc} = f_{kc} + [2(kc|me) - (ke|mc)] T_{m}^{e}
         // In closed-shell RHF reference, f_{kc} is zero
-        Fkc_bar[ij] = std::make_shared<Matrix>(nlmo_ij, npno_ij);
+        Fkc_bar[ij] = submatrix_rows_and_cols(*F_lmo_pao_, lmopair_to_lmos_[ij], lmopair_to_paos_[ij]);
+        Fkc_bar[ij] = linalg::doublet(Fkc_bar[ij], X_pno_[ij], false, false); // (k, c)
 
         // \overline{F}_{ab} = f_{ab} + [2(ab|me) - (ae|mb)] T_{m}^{e}
         // In canonical PNO representation, f_{ab} is diagonal
@@ -1864,7 +1865,8 @@ void DLPNOCCSD::t1_fock() {
         if (i == j) {
             // \overline{F}_{ai} = f_{ai} + [2(ai|me) - (ae|mi)] T_{m}^{e}
             // In closed-shell RHF reference, f_{kc} is zero
-            Fai_bar[i] = std::make_shared<Matrix>(npno_ij, 1);
+            Fai_bar[i] = submatrix_rows_and_cols(*F_lmo_pao_, std::vector<int>(1, i), lmopair_to_paos_[ij]);
+            Fai_bar[i] = linalg::doublet(Fai_bar[i], X_pno_[ij], false, false)->transpose(); // (a, i)
 
             auto Qia = i_Qa_ij_[ij];
             auto Qik = i_Qk_ij_[ij];
@@ -1918,7 +1920,8 @@ void DLPNOCCSD::t1_fock() {
         // (built separately since \overline{F}_{kc} intermediate is NOT built over weak pairs)
         // \widetilde{F}_{ia} = \overline{F}_{ia} = f_{ia} + [2(ia|kc) - (ic|ka)] T_{k}^{c}
         // => L_{ik}^{ac} T_{k}^{c}
-        Fkc_[ij] = std::make_shared<Matrix>(npno_ij, 1);
+        Fkc_[ij] = submatrix_rows_and_cols(*F_lmo_pao_, std::vector<int>(1, i), lmopair_to_paos_[ij]);
+        Fkc_[ij] = linalg::doublet(Fkc_[ij], X_pno_[ij], false, false)->transpose();
 
         for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
             int k = lmopair_to_lmos_[ij][k_ij];
@@ -2872,7 +2875,7 @@ double DLPNOCCSD::compute_energy() {
     timer_off("Refined Pair Prescreening");
 
     // Set variables from LMP2
-    double e_scf = reference_wavefunction_->energy();
+    double e_scf = variables_["SCF TOTAL ENERGY"];
     double e_lmp2_corr = e_lmp2_ + de_lmp2_eliminated_ + de_dipole_ + de_pno_total_;
     double e_lmp2_total = e_scf + e_lmp2_corr;
 
@@ -3072,6 +3075,1872 @@ void DLPNOCCSD::print_results() {
     outfile->Printf("\n\n  @Total DLPNO-CCSD Energy: %16.12f \n", variables_["SCF TOTAL ENERGY"] + e_lccsd_ + de_lmp2_eliminated_ + de_weak_ + de_pno_total_ + de_dipole_);
     outfile->Printf("    *** Wow, that was fast! A thousand hallelujahs!!! \n\n");
 }
+
+RO_DLPNOCCSD::RO_DLPNOCCSD(SharedWavefunction ref_wfn, Options& options) : DLPNOCCSD(ref_wfn, options) {}
+RO_DLPNOCCSD::~RO_DLPNOCCSD() {}
+
+void RO_DLPNOCCSD::extend_virtual_by_somo() {
+    int n_lmo_pairs = ij_to_i_j_.size();
+    int nbf = basisset_->nbf();
+    int naocc = nalpha_ - nfrzc();
+    int nbocc = nbeta_ - nfrzc();
+    int nsomo = nalpha_ - nbeta_;
+
+    // Update PAO transformation matrix
+    auto C_aocc = reference_wavefunction_->Ca_subset("AO", "ACTIVE_OCC");
+    auto eps_aocc = reference_wavefunction_->epsilon_a_subset("AO", "ACTIVE_OCC");
+    auto C_pao_new = std::make_shared<Matrix>(nbf, nbf + nsomo);
+
+#pragma omp parallel for
+    for (int u = 0; u < nbf; ++u) {
+        // Original PAO block
+        for (int v = 0; v < nbf; ++v) {
+            C_pao_new->set(u, v, C_pao_->get(u, v));
+        } // end for
+
+        // Block with SOMOs
+        for (int v = nbf; v < nbf + nsomo; ++v) {
+            C_pao_new->set(u, v, C_aocc->get(u, nbocc + (v-nbf)));
+        } // end for
+    } // end for
+
+    // Reset PAO coefficient matrix
+    C_pao_ = C_pao_new;
+    // Recompute S_pao and F_pao
+    S_pao_ = linalg::triplet(C_pao_, reference_wavefunction_->S(), C_pao_, true, false, false);
+    F_pao_ = linalg::triplet(C_pao_, F_ao_, C_pao_, true, false, false);
+
+#pragma omp parallel for
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        int ji = ij_to_ji_[ij];
+
+        if (i > j) continue;
+
+        int npao_ij = lmopair_to_paos_[ij].size();
+        int npno_ij = n_pno_[ij];
+
+        auto X_pno_new = std::make_shared<Matrix>(npao_ij + nsomo, npno_ij + nsomo);
+
+        for (int u_ij = 0; u_ij < npao_ij; ++u_ij) {
+            for (int a_ij = 0; a_ij < npno_ij; ++a_ij) {
+                X_pno_new->set(u_ij, a_ij, X_pno_[ij]->get(u_ij, a_ij));
+            } // end a_ij
+        } // end u_ij
+
+        for (int t = 0; t < nsomo; ++t) {
+            X_pno_new->set(npao_ij + t, npno_ij + t, 1.0);
+        } // end t
+
+        auto e_pno_new = std::make_shared<Vector>(npno_ij + nsomo);
+
+        for (int a_ij = 0; a_ij < npno_ij; ++a_ij) {
+            e_pno_new->set(a_ij, e_pno_[ij]->get(a_ij));
+        } // end for
+
+        for (int t = 0; t < nsomo; ++t) {
+            e_pno_new->set(npno_ij + t, eps_aocc->get(nbocc + t));
+        } // end for
+
+        X_pno_[ij] = X_pno_new;
+        e_pno_[ij] = e_pno_new;
+        n_pno_[ij] = n_pno_[ij] + nsomo;
+
+        if (i < j) {
+            X_pno_[ji] = X_pno_new;
+            e_pno_[ji] = e_pno_new;
+            n_pno_[ji] = n_pno_[ji] + nsomo;
+        } // end if
+    } // end for
+}
+
+SharedMatrix RO_DLPNOCCSD::T_iajb_spin_helper(const int ij, const SpinCase& sigma1, const SpinCase& sigma2) {
+    const int ji = ij_to_ji_[ij];
+    const int s1 = static_cast<int>(sigma1), s2 = static_cast<int>(sigma2);
+    DoubleSpinCase double_sigma = to_double_spin(sigma1, sigma2);
+    const int ds = static_cast<int>(double_sigma);
+
+    SharedMatrix T_iajb_s1_s2 = (s1 <= s2) ? T_iajb_spin_[ds][ij] : T_iajb_spin_[ds][ji]->transpose();
+    return T_iajb_s1_s2;
+}
+
+void RO_DLPNOCCSD::spin_enforcer(std::vector<SharedMatrix>& X_ia, const SpinCase &sigma) {
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = naocc - nbocc;
+
+    if (sigma == SpinCase::Alpha) {
+        // For the alpha case, set the last nsomo virtual elements to zero
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int i = 0; i < naocc; ++i) {
+            int ii = i_j_to_ij_[i][i];
+            for (int a_ii = 0; a_ii < nsomo; ++a_ii) {
+                (*X_ia[i])(n_pno_[ii] - a_ii - 1, 0) = 0.0;
+            } // end a_ii
+        } // end i
+    } else if (sigma == SpinCase::Beta) {
+        // For the beta case, set the last somo occupied amplitudes to zero
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int i = nbocc; i < nbocc + nsomo; ++i) {
+            X_ia[i]->zero();
+        } // end i
+    } else {
+        throw PSIEXCEPTION("Undefined spin case in function RO_DLPNOCCSD::spin_enforcer");
+    } // end else
+}
+
+void RO_DLPNOCCSD::double_spin_enforcer(std::vector<SharedMatrix>& X_iajb, const DoubleSpinCase &double_sigma, bool reverse_ab) {
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = naocc - nbocc;
+
+    if (double_sigma == DoubleSpinCase::AA) {
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+            auto &[i, j] = ij_to_i_j_[ij];
+
+            // AA spin case, last nsomo virtual elements are zero
+            for (int a_ij = 0; a_ij < nsomo; ++a_ij) {
+                for (int b_ij = 0; b_ij < n_pno_[ij]; ++b_ij) {
+                    (*X_iajb[ij])(n_pno_[ij] - a_ij - 1, b_ij) = 0.0;
+                } // end b_ij
+            } // end a_ij
+
+            for (int a_ij = 0; a_ij < n_pno_[ij]; ++a_ij) {
+                for (int b_ij = 0; b_ij < nsomo; ++b_ij) {
+                    (*X_iajb[ij])(a_ij, n_pno_[ij] - b_ij - 1) = 0.0;
+                } // end b_ij
+            } // end a_ij
+        }
+    } else if (double_sigma == DoubleSpinCase::AB) {
+        // For T2 amplitudes, yikes
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+            auto &[i, j] = ij_to_i_j_[ij];
+
+            if (!reverse_ab) {
+                // AB spin case, for i, zero out last somo virtuals, for j... zero out occupied >= nbocc
+                for (int a_ij = 0; a_ij < nsomo; ++a_ij) {
+                    for (int b_ij = 0; b_ij < n_pno_[ij]; ++b_ij) {
+                        (*X_iajb[ij])(n_pno_[ij] - a_ij - 1, b_ij) = 0.0;
+                    } // end b_ij
+                } // end a_ij
+
+                if (j >= nbocc) X_iajb[ij]->zero();
+
+            } else {
+                if (i >= nbocc) X_iajb[ij]->zero();
+
+                for (int a_ij = 0; a_ij < n_pno_[ij]; ++a_ij) {
+                    for (int b_ij = 0; b_ij < nsomo; ++b_ij) {
+                        (*X_iajb[ij])(a_ij, n_pno_[ij] - b_ij - 1) = 0.0;
+                    } // end b_ij
+                } // end a_ij
+
+            } // end else
+        } // end for
+    } else if (double_sigma == DoubleSpinCase::BB) {
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+            auto &[i, j] = ij_to_i_j_[ij];
+
+            if (i >= nbocc || j >= nbocc) X_iajb[ij]->zero();
+        }
+    } else {
+        throw PSIEXCEPTION("Undefined spin case in function RO_DLPNOCCSD::double_spin_enforcer");
+    } // end else
+} // end function
+
+void RO_DLPNOCCSD::matrix_spin_enforcer_qo(SharedMatrix &X, const int &ij, const SpinCase &sigma) {
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = naocc - nbocc;
+
+    // Do nothing in alpha case, all occupied indices are valid
+    if (sigma == SpinCase::Alpha) return;
+
+    // Zero out occupied indices greater than nbocc (they are not occupied in beta case)
+    if (sigma == SpinCase::Beta) {
+        for (int q_ij = 0; q_ij < X->rowspi(0); ++q_ij) {
+            for (int k_ij = 0; k_ij < X->colspi(0); ++k_ij) {
+                int k = lmopair_to_lmos_[ij][k_ij];
+                if (k >= nbocc) (*X)(q_ij, k_ij) = 0.0;
+            } // end for
+        } // end for
+    } // end if
+}
+
+void RO_DLPNOCCSD::matrix_spin_enforcer_qv(SharedMatrix &X, const SpinCase &sigma) {
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = naocc - nbocc;
+
+    // Do nothing in beta case, all virtual indices are valid
+    if (sigma == SpinCase::Beta) return;
+
+    if (sigma == SpinCase::Alpha) {
+        for (int q_ij = 0; q_ij < X->rowspi(0); ++q_ij) {
+            for (int a_ij = 0; a_ij < nsomo; ++a_ij) {
+                int a_idx = X->colspi(0) - a_ij - 1;
+                (*X)(q_ij, a_idx) = 0.0;
+            } // end for
+        } // end for
+    } // end if
+}
+
+void RO_DLPNOCCSD::matrix_spin_enforcer_oo(SharedMatrix &X, const int &ij, const SpinCase &sigma) {
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = naocc - nbocc;
+
+    // Do nothing in alpha case, all occupied indices are valid
+    if (sigma == SpinCase::Alpha) return;
+
+    // Zero out occupied indices greater than nbocc (they are not occupied in beta case)
+    if (sigma == SpinCase::Beta) {
+        for (int k_ij = 0; k_ij < X->rowspi(0); ++k_ij) {
+            int k = lmopair_to_lmos_[ij][k_ij];
+            for (int l_ij = 0; l_ij < X->colspi(0); ++l_ij) {
+                int l = lmopair_to_lmos_[ij][l_ij];
+                if (k >= nbocc || l >= nbocc) (*X)(k_ij, l_ij) = 0.0;
+            }
+        } // end for
+    } // end if
+}
+
+void RO_DLPNOCCSD::matrix_spin_enforcer_vv(SharedMatrix &X, const SpinCase &sigma) {
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = naocc - nbocc;
+
+    // Do nothing in beta case, all virtual indices are valid
+    if (sigma == SpinCase::Beta) return;
+
+    if (sigma == SpinCase::Alpha) {
+        // For alpha spin the appended SOMOs are occupied, not virtual.  Remove
+        // every matrix element carrying one of those virtual indices.
+        for (int a = 0; a < nsomo; ++a) {
+            int a_idx = X->rowspi(0) - a - 1;
+            for (int b = 0; b < X->colspi(0); ++b) (*X)(a_idx, b) = 0.0;
+        }
+        for (int b = 0; b < nsomo; ++b) {
+            int b_idx = X->colspi(0) - b - 1;
+            for (int a = 0; a < X->rowspi(0); ++a) (*X)(a, b_idx) = 0.0;
+        }
+
+    } else {
+        throw PSIEXCEPTION("Undefined spin case in function RO_DLPNOCCSD::matrix_spin_enforcer_vv");
+    }
+}
+
+void RO_DLPNOCCSD::form_projected_singles() {
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const int nbocc = nbeta_ - nfrzc();
+    constexpr std::array<SpinCase, 2> spins = {SpinCase::Alpha, SpinCase::Beta};
+
+    for (SpinCase sigma : spins) {
+        const int s = static_cast<int>(sigma);
+        T_n_ij_spin_[s].resize(n_lmo_pairs);
+
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+            const int nlmo_ij = lmopair_to_lmos_[ij].size();
+            const int npno_ij = n_pno_[ij];
+            T_n_ij_spin_[s][ij] = std::make_shared<Matrix>(nlmo_ij, npno_ij);
+
+            for (int n_ij = 0; n_ij < nlmo_ij; ++n_ij) {
+                const int n = lmopair_to_lmos_[ij][n_ij];
+                if (sigma == SpinCase::Beta && n >= nbocc) continue;
+
+                const int nn = i_j_to_ij_[n][n];
+                auto S_ij_nn = S_PNO(ij, nn)->clone();
+                matrix_spin_enforcer_vv(S_ij_nn, sigma);
+                auto T_n = linalg::doublet(S_ij_nn, T_ia_spin_[s][n]);
+
+                for (int a_ij = 0; a_ij < npno_ij; ++a_ij) {
+                    (*T_n_ij_spin_[s][ij])(n_ij, a_ij) = (*T_n)(a_ij, 0);
+                }
+            }
+        }
+    }
+}
+
+void RO_DLPNOCCSD::t1_ints_spin() {
+    timer_on("DLPNO-ROCCSD: T1 Ints");
+
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const int nbocc = nbeta_ - nfrzc();
+    constexpr std::array<SpinCase, 2> spins = {SpinCase::Alpha, SpinCase::Beta};
+
+    for (SpinCase sigma : spins) {
+        const int s = static_cast<int>(sigma);
+        i_Qk_t1_spin_[s].resize(n_lmo_pairs);
+        i_Qa_t1_spin_[s].resize(n_lmo_pairs);
+
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+            auto &[i, j] = ij_to_i_j_[ij];
+            const int nlmo_ij = lmopair_to_lmos_[ij].size();
+            const int naux_ij = lmopair_to_ribfs_[ij].size();
+            const int npno_ij = n_pno_[ij];
+            const int i_ij = lmopair_to_lmos_dense_[ij][i];
+
+            // Always allocate these intermediates.  Invalid beta blocks and
+            // screened pairs remain exactly zero, avoiding null matrices in
+            // the spin-summed contractions downstream.
+            i_Qk_t1_spin_[s][ij] = std::make_shared<Matrix>(naux_ij, nlmo_ij);
+            i_Qa_t1_spin_[s][ij] = std::make_shared<Matrix>(naux_ij, npno_ij);
+
+            if (i_j_to_ij_strong_[i][j] == -1) continue;
+            if (sigma == SpinCase::Beta && i >= nbocc) continue;
+
+            // Eq. 1: B~(Q,ki) = B(Q,ki) + B(Q,ka) t(i,a).
+            i_Qk_t1_spin_[s][ij]->copy(i_Qk_ij_[ij]);
+            matrix_spin_enforcer_qo(i_Qk_t1_spin_[s][ij], ij, sigma);
+
+            auto qma_ij = QIA_PNO(ij);
+            for (int q_ij = 0; q_ij < naux_ij; ++q_ij) {
+                for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
+                    for (int a_ij = 0; a_ij < npno_ij; ++a_ij) {
+                        (*i_Qk_t1_spin_[s][ij])(q_ij, k_ij) +=
+                            (*qma_ij[q_ij])(k_ij, a_ij) * (*T_n_ij_spin_[s][ij])(i_ij, a_ij);
+                    }
+                }
+            }
+
+            // Eq. 3: B~(Q,ai) = B(Q,ai) - t(k,a) B~(Q,ki)
+            //                         + B(Q,ab) t(i,b).
+            i_Qa_t1_spin_[s][ij]->copy(i_Qa_ij_[ij]);
+            matrix_spin_enforcer_qv(i_Qa_t1_spin_[s][ij], sigma);
+            i_Qa_t1_spin_[s][ij]->subtract(
+                linalg::doublet(i_Qk_t1_spin_[s][ij], T_n_ij_spin_[s][ij]));
+
+            auto qab_ij = QAB_PNO(ij);
+            for (int q_ij = 0; q_ij < naux_ij; ++q_ij) {
+                auto Qab = qab_ij[q_ij]->clone();
+                matrix_spin_enforcer_vv(Qab, sigma);
+                for (int a_ij = 0; a_ij < npno_ij; ++a_ij) {
+                    for (int b_ij = 0; b_ij < npno_ij; ++b_ij) {
+                        (*i_Qa_t1_spin_[s][ij])(q_ij, a_ij) +=
+                            (*Qab)(a_ij, b_ij) * (*T_n_ij_spin_[s][ij])(i_ij, b_ij);
+                    }
+                }
+            }
+            matrix_spin_enforcer_qv(i_Qa_t1_spin_[s][ij], sigma);
+        }
+    }
+
+    timer_off("DLPNO-ROCCSD: T1 Ints");
+}
+
+void RO_DLPNOCCSD::t1_fock_spin() {
+    timer_on("DLPNO-ROCCSD: T1 Fock");
+
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = naocc - nbocc;
+    constexpr std::array<SpinCase, 2> spins = {SpinCase::Alpha, SpinCase::Beta};
+
+    std::array<SharedMatrix, 2> F_lmo_pao_spin = {
+        linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_pao_, true, false, false),
+        linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_pao_, true, false, false)};
+
+    // The bars denote dressing over contracted indices.  The Coulomb part
+    // contains alpha + beta T1 density; exchange is same-spin only.
+    std::array<SharedMatrix, 2> Fki_bar;
+    std::array<std::vector<SharedMatrix>, 2> Fkc_bar;
+    std::array<std::vector<SharedMatrix>, 2> Fai_bar;
+    std::array<std::vector<SharedMatrix>, 2> Fab_bar;
+
+    for (SpinCase sigma : spins) {
+        const int s = static_cast<int>(sigma);
+        Fki_bar[s] = (sigma == SpinCase::Alpha) ? F_lmo_a_->clone() : F_lmo_b_->clone();
+        Fkc_bar[s].resize(n_lmo_pairs);
+        Fai_bar[s].resize(naocc);
+        Fab_bar[s].resize(n_lmo_pairs);
+        Fkc_tilde_spin_[s].resize(n_lmo_pairs);
+        Fai_tilde_spin_[s].resize(naocc);
+        Fab_tilde_spin_[s].resize(n_lmo_pairs);
+    }
+
+    // Eq. 9 occupied/occupied barred block.
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        const int ji = ij_to_ji_[ij];
+        if (i_j_to_ij_strong_[i][j] == -1) continue;
+
+        for (SpinCase sigma : spins) {
+            const int s = static_cast<int>(sigma);
+            if (sigma == SpinCase::Beta && (i >= nbocc || j >= nbocc)) continue;
+
+            for (SpinCase tau : spins) {
+                const int t = static_cast<int>(tau);
+                (*Fki_bar[s])(i, j) += T_n_ij_spin_[t][ij]->vector_dot(J_ijmb_[ij]);
+            }
+            (*Fki_bar[s])(i, j) -= T_n_ij_spin_[s][ij]->vector_dot(K_mibj_[ji]);
+        }
+    }
+
+    // Remaining barred blocks.  The expensive DF objects exist only for
+    // strong pairs; all local CC equations below intentionally use that same
+    // strong-pair space.
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        const int ji = ij_to_ji_[ij];
+        if (i > j) continue;
+
+        const int naux_ij = lmopair_to_ribfs_[ij].size();
+        const int nlmo_ij = lmopair_to_lmos_[ij].size();
+        const int npno_ij = n_pno_[ij];
+        const bool strong = (i_j_to_ij_strong_[i][j] != -1);
+
+        for (SpinCase sigma : spins) {
+            const int s = static_cast<int>(sigma);
+
+            Fkc_bar[s][ij] = submatrix_rows_and_cols(*F_lmo_pao_spin[s],
+                                                      lmopair_to_lmos_[ij], lmopair_to_paos_[ij]);
+            Fkc_bar[s][ij] = linalg::doublet(Fkc_bar[s][ij], X_pno_[ij]);
+            Fab_bar[s][ij] = F_pno_spin_[s][ij]->clone();
+
+            if (i == j) {
+                Fai_bar[s][i] = submatrix_rows_and_cols(*F_lmo_pao_spin[s],
+                                                        std::vector<int>(1, i), lmopair_to_paos_[ij]);
+                Fai_bar[s][i] = linalg::doublet(Fai_bar[s][i], X_pno_[ij])->transpose();
+            }
+
+            if (strong && !(sigma == SpinCase::Beta && i >= nbocc)) {
+                auto qma_ij = QIA_PNO(ij);
+                auto qab_ij = QAB_PNO(ij);
+                auto Qia = i_Qa_ij_[ij]->clone();
+                auto Qik = i_Qk_ij_[ij]->clone();
+                matrix_spin_enforcer_qv(Qia, sigma);
+                matrix_spin_enforcer_qo(Qik, ij, sigma);
+
+                for (int q_ij = 0; q_ij < naux_ij; ++q_ij) {
+                    for (SpinCase tau : spins) {
+                        const int t = static_cast<int>(tau);
+                        const double density_q = qma_ij[q_ij]->vector_dot(T_n_ij_spin_[t][ij]);
+
+                        auto Jkc = qma_ij[q_ij]->clone();
+                        Jkc->scale(density_q);
+                        Fkc_bar[s][ij]->add(Jkc);
+
+                        auto Jab = qab_ij[q_ij]->clone();
+                        Jab->scale(density_q);
+                        Fab_bar[s][ij]->add(Jab);
+
+                        if (i == j) {
+                            for (int a_ij = 0; a_ij < npno_ij; ++a_ij) {
+                                (*Fai_bar[s][i])(a_ij, 0) += density_q * (*Qia)(q_ij, a_ij);
+                            }
+                        }
+                    }
+
+                    // Same-spin exchange pieces.
+                    Fkc_bar[s][ij]->subtract(linalg::triplet(
+                        qma_ij[q_ij], T_n_ij_spin_[s][ij], qma_ij[q_ij], false, true, false));
+                    Fab_bar[s][ij]->subtract(linalg::triplet(
+                        qab_ij[q_ij], T_n_ij_spin_[s][ij], qma_ij[q_ij], false, true, false));
+
+                    if (i == j) {
+                        auto lambda = linalg::doublet(qab_ij[q_ij], T_n_ij_spin_[s][ij], false, true);
+                        for (int a_ij = 0; a_ij < npno_ij; ++a_ij) {
+                            for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
+                                (*Fai_bar[s][i])(a_ij, 0) -=
+                                    (*lambda)(a_ij, k_ij) * (*Qik)(q_ij, k_ij);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Enforce the ROHF occupied/virtual interpretation explicitly.
+            if (sigma == SpinCase::Alpha) {
+                for (int a = 0; a < nsomo; ++a) {
+                    const int av = npno_ij - a - 1;
+                    for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) (*Fkc_bar[s][ij])(k_ij, av) = 0.0;
+                    if (i == j) (*Fai_bar[s][i])(av, 0) = 0.0;
+                }
+            } else {
+                for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
+                    if (lmopair_to_lmos_[ij][k_ij] >= nbocc) {
+                        for (int a = 0; a < npno_ij; ++a) (*Fkc_bar[s][ij])(k_ij, a) = 0.0;
+                    }
+                }
+                if (i == j && i >= nbocc) Fai_bar[s][i]->zero();
+            }
+            matrix_spin_enforcer_vv(Fab_bar[s][ij], sigma);
+
+            if (i != j) {
+                Fkc_bar[s][ji] = Fkc_bar[s][ij];
+                Fab_bar[s][ji] = Fab_bar[s][ij];
+            }
+        }
+    }
+
+    // Eq. 5.  Notice the plus sign from dressing the free occupied index.
+    for (SpinCase sigma : spins) {
+        const int s = static_cast<int>(sigma);
+        Fki_tilde_spin_[s] = Fki_bar[s]->clone();
+
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+            auto &[i, j] = ij_to_i_j_[ij];
+            if (sigma == SpinCase::Beta && (i >= nbocc || j >= nbocc)) continue;
+            const int jj = i_j_to_ij_[j][j];
+            const int i_jj = lmopair_to_lmos_dense_[jj][i];
+            if (i_jj == -1 || !Fkc_bar[s][jj]) continue;
+
+            for (int a_jj = 0; a_jj < n_pno_[jj]; ++a_jj) {
+                (*Fki_tilde_spin_[s])(i, j) +=
+                    (*Fkc_bar[s][jj])(i_jj, a_jj) * (*T_ia_spin_[s][j])(a_jj, 0);
+            }
+        }
+
+        if (sigma == SpinCase::Beta) {
+            for (int k = 0; k < naocc; ++k) {
+                for (int i = 0; i < naocc; ++i) {
+                    if (k >= nbocc || i >= nbocc) (*Fki_tilde_spin_[s])(k, i) = 0.0;
+                }
+            }
+        }
+    }
+
+    // Eqs. 6--8: form the free-index transformed blocks.
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        const int ji = ij_to_ji_[ij];
+        const int pair_idx = (i > j) ? ji : ij;
+        const int i_pair = lmopair_to_lmos_dense_[pair_idx][i];
+        const bool strong = (i_j_to_ij_strong_[i][j] != -1);
+
+        for (SpinCase sigma : spins) {
+            const int s = static_cast<int>(sigma);
+
+            Fkc_tilde_spin_[s][ij] = std::make_shared<Matrix>(n_pno_[ij], 1);
+            if (Fkc_bar[s][pair_idx] && i_pair != -1) {
+                auto row = submatrix_rows(*Fkc_bar[s][pair_idx], std::vector<int>(1, i_pair));
+                Fkc_tilde_spin_[s][ij]->copy(row->transpose());
+            }
+            if (sigma == SpinCase::Beta && i >= nbocc) Fkc_tilde_spin_[s][ij]->zero();
+
+            if (i <= j) {
+                Fab_tilde_spin_[s][ij] = Fab_bar[s][ij]->clone();
+                if (strong) {
+                    // Eq. 8 has a minus sign from e^{-T1} H e^{T1}; this
+                    // also recovers the validated closed-shell implementation.
+                    Fab_tilde_spin_[s][ij]->subtract(linalg::doublet(
+                        T_n_ij_spin_[s][ij], Fkc_bar[s][ij], true, false));
+                }
+                matrix_spin_enforcer_vv(Fab_tilde_spin_[s][ij], sigma);
+                if (i != j) Fab_tilde_spin_[s][ji] = Fab_tilde_spin_[s][ij];
+            }
+
+            if (i == j) {
+                Fai_tilde_spin_[s][i] = Fai_bar[s][i]->clone();
+                Fai_tilde_spin_[s][i]->add(linalg::doublet(
+                    Fab_bar[s][ij], T_ia_spin_[s][i]));
+                Fai_tilde_spin_[s][i]->subtract(linalg::triplet(
+                    T_n_ij_spin_[s][ij], Fkc_bar[s][ij], T_ia_spin_[s][i], true, false, false));
+
+                for (int a_i = 0; a_i < n_pno_[ij]; ++a_i) {
+                    for (int k_i = 0; k_i < static_cast<int>(lmopair_to_lmos_[ij].size()); ++k_i) {
+                        const int k = lmopair_to_lmos_[ij][k_i];
+                        (*Fai_tilde_spin_[s][i])(a_i, 0) -=
+                            (*T_n_ij_spin_[s][ij])(k_i, a_i) * (*Fki_bar[s])(k, i);
+                    }
+                }
+
+                if (sigma == SpinCase::Alpha) {
+                    for (int a = 0; a < nsomo; ++a) {
+                        (*Fai_tilde_spin_[s][i])(n_pno_[ij] - a - 1, 0) = 0.0;
+                    }
+                } else if (i >= nbocc) {
+                    Fai_tilde_spin_[s][i]->zero();
+                }
+            }
+        }
+    }
+
+    timer_off("DLPNO-ROCCSD: T1 Fock");
+}
+
+std::array<std::vector<SharedMatrix>, 3> RO_DLPNOCCSD::compute_beta() {
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const int nbocc = nbeta_ - nfrzc();
+
+    std::array<std::vector<SharedMatrix>, 3> beta_ijkl;
+    constexpr std::array<DoubleSpinCase, 3> doubles_spin_cases = { DoubleSpinCase::AA, DoubleSpinCase::AB, DoubleSpinCase::BB };
+
+    for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+        beta_ijkl[static_cast<int>(double_sigma)].resize(n_lmo_pairs);
+    }
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        const int ji = ij_to_ji_[ij];
+
+        const int nlmo_ij = lmopair_to_lmos_[ij].size();
+        const int naux_ij = lmopair_to_ribfs_[ij].size();
+
+        for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+            auto [sigma1, sigma2] = get_spin_pair(double_sigma);
+            const int ds = static_cast<int>(double_sigma);
+            const int s1 = static_cast<int>(sigma1), s2 = static_cast<int>(sigma2);
+
+            beta_ijkl[ds][ij] = std::make_shared<Matrix>(nlmo_ij, nlmo_ij);
+            if (i_j_to_ij_strong_[i][j] == -1) continue;
+            if (sigma1 == SpinCase::Beta && i >= nbocc) continue;
+            if (sigma2 == SpinCase::Beta && j >= nbocc) continue;
+
+            beta_ijkl[ds][ij]->add(linalg::doublet(
+                i_Qk_t1_spin_[s1][ij], i_Qk_t1_spin_[s2][ji], true, false));
+
+            double prefactor = (s1 == s2) ? 0.5 : 1.0;
+
+            auto qma_ij = QIA_PNO(ij);
+            for (int q_ij = 0; q_ij < naux_ij; ++q_ij) {
+                auto beta_temp = linalg::triplet(qma_ij[q_ij], T_iajb_spin_[ds][ij],
+                                                 qma_ij[q_ij], false, false, true);
+                beta_temp->scale(prefactor);
+                beta_ijkl[ds][ij]->add(beta_temp);
+            }
+        }
+    }
+
+    return beta_ijkl;
+}
+
+std::array<std::array<std::vector<SharedMatrix>, 2>, 2> RO_DLPNOCCSD::compute_gamma() {
+
+    int n_lmo_pairs = ij_to_i_j_.size();
+    int nbocc = nbeta_ - nfrzc();
+
+    constexpr std::array<SpinCase, 2> singles_spin_cases = { SpinCase::Alpha, SpinCase::Beta };
+
+    std::array<std::array<std::vector<SharedMatrix>, 2>, 2> gamma;
+
+    for (SpinCase sigma1 : singles_spin_cases) {
+        const int s1 = static_cast<int>(sigma1);
+        for (SpinCase sigma2 : singles_spin_cases) {
+            const int s2 = static_cast<int>(sigma2);
+            gamma[s1][s2].resize(n_lmo_pairs);
+        } // end sigma2
+    } // end sigma1
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ki = 0; ki < n_lmo_pairs; ++ki) {
+        auto &[k, i] = ij_to_i_j_[ki];
+        const int ii = i_j_to_ij_[i][i];
+
+        const int nlmo_ki = lmopair_to_lmos_[ki].size();
+        const int npno_ki = n_pno_[ki];
+
+        for (SpinCase sigma1 : singles_spin_cases) {
+            const int s1 = static_cast<int>(sigma1);
+
+            for (SpinCase sigma2 : singles_spin_cases) {
+                const int s2 = static_cast<int>(sigma2);
+
+                gamma[s1][s2][ki] = std::make_shared<Matrix>(npno_ki, npno_ki);
+                if (sigma1 == SpinCase::Beta && (k >= nbocc || i >= nbocc)) continue;
+
+                // Eq. 14a: -t_l^a(s2) (ki|lc).
+                gamma[s1][s2][ki]->subtract(linalg::doublet(
+                    T_n_ij_spin_[s2][ki], J_ijmb_[ki], true, false));
+
+                // Eq. 14b: +t_i^b(s1) (kb|ac).
+                auto S_ki_ii_s1 = S_PNO(ki, ii)->clone();
+                matrix_spin_enforcer_vv(S_ki_ii_s1, sigma1);
+                auto T_i = linalg::doublet(S_ki_ii_s1, T_ia_spin_[s1][i]);
+                auto gamma_vvv = linalg::doublet(T_i, K_ivvv_[ki], true, false);
+                gamma_vvv->reshape(npno_ki, npno_ki);
+                matrix_spin_enforcer_vv(gamma_vvv, sigma2);
+                gamma[s1][s2][ki]->add(gamma_vvv);
+
+                // Eq. 14c: -t_i^b(s1) (kb|lc) t_l^a(s2).
+                for (int l_ki = 0; l_ki < nlmo_ki; ++l_ki) {
+                    const int l = lmopair_to_lmos_[ki][l_ki];
+                    if (sigma2 == SpinCase::Beta && l >= nbocc) continue;
+                    const int kl = i_j_to_ij_[k][l];
+                    const int ll = i_j_to_ij_[l][l];
+                    if (kl == -1 || ll == -1) continue;
+
+                    auto S_ki_ll_s2 = S_PNO(ki, ll)->clone();
+                    matrix_spin_enforcer_vv(S_ki_ll_s2, sigma2);
+                    auto T_l = linalg::doublet(S_ki_ll_s2, T_ia_spin_[s2][l]);
+
+                    auto S_kl_ii_s1 = S_PNO(kl, ii)->clone();
+                    matrix_spin_enforcer_vv(S_kl_ii_s1, sigma1);
+                    auto T_i_kl = linalg::doublet(S_kl_ii_s1, T_ia_spin_[s1][i]);
+
+                    auto S_ki_kl_s2 = S_PNO(ki, kl)->clone();
+                    matrix_spin_enforcer_vv(S_ki_kl_s2, sigma2);
+                    auto K_kl = linalg::triplet(S_ki_kl_s2, K_iajb_[kl], T_i_kl,
+                                                false, true, false);
+                    C_DGER(npno_ki, npno_ki, -1.0, T_l->get_pointer(), 1,
+                           K_kl->get_pointer(), 1, gamma[s1][s2][ki]->get_pointer(), npno_ki);
+                }
+
+                for (int l_ki = 0; l_ki < nlmo_ki; ++l_ki) {
+                    int l = lmopair_to_lmos_[ki][l_ki];
+                    int li = i_j_to_ij_[l][i], kl = i_j_to_ij_[k][l];
+                    if (li == -1 || kl == -1) continue;
+                    if (sigma2 == SpinCase::Beta && l >= nbocc) continue;
+
+                    auto T_iajb_li_s2_s1 = T_iajb_spin_helper(li, sigma2, sigma1);
+                    auto S_li_kl_s1 = S_PNO(li, kl)->clone();
+                    matrix_spin_enforcer_vv(S_li_kl_s1, sigma1);
+
+                    auto gamma_temp = linalg::triplet(T_iajb_li_s2_s1, S_li_kl_s1, K_iajb_[kl]);
+
+                    auto S_ki_li_s2 = S_PNO(ki, li)->clone();
+                    matrix_spin_enforcer_vv(S_ki_li_s2, sigma2);
+                    auto S_kl_ki_s2 = S_PNO(kl, ki)->clone();
+                    matrix_spin_enforcer_vv(S_kl_ki_s2, sigma2);
+
+                    gamma_temp = linalg::triplet(S_ki_li_s2, gamma_temp, S_kl_ki_s2);
+                    gamma_temp->scale(0.5);
+
+                    gamma[s1][s2][ki]->add(gamma_temp);
+                } // end l_ki
+
+                matrix_spin_enforcer_vv(gamma[s1][s2][ki], sigma2);
+            } // end sigma2
+        } // end sigma1
+    } // end ki
+
+    return gamma;
+}
+
+std::array<std::array<std::vector<SharedMatrix>, 2>, 2> RO_DLPNOCCSD::compute_delta() {
+
+    int n_lmo_pairs = ij_to_i_j_.size();
+    int naocc = nalpha_ - nfrzc();
+    int nbocc = nbeta_ - nfrzc();
+    int nsomo = naocc - nbocc;
+
+    constexpr std::array<SpinCase, 2> singles_spin_cases = { SpinCase::Alpha, SpinCase::Beta };
+
+    std::array<std::array<std::vector<SharedMatrix>, 2>, 2> delta;
+
+    for (SpinCase sigma1 : singles_spin_cases) {
+        const int s1 = static_cast<int>(sigma1);
+        for (SpinCase sigma2 : singles_spin_cases) {
+            const int s2 = static_cast<int>(sigma2);
+            delta[s1][s2].resize(n_lmo_pairs);
+        } // end sigma2
+    } // end sigma1
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ik = 0; ik < n_lmo_pairs; ++ik) {
+        auto &[i, k] = ij_to_i_j_[ik];
+        const int ki = ij_to_ji_[ik];
+        const int ii = i_j_to_ij_[i][i];
+
+        const int nlmo_ik = lmopair_to_lmos_[ik].size();
+        const int npno_ik = n_pno_[ik];
+
+        for (SpinCase sigma1 : singles_spin_cases) {
+            const int s1 = static_cast<int>(sigma1);
+            for (SpinCase sigma2 : singles_spin_cases) {
+                const int s2 = static_cast<int>(sigma2);
+
+                delta[s1][s2][ik] = std::make_shared<Matrix>(npno_ik, npno_ik);
+                delta[s1][s2][ik]->zero();
+
+                if (sigma1 == SpinCase::Beta && i >= nbocc) continue;
+                if (sigma2 == SpinCase::Beta && k >= nbocc) continue; 
+
+                // Eq. 15a: -t_l^a(s1) [(il|kc) - delta(s1,s2)(ik|lc)].
+                auto M_iklc = K_mibj_[ik]->clone();
+                if (s1 == s2) M_iklc->subtract(J_ijmb_[ik]);
+                delta[s1][s2][ik]->subtract(linalg::doublet(
+                    T_n_ij_spin_[s1][ik], M_iklc, true, false));
+
+                // Eq. 15b: t_i^b(s1) [(kc|ab) - delta(s1,s2)(kb|ca)].
+                auto S_ik_ii_s1 = S_PNO(ik, ii)->clone();
+                matrix_spin_enforcer_vv(S_ik_ii_s1, sigma1);
+                auto T_i = linalg::doublet(S_ik_ii_s1, T_ia_spin_[s1][i]);
+
+                auto direct = K_ivvv_[ki]->clone();
+                direct->reshape(npno_ik * npno_ik, npno_ik);
+                direct = linalg::doublet(direct, T_i);
+                direct->reshape(npno_ik, npno_ik);
+                delta[s1][s2][ik]->add(direct->transpose());
+
+                if (s1 == s2) {
+                    auto exchange = linalg::doublet(T_i, K_ivvv_[ki], true, false);
+                    exchange->reshape(npno_ik, npno_ik);
+                    delta[s1][s2][ik]->subtract(exchange);
+                }
+
+                // Eq. 15c: -t_l^a(s1) [(lb|kc) - delta(s1,s2)(lc|kb)] t_i^b(s1).
+                for (int l_ik = 0; l_ik < nlmo_ik; ++l_ik) {
+                    const int l = lmopair_to_lmos_[ik][l_ik];
+                    if (sigma1 == SpinCase::Beta && l >= nbocc) continue;
+                    const int ll = i_j_to_ij_[l][l];
+                    const int lk = i_j_to_ij_[l][k];
+                    if (ll == -1 || lk == -1) continue;
+
+                    auto S_ik_ll_s1 = S_PNO(ik, ll)->clone();
+                    matrix_spin_enforcer_vv(S_ik_ll_s1, sigma1);
+                    auto T_l = linalg::doublet(S_ik_ll_s1, T_ia_spin_[s1][l]);
+
+                    auto S_lk_ii_s1 = S_PNO(lk, ii)->clone();
+                    matrix_spin_enforcer_vv(S_lk_ii_s1, sigma1);
+                    auto T_i_lk = linalg::doublet(S_lk_ii_s1, T_ia_spin_[s1][i]);
+
+                    auto L_lk = K_iajb_[lk]->clone();
+                    if (s1 == s2) L_lk->subtract(K_iajb_[lk]->transpose());
+                    auto S_lk_ik_s2 = S_PNO(lk, ik)->clone();
+                    matrix_spin_enforcer_vv(S_lk_ik_s2, sigma2);
+                    auto L_contract = linalg::triplet(T_i_lk, L_lk, S_lk_ik_s2,
+                                                      true, false, false);
+                    C_DGER(npno_ik, npno_ik, -1.0, T_l->get_pointer(), 1,
+                           L_contract->get_pointer(), 1,
+                           delta[s1][s2][ik]->get_pointer(), npno_ik);
+                }
+
+                // Jiang Eq. 84d \delta_{ik}^{ac} += 0.5 u_{il}^{ad} [2(kc|ld) - (kd|lc)]
+                // => 0.5 u_{il}^{ad} L_{kl}^{cd} or 0.5 u_{il}^{ad} L_{lk}^{dc}
+                for (int l_ik = 0; l_ik < nlmo_ik; ++l_ik) {
+                    int l = lmopair_to_lmos_[ik][l_ik];
+                    int il = i_j_to_ij_[i][l], lk = i_j_to_ij_[l][k];
+                    if (il == -1 || lk == -1) continue;
+
+                    for (SpinCase gamma : singles_spin_cases) {
+                        auto S_ik_il_s1 = S_PNO(ik, il)->clone();
+                        matrix_spin_enforcer_vv(S_ik_il_s1, sigma1);
+
+                        if (gamma == SpinCase::Beta && l >= nbocc) continue;
+
+                        auto T_il_s1_g = T_iajb_spin_helper(il, sigma1, gamma);
+                        auto S_il_lk_g = S_PNO(il, lk)->clone();
+                        matrix_spin_enforcer_vv(S_il_lk_g, gamma);
+
+                        auto L_lk = K_iajb_[lk]->clone();
+                        if (sigma2 == gamma) L_lk->subtract(K_iajb_[lk]->transpose());
+                        auto S_lk_ik_s2 = S_PNO(lk, ik)->clone();
+                        matrix_spin_enforcer_vv(S_lk_ik_s2, sigma2);
+
+                        // (a_{il}, d_{il}) (d_{il}, d_{lk}) (d_{lk}, c_{lk}) -> (a_{il}, c_{lk})
+                        auto delta_temp = linalg::triplet(T_il_s1_g, S_il_lk_g, L_lk);
+
+                        // (a_{ik}, a_{il}) (a_{il}, c_{lk}) (c_{lk}, c_{ik}) -> (a_{ik}, c_{ik})
+                        delta_temp = linalg::triplet(S_ik_il_s1, delta_temp, S_lk_ik_s2);
+                        delta_temp->scale(0.5);
+
+                        delta[s1][s2][ik]->add(delta_temp);
+                    }
+                } // end l_ik
+
+                // Rows carry s1 virtuals; columns carry s2 virtuals.
+                if (sigma1 == SpinCase::Alpha) {
+                    for (int a = 0; a < nsomo; ++a) {
+                        const int av = npno_ik - a - 1;
+                        for (int c = 0; c < npno_ik; ++c) (*delta[s1][s2][ik])(av, c) = 0.0;
+                    }
+                }
+                if (sigma2 == SpinCase::Alpha) {
+                    for (int c = 0; c < nsomo; ++c) {
+                        const int cv = npno_ik - c - 1;
+                        for (int a = 0; a < npno_ik; ++a) (*delta[s1][s2][ik])(a, cv) = 0.0;
+                    }
+                }
+            } // end sigma2
+        } // end sigma1
+    } // end ik
+
+    return delta;
+}
+
+std::array<std::vector<SharedMatrix>, 2> RO_DLPNOCCSD::compute_Fbc_double_tilde() {
+
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const int nbocc = nbeta_ - nfrzc();
+
+    std::array<std::vector<SharedMatrix>, 2> F_bc_double_tilde;
+
+    constexpr std::array<SpinCase, 2> singles_spin_cases = { SpinCase::Alpha, SpinCase::Beta };
+    F_bc_double_tilde[static_cast<int>(SpinCase::Alpha)].resize(n_lmo_pairs);
+    F_bc_double_tilde[static_cast<int>(SpinCase::Beta)].resize(n_lmo_pairs);
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        const int ji = ij_to_ji_[ij];
+
+        int nlmo_ij = lmopair_to_lmos_[ij].size();
+
+        if (i > j) continue;
+
+        for (SpinCase sigma : singles_spin_cases) {
+            const int s = static_cast<int>(sigma);
+            F_bc_double_tilde[s][ij] = Fab_tilde_spin_[s][ij]->clone();
+
+            for (SpinCase gamma : singles_spin_cases) {
+                for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
+                    int k = lmopair_to_lmos_[ij][k_ij];
+                    if (sigma == SpinCase::Beta && k >= nbocc) continue;
+
+                    for (int l_ij = 0; l_ij < nlmo_ij; ++l_ij) {
+                        int l = lmopair_to_lmos_[ij][l_ij];
+                        if (gamma == SpinCase::Beta && l >= nbocc) continue;
+                        int kl = i_j_to_ij_[k][l];
+                        if (kl == -1) continue;
+
+                        auto S_ij_kl_s = S_PNO(ij, kl)->clone();
+                        matrix_spin_enforcer_vv(S_ij_kl_s, sigma);
+
+                        auto T_iajb_s_g = T_iajb_spin_helper(kl, sigma, gamma);
+                        auto F_bc_double_tilde_temp = linalg::doublet(T_iajb_s_g, K_iajb_[kl], false, true); // (b, d) (c, d) -> (b, c)
+                        F_bc_double_tilde[s][ij]->subtract(linalg::triplet(S_ij_kl_s, F_bc_double_tilde_temp, S_ij_kl_s, false, false, true));
+                    } // end l_ij
+                } // end k_ij
+
+            } // end gamma
+
+            // Probably not necessary, since enforcing spin on overlap matrices takes care of this
+            matrix_spin_enforcer_vv(F_bc_double_tilde[s][ij], sigma);
+            if (i != j) F_bc_double_tilde[s][ji] = F_bc_double_tilde[s][ij];
+        } // end sigma
+
+    } // end ij
+
+    return F_bc_double_tilde;
+}
+
+std::array<SharedMatrix, 2> RO_DLPNOCCSD::compute_Fki_double_tilde() {
+
+    int n_lmo_pairs = ij_to_i_j_.size();
+    int naocc = nalpha_ - nfrzc();
+    int nbocc = nbeta_ - nfrzc();
+
+    constexpr std::array<SpinCase, 2> singles_spin_cases = { SpinCase::Alpha, SpinCase::Beta };
+    std::array<SharedMatrix, 2> F_ki_double_tilde;
+
+    // Begin from the spin-resolved T1-transformed occupied block.
+    F_ki_double_tilde[static_cast<int>(SpinCase::Alpha)] =
+        Fki_tilde_spin_[static_cast<int>(SpinCase::Alpha)]->clone();
+    F_ki_double_tilde[static_cast<int>(SpinCase::Beta)] =
+        Fki_tilde_spin_[static_cast<int>(SpinCase::Beta)]->clone();
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        int nlmo_ij = lmopair_to_lmos_[ij].size();
+
+        for (SpinCase sigma : singles_spin_cases) {
+            const int s = static_cast<int>(sigma);
+            if (sigma == SpinCase::Beta && (i >= nbocc || j >= nbocc)) continue;
+
+            for (SpinCase gamma : singles_spin_cases) {
+                for (int l_ij = 0; l_ij < nlmo_ij; ++l_ij) {
+                    int l = lmopair_to_lmos_[ij][l_ij];
+                    int il = i_j_to_ij_[i][l], jl = i_j_to_ij_[j][l];
+                    if (gamma == SpinCase::Beta && l >= nbocc) continue;
+
+                    auto S_il_jl_s = S_PNO(il, jl)->clone();
+                    matrix_spin_enforcer_vv(S_il_jl_s, sigma);
+                    auto S_il_jl_g = S_PNO(il, jl)->clone();
+                    matrix_spin_enforcer_vv(S_il_jl_g, gamma);
+
+                    auto T_jl_s_g = T_iajb_spin_helper(jl, sigma, gamma);
+                    auto T_jl_s_g_proj = linalg::triplet(S_il_jl_s, T_jl_s_g, S_il_jl_g, false, false, true);
+
+                    // The zero-ing of necessary virtuals is taken care of by the T amplitudes and overlaps S
+                    (*F_ki_double_tilde[s])(i, j) += K_iajb_[il]->vector_dot(T_jl_s_g_proj);
+                } // end l_ij
+
+            } // end gamma
+        } // end sigma
+    } // end ij
+
+#pragma omp parallel for collapse(2)
+    for (int k = 0; k < naocc; ++k) {
+        for (int i = 0; i < naocc; ++i) {
+            if (k >= nbocc || i >= nbocc) {
+                (*F_ki_double_tilde[static_cast<int>(SpinCase::Beta)])(k, i) = 0.0;
+            }
+        }
+    }
+
+    return F_ki_double_tilde;
+}
+
+void RO_DLPNOCCSD::compute_R_ia(
+    std::array<std::vector<SharedMatrix>, 2>& R_ia,
+    std::array<std::vector<std::vector<SharedMatrix>>, 2>& R_ia_buffer) {
+
+    timer_on("DLPNO-ROCCSD: Compute R1");
+
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    int nthreads = 1;
+#ifdef _OPENMP
+    nthreads = Process::environment.get_n_threads();
+#endif
+
+    constexpr std::array<SpinCase, 2> spins = {SpinCase::Alpha, SpinCase::Beta};
+
+    // Eq. 12a: the one-body T1-transformed contribution.
+    for (SpinCase sigma : spins) {
+        const int s = static_cast<int>(sigma);
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int i = 0; i < naocc; ++i) {
+            R_ia[s][i]->copy(Fai_tilde_spin_[s][i]);
+            if (sigma == SpinCase::Beta && i >= nbocc) R_ia[s][i]->zero();
+        }
+        for (int thread = 0; thread < nthreads; ++thread) {
+            for (int i = 0; i < naocc; ++i) R_ia_buffer[s][thread][i]->zero();
+        }
+    }
+
+    // Three-external and F*T2 pieces of Eq. 12.
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ik = 0; ik < n_lmo_pairs; ++ik) {
+        auto &[i, k] = ij_to_i_j_[ik];
+        const int ki = ij_to_ji_[ik];
+        const int ii = i_j_to_ij_[i][i];
+        const int nlmo_ik = lmopair_to_lmos_[ik].size();
+        const int npno_ik = n_pno_[ik];
+
+        int thread = 0;
+#ifdef _OPENMP
+        thread = omp_get_thread_num();
+#endif
+
+        for (SpinCase sigma : spins) {
+            const int s = static_cast<int>(sigma);
+            if (sigma == SpinCase::Beta && i >= nbocc) continue;
+
+            for (SpinCase tau : spins) {
+                const int t = static_cast<int>(tau);
+                if (tau == SpinCase::Beta && k >= nbocc) continue;
+                const double prefactor = (s == t) ? 0.5 : 1.0;
+
+                // 1/2 t(ki,cd)<kc||da>; the explicit spin blocks turn the
+                // 1/2 into 1 for an opposite-spin partner.
+                auto T_ki = T_iajb_spin_helper(ki, tau, sigma)->clone();
+                auto K_kcad = K_ivvv_[ki]->clone();
+                K_kcad->reshape(npno_ik * npno_ik, npno_ik);
+                T_ki->reshape(npno_ik * npno_ik, 1);
+
+                auto S_ki_ii_s = S_PNO(ki, ii)->clone();
+                matrix_spin_enforcer_vv(S_ki_ii_s, sigma);
+                auto A_i = linalg::triplet(S_ki_ii_s, K_kcad, T_ki, true, true, false);
+                A_i->scale(prefactor);
+                R_ia_buffer[s][thread][i]->add(A_i);
+
+                // The T1 part of the transformed three-external integral.
+                auto T_ki_mat = T_iajb_spin_helper(ki, tau, sigma);
+                for (int l_ik = 0; l_ik < nlmo_ik; ++l_ik) {
+                    const int l = lmopair_to_lmos_[ik][l_ik];
+                    if (sigma == SpinCase::Beta && l >= nbocc) continue;
+                    const int kl = i_j_to_ij_[k][l];
+                    const int ll = i_j_to_ij_[l][l];
+                    if (kl == -1 || ll == -1) continue;
+
+                    auto S_kl_ki_t = S_PNO(kl, ki)->clone();
+                    matrix_spin_enforcer_vv(S_kl_ki_t, tau);
+                    auto S_ki_kl_s = S_PNO(ki, kl)->clone();
+                    matrix_spin_enforcer_vv(S_ki_kl_s, sigma);
+                    auto T_proj = linalg::triplet(S_kl_ki_t, T_ki_mat, S_ki_kl_s);
+
+                    auto S_ii_ll_s = S_PNO(ii, ll)->clone();
+                    matrix_spin_enforcer_vv(S_ii_ll_s, sigma);
+                    auto T_l = linalg::doublet(S_ii_ll_s, T_ia_spin_[s][l]);
+                    T_l->scale(prefactor * T_proj->vector_dot(K_iajb_[kl]));
+                    R_ia_buffer[s][thread][i]->subtract(T_l);
+                }
+
+                // F~(kc,tau) t(ik,ac;sigma,tau).
+                auto T_ik = T_iajb_spin_helper(ik, sigma, tau);
+                auto C_i = linalg::triplet(S_PNO(ik, ii), T_ik,
+                                           Fkc_tilde_spin_[t][ki], true, false, false);
+                R_ia_buffer[s][thread][i]->add(C_i);
+            }
+        }
+    }
+
+    // Negative occupied/external contraction in Eq. 12.
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int kl = 0; kl < n_lmo_pairs; ++kl) {
+        auto &[k, l] = ij_to_i_j_[kl];
+        const int nlmo_kl = lmopair_to_lmos_[kl].size();
+
+        int thread = 0;
+#ifdef _OPENMP
+        thread = omp_get_thread_num();
+#endif
+
+        for (SpinCase sigma : spins) {
+            const int s = static_cast<int>(sigma);
+            if (sigma == SpinCase::Beta && k >= nbocc) continue;
+
+            for (SpinCase tau : spins) {
+                const int t = static_cast<int>(tau);
+                if (tau == SpinCase::Beta && l >= nbocc) continue;
+                const double prefactor = (s == t) ? 0.5 : 1.0;
+
+                auto K_kilc = K_mibj_[kl]->clone();
+                K_kilc->add(linalg::doublet(T_n_ij_spin_[s][kl], K_iajb_[kl]));
+                auto T_kl = T_iajb_spin_helper(kl, sigma, tau);
+                auto B_ia = linalg::doublet(K_kilc, T_kl, false, true);
+                B_ia->scale(prefactor);
+
+                for (int i_kl = 0; i_kl < nlmo_kl; ++i_kl) {
+                    const int i = lmopair_to_lmos_[kl][i_kl];
+                    if (sigma == SpinCase::Beta && i >= nbocc) continue;
+                    const int ii = i_j_to_ij_[i][i];
+                    auto S_kl_ii_s = S_PNO(kl, ii)->clone();
+                    matrix_spin_enforcer_vv(S_kl_ii_s, sigma);
+                    auto B_i = linalg::doublet(
+                        submatrix_rows(*B_ia, std::vector<int>(1, i_kl)), S_kl_ii_s);
+                    R_ia_buffer[s][thread][i]->subtract(B_i->transpose());
+                }
+            }
+        }
+    }
+
+    for (SpinCase sigma : spins) {
+        const int s = static_cast<int>(sigma);
+        for (int i = 0; i < naocc; ++i) {
+            for (int thread = 0; thread < nthreads; ++thread) {
+                R_ia[s][i]->add(R_ia_buffer[s][thread][i]);
+            }
+        }
+        spin_enforcer(R_ia[s], sigma);
+    }
+
+    timer_off("DLPNO-ROCCSD: Compute R1");
+}
+
+void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_iajb, std::array<std::vector<SharedMatrix>, 3> &Rn_iajb) {
+
+    int n_lmo_pairs = ij_to_i_j_.size();
+    int naocc = nalpha_ - nfrzc();
+    int nbocc = nbeta_ - nfrzc();
+
+    auto beta_ijkl = compute_beta();
+    auto gamma_ki = compute_gamma();
+    auto delta_jk = compute_delta();
+    auto F_bc_double_tilde = compute_Fbc_double_tilde();
+    auto F_ki_double_tilde = compute_Fki_double_tilde();
+
+    constexpr std::array<SpinCase, 2> singles_spin_cases = { SpinCase::Alpha, SpinCase::Beta };
+    constexpr std::array<DoubleSpinCase, 3> doubles_spin_cases = { DoubleSpinCase::AA, DoubleSpinCase::AB, DoubleSpinCase::BB };
+
+    // Residual matrices persist across iterations.  Clear every spin block,
+    // including invalid beta/SOMO blocks, before any early exit below.
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+            const int ds = static_cast<int>(double_sigma);
+            R_iajb[ds][ij]->zero();
+            Rn_iajb[ds][ij]->zero();
+        }
+    }
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        const int ji = ij_to_ji_[ij];
+
+        const int nlmo_ij = lmopair_to_lmos_[ij].size();
+        const int naux_ij = lmopair_to_ribfs_[ij].size();
+
+        // The CC equations in this first implementation are strong-pair only.
+        // Weak/semicanonical/dipole corrections remain the existing MP2 ones.
+        if (i_j_to_ij_strong_[i][j] == -1) continue;
+
+        auto qma_ij = QIA_PNO(ij);
+        auto qab_ij = QAB_PNO(ij);
+
+        for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+            auto [sigma1, sigma2] = get_spin_pair(double_sigma);
+            const int ds = static_cast<int>(double_sigma);
+            const int s1 = static_cast<int>(sigma1), s2 = static_cast<int>(sigma2);
+
+            // All pairs are valid for AA case
+
+            // j >= nbocc is not valid for AB spin case
+            if (double_sigma == DoubleSpinCase::AB && j >= nbocc) continue;
+
+            // Both i >= nbocc and j >= nbocc make invalid pairs in BB spin case
+            if (double_sigma == DoubleSpinCase::BB && (i >= nbocc || j >= nbocc)) continue;
+
+            // Helpful alias
+            auto T_ij = T_iajb_spin_[ds][ij];
+
+            // Jiang and Toth Eq. 11a
+            auto L_iajb = linalg::doublet(i_Qa_t1_spin_[s1][ij],
+                                           i_Qa_t1_spin_[s2][ji], true, false);
+            R_iajb[ds][ij]->add(L_iajb);
+            if (s1 == s2) R_iajb[ds][ij]->subtract(L_iajb->transpose());
+
+            // Jiang and Toth Eq. 20
+            for (int q_ij = 0; q_ij < naux_ij; ++q_ij) {
+                auto Qab_t1_s1 = qab_ij[q_ij]->clone();
+                Qab_t1_s1->subtract(linalg::doublet(
+                    T_n_ij_spin_[s1][ij], qma_ij[q_ij], true, false));
+                matrix_spin_enforcer_vv(Qab_t1_s1, sigma1);
+                auto Qab_t1_s2 = qab_ij[q_ij]->clone();
+                Qab_t1_s2->subtract(linalg::doublet(
+                    T_n_ij_spin_[s2][ij], qma_ij[q_ij], true, false));
+                matrix_spin_enforcer_vv(Qab_t1_s2, sigma2);
+
+                R_iajb[ds][ij]->add(linalg::triplet(Qab_t1_s1, T_ij, Qab_t1_s2, false, false, true)); // (a, c) (c, d) (b, d)
+            } // end for
+
+            // Jiang and Toth Eq. 21
+            for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
+                int k = lmopair_to_lmos_[ij][k_ij];
+                if (sigma1 == SpinCase::Beta && k >= nbocc) continue;
+
+                for (int l_ij = 0; l_ij < nlmo_ij; ++l_ij) {
+                    int l = lmopair_to_lmos_[ij][l_ij];
+                    int kl = i_j_to_ij_[k][l];
+                    if (kl == -1) continue;
+
+                    if (sigma2 == SpinCase::Beta && l >= nbocc) continue;
+
+                    auto S_ij_kl_s1 = S_PNO(ij, kl)->clone();
+                    matrix_spin_enforcer_vv(S_ij_kl_s1, sigma1);
+                    auto S_ij_kl_s2 = S_PNO(ij, kl)->clone();
+                    matrix_spin_enforcer_vv(S_ij_kl_s2, sigma2);
+                    auto T_kl = T_iajb_spin_[ds][kl]->clone();
+
+                    T_kl = linalg::triplet(S_ij_kl_s1, T_kl, S_ij_kl_s2, false, false, true);
+                    T_kl->scale((*beta_ijkl[static_cast<int>(double_sigma)][ij])(k_ij, l_ij));
+
+                    R_iajb[ds][ij]->add(T_kl);
+                } // end for
+            } // end for
+
+            // Jiang and Toth Eq. 22
+            R_iajb[ds][ij]->add(linalg::doublet(T_ij, F_bc_double_tilde[s2][ij], false, true));
+            R_iajb[ds][ij]->add(linalg::doublet(F_bc_double_tilde[s1][ij], T_ij, false, false));
+
+            // Jiang and Toth Eq. 23
+            for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
+                const int k = lmopair_to_lmos_[ij][k_ij];
+                const int ik = i_j_to_ij_[i][k], kj = i_j_to_ij_[k][j];
+                if (ik == -1 || kj == -1) continue;
+
+                // Get necessary overlap matrices
+                auto S_ij_ik_s1 = S_PNO(ij, ik)->clone();
+                matrix_spin_enforcer_vv(S_ij_ik_s1, sigma1);
+
+                auto S_ij_ik_s2 = S_PNO(ij, ik)->clone();
+                matrix_spin_enforcer_vv(S_ij_ik_s2, sigma2);
+
+                auto S_ij_kj_s1 = S_PNO(ij, kj)->clone();
+                matrix_spin_enforcer_vv(S_ij_kj_s1, sigma1);
+
+                auto S_ij_kj_s2 = S_PNO(ij, kj)->clone();
+                matrix_spin_enforcer_vv(S_ij_kj_s2, sigma2);
+
+                // ik contribution
+                auto T_ik = linalg::triplet(S_ij_ik_s1, T_iajb_spin_[ds][ik], S_ij_ik_s2, false, false, true);
+                T_ik->scale((*F_ki_double_tilde[s2])(k, j));
+                R_iajb[ds][ij]->subtract(T_ik);
+
+                // kj contribution
+                auto T_kj = linalg::triplet(S_ij_kj_s1, T_iajb_spin_[ds][kj], S_ij_kj_s2, false, false, true);
+                T_kj->scale((*F_ki_double_tilde[s1])(k, i));
+                R_iajb[ds][ij]->subtract(T_kj);
+            } // end k_ij
+
+            for (int k_ij = 0; k_ij < nlmo_ij; ++k_ij) {
+                int k = lmopair_to_lmos_[ij][k_ij];
+                int ik = i_j_to_ij_[i][k], kj = i_j_to_ij_[k][j];
+                if (ik == -1 || kj == -1) continue;
+                int ki = ij_to_ji_[ik], jk = ij_to_ji_[kj];
+
+                auto S_ij_ik_s1 = S_PNO(ij, ik)->clone();
+                matrix_spin_enforcer_vv(S_ij_ik_s1, sigma1);
+
+                auto S_ij_ik_s2 = S_PNO(ij, ik)->clone();
+                matrix_spin_enforcer_vv(S_ij_ik_s2, sigma2);
+
+                auto S_ij_kj_s1 = S_PNO(ij, kj)->clone();
+                matrix_spin_enforcer_vv(S_ij_kj_s1, sigma1);
+
+                auto S_ij_kj_s2 = S_PNO(ij, kj)->clone();
+                matrix_spin_enforcer_vv(S_ij_kj_s2, sigma2);
+
+                auto S_ik_kj_s1 = S_PNO(ik, kj)->clone();
+                matrix_spin_enforcer_vv(S_ik_kj_s1, sigma1);
+
+                auto S_ik_kj_s2 = S_PNO(ik, kj)->clone();
+                matrix_spin_enforcer_vv(S_ik_kj_s2, sigma2);
+
+                // Same spin contributions
+                if (s1 == s2) {
+                    for (SpinCase gamma : singles_spin_cases) {
+                        const int g = static_cast<int>(gamma);
+                        if (gamma == SpinCase::Beta && k >= nbocc) continue;
+
+                        // "C" term: Jiang and Toth Eq. 24
+                        SharedMatrix T_ik_s1_g = T_iajb_spin_helper(ik, sigma1, gamma);
+
+                        SharedMatrix L_jbck = K_iakc_non_proj_[ji][k_ij]->clone();
+                        if (g == s2) L_jbck->subtract(J_ikac_non_proj_[ji][k_ij]);
+
+                        // last somo occupied orbitals DO NOT contribute to the beta spin case
+                        auto C_iajb = linalg::triplet(S_ij_ik_s1, T_ik_s1_g, L_jbck, false, false, true);
+
+                        Rn_iajb[ds][ij]->add(C_iajb);
+                        Rn_iajb[ds][ij]->subtract(C_iajb->transpose());
+
+                        // "D" term: Jiang and Toth Eq. 26
+                        auto S_ik_jk_g = S_PNO(ik, jk)->clone();
+                        matrix_spin_enforcer_vv(S_ik_jk_g, gamma);
+                        auto D_iajb = linalg::triplet(S_ij_ik_s1, T_ik_s1_g, S_ik_jk_g);
+                        D_iajb = linalg::triplet(D_iajb, delta_jk[s1][g][jk], S_ij_kj_s1, false, true, true);
+
+                        SharedMatrix T_jk_s1_g = T_iajb_spin_helper(jk, sigma1, gamma);
+                        auto D_jaib = linalg::triplet(S_ij_kj_s1, T_jk_s1_g, S_ik_jk_g, false, false, true);
+                        D_jaib = linalg::triplet(D_jaib, delta_jk[s1][g][ik], S_ij_ik_s1, false, true, true);
+
+                        R_iajb[ds][ij]->add(D_iajb);
+                        R_iajb[ds][ij]->subtract(D_jaib);
+
+                    } // end gamma
+                } else {
+                    // "C" term: Jiang and Toth Eq. 25
+                    SharedMatrix J_kjac = J_ikac_non_proj_[ji][k_ij]->clone();
+                    J_kjac->scale(-1.0);
+                    matrix_spin_enforcer_vv(J_kjac, sigma1);
+
+                    SharedMatrix T_ik_s1_s2 = T_iajb_spin_helper(ik, sigma1, sigma2);
+                    R_iajb[ds][ij]->add(linalg::triplet(J_kjac, T_ik_s1_s2, S_ij_ik_s2, false, false, true));
+
+                    auto gamma_kj_temp = linalg::triplet(S_ij_kj_s1, gamma_ki[s2][s1][kj], S_ik_kj_s1, false, false, true);
+                    R_iajb[ds][ij]->add(linalg::triplet(gamma_kj_temp, T_ik_s1_s2, S_ij_ik_s2, false, false, true));
+
+                    SharedMatrix J_kibc = J_ikac_non_proj_[ij][k_ij]->clone();
+                    J_kibc->scale(-1.0);
+                    matrix_spin_enforcer_vv(J_kibc, sigma2);
+
+                    SharedMatrix T_kj_s1_s2 = T_iajb_spin_helper(kj, sigma1, sigma2);
+                    R_iajb[ds][ij]->add(linalg::triplet(S_ij_kj_s1, T_kj_s1_s2, J_kibc, false, false, true));
+
+                    auto gamma_ki_temp = linalg::triplet(S_ij_ik_s2, gamma_ki[s1][s2][ki], S_ik_kj_s2, false, false, false);
+                    R_iajb[ds][ij]->add(linalg::triplet(S_ij_kj_s1, T_kj_s1_s2, gamma_ki_temp, false, false, true));
+
+                    // "D" term: Jiang and Toth Eq. 27
+                    for (SpinCase gamma : singles_spin_cases) {
+                        const int g = static_cast<int>(gamma);
+
+                        SharedMatrix T_ik_s1_g = T_iajb_spin_helper(ik, sigma1, gamma);
+                        SharedMatrix L_jbck = K_iakc_non_proj_[ji][k_ij]->clone();
+                        if (g == s2) L_jbck->subtract(J_ikac_non_proj_[ji][k_ij]);
+
+                        // last somo occupied orbitals DO NOT contribute to the beta spin case
+                        R_iajb[ds][ij]->add(linalg::triplet(S_ij_ik_s1, T_ik_s1_g, L_jbck, false, false, true));
+
+                        SharedMatrix T_jk_s2_g = T_iajb_spin_helper(jk, sigma2, gamma);
+                        SharedMatrix L_iack = K_iakc_non_proj_[ij][k_ij]->clone();
+                        if (g == s1) L_iack->subtract(J_ikac_non_proj_[ij][k_ij]);
+
+                        R_iajb[ds][ij]->add(linalg::triplet(L_iack, T_jk_s2_g, S_ij_kj_s2, false, true, true));
+
+                        auto S_ik_jk_g = S_PNO(ik, jk)->clone();
+                        matrix_spin_enforcer_vv(S_ik_jk_g, gamma);
+                        auto T_ik_proj = linalg::triplet(S_ij_ik_s1, T_ik_s1_g, S_ik_jk_g);
+                        R_iajb[ds][ij]->add(linalg::triplet(T_ik_proj, delta_jk[s2][g][jk], S_ij_kj_s2, false, true, true));
+
+                        auto T_jk_proj = linalg::triplet(S_ij_kj_s2, T_jk_s2_g, S_ik_jk_g, false, false, true);
+                        R_iajb[ds][ij]->add(linalg::triplet(S_ij_kj_s1, delta_jk[s1][g][ik], T_jk_proj, false, false, true));
+                    } // end for
+                } // end else
+            }
+        } // end for
+    } // end for
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        const int ji = ij_to_ji_[ij];
+        if (i_j_to_ij_strong_[i][j] == -1) continue;
+
+        for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+            const int ds = static_cast<int>(double_sigma);
+
+            R_iajb[ds][ij]->add(Rn_iajb[ds][ij]);
+            R_iajb[ds][ij]->add(Rn_iajb[ds][ji]->transpose());
+        } // end for
+    } // end for
+
+    for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+        const int ds = static_cast<int>(double_sigma);
+        double_spin_enforcer(R_iajb[ds], double_sigma);
+    }
+} // end void
+
+void RO_DLPNOCCSD::lccsd_iterations() {
+
+    int n_lmo_pairs = ij_to_i_j_.size();
+    int naocc = nalpha_ - nfrzc();
+    int nbocc = nbeta_ - nfrzc();
+    int nsomo = naocc - nbocc;
+
+    // Thread and OMP Parallel info
+    int nthreads = 1;
+#ifdef _OPENMP
+    nthreads = Process::environment.get_n_threads();
+#endif
+
+    std::array<SharedMatrix, 2> F_lmo_spin;
+
+    F_lmo_a_ = linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_lmo_, true, false, false);
+    F_lmo_b_ = linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_lmo_, true, false, false);
+
+    F_pao_a_ = linalg::triplet(C_pao_, reference_wavefunction_->Fa(), C_pao_, true, false, false);
+    F_pao_b_ = linalg::triplet(C_pao_, reference_wavefunction_->Fb(), C_pao_, true, false, false);
+
+    F_lmo_spin[static_cast<int>(SpinCase::Alpha)] = F_lmo_a_;
+    F_lmo_spin[static_cast<int>(SpinCase::Beta)] = F_lmo_b_;
+
+    // The appended SOMOs make a single spin-independent e_pno denominator
+    // inappropriate.  Retain the actual alpha/beta Fock matrices in every
+    // PNO domain for the Jacobi updates.
+    for (SpinCase sigma : {SpinCase::Alpha, SpinCase::Beta}) {
+        F_pno_spin_[static_cast<int>(sigma)].resize(n_lmo_pairs);
+    }
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        F_pno_spin_[static_cast<int>(SpinCase::Alpha)][ij] =
+            linalg::triplet(X_pno_[ij], F_pao_a_, X_pno_[ij], true, false, false);
+        F_pno_spin_[static_cast<int>(SpinCase::Beta)][ij] =
+            linalg::triplet(X_pno_[ij], F_pao_b_, X_pno_[ij], true, false, false);
+    }
+
+    outfile->Printf("\n  ==> Restricted Open Shell Local CCSD <==\n\n");
+    outfile->Printf("    E_CONVERGENCE = %.2e\n", options_.get_double("E_CONVERGENCE"));
+    outfile->Printf("    R_CONVERGENCE = %.2e\n\n", options_.get_double("R_CONVERGENCE"));
+    outfile->Printf("                      Corr. Energy    Delta E     Max R1     Max R2     Time (s)\n");
+
+    // => Initialize Residuals and Amplitudes <= //
+    std::array<std::vector<SharedMatrix>, 2> R_ia_spin;
+    std::array<std::vector<SharedMatrix>, 3> R_iajb_spin;
+    std::array<std::vector<SharedMatrix>, 3> Rn_iajb_spin;
+
+    // To make the loops easier to deal with, we are letting both dimensions be equal to naocc
+    // For the Beta spin case, all occupied indices >= nbocc will be zeroed out!!!
+    // Likewise, all virtual dimensions for the Alpha spin case that is in the somo indices will be zeroed out!
+
+    constexpr std::array<SpinCase, 2> singles_spin_cases = { SpinCase::Alpha, SpinCase::Beta };
+    constexpr std::array<DoubleSpinCase, 3> doubles_spin_cases = { DoubleSpinCase::AA, DoubleSpinCase::AB, DoubleSpinCase::BB };
+
+    for (SpinCase sigma : singles_spin_cases) {
+        const int s = static_cast<int>(sigma);
+        R_ia_spin[s].clear();
+        T_ia_spin_[s].clear();
+
+        R_ia_spin[s].resize(naocc);
+        T_ia_spin_[s].resize(naocc);
+
+#pragma omp parallel for
+        for (int i = 0; i < naocc; ++i) {
+            int ii = i_j_to_ij_[i][i];
+            R_ia_spin[s][i] = std::make_shared<Matrix>(n_pno_[ii], 1);
+            T_ia_spin_[s][i] = std::make_shared<Matrix>(n_pno_[ii], 1);
+        }
+    }
+
+    for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+        const int ds = static_cast<int>(double_sigma);
+        R_iajb_spin[ds].clear();
+        Rn_iajb_spin[ds].clear();
+        T_iajb_spin_[ds].clear();
+
+        R_iajb_spin[ds].resize(n_lmo_pairs);
+        Rn_iajb_spin[ds].resize(n_lmo_pairs);
+        T_iajb_spin_[ds].resize(n_lmo_pairs);
+
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+            R_iajb_spin[ds][ij] = std::make_shared<Matrix>(n_pno_[ij], n_pno_[ij]);
+            Rn_iajb_spin[ds][ij] = std::make_shared<Matrix>(n_pno_[ij], n_pno_[ij]);
+            T_iajb_spin_[ds][ij] = std::make_shared<Matrix>(n_pno_[ij], n_pno_[ij]);
+        } // end for
+    } // end for
+
+    // => Thread buffers <= //
+
+    std::array<std::vector<std::vector<SharedMatrix>>, 2> R_ia_buffer;
+
+    for (SpinCase sigma : singles_spin_cases) {
+        const int s = static_cast<int>(sigma);
+        R_ia_buffer[s].resize(nthreads);
+
+        for (int thread = 0; thread < nthreads; ++thread) {
+            R_ia_buffer[s][thread].resize(naocc);
+            for (int i = 0; i < naocc; ++i) {
+                int ii = i_j_to_ij_[i][i];
+                R_ia_buffer[s][thread][i] = std::make_shared<Matrix>(n_pno_[ii], 1);
+            } // end for
+        } // end for
+    } // end for
+
+    int iteration = 1, max_iteration = options_.get_int("DLPNO_MAXITER");
+    double e_curr = 0.0, e_prev = 0.0, e_weak = 0.0;
+    bool e_converged = false, r_converged = false;
+
+    DIISManager diis(options_.get_int("DIIS_MAX_VECS"), "LCCSD DIIS", DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::InCore);
+
+    while (!(e_converged && r_converged)) {
+        // RMS of residual per single LMO, for assesing convergence
+        std::vector<double> R_ia_rms(naocc, 0.0);
+        // RMS of residual per LMO pair, for assessing convergence
+        std::vector<double> R_iajb_rms(n_lmo_pairs, 0.0);
+
+        std::time_t time_start = std::time(nullptr);
+
+        // Project T1 and form the similarity-transformed Hamiltonian.
+        form_projected_singles();
+        t1_ints_spin();
+        t1_fock_spin();
+
+        // Compute singles residual.
+        compute_R_ia(R_ia_spin, R_ia_buffer);
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int i = 0; i < naocc; ++i) {
+            for (SpinCase sigma : singles_spin_cases) {
+                const int s = static_cast<int>(sigma);
+                R_ia_rms[i] = std::max(R_ia_rms[i], R_ia_spin[s][i]->rms());
+            }
+        }
+
+        // Compute doubles residual.
+        compute_R_iajb(R_iajb_spin, Rn_iajb_spin);
+
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+            for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+                const int ds = static_cast<int>(double_sigma);
+                R_iajb_rms[ij] = std::max(R_iajb_rms[ij], R_iajb_spin[ds][ij]->rms());
+            } // end double_sigma
+        } // end for
+
+        // Spin-resolved singles Jacobi update.
+        for (SpinCase sigma : singles_spin_cases) {
+            const int s = static_cast<int>(sigma);
+#pragma omp parallel for schedule(dynamic, 1)
+            for (int i = 0; i < naocc; ++i) {
+                if (sigma == SpinCase::Beta && i >= nbocc) continue;
+                const int ii = i_j_to_ij_[i][i];
+                const int alpha_virtual_end = n_pno_[ii] - nsomo;
+                for (int a_ii = 0; a_ii < n_pno_[ii]; ++a_ii) {
+                    if (sigma == SpinCase::Alpha && a_ii >= alpha_virtual_end) continue;
+                    const double denom = (*F_pno_spin_[s][ii])(a_ii, a_ii) - (*F_lmo_spin[s])(i, i);
+                    (*T_ia_spin_[s][i])(a_ii, 0) -= (*R_ia_spin[s][i])(a_ii, 0) / denom;
+                }
+            }
+            spin_enforcer(T_ia_spin_[s], sigma);
+        }
+
+        // Update doubles amplitude
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+            auto &[i, j] = ij_to_i_j_[ij];
+
+            for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+                auto [sigma1, sigma2] = get_spin_pair(double_sigma);
+                const int ds = static_cast<int>(double_sigma);
+                const int s1 = static_cast<int>(sigma1), s2 = static_cast<int>(sigma2);
+
+                if (sigma1 == SpinCase::Beta && i >= nbocc) continue;
+                if (sigma2 == SpinCase::Beta && j >= nbocc) continue;
+
+                auto T_ij = T_iajb_spin_[ds][ij];
+                const int alpha_virtual_end = n_pno_[ij] - nsomo;
+
+                for (int a_ij = 0; a_ij < n_pno_[ij]; ++a_ij) {
+                    if (sigma1 == SpinCase::Alpha && a_ij >= alpha_virtual_end) continue;
+                    for (int b_ij = 0; b_ij < n_pno_[ij]; ++b_ij) {
+                        if (sigma2 == SpinCase::Alpha && b_ij >= alpha_virtual_end) continue;
+                        const double denom = (*F_pno_spin_[s1][ij])(a_ij, a_ij) +
+                                             (*F_pno_spin_[s2][ij])(b_ij, b_ij) -
+                                             (*F_lmo_spin[s1])(i, i) - (*F_lmo_spin[s2])(j, j);
+                        (*T_ij)(a_ij, b_ij) -= (*R_iajb_spin[ds][ij])(a_ij, b_ij) / 
+                                                       denom;
+                    } // end b_ij
+                } // end a_ij
+
+            } // end double_sigma
+        } // end ij
+
+        // Probably not needed, but good to get into the habit of doing
+        for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+            const int ds = static_cast<int>(double_sigma);
+            double_spin_enforcer(T_iajb_spin_[ds], double_sigma);
+        }
+
+        // DIIS Extrapolation
+        std::vector<SharedMatrix> T_vecs;
+        T_vecs.reserve(T_ia_spin_[0].size() + T_ia_spin_[1].size() +
+                       T_iajb_spin_[0].size() + T_iajb_spin_[1].size() + T_iajb_spin_[2].size());
+        T_vecs.insert(T_vecs.end(), T_ia_spin_[0].begin(), T_ia_spin_[0].end());
+        T_vecs.insert(T_vecs.end(), T_ia_spin_[1].begin(), T_ia_spin_[1].end());
+        T_vecs.insert(T_vecs.end(), T_iajb_spin_[0].begin(), T_iajb_spin_[0].end());
+        T_vecs.insert(T_vecs.end(), T_iajb_spin_[1].begin(), T_iajb_spin_[1].end());
+        T_vecs.insert(T_vecs.end(), T_iajb_spin_[2].begin(), T_iajb_spin_[2].end());
+
+        std::vector<SharedMatrix> R_vecs;
+        R_vecs.reserve(R_ia_spin[0].size() + R_ia_spin[1].size() +
+                       R_iajb_spin[0].size() + R_iajb_spin[1].size() + R_iajb_spin[2].size());
+        R_vecs.insert(R_vecs.end(), R_ia_spin[0].begin(), R_ia_spin[0].end());
+        R_vecs.insert(R_vecs.end(), R_ia_spin[1].begin(), R_ia_spin[1].end());
+        R_vecs.insert(R_vecs.end(), R_iajb_spin[0].begin(), R_iajb_spin[0].end());
+        R_vecs.insert(R_vecs.end(), R_iajb_spin[1].begin(), R_iajb_spin[1].end());
+        R_vecs.insert(R_vecs.end(), R_iajb_spin[2].begin(), R_iajb_spin[2].end());
+
+        auto T_vecs_flat = flatten_mats(T_vecs);
+        auto R_vecs_flat = flatten_mats(R_vecs);
+
+        if (iteration == 1) {
+            diis.set_error_vector_size(R_vecs_flat);
+            diis.set_vector_size(T_vecs_flat);
+        }
+
+        diis.add_entry(R_vecs_flat.get(), T_vecs_flat.get());
+        diis.extrapolate(T_vecs_flat.get());
+
+        copy_flat_mats(T_vecs_flat, T_vecs);
+
+        // DIIS combines flattened matrices without knowing the ROHF masks.
+        // Reimpose them so invalid SOMO amplitudes cannot leak back in.
+        for (SpinCase sigma : singles_spin_cases) {
+            spin_enforcer(T_ia_spin_[static_cast<int>(sigma)], sigma);
+        }
+        for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+            double_spin_enforcer(T_iajb_spin_[static_cast<int>(double_sigma)], double_sigma);
+        }
+
+        // evaluate convergence using current amplitudes and residuals
+        e_prev = e_curr;
+
+        e_curr = 0.0, e_weak = 0.0;
+#pragma omp parallel for schedule(dynamic, 1) reduction(+ : e_curr, e_weak)
+        for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+            auto &[i, j] = ij_to_i_j_[ij];
+            int ii = i_j_to_ij_[i][i], jj = i_j_to_ij_[j][j];
+
+            double e_ij = 0.0;
+
+            // The amplitudes are already spin-enforced
+
+            for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+                auto [sigma1, sigma2] = get_spin_pair(double_sigma);
+                const int ds = static_cast<int>(double_sigma);
+                const int s1 = static_cast<int>(sigma1), s2 = static_cast<int>(sigma2);
+
+                auto S_ij_ii_s1 = S_PNO(ij, ii)->clone();
+                matrix_spin_enforcer_vv(S_ij_ii_s1, sigma1);
+                auto S_ij_jj_s2 = S_PNO(ij, jj)->clone();
+                matrix_spin_enforcer_vv(S_ij_jj_s2, sigma2);
+                auto T_i = linalg::doublet(S_ij_ii_s1, T_ia_spin_[s1][i]);
+                auto T_j = linalg::doublet(S_ij_jj_s2, T_ia_spin_[s2][j]);
+                auto t1t1 = std::make_shared<Matrix>(n_pno_[ij], n_pno_[ij]);
+                C_DGER(n_pno_[ij], n_pno_[ij], 1.0, T_i->get_pointer(), 1,
+                       T_j->get_pointer(), 1, t1t1->get_pointer(), n_pno_[ij]);
+
+                auto g_iajb = K_iajb_[ij]->clone();
+                if (s1 == s2) {
+                    g_iajb->subtract(K_iajb_[ij]->transpose());
+                    e_ij += 0.25 * T_iajb_spin_[ds][ij]->vector_dot(g_iajb);
+                    e_ij += 0.50 * t1t1->vector_dot(g_iajb);
+                } else {
+                    e_ij += T_iajb_spin_[ds][ij]->vector_dot(g_iajb);
+                    e_ij += t1t1->vector_dot(g_iajb);
+                }
+            }
+
+            // Update energies
+            e_curr += e_ij;
+            if (i_j_to_ij_strong_[i][j] == -1) e_weak += e_ij;
+        }
+        double r_curr1 = *max_element(R_ia_rms.begin(), R_ia_rms.end());
+        double r_curr2 = *max_element(R_iajb_rms.begin(), R_iajb_rms.end());
+
+        r_converged = (fabs(r_curr1) < options_.get_double("R_CONVERGENCE"));
+        r_converged &= (fabs(r_curr2) < options_.get_double("R_CONVERGENCE"));
+
+        e_converged = (fabs(e_curr - e_prev) < options_.get_double("E_CONVERGENCE"));
+
+        std::time_t time_stop = std::time(nullptr);
+
+        outfile->Printf("  @LCCSD iter %3d: %16.12f %10.3e %10.3e %10.3e %8d\n", iteration, e_curr, e_curr - e_prev, r_curr1, r_curr2, (int)time_stop - (int)time_start);
+
+        iteration++;
+
+        if (iteration > max_iteration + 1) {
+            throw PSIEXCEPTION("Maximum DLPNO iterations exceeded.");
+        }
+    }
+
+    e_lccsd_ = e_curr - e_weak;
+    de_weak_ = e_weak;
+}
+
+double RO_DLPNOCCSD::compute_dlpno_ccsd_energy() {
+    timer_on("DLPNO-CCSD");
+
+    print_header();
+
+    timer_on("Setup Orbitals");
+    setup_orbitals();
+    timer_off("Setup Orbitals");
+
+    timer_on("Overlap Ints");
+    compute_overlap_ints();
+    timer_off("Overlap Ints");
+
+    /* TODO: Update this function to account for alpha and beta spin cases
+    (This function currently assumes nalpha = ndocc, but nalpha > ndocc in ROHF) */
+    timer_on("Dipole Ints");
+    compute_dipole_ints();
+    timer_off("Dipole Ints");
+
+    timer_on("Compute Metric");
+    compute_metric();
+    timer_off("Compute Metric");
+
+    // Adjust parameters for "crude" prescreening
+    T_CUT_MKN_ *= 100;
+    T_CUT_DO_ *= 2;
+
+    outfile->Printf("  ==> Crude Prescreening (Determines Semicanonical-MP2 Pairs) <==\n\n");
+    outfile->Printf("    T_CUT_MKN set to %6.3e\n", T_CUT_MKN_);
+    outfile->Printf("    T_CUT_DO  set to %6.3e\n\n", T_CUT_DO_);
+
+    timer_on("Sparsity");
+    prep_sparsity(true, false);
+    timer_off("Sparsity");
+
+    timer_on("Crude DF Ints");
+    compute_qia();
+    timer_off("Crude DF Ints");
+
+    timer_on("Initial Pair Prescreening");
+    pair_prescreening<true>();
+    timer_off("Initial Pair Prescreening");
+
+    // Reset Sparsity After
+    T_CUT_MKN_ *= 0.01;
+    T_CUT_DO_ *= 0.5;
+
+    outfile->Printf("  ==> Refined Prescreening (Determines Strong and Weak Pairs) <==\n\n");
+    outfile->Printf("    T_CUT_MKN reset to %6.3e\n", T_CUT_MKN_);
+    outfile->Printf("    T_CUT_DO  reset to %6.3e\n\n", T_CUT_DO_);
+
+    timer_on("Sparsity");
+    prep_sparsity(false, false);
+    timer_off("Sparsity");
+
+    timer_on("Refined DF Ints");
+    print_integral_sparsity();
+    compute_qia();
+    timer_off("Refined DF Ints");
+
+    timer_on("Refined Pair Prescreening");
+    pair_prescreening<false>();
+    timer_off("Refined Pair Prescreening");
+
+    // Set variables from LMP2
+    double e_scf = variables_["SCF TOTAL ENERGY"];
+    double e_lmp2_corr = e_lmp2_ + de_lmp2_eliminated_ + de_dipole_ + de_pno_total_;
+    double e_lmp2_total = e_scf + e_lmp2_corr;
+
+    set_scalar_variable("MP2 CORRELATION ENERGY", e_lmp2_corr);
+    set_scalar_variable("CURRENT CORRELATION ENERGY", e_lmp2_corr);
+    set_scalar_variable("MP2 TOTAL ENERGY", e_lmp2_total);
+    set_scalar_variable("CURRENT ENERGY", e_lmp2_total);
+
+    outfile->Printf("  \n");
+    outfile->Printf("  Total DLPNO-MP2 Correlation Energy: %16.12f \n", e_lmp2_ + de_lmp2_eliminated_ + de_pno_total_ + de_dipole_);
+    outfile->Printf("    MP2 Correlation Energy:           %16.12f \n", e_lmp2_);
+    outfile->Printf("    Semicanonical MP2 Correction:     %16.12f \n", de_lmp2_eliminated_);
+    outfile->Printf("    Dipole Correction:                %16.12f \n", de_dipole_);
+    outfile->Printf("    PNO Truncation Correction:        %16.12f \n", de_pno_total_);
+    outfile->Printf("\n\n  @Total DLPNO-MP2 Energy: %16.12f \n", variables_["SCF TOTAL ENERGY"] + e_lmp2_ + de_lmp2_eliminated_ + de_pno_total_ + de_dipole_);
+    outfile->Printf("\n   * WARNING: This answer will likely vary from one obtained by a energy('dlpno-mp2') call");
+    outfile->Printf("\n                due to lack of a semi-canonical MP2 prescreening step in DLPNO-MP2, as well");
+    outfile->Printf("\n                as slightly tighter cutoffs utilized to increase accuracy in the context of CC!!!\n\n");
+
+    // Recompute PNOs using MP2 densities
+    recompute_pnos();
+    // Add SOMOs to PAO and PNO space (for open-shell case)
+    extend_virtual_by_somo();
+
+    // Prepare Sparsity Information with augmented virtual space (after adding SOMOs)
+    timer_on("Sparsity");
+    prep_sparsity(false, true);
+    timer_off("Sparsity");
+
+    timer_on("DF Ints");
+    compute_qij();
+    compute_qia();
+    compute_qab();
+    timer_off("DF Ints");
+
+    timer_on("PNO Integrals");
+    estimate_memory();
+    compute_pno_integrals();
+    timer_off("PNO Integrals");
+
+    timer_on("PNO Overlaps");
+    compute_pno_overlaps();
+    timer_off("PNO Overlaps");
+
+    timer_on("LCCSD");
+    lccsd_iterations();
+    timer_off("LCCSD");
+
+    // Bye bye (Q_ij | m_ij a_ij) integrals. You won't be missed
+    psio_->close(PSIF_DLPNO_QIA_PNO, 0);
+    // Bye bye (Q_ij | a_ij b_ij) integrals. You won't be missed
+    psio_->close(PSIF_DLPNO_QAB_PNO, 0);
+
+    // print_results();
+
+    timer_off("DLPNO-CCSD");
+
+    double e_ccsd_corr = e_lccsd_ + de_weak_ + de_lmp2_eliminated_ + de_dipole_ + de_pno_total_;
+    double e_ccsd_total = e_scf + e_ccsd_corr;
+
+    set_scalar_variable("CCSD CORRELATION ENERGY", e_ccsd_corr);
+    set_scalar_variable("CURRENT CORRELATION ENERGY", e_ccsd_corr);
+    set_scalar_variable("CCSD TOTAL ENERGY", e_ccsd_total);
+    set_scalar_variable("CURRENT ENERGY", e_ccsd_total);
+
+    // psivars for LCCSD energy components
+    set_scalar_variable("DLPNO LMP2 WEAK PAIR ENERGY", de_weak_);
+    set_scalar_variable("DLPNO SC-LMP2 PAIR ENERGY", de_lmp2_eliminated_);
+    set_scalar_variable("DLPNO DIPOLE ENERGY", de_dipole_);
+    set_scalar_variable("DLPNO PNO TRUNCATION ERROR", de_pno_total_);
+
+    return e_ccsd_total;
+}
+
+double RO_DLPNOCCSD::compute_energy() { return compute_dlpno_ccsd_energy(); }
 
 }  // namespace dlpno
 }  // namespace psi

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -4563,7 +4563,7 @@ void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_ia
                         auto delta_full_ik = delta_jk[s1][g][ik]->clone();
                         delta_full_ik->add(delta_bar_jk[s1][g][ik]);
                         R_iajb[ds][ij]->add(linalg::triplet(
-                            S_ij_kj_s1, delta_full_ik, T_jk_proj,
+                            S_ij_ik_s1, delta_full_ik, T_jk_proj,
                             false, false, true));
                     } // end for
                 } // end else

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -3108,7 +3108,7 @@ void RO_DLPNOCCSD::extend_virtual_by_somo() {
     C_pao_ = C_pao_new;
     // Recompute S_pao and F_pao
     S_pao_ = linalg::triplet(C_pao_, reference_wavefunction_->S(), C_pao_, true, false, false);
-    F_pao_ = linalg::triplet(C_pao_, F_ao_, C_pao_, true, false, false);
+    F_pao_ = linalg::triplet(C_pao_, reference_wavefunction_->Fa(), C_pao_, true, false, false);
 
 #pragma omp parallel for
     for (int ij = 0; ij < n_lmo_pairs; ++ij) {

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -3089,6 +3089,409 @@ void DLPNOCCSD::print_results() {
 RO_DLPNOCCSD::RO_DLPNOCCSD(SharedWavefunction ref_wfn, Options& options) : DLPNOCCSD(ref_wfn, options) {}
 RO_DLPNOCCSD::~RO_DLPNOCCSD() {}
 
+std::vector<double> RO_DLPNOCCSD::compute_semicanonical_sromp2_pair_energies(bool print_header) {
+    /*
+     * The selector amplitudes deliberately have the same spatial form as
+     * closed-shell MP2.  This is the essential SROMP2 idea of Krause and
+     * Werner, JCTC 15, 987 (2019), DOI: 10.1021/acs.jctc.8b01012: one set of
+     * spin-free amplitudes and therefore one set of PNOs per spatial pair.
+     * Ma and Werner subsequently used spin-independent SROMP2 PNOs for
+     * PNO-RCCSD, JCTC 16, 3135 (2020), DOI: 10.1021/acs.jctc.0c00192.
+     *
+     * Only the energy bookkeeping below is spin resolved.  Consequently the
+     * PNO occupation, trace, and energy truncation tests remain exactly the
+     * closed-shell Jiang implementation, independent of whether i and j are
+     * DOCCs or SOMOs.
+     */
+    const int nbocc = nbeta_ - nfrzc();
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const std::array<SharedMatrix, 2> F_lmo_spin = {
+        linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_lmo_, true, false, false),
+        linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_lmo_, true, false, false)};
+    const std::array<SharedMatrix, 2> F_pao_spin = {
+        linalg::triplet(C_pao_, reference_wavefunction_->Fa(), C_pao_, true, false, false),
+        linalg::triplet(C_pao_, reference_wavefunction_->Fb(), C_pao_, true, false, false)};
+    const std::array<SharedMatrix, 2> F_lmo_pao_spin = {
+        linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_pao_, true, false, false),
+        linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_pao_, true, false, false)};
+
+    if (print_header) {
+        outfile->Printf("\n  ==> Spin-Restricted Open-Shell Semicanonical MP2 Pair Prescreening <==\n\n");
+    }
+
+    for (auto& block : sromp2_pair_energies_) block.assign(n_lmo_pairs, 0.0);
+    std::vector<double> e_ijs(n_lmo_pairs, 0.0);
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        const int ji = ij_to_ji_[ij];
+        if (i > j) continue;
+
+        const int npao_ij = lmopair_to_paos_[ij].size();
+        const int naux_ij = lmopair_to_ribfs_[ij].size();
+        auto i_qa = std::make_shared<Matrix>("Three-index Integrals", naux_ij, npao_ij);
+        auto j_qa = std::make_shared<Matrix>("Three-index Integrals", naux_ij, npao_ij);
+
+        for (int q_ij = 0; q_ij < naux_ij; ++q_ij) {
+            const int q = lmopair_to_ribfs_[ij][q_ij];
+            const int centerq = ribasis_->function_to_center(q);
+            for (int a_ij = 0; a_ij < npao_ij; ++a_ij) {
+                const int a = lmopair_to_paos_[ij][a_ij];
+                i_qa->set(q_ij, a_ij,
+                          qia_[q]->get(riatom_to_lmos_ext_dense_[centerq][i],
+                                       riatom_to_paos_ext_dense_[centerq][a]));
+                j_qa->set(q_ij, a_ij,
+                          qia_[q]->get(riatom_to_lmos_ext_dense_[centerq][j],
+                                       riatom_to_paos_ext_dense_[centerq][a]));
+            }
+        }
+
+        auto A_solve = submatrix_rows_and_cols(*full_metric_, lmopair_to_ribfs_[ij],
+                                                lmopair_to_ribfs_[ij]);
+        C_DGESV_wrapper(A_solve, i_qa);
+        auto K_pao_ij = linalg::doublet(i_qa, j_qa, true, false);
+
+        auto S_pao_ij = submatrix_rows_and_cols(*S_pao_, lmopair_to_paos_[ij],
+                                                lmopair_to_paos_[ij]);
+        auto F_pao_ij = submatrix_rows_and_cols(*F_pao_, lmopair_to_paos_[ij],
+                                                lmopair_to_paos_[ij]);
+        SharedMatrix X_pao_ij;
+        SharedVector e_pao_ij;
+        std::tie(X_pao_ij, e_pao_ij) = orthocanonicalizer(S_pao_ij, F_pao_ij);
+        K_pao_ij = linalg::triplet(X_pao_ij, K_pao_ij, X_pao_ij, true, false, false);
+
+        auto T_pao_ij = K_pao_ij->clone();
+        for (int a = 0; a < T_pao_ij->nrow(); ++a) {
+            for (int b = 0; b < T_pao_ij->ncol(); ++b) {
+                const double denominator = F_lmo_->get(i, i) + F_lmo_->get(j, j) -
+                                           e_pao_ij->get(a) - e_pao_ij->get(b);
+                T_pao_ij->set(a, b, T_pao_ij->get(a, b) / denominator);
+            }
+        }
+
+        auto set_ordered_components = [&](int pair, int occ1, int occ2,
+                                          const SharedMatrix& K, const SharedMatrix& T) {
+            double e_aa = 0.0;
+            if (occ1 != occ2) {
+                auto L = K->clone();
+                L->subtract(K->transpose());
+                auto U = T->clone();
+                U->subtract(T->transpose());
+                e_aa = 0.25 * L->vector_dot(U);
+            }
+            const double e_ab = (occ2 < nbocc) ? K->vector_dot(T) : 0.0;
+            const double e_bb = (occ1 < nbocc && occ2 < nbocc) ? e_aa : 0.0;
+
+            sromp2_pair_energies_[static_cast<int>(DoubleSpinCase::AA)][pair] = e_aa;
+            sromp2_pair_energies_[static_cast<int>(DoubleSpinCase::AB)][pair] = e_ab;
+            sromp2_pair_energies_[static_cast<int>(DoubleSpinCase::BB)][pair] = e_bb;
+            e_ijs[pair] = e_aa + e_ab + e_bb;
+        };
+
+        set_ordered_components(ij, i, j, K_pao_ij, T_pao_ij);
+        if (i < j) {
+            set_ordered_components(ji, j, i, K_pao_ij->transpose(), T_pao_ij->transpose());
+        } else {
+            // ROHF Brillouin conditions apply to the spin-adapted orbital
+            // rotations, not necessarily to Fa(ia) and Fb(ia) separately.
+            // Assign their second-order f(ia)t(i,a) contribution to the
+            // diagonal spatial pair.  It never changes pair survival because
+            // diagonal pairs are retained unconditionally.
+            double e_singles = 0.0;
+            for (SpinCase sigma : {SpinCase::Alpha, SpinCase::Beta}) {
+                const int s = static_cast<int>(sigma);
+                if (sigma == SpinCase::Beta && i >= nbocc) continue;
+                auto Fia_pao = submatrix_rows_and_cols(
+                    *F_lmo_pao_spin[s], std::vector<int>(1, i), lmopair_to_paos_[ij]);
+                auto Fia = linalg::doublet(Fia_pao, X_pao_ij);
+                auto Fvv_pao = submatrix_rows_and_cols(
+                    *F_pao_spin[s], lmopair_to_paos_[ij], lmopair_to_paos_[ij]);
+                auto Fvv = linalg::triplet(X_pao_ij, Fvv_pao, X_pao_ij,
+                                            true, false, false);
+                for (int a = 0; a < Fia->ncol(); ++a) {
+                    const double denominator = (*F_lmo_spin[s])(i, i) - (*Fvv)(a, a);
+                    if (std::fabs(denominator) > 1.0e-12) {
+                        e_singles += (*Fia)(0, a) * (*Fia)(0, a) / denominator;
+                    }
+                }
+            }
+            e_ijs[ij] += e_singles;
+        }
+    }
+
+    return e_ijs;
+}
+
+std::vector<double> RO_DLPNOCCSD::update_sromp2_pair_energies() {
+    const int nbocc = nbeta_ - nfrzc();
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const std::array<SharedMatrix, 2> F_lmo_spin = {
+        linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_lmo_, true, false, false),
+        linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_lmo_, true, false, false)};
+    const std::array<SharedMatrix, 2> F_pao_spin = {
+        linalg::triplet(C_pao_, reference_wavefunction_->Fa(), C_pao_, true, false, false),
+        linalg::triplet(C_pao_, reference_wavefunction_->Fb(), C_pao_, true, false, false)};
+    const std::array<SharedMatrix, 2> F_lmo_pao_spin = {
+        linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_pao_, true, false, false),
+        linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_pao_, true, false, false)};
+    for (auto& block : sromp2_pair_energies_) block.assign(n_lmo_pairs, 0.0);
+    std::vector<double> e_ijs(n_lmo_pairs, 0.0);
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        auto K = K_iajb_[ij];
+        auto T = T_iajb_[ij];
+
+        double e_aa = 0.0;
+        if (i != j) {
+            auto L = K->clone();
+            L->subtract(K->transpose());
+            auto U = T->clone();
+            U->subtract(T->transpose());
+            e_aa = 0.25 * L->vector_dot(U);
+        }
+        const double e_ab = (j < nbocc) ? K->vector_dot(T) : 0.0;
+        const double e_bb = (i < nbocc && j < nbocc) ? e_aa : 0.0;
+
+        sromp2_pair_energies_[static_cast<int>(DoubleSpinCase::AA)][ij] = e_aa;
+        sromp2_pair_energies_[static_cast<int>(DoubleSpinCase::AB)][ij] = e_ab;
+        sromp2_pair_energies_[static_cast<int>(DoubleSpinCase::BB)][ij] = e_bb;
+        e_ijs[ij] = e_aa + e_ab + e_bb;
+
+        if (i == j) {
+            double e_singles = 0.0;
+            for (SpinCase sigma : {SpinCase::Alpha, SpinCase::Beta}) {
+                const int s = static_cast<int>(sigma);
+                if (sigma == SpinCase::Beta && i >= nbocc) continue;
+                auto Fia_pao = submatrix_rows_and_cols(
+                    *F_lmo_pao_spin[s], std::vector<int>(1, i), lmopair_to_paos_[ij]);
+                auto Fia = linalg::doublet(Fia_pao, X_pno_[ij]);
+                auto Fvv_pao = submatrix_rows_and_cols(
+                    *F_pao_spin[s], lmopair_to_paos_[ij], lmopair_to_paos_[ij]);
+                auto Fvv = linalg::triplet(X_pno_[ij], Fvv_pao, X_pno_[ij],
+                                            true, false, false);
+                for (int a = 0; a < Fia->ncol(); ++a) {
+                    const double denominator = (*F_lmo_spin[s])(i, i) - (*Fvv)(a, a);
+                    if (std::fabs(denominator) > 1.0e-12) {
+                        e_singles += (*Fia)(0, a) * (*Fia)(0, a) / denominator;
+                    }
+                }
+            }
+            e_ijs[ij] += e_singles;
+        }
+    }
+
+    return e_ijs;
+}
+
+template<bool crude>
+std::vector<double> RO_DLPNOCCSD::compute_pair_energies() {
+    if constexpr (crude) {
+        return compute_semicanonical_sromp2_pair_energies(true);
+    } else {
+        // Save the untruncated physical pair energy.  The base routine then
+        // constructs and truncates one closed-shell-form PNO density, exactly
+        // as required for SOMO-independent PNO selection.
+        const auto e_ijs_full = compute_semicanonical_sromp2_pair_energies(false);
+        DLPNOCCSD::compute_pair_energies<false>();
+        const auto e_ijs_truncated = update_sromp2_pair_energies();
+
+        de_pno_total_ = 0.0;
+        for (int ij = 0; ij < static_cast<int>(de_pno_.size()); ++ij) {
+            de_pno_[ij] = e_ijs_full[ij] - e_ijs_truncated[ij];
+            de_pno_total_ += de_pno_[ij];
+        }
+        outfile->Printf("    SROMP2 spin-adapted PNO truncation energy = %.12f\n", de_pno_total_);
+        return e_ijs_full;
+    }
+}
+
+std::vector<double> RO_DLPNOCCSD::pno_lmp2_iterations() {
+    // Optimize the single spin-free SROMP2 amplitude set with precisely the
+    // mature closed-shell local-MP2 machinery.  Only the physical energy and
+    // subsequent pair classification are spin resolved.
+    DLPNOCCSD::pno_lmp2_iterations();
+    auto e_ijs = update_sromp2_pair_energies();
+    e_lmp2_ = 0.0;
+    for (double e_ij : e_ijs) e_lmp2_ += e_ij;
+    outfile->Printf("    Final spin-adapted SROLMP2 correlation energy = %.12f\n", e_lmp2_);
+    return e_ijs;
+}
+
+template<bool crude>
+double RO_DLPNOCCSD::filter_pairs(const std::vector<double>& e_ijs) {
+    const int naocc = i_j_to_ij_.size();
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    const double threshold = crude ? T_CUT_PAIRS_MP2_ : T_CUT_PAIRS_;
+
+    auto spatial_pair_survives = [&](int ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        if (i == j) return true;
+        const int ji = ij_to_ji_[ij];
+        // A spatial pair is discarded if and only if AA, AB/BA, and BB all
+        // fail.  Inspecting both ordered orientations makes the decision
+        // symmetric for a DOCC-SOMO pair, for which only one AB orientation
+        // is physically occupied.
+        for (DoubleSpinCase spin : {DoubleSpinCase::AA, DoubleSpinCase::AB,
+                                    DoubleSpinCase::BB}) {
+            const int ds = static_cast<int>(spin);
+            if (std::fabs(sromp2_pair_energies_[ds][ij]) >= threshold ||
+                std::fabs(sromp2_pair_energies_[ds][ji]) >= threshold) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    if constexpr (crude) {
+        std::vector<std::vector<int>> i_j_to_ij_new(naocc, std::vector<int>(naocc, -1));
+        std::vector<std::pair<int, int>> ij_to_i_j_new;
+        std::vector<int> ij_to_ji_new;
+        double delta_e_crude = 0.0;
+
+        for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+            auto &[i, j] = ij_to_i_j_[ij];
+            if (spatial_pair_survives(ij)) {
+                i_j_to_ij_new[i][j] = ij_to_i_j_new.size();
+                ij_to_i_j_new.emplace_back(i, j);
+            } else {
+                delta_e_crude += e_ijs[ij];
+            }
+        }
+        for (const auto& pair : ij_to_i_j_new) {
+            ij_to_ji_new.push_back(i_j_to_ij_new[pair.second][pair.first]);
+        }
+        i_j_to_ij_ = std::move(i_j_to_ij_new);
+        ij_to_i_j_ = std::move(ij_to_i_j_new);
+        ij_to_ji_ = std::move(ij_to_ji_new);
+        return delta_e_crude;
+    } else {
+        i_j_to_ij_strong_.assign(naocc, std::vector<int>(naocc, -1));
+        i_j_to_ij_weak_.assign(naocc, std::vector<int>(naocc, -1));
+        ij_to_i_j_strong_.clear();
+        ij_to_i_j_weak_.clear();
+        double delta_e_weak = 0.0;
+
+        for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+            auto &[i, j] = ij_to_i_j_[ij];
+            if (spatial_pair_survives(ij)) {
+                i_j_to_ij_strong_[i][j] = ij_to_i_j_strong_.size();
+                ij_to_i_j_strong_.emplace_back(i, j);
+            } else {
+                i_j_to_ij_weak_[i][j] = ij_to_i_j_weak_.size();
+                ij_to_i_j_weak_.emplace_back(i, j);
+                delta_e_weak += e_ijs[ij];
+            }
+        }
+
+        ij_to_ji_strong_.clear();
+        for (const auto& pair : ij_to_i_j_strong_) {
+            ij_to_ji_strong_.push_back(i_j_to_ij_strong_[pair.second][pair.first]);
+        }
+        ij_to_ji_weak_.clear();
+        for (const auto& pair : ij_to_i_j_weak_) {
+            ij_to_ji_weak_.push_back(i_j_to_ij_weak_[pair.second][pair.first]);
+        }
+        return delta_e_weak;
+    }
+}
+
+template<bool crude>
+void RO_DLPNOCCSD::pair_prescreening() {
+    if constexpr (crude) {
+        outfile->Printf("\n  ==> Initial SROMP2 prescreening of pairs <==\n");
+        const int n_lmo_pairs_init = ij_to_i_j_.size();
+        const auto e_ijs_crude = compute_pair_energies<true>();
+        de_lmp2_eliminated_ = filter_pairs<true>(e_ijs_crude);
+        const int n_lmo_pairs_final = ij_to_i_j_.size();
+        outfile->Printf("    Eliminated Pairs (SC-SROMP2)       = %d\n",
+                        n_lmo_pairs_init - n_lmo_pairs_final);
+        outfile->Printf("    Surviving Pairs                    = %d\n", n_lmo_pairs_final);
+        outfile->Printf("    Surviving Pairs / Non-dipole Pairs = (%.2f %%)\n",
+                        100.0 * n_lmo_pairs_final / n_lmo_pairs_init);
+        outfile->Printf("    Eliminated Pair dE                 = %.12f\n\n", de_lmp2_eliminated_);
+    } else {
+        outfile->Printf("\n  ==> Determining Strong and Weak Pairs with SROLMP2 <==\n");
+        const int n_lmo_pairs = ij_to_i_j_.size();
+        compute_pair_energies<false>();
+        timer_on("PNO-SROLMP2 Iterations");
+        const auto e_ijs = pno_lmp2_iterations();
+        timer_off("PNO-SROLMP2 Iterations");
+        filter_pairs<false>(e_ijs);
+
+        outfile->Printf("\n  ==> Final Strong and Weak Pairs <==\n\n");
+        outfile->Printf("    Weak Pairs                      = %d\n",
+                        static_cast<int>(ij_to_i_j_weak_.size()));
+        outfile->Printf("    Strong Pairs                    = %d\n",
+                        static_cast<int>(ij_to_i_j_strong_.size()));
+        outfile->Printf("    Strong Pairs / Total Pairs      = (%.2f %%)\n",
+                        100.0 * ij_to_i_j_strong_.size() / n_lmo_pairs);
+    }
+}
+
+void RO_DLPNOCCSD::cache_srolmp2_spin_amplitudes() {
+    const int nbocc = nbeta_ - nfrzc();
+    const int n_lmo_pairs = ij_to_i_j_.size();
+    for (auto& block : T_iajb_srolmp2_spin_) block.resize(n_lmo_pairs);
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        auto same_spin = T_iajb_[ij]->clone();
+        same_spin->subtract(T_iajb_[ij]->transpose());
+
+        T_iajb_srolmp2_spin_[static_cast<int>(DoubleSpinCase::AA)][ij] = same_spin;
+        T_iajb_srolmp2_spin_[static_cast<int>(DoubleSpinCase::AB)][ij] = T_iajb_[ij]->clone();
+        T_iajb_srolmp2_spin_[static_cast<int>(DoubleSpinCase::BB)][ij] = same_spin->clone();
+
+        if (j >= nbocc) {
+            T_iajb_srolmp2_spin_[static_cast<int>(DoubleSpinCase::AB)][ij]->zero();
+        }
+        if (i >= nbocc || j >= nbocc) {
+            T_iajb_srolmp2_spin_[static_cast<int>(DoubleSpinCase::BB)][ij]->zero();
+        }
+    }
+}
+
+void RO_DLPNOCCSD::recompute_pnos() {
+    // Preserve the physical correction already accumulated in the first PNO
+    // truncation, then add the second truncation in spin-adapted form.
+    const auto e_before = update_sromp2_pair_energies();
+    const auto de_pno_before = de_pno_;
+    DLPNOCCSD::recompute_pnos();
+    const auto e_after = update_sromp2_pair_energies();
+
+    de_pno_total_ = 0.0;
+    de_weak_ = 0.0;
+    for (int ij = 0; ij < static_cast<int>(de_pno_.size()); ++ij) {
+        de_pno_[ij] = de_pno_before[ij] + e_before[ij] - e_after[ij];
+        de_pno_total_ += de_pno_[ij];
+        auto &[i, j] = ij_to_i_j_[ij];
+        if (i_j_to_ij_strong_[i][j] == -1) de_weak_ += e_after[ij];
+    }
+    cache_srolmp2_spin_amplitudes();
+
+    outfile->Printf("    Spin-adapted SROLMP2 weak-pair energy = %.12f\n", de_weak_);
+    outfile->Printf("    Spin-adapted total PNO truncation energy = %.12f\n", de_pno_total_);
+}
+
+void RO_DLPNOCCSD::restore_srolmp2_weak_amplitudes() {
+    const int n_lmo_pairs = ij_to_i_j_.size();
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        if (i_j_to_ij_strong_[i][j] != -1) continue;
+        for (DoubleSpinCase spin : {DoubleSpinCase::AA, DoubleSpinCase::AB,
+                                    DoubleSpinCase::BB}) {
+            const int ds = static_cast<int>(spin);
+            T_iajb_spin_[ds][ij]->copy(T_iajb_srolmp2_spin_[ds][ij]);
+        }
+    }
+}
+
 void RO_DLPNOCCSD::extend_virtual_by_somo() {
     int n_lmo_pairs = ij_to_i_j_.size();
     int nbf = basisset_->nbf();
@@ -4724,6 +5127,9 @@ void RO_DLPNOCCSD::lccsd_iterations() {
 
     for (DoubleSpinCase double_sigma : doubles_spin_cases) {
         const int ds = static_cast<int>(double_sigma);
+        const auto [sigma1, sigma2] = get_spin_pair(double_sigma);
+        const int s1 = static_cast<int>(sigma1);
+        const int s2 = static_cast<int>(sigma2);
         R_iajb_spin[ds].clear();
         Rn_iajb_spin[ds].clear();
         T_iajb_spin_[ds].clear();
@@ -4737,8 +5143,66 @@ void RO_DLPNOCCSD::lccsd_iterations() {
             R_iajb_spin[ds][ij] = std::make_shared<Matrix>(n_pno_[ij], n_pno_[ij]);
             Rn_iajb_spin[ds][ij] = std::make_shared<Matrix>(n_pno_[ij], n_pno_[ij]);
             T_iajb_spin_[ds][ij] = std::make_shared<Matrix>(n_pno_[ij], n_pno_[ij]);
+
+            // Initialize every spin block from the single spin-free SROLMP2
+            // amplitude set.  Strong pairs subsequently relax at RCCSD;
+            // weak pairs retain this value and enter the neighboring strong-
+            // pair residuals through the existing pair-coupling terms.
+            const int n_selector_pno = n_pno_[ij] - nsomo;
+            for (int a = 0; a < n_selector_pno; ++a) {
+                for (int b = 0; b < n_selector_pno; ++b) {
+                    T_iajb_spin_[ds][ij]->set(
+                        a, b, T_iajb_srolmp2_spin_[ds][ij]->get(a, b));
+                }
+            }
+
+            // The SOMOs are appended only after the common spatial PNOs have
+            // been selected.  Supply the new, physically allowed beta-
+            // virtual sectors with semicanonical first-order amplitudes;
+            // leaving these blocks at zero would omit semi-internal weak-pair
+            // correlation even though the augmented orbitals are present.
+            auto &[i, j] = ij_to_i_j_[ij];
+            const bool occupied_block_allowed =
+                !(sigma1 == SpinCase::Beta && i >= nbocc) &&
+                !(sigma2 == SpinCase::Beta && j >= nbocc);
+            if (occupied_block_allowed) {
+                for (int a = 0; a < n_pno_[ij]; ++a) {
+                    if (sigma1 == SpinCase::Alpha && a >= n_selector_pno) continue;
+                    for (int b = 0; b < n_pno_[ij]; ++b) {
+                        if (a < n_selector_pno && b < n_selector_pno) continue;
+                        if (sigma2 == SpinCase::Alpha && b >= n_selector_pno) continue;
+
+                        double numerator = K_iajb_[ij]->get(a, b);
+                        if (sigma1 == sigma2) {
+                            numerator -= K_iajb_[ij]->get(b, a);
+                        }
+                        const double denominator =
+                            (*F_lmo_spin[s1])(i, i) + (*F_lmo_spin[s2])(j, j) -
+                            (*F_pno_spin_[s1][ij])(a, a) - (*F_pno_spin_[s2][ij])(b, b);
+                        if (std::fabs(denominator) > 1.0e-12) {
+                            T_iajb_spin_[ds][ij]->set(a, b, numerator / denominator);
+                        }
+                    }
+                }
+            }
         } // end for
     } // end for
+
+    for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+        double_spin_enforcer(T_iajb_spin_[static_cast<int>(double_sigma)], double_sigma);
+    }
+
+    // From this point onward the fixed weak-pair cache must span the full
+    // SOMO-augmented PNO space, including the semi-internal blocks above.
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        auto &[i, j] = ij_to_i_j_[ij];
+        if (i_j_to_ij_strong_[i][j] != -1) continue;
+        for (DoubleSpinCase double_sigma : doubles_spin_cases) {
+            const int ds = static_cast<int>(double_sigma);
+            T_iajb_srolmp2_spin_[ds][ij] = T_iajb_spin_[ds][ij]->clone();
+        }
+    }
 
     // => Thread buffers <= //
 
@@ -4891,6 +5355,10 @@ void RO_DLPNOCCSD::lccsd_iterations() {
         for (DoubleSpinCase double_sigma : doubles_spin_cases) {
             double_spin_enforcer(T_iajb_spin_[static_cast<int>(double_sigma)], double_sigma);
         }
+        // A zero residual is not, by itself, a sufficiently explicit promise
+        // that DIIS will leave a weak-pair vector bit-for-bit fixed.  Restore
+        // the SROLMP2 blocks after every extrapolation.
+        restore_srolmp2_weak_amplitudes();
 
         // evaluate convergence using current amplitudes and residuals
         e_prev = e_curr;
@@ -4973,6 +5441,16 @@ double RO_DLPNOCCSD::compute_dlpno_ccsd_energy() {
 
     timer_on("Setup Orbitals");
     setup_orbitals();
+
+    // SROMP2/PNO-RCCSD uses one spin-free Fock operator for the common
+    // spatial selector amplitudes and PNOs.  The actual RCCSD equations and
+    // Jacobi denominators below continue to use F^alpha and F^beta.
+    auto F_spin_free_ao = reference_wavefunction_->Fa()->clone();
+    F_spin_free_ao->add(reference_wavefunction_->Fb());
+    F_spin_free_ao->scale(0.5);
+    F_lmo_ = linalg::triplet(C_lmo_, F_spin_free_ao, C_lmo_, true, false, false);
+    F_pao_ = linalg::triplet(C_pao_, F_spin_free_ao, C_pao_, true, false, false);
+    F_lmo_pao_ = linalg::triplet(C_lmo_, F_spin_free_ao, C_pao_, true, false, false);
     timer_off("Setup Orbitals");
 
     timer_on("Overlap Ints");

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -4132,21 +4132,29 @@ void RO_DLPNOCCSD::compute_R_ia(
                 if (tau == SpinCase::Beta && k >= nbocc) continue;
                 const double prefactor = (s == t) ? 0.5 : 1.0;
 
-                // 1/2 t(ki,cd)<kc||da>; the explicit spin blocks turn the
-                // 1/2 into 1 for an opposite-spin partner.
-                auto T_ki = T_iajb_spin_helper(ki, tau, sigma)->clone();
+                // Eq. 12 contains u(ki,cd) = t(ki,cd) - t(ki,dc) for a
+                // same-spin partner, not the raw same-spin t amplitude.  The
+                // distinction is essential even though a converged same-spin
+                // amplitude is antisymmetric: in that case u = 2 t, so using
+                // raw t below would make both same-spin R1 contributions too
+                // small by exactly a factor of two.  Opposite-spin u is just t.
+                auto U_ki = T_iajb_spin_helper(ki, tau, sigma)->clone();
+                if (s == t) U_ki->subtract(U_ki->transpose());
+
+                // 1/2 u(ki,cd)<kc|da> for same spin; the explicit
+                // opposite-spin block carries unit prefactor.
+                auto U_ki_flat = U_ki->clone();
                 auto K_kcad = K_ivvv_[ki]->clone();
                 K_kcad->reshape(npno_ik * npno_ik, npno_ik);
-                T_ki->reshape(npno_ik * npno_ik, 1);
+                U_ki_flat->reshape(npno_ik * npno_ik, 1);
 
                 auto S_ki_ii_s = S_PNO(ki, ii)->clone();
                 matrix_spin_enforcer_vv(S_ki_ii_s, sigma);
-                auto A_i = linalg::triplet(S_ki_ii_s, K_kcad, T_ki, true, true, false);
+                auto A_i = linalg::triplet(S_ki_ii_s, K_kcad, U_ki_flat, true, true, false);
                 A_i->scale(prefactor);
                 R_ia_buffer[s][thread][i]->add(A_i);
 
                 // The T1 part of the transformed three-external integral.
-                auto T_ki_mat = T_iajb_spin_helper(ki, tau, sigma);
                 for (int l_ik = 0; l_ik < nlmo_ik; ++l_ik) {
                     const int l = lmopair_to_lmos_[ik][l_ik];
                     if (sigma == SpinCase::Beta && l >= nbocc) continue;
@@ -4158,12 +4166,12 @@ void RO_DLPNOCCSD::compute_R_ia(
                     matrix_spin_enforcer_vv(S_kl_ki_t, tau);
                     auto S_ki_kl_s = S_PNO(ki, kl)->clone();
                     matrix_spin_enforcer_vv(S_ki_kl_s, sigma);
-                    auto T_proj = linalg::triplet(S_kl_ki_t, T_ki_mat, S_ki_kl_s);
+                    auto U_proj = linalg::triplet(S_kl_ki_t, U_ki, S_ki_kl_s);
 
                     auto S_ii_ll_s = S_PNO(ii, ll)->clone();
                     matrix_spin_enforcer_vv(S_ii_ll_s, sigma);
                     auto T_l = linalg::doublet(S_ii_ll_s, T_ia_spin_[s][l]);
-                    T_l->scale(prefactor * T_proj->vector_dot(K_iajb_[kl]));
+                    T_l->scale(prefactor * U_proj->vector_dot(K_iajb_[kl]));
                     R_ia_buffer[s][thread][i]->subtract(T_l);
                 }
 
@@ -4198,8 +4206,10 @@ void RO_DLPNOCCSD::compute_R_ia(
 
                 auto K_kilc = K_mibj_[kl]->clone();
                 K_kilc->add(linalg::doublet(T_n_ij_spin_[s][kl], K_iajb_[kl]));
-                auto T_kl = T_iajb_spin_helper(kl, sigma, tau);
-                auto B_ia = linalg::doublet(K_kilc, T_kl, false, true);
+                // The same-spin term in Eq. 12 again contracts u, not raw t.
+                auto U_kl = T_iajb_spin_helper(kl, sigma, tau)->clone();
+                if (s == t) U_kl->subtract(U_kl->transpose());
+                auto B_ia = linalg::doublet(K_kilc, U_kl, false, true);
                 B_ia->scale(prefactor);
 
                 for (int i_kl = 0; i_kl < nlmo_kl; ++i_kl) {

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -1710,6 +1710,15 @@ void DLPNOCCSD::compute_pno_integrals() {
             }
         }
 
+        // K_iajb.  recompute_pnos() built this *before* the SOMOs were appended to the PNO
+        // space, so in the open-shell case the cached copy still has the pre-augmentation
+        // dimensions (and is missing the (i a | j s) / (i s | j t) blocks entirely).  Rebuild
+        // it here from the symmetrically fitted DF integrals of the current (augmented) basis.
+        if (somo_augmented_) {
+            K_iajb_[ij] = linalg::doublet(q_iv, q_jv, true, false);
+            if (i != j) K_iajb_[ji] = K_iajb_[ij]->transpose();
+        }
+
         // L_iajb
         L_iajb_[ij] = K_iajb_[ij]->clone();
         L_iajb_[ij]->scale(2.0);
@@ -3153,6 +3162,9 @@ void RO_DLPNOCCSD::extend_virtual_by_somo() {
             n_pno_[ji] = n_pno_[ji] + nsomo;
         } // end if
     } // end for
+
+    // Everything cached in the pre-augmentation PNO basis (K_iajb_ above all) is now stale.
+    somo_augmented_ = true;
 }
 
 SharedMatrix RO_DLPNOCCSD::T_iajb_spin_helper(const int ij, const SpinCase& sigma1, const SpinCase& sigma2) {

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -48,6 +48,7 @@
 
 #include <ctime>
 #include <algorithm>
+#include <utility>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -3811,9 +3812,12 @@ std::array<std::array<std::vector<SharedMatrix>, 2>, 2> RO_DLPNOCCSD::compute_ga
                     matrix_spin_enforcer_vv(S_kl_ki_s2, sigma2);
 
                     gamma_temp = linalg::triplet(S_ki_li_s2, gamma_temp, S_kl_ki_s2);
+                    // The authoritative spin-resolved contraction uses
+                    // gamma_T2 = -1/2 T(li) K(kl).  Together with -J-gamma
+                    // in Eq. 25 this gives the positive quadratic C term.
                     gamma_temp->scale(0.5);
 
-                    gamma[s1][s2][ki]->add(gamma_temp);
+                    gamma[s1][s2][ki]->subtract(gamma_temp);
                 } // end l_ki
 
                 matrix_spin_enforcer_vv(gamma[s1][s2][ki], sigma2);
@@ -3824,7 +3828,7 @@ std::array<std::array<std::vector<SharedMatrix>, 2>, 2> RO_DLPNOCCSD::compute_ga
     return gamma;
 }
 
-std::array<std::array<std::vector<SharedMatrix>, 2>, 2> RO_DLPNOCCSD::compute_delta() {
+std::array<RO_DLPNOCCSD::SpinPairMatrixBlocks, 2> RO_DLPNOCCSD::compute_delta() {
 
     int n_lmo_pairs = ij_to_i_j_.size();
     int naocc = nalpha_ - nfrzc();
@@ -3833,13 +3837,15 @@ std::array<std::array<std::vector<SharedMatrix>, 2>, 2> RO_DLPNOCCSD::compute_de
 
     constexpr std::array<SpinCase, 2> singles_spin_cases = { SpinCase::Alpha, SpinCase::Beta };
 
-    std::array<std::array<std::vector<SharedMatrix>, 2>, 2> delta;
+    SpinPairMatrixBlocks delta;
+    SpinPairMatrixBlocks delta_bar;
 
     for (SpinCase sigma1 : singles_spin_cases) {
         const int s1 = static_cast<int>(sigma1);
         for (SpinCase sigma2 : singles_spin_cases) {
             const int s2 = static_cast<int>(sigma2);
             delta[s1][s2].resize(n_lmo_pairs);
+            delta_bar[s1][s2].resize(n_lmo_pairs);
         } // end sigma2
     } // end sigma1
 
@@ -3859,6 +3865,8 @@ std::array<std::array<std::vector<SharedMatrix>, 2>, 2> RO_DLPNOCCSD::compute_de
 
                 delta[s1][s2][ik] = std::make_shared<Matrix>(npno_ik, npno_ik);
                 delta[s1][s2][ik]->zero();
+                delta_bar[s1][s2][ik] = std::make_shared<Matrix>(npno_ik, npno_ik);
+                delta_bar[s1][s2][ik]->zero();
 
                 if (sigma1 == SpinCase::Beta && i >= nbocc) continue;
                 if (sigma2 == SpinCase::Beta && k >= nbocc) continue; 
@@ -3942,7 +3950,7 @@ std::array<std::array<std::vector<SharedMatrix>, 2>, 2> RO_DLPNOCCSD::compute_de
                         delta_temp = linalg::triplet(S_ik_il_s1, delta_temp, S_lk_ik_s2);
                         delta_temp->scale(0.5);
 
-                        delta[s1][s2][ik]->add(delta_temp);
+                        delta_bar[s1][s2][ik]->add(delta_temp);
                     }
                 } // end l_ik
 
@@ -3950,20 +3958,26 @@ std::array<std::array<std::vector<SharedMatrix>, 2>, 2> RO_DLPNOCCSD::compute_de
                 if (sigma1 == SpinCase::Alpha) {
                     for (int a = 0; a < nsomo; ++a) {
                         const int av = npno_ik - a - 1;
-                        for (int c = 0; c < npno_ik; ++c) (*delta[s1][s2][ik])(av, c) = 0.0;
+                        for (int c = 0; c < npno_ik; ++c) {
+                            (*delta[s1][s2][ik])(av, c) = 0.0;
+                            (*delta_bar[s1][s2][ik])(av, c) = 0.0;
+                        }
                     }
                 }
                 if (sigma2 == SpinCase::Alpha) {
                     for (int c = 0; c < nsomo; ++c) {
                         const int cv = npno_ik - c - 1;
-                        for (int a = 0; a < npno_ik; ++a) (*delta[s1][s2][ik])(a, cv) = 0.0;
+                        for (int a = 0; a < npno_ik; ++a) {
+                            (*delta[s1][s2][ik])(a, cv) = 0.0;
+                            (*delta_bar[s1][s2][ik])(a, cv) = 0.0;
+                        }
                     }
                 }
             } // end sigma2
         } // end sigma1
     } // end ik
 
-    return delta;
+    return {std::move(delta), std::move(delta_bar)};
 }
 
 std::array<std::vector<SharedMatrix>, 2> RO_DLPNOCCSD::compute_Fbc_double_tilde() {
@@ -4132,14 +4146,13 @@ void RO_DLPNOCCSD::compute_R_ia(
                 if (tau == SpinCase::Beta && k >= nbocc) continue;
                 const double prefactor = (s == t) ? 0.5 : 1.0;
 
-                // Eq. 12 contains u(ki,cd) = t(ki,cd) - t(ki,dc) for a
-                // same-spin partner, not the raw same-spin t amplitude.  The
-                // distinction is essential even though a converged same-spin
-                // amplitude is antisymmetric: in that case u = 2 t, so using
-                // raw t below would make both same-spin R1 contributions too
-                // small by exactly a factor of two.  Opposite-spin u is just t.
+                // Match the executable spin-resolved equation literally:
+                // u(ki,cd) = t(ki,cd) - t(ik,cd).  Fermionic symmetry also
+                // makes this equal to t(ki,cd) - t(ki,dc), but using the
+                // occupied-pair swap avoids assuming that the independently
+                // stored local blocks already obey the latter identity.
                 auto U_ki = T_iajb_spin_helper(ki, tau, sigma)->clone();
-                if (s == t) U_ki->subtract(U_ki->transpose());
+                if (s == t) U_ki->subtract(T_iajb_spin_helper(ik, tau, sigma));
 
                 // 1/2 u(ki,cd)<kc|da> for same spin; the explicit
                 // opposite-spin block carries unit prefactor.
@@ -4188,6 +4201,7 @@ void RO_DLPNOCCSD::compute_R_ia(
 #pragma omp parallel for schedule(dynamic, 1)
     for (int kl = 0; kl < n_lmo_pairs; ++kl) {
         auto &[k, l] = ij_to_i_j_[kl];
+        const int lk = ij_to_ji_[kl];
         const int nlmo_kl = lmopair_to_lmos_[kl].size();
 
         int thread = 0;
@@ -4206,9 +4220,9 @@ void RO_DLPNOCCSD::compute_R_ia(
 
                 auto K_kilc = K_mibj_[kl]->clone();
                 K_kilc->add(linalg::doublet(T_n_ij_spin_[s][kl], K_iajb_[kl]));
-                // The same-spin term in Eq. 12 again contracts u, not raw t.
+                // The NumPy reference forms u with the occupied-pair swap.
                 auto U_kl = T_iajb_spin_helper(kl, sigma, tau)->clone();
-                if (s == t) U_kl->subtract(U_kl->transpose());
+                if (s == t) U_kl->subtract(T_iajb_spin_helper(lk, sigma, tau));
                 auto B_ia = linalg::doublet(K_kilc, U_kl, false, true);
                 B_ia->scale(prefactor);
 
@@ -4247,7 +4261,9 @@ void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_ia
 
     auto beta_ijkl = compute_beta();
     auto gamma_ki = compute_gamma();
-    auto delta_jk = compute_delta();
+    auto delta_terms = compute_delta();
+    auto& delta_jk = delta_terms[0];
+    auto& delta_bar_jk = delta_terms[1];
     auto F_bc_double_tilde = compute_Fbc_double_tilde();
     auto F_ki_double_tilde = compute_Fki_double_tilde();
 
@@ -4407,9 +4423,19 @@ void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_ia
 
                         // "C" term: Jiang and Toth Eq. 24
                         SharedMatrix T_ik_s1_g = T_iajb_spin_helper(ik, sigma1, gamma);
+                        auto S_ik_jk_g = S_PNO(ik, jk)->clone();
+                        matrix_spin_enforcer_vv(S_ik_jk_g, gamma);
 
                         SharedMatrix L_jbck = K_iakc_non_proj_[ji][k_ij]->clone();
                         if (g == s2) L_jbck->subtract(J_ikac_non_proj_[ji][k_ij]);
+
+                        // Eq. 24 contains the unbarred delta from Eq. 15.  It
+                        // is the part that completes the T1 transformation of
+                        // L(kbcj); it must be inside both P(i/j) and P(a/b).
+                        auto delta_jbck = linalg::triplet(
+                            S_ij_kj_s1, delta_jk[s1][g][jk], S_ik_jk_g,
+                            false, false, true);
+                        L_jbck->add(delta_jbck);
 
                         // last somo occupied orbitals DO NOT contribute to the beta spin case
                         auto C_iajb = linalg::triplet(S_ij_ik_s1, T_ik_s1_g, L_jbck, false, false, true);
@@ -4418,14 +4444,24 @@ void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_ia
                         Rn_iajb[ds][ij]->subtract(C_iajb->transpose());
 
                         // "D" term: Jiang and Toth Eq. 26
-                        auto S_ik_jk_g = S_PNO(ik, jk)->clone();
-                        matrix_spin_enforcer_vv(S_ik_jk_g, gamma);
                         auto D_iajb = linalg::triplet(S_ij_ik_s1, T_ik_s1_g, S_ik_jk_g);
-                        D_iajb = linalg::triplet(D_iajb, delta_jk[s1][g][jk], S_ij_kj_s1, false, true, true);
+                        D_iajb = linalg::triplet(
+                            D_iajb, delta_bar_jk[s1][g][jk], S_ij_kj_s1,
+                            false, true, true);
 
                         SharedMatrix T_jk_s1_g = T_iajb_spin_helper(jk, sigma1, gamma);
                         auto D_jaib = linalg::triplet(S_ij_kj_s1, T_jk_s1_g, S_ik_jk_g, false, false, true);
-                        D_jaib = linalg::triplet(D_jaib, delta_jk[s1][g][ik], S_ij_ik_s1, false, true, true);
+                        D_jaib = linalg::triplet(
+                            D_jaib, delta_bar_jk[s1][g][ik], S_ij_ik_s1,
+                            false, true, true);
+
+                        // Eq. 16 defines delta_bar with 1/2.  In the
+                        // opposite-spin Eq. 27 both spin-swapped halves supply
+                        // that factor; Eq. 26 has only one half before P(i/j).
+                        // The executable NumPy contraction therefore equals
+                        // 2 * Eq. 26 as printed in the current manuscript.
+                        D_iajb->scale(2.0);
+                        D_jaib->scale(2.0);
 
                         R_iajb[ds][ij]->add(D_iajb);
                         R_iajb[ds][ij]->subtract(D_jaib);
@@ -4441,7 +4477,9 @@ void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_ia
                     R_iajb[ds][ij]->add(linalg::triplet(J_kjac, T_ik_s1_s2, S_ij_ik_s2, false, false, true));
 
                     auto gamma_kj_temp = linalg::triplet(S_ij_kj_s1, gamma_ki[s2][s1][kj], S_ik_kj_s1, false, false, true);
-                    R_iajb[ds][ij]->add(linalg::triplet(gamma_kj_temp, T_ik_s1_s2, S_ij_ik_s2, false, false, true));
+                    R_iajb[ds][ij]->subtract(linalg::triplet(
+                        gamma_kj_temp, T_ik_s1_s2, S_ij_ik_s2,
+                        false, false, true));
 
                     SharedMatrix J_kibc = J_ikac_non_proj_[ij][k_ij]->clone();
                     J_kibc->scale(-1.0);
@@ -4451,7 +4489,9 @@ void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_ia
                     R_iajb[ds][ij]->add(linalg::triplet(S_ij_kj_s1, T_kj_s1_s2, J_kibc, false, false, true));
 
                     auto gamma_ki_temp = linalg::triplet(S_ij_ik_s2, gamma_ki[s1][s2][ki], S_ik_kj_s2, false, false, false);
-                    R_iajb[ds][ij]->add(linalg::triplet(S_ij_kj_s1, T_kj_s1_s2, gamma_ki_temp, false, false, true));
+                    R_iajb[ds][ij]->subtract(linalg::triplet(
+                        S_ij_kj_s1, T_kj_s1_s2, gamma_ki_temp,
+                        false, false, true));
 
                     // "D" term: Jiang and Toth Eq. 27
                     for (SpinCase gamma : singles_spin_cases) {
@@ -4473,10 +4513,18 @@ void RO_DLPNOCCSD::compute_R_iajb(std::array<std::vector<SharedMatrix>, 3> &R_ia
                         auto S_ik_jk_g = S_PNO(ik, jk)->clone();
                         matrix_spin_enforcer_vv(S_ik_jk_g, gamma);
                         auto T_ik_proj = linalg::triplet(S_ij_ik_s1, T_ik_s1_g, S_ik_jk_g);
-                        R_iajb[ds][ij]->add(linalg::triplet(T_ik_proj, delta_jk[s2][g][jk], S_ij_kj_s2, false, true, true));
+                        auto delta_full_jk = delta_jk[s2][g][jk]->clone();
+                        delta_full_jk->add(delta_bar_jk[s2][g][jk]);
+                        R_iajb[ds][ij]->add(linalg::triplet(
+                            T_ik_proj, delta_full_jk, S_ij_kj_s2,
+                            false, true, true));
 
                         auto T_jk_proj = linalg::triplet(S_ij_kj_s2, T_jk_s2_g, S_ik_jk_g, false, false, true);
-                        R_iajb[ds][ij]->add(linalg::triplet(S_ij_kj_s1, delta_jk[s1][g][ik], T_jk_proj, false, false, true));
+                        auto delta_full_ik = delta_jk[s1][g][ik]->clone();
+                        delta_full_ik->add(delta_bar_jk[s1][g][ik]);
+                        R_iajb[ds][ij]->add(linalg::triplet(
+                            S_ij_kj_s1, delta_full_ik, T_jk_proj,
+                            false, false, true));
                     } // end for
                 } // end else
             }
@@ -4517,6 +4565,7 @@ void RO_DLPNOCCSD::lccsd_iterations() {
 #endif
 
     std::array<SharedMatrix, 2> F_lmo_spin;
+    std::array<std::vector<SharedMatrix>, 2> Fia_energy_spin;
 
     F_lmo_a_ = linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_lmo_, true, false, false);
     F_lmo_b_ = linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_lmo_, true, false, false);
@@ -4526,6 +4575,27 @@ void RO_DLPNOCCSD::lccsd_iterations() {
 
     F_lmo_spin[static_cast<int>(SpinCase::Alpha)] = F_lmo_a_;
     F_lmo_spin[static_cast<int>(SpinCase::Beta)] = F_lmo_b_;
+
+    // Bare f(ia) blocks for the spin-resolved CCSD energy.  These vanish in
+    // the canonical closed-shell limit, but not for a general ROHF reference.
+    std::array<SharedMatrix, 2> F_lmo_pao_spin = {
+        linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_pao_, true, false, false),
+        linalg::triplet(C_lmo_, reference_wavefunction_->Fb(), C_pao_, true, false, false)};
+    for (SpinCase sigma : {SpinCase::Alpha, SpinCase::Beta}) {
+        Fia_energy_spin[static_cast<int>(sigma)].resize(naocc);
+    }
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int i = 0; i < naocc; ++i) {
+        const int ii = i_j_to_ij_[i][i];
+        for (SpinCase sigma : {SpinCase::Alpha, SpinCase::Beta}) {
+            const int s = static_cast<int>(sigma);
+            auto Fia_pao = submatrix_rows_and_cols(
+                *F_lmo_pao_spin[s], std::vector<int>(1, i), lmopair_to_paos_[ii]);
+            Fia_energy_spin[s][i] = linalg::doublet(Fia_pao, X_pno_[ii]);
+            matrix_spin_enforcer_qv(Fia_energy_spin[s][i], sigma);
+            if (sigma == SpinCase::Beta && i >= nbocc) Fia_energy_spin[s][i]->zero();
+        }
+    }
 
     // The appended SOMOs make a single spin-independent e_pno denominator
     // inappropriate.  Retain the actual alpha/beta Fock matrices in every
@@ -4786,6 +4856,14 @@ void RO_DLPNOCCSD::lccsd_iterations() {
             // Update energies
             e_curr += e_ij;
             if (i_j_to_ij_strong_[i][j] == -1) e_weak += e_ij;
+        }
+
+        // Authoritative roccsd.py lines 306--307: sum_sigma f(ia) t(i,a).
+        for (SpinCase sigma : singles_spin_cases) {
+            const int s = static_cast<int>(sigma);
+            for (int i = 0; i < naocc; ++i) {
+                e_curr += Fia_energy_spin[s][i]->vector_dot(T_ia_spin_[s][i]);
+            }
         }
         double r_curr1 = *max_element(R_ia_rms.begin(), R_ia_rms.end());
         double r_curr2 = *max_element(R_iajb_rms.begin(), R_iajb_rms.end());

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -3621,19 +3621,59 @@ void RO_DLPNOCCSD::t1_fock_spin() {
     for (int ij = 0; ij < n_lmo_pairs; ++ij) {
         auto &[i, j] = ij_to_i_j_[ij];
         const int ji = ij_to_ji_[ij];
-        const int pair_idx = (i > j) ? ji : ij;
-        const int i_pair = lmopair_to_lmos_dense_[pair_idx][i];
         const bool strong = (i_j_to_ij_strong_[i][j] != -1);
 
         for (SpinCase sigma : spins) {
             const int s = static_cast<int>(sigma);
 
-            Fkc_tilde_spin_[s][ij] = std::make_shared<Matrix>(n_pno_[ij], 1);
-            if (Fkc_bar[s][pair_idx] && i_pair != -1) {
-                auto row = submatrix_rows(*Fkc_bar[s][pair_idx], std::vector<int>(1, i_pair));
-                Fkc_tilde_spin_[s][ij]->copy(row->transpose());
+            // Eq. 6 is unchanged by the free-index T1 transformation, but in
+            // the local algorithm it must be formed by the direct analogue of
+            // Jiang Eq. 95.  Taking a row of Fkc_bar evaluates the contraction
+            // after projecting every T1 amplitude into the current ij domain;
+            // that is not the RHF DLPNO projection convention and does not
+            // recover the closed-shell implementation at finite PNO cutoffs.
+            auto Fia_pao = submatrix_rows_and_cols(
+                *F_lmo_pao_spin[s], std::vector<int>(1, i), lmopair_to_paos_[ij]);
+            Fkc_tilde_spin_[s][ij] =
+                linalg::doublet(Fia_pao, X_pno_[ij], false, false)->transpose();
+
+            for (int k_ij = 0; k_ij < static_cast<int>(lmopair_to_lmos_[ij].size()); ++k_ij) {
+                const int k = lmopair_to_lmos_[ij][k_ij];
+                const int ik = i_j_to_ij_[i][k];
+                const int kk = i_j_to_ij_[k][k];
+                if (ik == -1 || kk == -1) continue;
+
+                auto S_ij_ik_s = S_PNO(ij, ik)->clone();
+                matrix_spin_enforcer_vv(S_ij_ik_s, sigma);
+
+                // Coulomb density: sum the alpha and beta T1 amplitudes.
+                for (SpinCase tau : spins) {
+                    if (tau == SpinCase::Beta && k >= nbocc) continue;
+                    const int t = static_cast<int>(tau);
+                    auto S_ik_kk_t = S_PNO(ik, kk)->clone();
+                    matrix_spin_enforcer_vv(S_ik_kk_t, tau);
+                    auto T_k = linalg::doublet(S_ik_kk_t, T_ia_spin_[t][k]);
+                    Fkc_tilde_spin_[s][ij]->add(linalg::triplet(
+                        S_ij_ik_s, K_iajb_[ik], T_k));
+                }
+
+                // Exchange density: same spin only.
+                if (!(sigma == SpinCase::Beta && k >= nbocc)) {
+                    auto S_ik_kk_s = S_PNO(ik, kk)->clone();
+                    matrix_spin_enforcer_vv(S_ik_kk_s, sigma);
+                    auto T_k = linalg::doublet(S_ik_kk_s, T_ia_spin_[s][k]);
+                    Fkc_tilde_spin_[s][ij]->subtract(linalg::triplet(
+                        S_ij_ik_s, K_iajb_[ik], T_k, false, true, false));
+                }
             }
-            if (sigma == SpinCase::Beta && i >= nbocc) Fkc_tilde_spin_[s][ij]->zero();
+
+            if (sigma == SpinCase::Alpha) {
+                for (int a = 0; a < nsomo; ++a) {
+                    (*Fkc_tilde_spin_[s][ij])(n_pno_[ij] - a - 1, 0) = 0.0;
+                }
+            } else if (i >= nbocc) {
+                Fkc_tilde_spin_[s][ij]->zero();
+            }
 
             if (i <= j) {
                 Fab_tilde_spin_[s][ij] = Fab_bar[s][ij]->clone();

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -4645,10 +4645,15 @@ void RO_DLPNOCCSD::lccsd_iterations() {
     }
 #pragma omp parallel for schedule(dynamic, 1)
     for (int ij = 0; ij < n_lmo_pairs; ++ij) {
+        // F_pao_a_/F_pao_b_ span the *full* (nbf + nsomo) PAO space, while X_pno_[ij] only spans the
+        // PAO domain of pair ij. Restrict the Fock matrices to that domain before transforming.
+        auto F_pao_ij_a = submatrix_rows_and_cols(*F_pao_a_, lmopair_to_paos_[ij], lmopair_to_paos_[ij]);
+        auto F_pao_ij_b = submatrix_rows_and_cols(*F_pao_b_, lmopair_to_paos_[ij], lmopair_to_paos_[ij]);
+
         F_pno_spin_[static_cast<int>(SpinCase::Alpha)][ij] =
-            linalg::triplet(X_pno_[ij], F_pao_a_, X_pno_[ij], true, false, false);
+            linalg::triplet(X_pno_[ij], F_pao_ij_a, X_pno_[ij], true, false, false);
         F_pno_spin_[static_cast<int>(SpinCase::Beta)][ij] =
-            linalg::triplet(X_pno_[ij], F_pao_b_, X_pno_[ij], true, false, false);
+            linalg::triplet(X_pno_[ij], F_pao_ij_b, X_pno_[ij], true, false, false);
     }
 
     outfile->Printf("\n  ==> Restricted Open Shell Local CCSD <==\n\n");

--- a/psi4/src/psi4/dlpno/dlpno.cc
+++ b/psi4/src/psi4/dlpno/dlpno.cc
@@ -362,6 +362,7 @@ void DLPNO::setup_orbitals() {
     }
     S_pao_ = linalg::triplet(C_pao_, reference_wavefunction_->S(), C_pao_, true, false, false);
     F_pao_ = linalg::triplet(C_pao_, reference_wavefunction_->Fa(), C_pao_, true, false, false);
+    F_lmo_pao_ = linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_pao_, true, false, false);
 
     timer_off("Projected AOs");
 
@@ -622,7 +623,7 @@ void DLPNO::prep_sparsity(bool initial, bool final) {
     int nshell = basisset_->nshell();
     int naux = ribasis_->nbf();
     int naocc = nalpha_ - nfrzc();
-    int npao = C_pao_->ncol();  // same as nbf
+    int npao = C_pao_->ncol();  // either nbf or nbf + nsomo, depending on stage of computation
 
     auto bf_to_atom = std::vector<int>(nbf);
     auto ribf_to_atom = std::vector<int>(naux);
@@ -706,6 +707,13 @@ void DLPNO::prep_sparsity(bool initial, bool final) {
 
         // contains the same information as previous map
         lmo_to_paoatoms_[i] = block_list(lmo_to_paos_[i], bf_to_atom);
+
+        // Add SOMOs to each LMO (does not affect closed-shell case)
+        if (final) {
+            for (int u = nbf; u < npao; ++u) {
+                lmo_to_paos_[i].push_back(u);
+            } // end for
+        } // end if
     }
 
     // map from LMO to local occupied domain (other LMOs)
@@ -798,92 +806,92 @@ void DLPNO::prep_sparsity(bool initial, bool final) {
     print_lmo_pair_domains();
     print_pao_pair_domains();
 
-    if (initial) {
-        // => Coefficient Sparsity <= //
+    // => Coefficient Sparsity <= //
+    lmo_to_bfs_.clear();
+    lmo_to_atoms_.clear();
 
-        // which basis functions (on which atoms) contribute to each local MO?
-        lmo_to_bfs_.resize(naocc);
-        lmo_to_atoms_.resize(naocc);
+    // which basis functions (on which atoms) contribute to each local MO?
+    lmo_to_bfs_.resize(naocc);
+    lmo_to_atoms_.resize(naocc);
 
-        for (int i = 0; i < naocc; ++i) {
-            for (int bf_ind = 0; bf_ind < nbf; ++bf_ind) {
-                if (fabs(C_lmo_->get(bf_ind, i)) > options_.get_double("T_CUT_CLMO")) {
-                    lmo_to_bfs_[i].push_back(bf_ind);
-                }
-            }
-            lmo_to_atoms_[i] = block_list(lmo_to_bfs_[i], bf_to_atom);
-        }
-
-        // which basis functions (on which atoms) contribute to each projected AO?
-        pao_to_bfs_.resize(nbf);
-        pao_to_atoms_.resize(nbf);
-
-        for (int u = 0; u < nbf; ++u) {
-            for (int bf_ind = 0; bf_ind < nbf; ++bf_ind) {
-                if (fabs(C_pao_->get(bf_ind, u)) > options_.get_double("T_CUT_CPAO")) {
-                    pao_to_bfs_[u].push_back(bf_ind);
-                }
-            }
-            pao_to_atoms_[u] = block_list(pao_to_bfs_[u], bf_to_atom);
-        }
-    } // end if
-
-    if (!final) {
-        // determine maps to extended LMO domains, which are the union of an LMO's domain with domains
-        //   of all interacting LMOs
-
-        lmo_to_riatoms_ext_ = extend_maps(lmo_to_riatoms_, ij_to_i_j_);
-        riatom_to_lmos_ext_ = invert_map(lmo_to_riatoms_ext_, natom);
-        riatom_to_paos_ext_ = chain_maps(riatom_to_lmos_ext_, lmo_to_paos_);
-
-        // We'll use these maps to screen the the local MO transform (first index):
-        //   (mn|Q) * C_mi -> (in|Q)
-        riatom_to_atoms1_ = chain_maps(riatom_to_lmos_ext_, lmo_to_atoms_);
-        riatom_to_shells1_ = chain_maps(riatom_to_atoms1_, atom_to_shell_);
-        riatom_to_bfs1_ = chain_maps(riatom_to_atoms1_, atom_to_bf_);
-
-        // We'll use these maps to screen the projected AO transform (second index):
-        //   (mn|Q) * C_nu -> (mu|Q)
-        riatom_to_atoms2_ = chain_maps(riatom_to_lmos_ext_, chain_maps(lmo_to_paos_, pao_to_atoms_));
-        riatom_to_shells2_ = chain_maps(riatom_to_atoms2_, atom_to_shell_);
-        riatom_to_bfs2_ = chain_maps(riatom_to_atoms2_, atom_to_bf_);
-
-        // Need dense versions of previous maps for quick lookup
-
-        // riatom_to_lmos_ext_dense_[riatom][lmo] is the index of lmo in riatom_to_lmos_ext_[riatom]
-        //   (if present), else -1
-        riatom_to_lmos_ext_dense_.resize(natom);
-        // riatom_to_paos_ext_dense_[riatom][pao] is the index of pao in riatom_to_paos_ext_[riatom]
-        //   (if present), else -1
-        riatom_to_paos_ext_dense_.resize(natom);
-
-        // riatom_to_atoms1_dense_(1,2)[riatom][a] is true if the orbitals basis functions of atom A
-        //   are needed for the (LMO,PAO) transform
-        riatom_to_atoms1_dense_.resize(natom);
-        riatom_to_atoms2_dense_.resize(natom);
-
-        for (int a_ri = 0; a_ri < natom; a_ri++) {
-            riatom_to_lmos_ext_dense_[a_ri] = std::vector<int>(naocc, -1);
-            riatom_to_paos_ext_dense_[a_ri] = std::vector<int>(npao, -1);
-            riatom_to_atoms1_dense_[a_ri] = std::vector<bool>(natom, false);
-            riatom_to_atoms2_dense_[a_ri] = std::vector<bool>(natom, false);
-
-            for (int i_ind = 0; i_ind < riatom_to_lmos_ext_[a_ri].size(); i_ind++) {
-                int i = riatom_to_lmos_ext_[a_ri][i_ind];
-                riatom_to_lmos_ext_dense_[a_ri][i] = i_ind;
-            }
-            for (int u_ind = 0; u_ind < riatom_to_paos_ext_[a_ri].size(); u_ind++) {
-                int u = riatom_to_paos_ext_[a_ri][u_ind];
-                riatom_to_paos_ext_dense_[a_ri][u] = u_ind;
-            }
-            for (int a_bf : riatom_to_atoms1_[a_ri]) {
-                riatom_to_atoms1_dense_[a_ri][a_bf] = true;
-            }
-            for (int a_bf : riatom_to_atoms2_[a_ri]) {
-                riatom_to_atoms2_dense_[a_ri][a_bf] = true;
+    for (int i = 0; i < naocc; ++i) {
+        for (int bf_ind = 0; bf_ind < nbf; ++bf_ind) {
+            if (fabs(C_lmo_->get(bf_ind, i)) > options_.get_double("T_CUT_CLMO")) {
+                lmo_to_bfs_[i].push_back(bf_ind);
             }
         }
-    } // end if
+        lmo_to_atoms_[i] = block_list(lmo_to_bfs_[i], bf_to_atom);
+    }
+
+    // which basis functions (on which atoms) contribute to each projected AO?
+    pao_to_bfs_.clear();
+    pao_to_atoms_.clear();
+    pao_to_bfs_.resize(npao);
+    pao_to_atoms_.resize(npao);
+
+    for (int u = 0; u < npao; ++u) {
+        for (int bf_ind = 0; bf_ind < nbf; ++bf_ind) {
+            if (fabs(C_pao_->get(bf_ind, u)) > options_.get_double("T_CUT_CPAO")) {
+                pao_to_bfs_[u].push_back(bf_ind);
+            }
+        } // end bf_ind
+        pao_to_atoms_[u] = block_list(pao_to_bfs_[u], bf_to_atom);
+    } // end u
+    
+    // determine maps to extended LMO domains, which are the union of an LMO's domain with domains
+    //   of all interacting LMOs
+
+    lmo_to_riatoms_ext_ = extend_maps(lmo_to_riatoms_, ij_to_i_j_);
+    riatom_to_lmos_ext_ = invert_map(lmo_to_riatoms_ext_, natom);
+    riatom_to_paos_ext_ = chain_maps(riatom_to_lmos_ext_, lmo_to_paos_);
+
+    // We'll use these maps to screen the the local MO transform (first index):
+    //   (mn|Q) * C_mi -> (in|Q)
+    riatom_to_atoms1_ = chain_maps(riatom_to_lmos_ext_, lmo_to_atoms_);
+    riatom_to_shells1_ = chain_maps(riatom_to_atoms1_, atom_to_shell_);
+    riatom_to_bfs1_ = chain_maps(riatom_to_atoms1_, atom_to_bf_);
+
+    // We'll use these maps to screen the projected AO transform (second index):
+    //   (mn|Q) * C_nu -> (mu|Q)
+    riatom_to_atoms2_ = chain_maps(riatom_to_lmos_ext_, chain_maps(lmo_to_paos_, pao_to_atoms_));
+    riatom_to_shells2_ = chain_maps(riatom_to_atoms2_, atom_to_shell_);
+    riatom_to_bfs2_ = chain_maps(riatom_to_atoms2_, atom_to_bf_);
+
+    // Need dense versions of previous maps for quick lookup
+
+    // riatom_to_lmos_ext_dense_[riatom][lmo] is the index of lmo in riatom_to_lmos_ext_[riatom]
+    //   (if present), else -1
+    riatom_to_lmos_ext_dense_.resize(natom);
+    // riatom_to_paos_ext_dense_[riatom][pao] is the index of pao in riatom_to_paos_ext_[riatom]
+    //   (if present), else -1
+    riatom_to_paos_ext_dense_.resize(natom);
+
+    // riatom_to_atoms1_dense_(1,2)[riatom][a] is true if the orbitals basis functions of atom A
+    //   are needed for the (LMO,PAO) transform
+    riatom_to_atoms1_dense_.resize(natom);
+    riatom_to_atoms2_dense_.resize(natom);
+
+    for (int a_ri = 0; a_ri < natom; a_ri++) {
+        riatom_to_lmos_ext_dense_[a_ri] = std::vector<int>(naocc, -1);
+        riatom_to_paos_ext_dense_[a_ri] = std::vector<int>(npao, -1);
+        riatom_to_atoms1_dense_[a_ri] = std::vector<bool>(natom, false);
+        riatom_to_atoms2_dense_[a_ri] = std::vector<bool>(natom, false);
+
+        for (int i_ind = 0; i_ind < riatom_to_lmos_ext_[a_ri].size(); i_ind++) {
+            int i = riatom_to_lmos_ext_[a_ri][i_ind];
+            riatom_to_lmos_ext_dense_[a_ri][i] = i_ind;
+        }
+        for (int u_ind = 0; u_ind < riatom_to_paos_ext_[a_ri].size(); u_ind++) {
+            int u = riatom_to_paos_ext_[a_ri][u_ind];
+            riatom_to_paos_ext_dense_[a_ri][u] = u_ind;
+        }
+        for (int a_bf : riatom_to_atoms1_[a_ri]) {
+            riatom_to_atoms1_dense_[a_ri][a_bf] = true;
+        }
+        for (int a_bf : riatom_to_atoms2_[a_ri]) {
+            riatom_to_atoms2_dense_[a_ri][a_bf] = true;
+        }
+    }
 }
 
 void DLPNO::compute_qij() {
@@ -1140,6 +1148,7 @@ void DLPNO::compute_qab() {
 
     int nbf = basisset_->nbf();
     int naux = ribasis_->nbf();
+    int npao = C_pao_->colspi(0);
     int natom = molecule_->natom();
     double ints_tolerance = options_.get_double("DLPNO_AO_INTS_TOL");
     double T_CUT_DO_UV = options_.get_double("T_CUT_DO_UV");
@@ -1150,22 +1159,22 @@ void DLPNO::compute_qab() {
 
     for (int Qatom = 0; Qatom < natom; ++Qatom) {
         int npao_Q = riatom_to_paos_ext_[Qatom].size();
-        riatom_to_pao_pairs_dense_[Qatom].resize(nbf);
+        riatom_to_pao_pairs_dense_[Qatom].resize(npao);
 
-        for (int u = 0; u < nbf; ++u) {
-            riatom_to_pao_pairs_dense_[Qatom][u].resize(nbf, -1);
+        for (int u = 0; u < npao; ++u) {
+            riatom_to_pao_pairs_dense_[Qatom][u].resize(npao, -1);
         }
 
         int uv_idx = 0;
-        for (int u = 0; u < nbf; ++u) {
+        for (int u = 0; u < npao; ++u) {
             int u_idx = riatom_to_paos_ext_dense_[Qatom][u];
             if (u_idx == -1) continue;
 
-            for (int v = 0; v < nbf; ++v) {
+            for (int v = 0; v < npao; ++v) {
                 int v_idx = riatom_to_paos_ext_dense_[Qatom][v];
                 if (v_idx == -1 || u > v) continue;
 
-                if (fabs(DOI_uv_->get(u,v)) > T_CUT_DO_UV) {
+                if (u >= nbf || v >= nbf || fabs(DOI_uv_->get(u,v)) > T_CUT_DO_UV) {
                     riatom_to_pao_pairs_[Qatom].push_back(std::make_pair(u,v));
                     riatom_to_pao_pairs_dense_[Qatom][u][v] = uv_idx;
                     riatom_to_pao_pairs_dense_[Qatom][v][u] = uv_idx;

--- a/psi4/src/psi4/dlpno/dlpno.cc
+++ b/psi4/src/psi4/dlpno/dlpno.cc
@@ -32,6 +32,7 @@
 #include "psi4/lib3index/3index.h"
 #include "psi4/libdiis/diismanager.h"
 #include "psi4/libfock/cubature.h"
+#include "psi4/libfock/jk.h"
 #include "psi4/libfock/points.h"
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/integral.h"
@@ -193,13 +194,207 @@ void DLPNO::common_init() {
     name_ = "DLPNO";
     module_ = "dlpno";
 
-    variables_["SCF TOTAL ENERGY"] = reference_wavefunction_->energy();
+    input_scf_energy_ = reference_wavefunction_->energy();
+    reference_energy_ = input_scf_energy_;
+    variables_["SCF TOTAL ENERGY"] = input_scf_energy_;
 
     ribasis_ = (algorithm_ == DLPNOMethod::MP2) ? get_basisset("DF_BASIS_MP2") : get_basisset("DF_BASIS_CC");
     psio_ = _default_psio_lib_;
 
     memory_ = Process::environment.get_memory();
     toggle_memory_ = options_.get_bool("DLPNO_TOGGLE_MEMORY");
+}
+
+void DLPNO::prepare_reference() {
+    if (reference_prepared_) return;
+
+    if (options_.get_str("REFERENCE") == "UHF") {
+        build_qro_reference();
+    } else {
+        C_reference_occ_ = reference_wavefunction_->Ca_subset("AO", "OCC");
+        C_reference_active_a_ = reference_wavefunction_->Ca_subset("AO", "ACTIVE_OCC");
+        C_reference_active_b_ = reference_wavefunction_->Cb_subset("AO", "ACTIVE_OCC");
+        F_reference_a_ = reference_wavefunction_->Fa_subset("AO");
+        F_reference_b_ = reference_wavefunction_->Fb_subset("AO");
+        reference_energy_ = input_scf_energy_;
+        set_scalar_variable("CURRENT REFERENCE ENERGY", reference_energy_);
+    }
+
+    reference_prepared_ = true;
+}
+
+void DLPNO::build_qro_reference() {
+    if (nalpha_ < nbeta_) {
+        throw PSIEXCEPTION(
+            "The UHF -> QRO DLPNO-CCSD path requires nalpha >= nbeta. "
+            "Reverse the spin convention of the reference determinant.");
+    }
+
+    const int nbf = basisset_->nbf();
+    const int nsomo = nalpha_ - nbeta_;
+    const int nfrzc = this->nfrzc();
+    if (nfrzc > nbeta_) {
+        throw PSIEXCEPTION(
+            "The frozen-core space cannot contain more orbitals than the QRO doubly occupied space.");
+    }
+    const auto S_ao = reference_wavefunction_->S();
+    const auto Fa_uhf = reference_wavefunction_->Fa_subset("AO");
+    const auto Fb_uhf = reference_wavefunction_->Fb_subset("AO");
+    const auto Da_uhf = reference_wavefunction_->Da_subset("AO");
+    const auto Db_uhf = reference_wavefunction_->Db_subset("AO");
+
+    auto S_half = S_ao->clone();
+    S_half->power(0.5);
+
+    // A broken-symmetry singlet cannot be represented by the high-spin
+    // restricted determinant assumed by RO_DLPNOCCSD.  A collapsed UHF
+    // singlet is allowed and provides a useful closed-shell limit.
+    auto spin_density_orth = Da_uhf->clone();
+    spin_density_orth->subtract(Db_uhf);
+    spin_density_orth->transform(S_half);
+    const double spin_density_norm = std::sqrt(spin_density_orth->sum_of_squares());
+    set_scalar_variable("QRO UHF SPIN DENSITY NORM", spin_density_norm);
+    if (nsomo == 0 && spin_density_norm > 1.0e-6) {
+        throw PSIEXCEPTION(
+            "UHF -> QRO DLPNO-CCSD does not support broken-symmetry singlet references. "
+            "Use a high-spin UHF reference, a collapsed UHF singlet, or an RHF/ROHF reference.");
+    }
+
+    // Neese's QRO construction starts from the natural orbitals of the
+    // spin-summed UHF density: S^(1/2) (Da + Db) S^(1/2).
+    auto density_orth = Da_uhf->clone();
+    density_orth->add(Db_uhf);
+    density_orth->transform(S_half);
+
+    auto uno_vectors = std::make_shared<Matrix>("UHF natural-orbital eigenvectors", nbf, nbf);
+    qro_noons_ = std::make_shared<Vector>("UHF natural occupations", nbf);
+    density_orth->diagonalize(uno_vectors, qro_noons_, descending);
+
+    auto S_half_inverse = S_ao->clone();
+    S_half_inverse->power(-0.5);
+    auto C_uno = linalg::doublet(S_half_inverse, uno_vectors, false, false);
+
+    auto column_block = [](const SharedMatrix& C, int first, int count, const std::string& name) {
+        auto block = std::make_shared<Matrix>(name, C->nrow(), count);
+        for (int mu = 0; mu < C->nrow(); ++mu) {
+            for (int p = 0; p < count; ++p) block->set(mu, p, C->get(mu, first + p));
+        }
+        return block;
+    };
+
+    auto semicanonicalize = [](const SharedMatrix& C, const SharedMatrix& F,
+                               const std::string& name) {
+        if (C->ncol() <= 1) return C->clone();
+        auto F_block = linalg::triplet(C, F, C, true, false, false);
+        auto U = std::make_shared<Matrix>(name + " eigenvectors", C->ncol(), C->ncol());
+        auto epsilon = std::make_shared<Vector>(name + " energies", C->ncol());
+        F_block->diagonalize(U, epsilon, ascending);
+        return linalg::doublet(C, U, false, false);
+    };
+
+    auto C_docc = column_block(C_uno, 0, nbeta_, "QRO DOMOs");
+    auto C_somo = column_block(C_uno, nbeta_, nsomo, "QRO SOMOs");
+    auto C_virtual = column_block(C_uno, nalpha_, nbf - nalpha_, "QRO virtual orbitals");
+
+    // Hansen, Liakos, and Neese, JCP 135, 214102 (2011): DOMOs
+    // diagonalize F_beta, virtuals F_alpha, and SOMOs their average.
+    auto F_average = Fa_uhf->clone();
+    F_average->add(Fb_uhf);
+    F_average->scale(0.5);
+    C_docc = semicanonicalize(C_docc, Fb_uhf, "QRO DOMO");
+    C_somo = semicanonicalize(C_somo, F_average, "QRO SOMO");
+    C_virtual = semicanonicalize(C_virtual, Fa_uhf, "QRO virtual");
+
+    auto C_qro = std::make_shared<Matrix>("Quasi-restricted orbitals", nbf, nbf);
+    for (int mu = 0; mu < nbf; ++mu) {
+        for (int i = 0; i < nbeta_; ++i) C_qro->set(mu, i, C_docc->get(mu, i));
+        for (int u = 0; u < nsomo; ++u) C_qro->set(mu, nbeta_ + u, C_somo->get(mu, u));
+        for (int a = 0; a < nbf - nalpha_; ++a)
+            C_qro->set(mu, nalpha_ + a, C_virtual->get(mu, a));
+    }
+
+    C_reference_occ_ = column_block(C_qro, 0, nalpha_, "QRO alpha occupied orbitals");
+    C_reference_active_a_ =
+        column_block(C_qro, nfrzc, nalpha_ - nfrzc, "Active QRO alpha occupied orbitals");
+    C_reference_active_b_ =
+        column_block(C_qro, nfrzc, nbeta_ - nfrzc, "Active QRO beta occupied orbitals");
+    auto C_occ_beta = column_block(C_qro, 0, nbeta_, "QRO beta occupied orbitals");
+
+    auto D_qro_a = linalg::doublet(C_reference_occ_, C_reference_occ_, false, true);
+    auto D_qro_b = linalg::doublet(C_occ_beta, C_occ_beta, false, true);
+
+    // The input UHF Focks define the QRO rotations above.  The correlation
+    // Hamiltonian must instead be normal ordered with respect to the QRO
+    // determinant, so rebuild its spin Focks once from the QRO densities.
+    auto jk = JK::build_JK(basisset_, get_basisset("DF_BASIS_SCF"), options_, false,
+                           std::max<size_t>(1, memory_ / sizeof(double)));
+    jk->set_print(0);
+    jk->set_do_J(true);
+    jk->set_do_K(true);
+    jk->set_memory(std::max<size_t>(1, memory_ / sizeof(double)));
+    jk->initialize();
+    auto& C_left = jk->C_left();
+    C_left.clear();
+    C_left.push_back(C_reference_occ_);
+    C_left.push_back(C_occ_beta);
+    jk->compute();
+    const auto& J = jk->J();
+    const auto& K = jk->K();
+
+    auto J_total = J[0]->clone();
+    J_total->add(J[1]);
+    F_reference_a_ = reference_wavefunction_->H()->clone();
+    F_reference_a_->add(J_total);
+    F_reference_a_->subtract(K[0]);
+    F_reference_b_ = reference_wavefunction_->H()->clone();
+    F_reference_b_->add(J_total);
+    F_reference_b_->subtract(K[1]);
+    jk->finalize();
+
+    reference_energy_ =
+        molecule_->nuclear_repulsion_energy(reference_wavefunction_->get_dipole_field_strength());
+    auto D_qro_total = D_qro_a->clone();
+    D_qro_total->add(D_qro_b);
+    reference_energy_ += 0.5 * D_qro_total->vector_dot(reference_wavefunction_->H());
+    reference_energy_ += 0.5 * D_qro_a->vector_dot(F_reference_a_);
+    reference_energy_ += 0.5 * D_qro_b->vector_dot(F_reference_b_);
+
+    auto qro_orthogonality = linalg::triplet(C_qro, S_ao, C_qro, true, false, false);
+    for (int p = 0; p < nbf; ++p)
+        qro_orthogonality->set(p, p, qro_orthogonality->get(p, p) - 1.0);
+    const double orthogonality_error = std::sqrt(qro_orthogonality->sum_of_squares());
+    const double qro_nalpha = D_qro_a->vector_dot(S_ao);
+    const double qro_nbeta = D_qro_b->vector_dot(S_ao);
+    if (orthogonality_error > 1.0e-6 || std::fabs(qro_nalpha - nalpha_) > 1.0e-6 ||
+        std::fabs(qro_nbeta - nbeta_) > 1.0e-6) {
+        throw PSIEXCEPTION("The UHF -> QRO transformation failed its orthonormality or electron-count check.");
+    }
+
+    qro_reference_ = true;
+    set_scalar_variable("QRO REFERENCE ENERGY", reference_energy_);
+    set_scalar_variable("CURRENT REFERENCE ENERGY", reference_energy_);
+    set_scalar_variable("QRO ORTHONORMALITY ERROR", orthogonality_error);
+    set_scalar_variable("QRO ALPHA ELECTRONS", qro_nalpha);
+    set_scalar_variable("QRO BETA ELECTRONS", qro_nbeta);
+
+    outfile->Printf("\n  ==> UHF -> Quasi-Restricted Orbital Transformation <==\n\n");
+    outfile->Printf("    The UHF natural orbitals are being transformed to a common QRO basis.\n");
+    outfile->Printf("    DLPNO-CCSD will use the QRO determinant and its spin Fock matrices.\n");
+    outfile->Printf("    The reported total energy is E(QRO reference) + E(CCSD correlation).\n\n");
+    outfile->Printf("    Input UHF SCF energy:       %20.12f\n", input_scf_energy_);
+    outfile->Printf("    QRO determinant energy:     %20.12f\n", reference_energy_);
+    outfile->Printf("    QRO - UHF energy:           %20.12f\n", reference_energy_ - input_scf_energy_);
+    outfile->Printf("    QRO orthonormality error:   %20.3e\n", orthogonality_error);
+    outfile->Printf("    QRO electron counts:        alpha = %.8f, beta = %.8f\n", qro_nalpha, qro_nbeta);
+    if (nbeta_ > 0) outfile->Printf("    Last DOMO occupation:       %20.12f\n", qro_noons_->get(nbeta_ - 1));
+    if (nsomo > 0) {
+        outfile->Printf("    First SOMO occupation:      %20.12f\n", qro_noons_->get(nbeta_));
+        outfile->Printf("    Last SOMO occupation:       %20.12f\n", qro_noons_->get(nalpha_ - 1));
+    }
+    if (nalpha_ < nbf)
+        outfile->Printf("    First virtual occupation:   %20.12f\n", qro_noons_->get(nalpha_));
+    outfile->Printf("\n    QROs are not converged ROHF orbitals; nonzero occupied-virtual Fock\n");
+    outfile->Printf("    elements and their singles contributions are retained.\n\n");
 }
 
 /* Utility function for making C_DGESV calls
@@ -311,6 +506,8 @@ std::pair<SharedMatrix, SharedVector> DLPNO::orthocanonicalizer(SharedMatrix S, 
 }
 
 void DLPNO::setup_orbitals() {
+    prepare_reference();
+
     int natom = molecule_->natom();
     int nbf = basisset_->nbf();
     int nshell = basisset_->nshell();
@@ -320,7 +517,7 @@ void DLPNO::setup_orbitals() {
     int nbocc = nbeta_ - nfrzc();
     int nsomo = naocc - nbocc;
 
-    auto C_occ = reference_wavefunction_->Ca_subset("AO", "OCC");
+    auto C_occ = C_reference_occ_;
 
     // Compute number of core orbitals
     if (options_.get_str("FREEZE_CORE") == "TRUE" || options_.get_str("FREEZE_CORE") == "1") {
@@ -360,7 +557,7 @@ void DLPNO::setup_orbitals() {
         return L;
     };
 
-    auto C_aocc = reference_wavefunction_->Ca_subset("AO", "ACTIVE_OCC");
+    auto C_aocc = C_reference_active_a_;
     if (nsomo == 0) {
         // Preserve the established closed-shell localization exactly.
         C_lmo_ = localize_block(C_aocc);
@@ -370,7 +567,7 @@ void DLPNO::setup_orbitals() {
         // span the singly occupied space.  Localizing all alpha occupied
         // orbitals at once violates that assumption because a Boys or PM
         // rotation may mix the two occupation classes.
-        auto C_docc = reference_wavefunction_->Cb_subset("AO", "ACTIVE_OCC");
+        auto C_docc = C_reference_active_b_;
         SharedMatrix C_somo;
 
         if (nbocc == 0) {
@@ -413,7 +610,7 @@ void DLPNO::setup_orbitals() {
     }
     timer_off("Local MOs");
 
-    F_lmo_ = linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_lmo_, true, false, false);
+    F_lmo_ = linalg::triplet(C_lmo_, F_reference_a_, C_lmo_, true, false, false);
 
     timer_on("Projected AOs");
 
@@ -428,8 +625,8 @@ void DLPNO::setup_orbitals() {
         C_pao_->scale_column(0, i, pow(S_pao_->get(i, i), -0.5));
     }
     S_pao_ = linalg::triplet(C_pao_, reference_wavefunction_->S(), C_pao_, true, false, false);
-    F_pao_ = linalg::triplet(C_pao_, reference_wavefunction_->Fa(), C_pao_, true, false, false);
-    F_lmo_pao_ = linalg::triplet(C_lmo_, reference_wavefunction_->Fa(), C_pao_, true, false, false);
+    F_pao_ = linalg::triplet(C_pao_, F_reference_a_, C_pao_, true, false, false);
+    F_lmo_pao_ = linalg::triplet(C_lmo_, F_reference_a_, C_pao_, true, false, false);
 
     timer_off("Projected AOs");
 
@@ -599,8 +796,8 @@ void DLPNO::compute_dipole_ints() {
     auto F_lmo_dipole = F_lmo_;
     auto F_pao_dipole = F_pao_;
     if (open_shell) {
-        auto F_rohf = reference_wavefunction_->Fa()->clone();
-        F_rohf->add(reference_wavefunction_->Fb());
+        auto F_rohf = F_reference_a_->clone();
+        F_rohf->add(F_reference_b_);
         F_rohf->scale(0.5);
         F_lmo_dipole = linalg::triplet(C_lmo_, F_rohf, C_lmo_, true, false, false);
         F_pao_dipole = linalg::triplet(C_pao_, F_rohf, C_pao_, true, false, false);

--- a/psi4/src/psi4/dlpno/dlpno.cc
+++ b/psi4/src/psi4/dlpno/dlpno.cc
@@ -699,15 +699,18 @@ void DLPNO::compute_dipole_ints() {
                     double num_actual = iu.dot(jv) - 3 * (iu.dot(Rh_ij) * jv.dot(Rh_ij));
                     num_actual *= num_actual;
 
-                    double num_linear = -2 * iu.dot(jv);
-                    num_linear *= num_linear;
+                    // Conservative parallel-dipole bound (Guo et al.,
+                    // J. Chem. Phys. 144, 094111 (2016), Eq. 25).  The norm
+                    // product is essential: using iu.dot(jv) can vanish for
+                    // orthogonal transition dipoles and underestimate a pair.
+                    double num_bound = 4 * iu.dot(iu) * jv.dot(jv);
 
                     double denom =
                         (lmo_pao_e[i]->get(u) + lmo_pao_e[j]->get(v)) -
                         (F_lmo_dipole->get(i, i) + F_lmo_dipole->get(j, j));
 
                     dipole_pair_e_temp += (num_actual / denom);
-                    dipole_pair_e_bound_temp += (num_linear / denom);
+                    dipole_pair_e_bound_temp += (num_bound / denom);
                 }
             }
 

--- a/psi4/src/psi4/dlpno/dlpno.cc
+++ b/psi4/src/psi4/dlpno/dlpno.cc
@@ -48,6 +48,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -580,7 +581,15 @@ void DLPNO::compute_overlap_ints() {
 void DLPNO::compute_dipole_ints() {
     int natom = molecule_->natom();
     int naocc = nalpha_ - nfrzc();
+    int nbocc = nbeta_ - nfrzc();
     int nbf = C_lmo_->nrow();
+    const bool open_shell = naocc != nbocc;
+
+    // The dipole estimate is well-defined only for pairs of doubly occupied
+    // orbitals in a high-spin open-shell reference.  Pairs involving at least
+    // one singly occupied orbital are retained unconditionally below, so no
+    // transition-dipole domains are needed for the SOMOs here.
+    const int ndipole_occ = open_shell ? nbocc : naocc;
 
     const auto ao_dipole = MintsHelper(basisset_, options_).ao_dipole();
 
@@ -596,17 +605,17 @@ void DLPNO::compute_dipole_ints() {
     std::vector<Vector3> R_i;
 
     // < i | dipole | u >
-    std::vector<std::vector<Vector3>> lmo_pao_dr(naocc);
+    std::vector<std::vector<Vector3>> lmo_pao_dr(ndipole_occ);
 
     // e_u
-    std::vector<SharedVector> lmo_pao_e(naocc);
+    std::vector<SharedVector> lmo_pao_e(ndipole_occ);
 
-    for (size_t i = 0; i < naocc; ++i) {
+    for (size_t i = 0; i < ndipole_occ; ++i) {
         R_i.push_back(Vector3(lmo_lmo_dipx->get(i, i), lmo_lmo_dipy->get(i, i), lmo_lmo_dipz->get(i, i)));
     }
 
     double T_CUT_DO_PRE = options_.get_double("T_CUT_DO_PRE");
-    for (size_t i = 0; i < naocc; ++i) {
+    for (size_t i = 0; i < ndipole_occ; ++i) {
         std::vector<int> pao_inds;
         for (size_t u = 0; u < nbf; u++) {
             if (fabs(DOI_iu_->get(i, u)) > T_CUT_DO_PRE) {
@@ -643,8 +652,24 @@ void DLPNO::compute_dipole_ints() {
     dipole_pair_e_ = std::make_shared<Matrix>("Dipole SC MP2 Energies", naocc, naocc);
     dipole_pair_e_bound_ = std::make_shared<Matrix>("Parallel Dipole SC MP2 Energies", naocc, naocc);
 
+    size_t n_somo_pairs_retained = 0;
     for (size_t i = 0; i < naocc; ++i) {
         for (size_t j = i + 1; j < naocc; ++j) {
+            // In the open-shell dipole/SC-NEVPT prescreen, a pair energy cannot
+            // be defined reliably for DOCC-SOMO (ip) or SOMO-SOMO (pq) pairs.
+            // Saitow et al., J. Chem. Phys. 146, 164105 (2017),
+            // DOI: 10.1063/1.4981521, therefore keep every such pair in the
+            // crude guess.  An infinite screening bound makes prep_sparsity()
+            // retain the pair, while leaving its dipole
+            // correction at zero; the later PAO pair-energy screen decides it.
+            if (open_shell && (i >= nbocc || j >= nbocc)) {
+                const double keep_pair = std::numeric_limits<double>::infinity();
+                dipole_pair_e_bound_->set(i, j, keep_pair);
+                dipole_pair_e_bound_->set(j, i, keep_pair);
+                ++n_somo_pairs_retained;
+                continue;
+            }
+
             auto R_ij = R_i[i] - R_i[j];
             auto Rh_ij = R_ij / R_ij.norm();
 
@@ -679,6 +704,10 @@ void DLPNO::compute_dipole_ints() {
             dipole_pair_e_bound_->set(i, j, dipole_pair_e_bound_temp);
             dipole_pair_e_bound_->set(j, i, dipole_pair_e_bound_temp);
         }
+    }
+
+    if (open_shell) {
+        outfile->Printf("    Retained %zu SOMO-containing pairs through dipole prescreening.\n", n_somo_pairs_retained);
     }
 }
 

--- a/psi4/src/psi4/dlpno/dlpno.cc
+++ b/psi4/src/psi4/dlpno/dlpno.cc
@@ -47,6 +47,7 @@
 #include "psi4/libqt/qt.h"
 
 #include <algorithm>
+#include <cmath>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -315,6 +316,8 @@ void DLPNO::setup_orbitals() {
     int naux = ribasis_->nbf();
     int nshellri = ribasis_->nshell();
     int naocc = nalpha_ - nfrzc();
+    int nbocc = nbeta_ - nfrzc();
+    int nsomo = naocc - nbocc;
 
     auto C_occ = reference_wavefunction_->Ca_subset("AO", "OCC");
 
@@ -328,21 +331,84 @@ void DLPNO::setup_orbitals() {
     }
 
     timer_on("Local MOs");
-    // Localize active occupied orbitals
-    if (options_.get_str("DLPNO_LOCAL_ORBITALS") == "BOYS") {
-        BoysLocalizer localizer = BoysLocalizer(basisset_, reference_wavefunction_->Ca_subset("AO", "ACTIVE_OCC"));
-        localizer.set_convergence(options_.get_double("LOCAL_CONVERGENCE"));
-        localizer.set_maxiter(options_.get_int("LOCAL_MAXITER"));
-        localizer.localize();
-        C_lmo_ = localizer.L();
-    } else if (options_.get_str("DLPNO_LOCAL_ORBITALS") == "PIPEK_MEZEY") {
-        PMLocalizer localizer = PMLocalizer(basisset_, reference_wavefunction_->Ca_subset("AO", "ACTIVE_OCC"));
-        localizer.set_convergence(options_.get_double("LOCAL_CONVERGENCE"));
-        localizer.set_maxiter(options_.get_int("LOCAL_MAXITER"));
-        localizer.localize();
-        C_lmo_ = localizer.L();
-    } else {
+    const auto localization_method = options_.get_str("DLPNO_LOCAL_ORBITALS");
+    if (localization_method != "BOYS" && localization_method != "PIPEK_MEZEY") {
         throw PSIEXCEPTION("Invalid option for DLPNO_LOCAL_ORBITALS");
+    }
+
+    auto localize_block = [&](const SharedMatrix& C) {
+        // A one-orbital block is already localized.  Skipping the localizer
+        // also handles the all-SOMO limit, where the active DOCC block is
+        // empty.
+        if (C->ncol() <= 1) return C->clone();
+
+        SharedMatrix L;
+        if (localization_method == "BOYS") {
+            BoysLocalizer localizer(basisset_, C);
+            localizer.set_convergence(options_.get_double("LOCAL_CONVERGENCE"));
+            localizer.set_maxiter(options_.get_int("LOCAL_MAXITER"));
+            localizer.localize();
+            L = localizer.L();
+        } else {
+            PMLocalizer localizer(basisset_, C);
+            localizer.set_convergence(options_.get_double("LOCAL_CONVERGENCE"));
+            localizer.set_maxiter(options_.get_int("LOCAL_MAXITER"));
+            localizer.localize();
+            L = localizer.L();
+        }
+        return L;
+    };
+
+    auto C_aocc = reference_wavefunction_->Ca_subset("AO", "ACTIVE_OCC");
+    if (nsomo == 0) {
+        // Preserve the established closed-shell localization exactly.
+        C_lmo_ = localize_block(C_aocc);
+    } else {
+        // Every ROHF spin projector below assumes that the first nbocc LMOs
+        // span the beta-occupied (DOCC) space and that the final nsomo LMOs
+        // span the singly occupied space.  Localizing all alpha occupied
+        // orbitals at once violates that assumption because a Boys or PM
+        // rotation may mix the two occupation classes.
+        auto C_docc = reference_wavefunction_->Cb_subset("AO", "ACTIVE_OCC");
+        SharedMatrix C_somo;
+
+        if (nbocc == 0) {
+            C_somo = C_aocc->clone();
+        } else {
+            // Obtain the SOMO space without relying on the energy ordering
+            // used by Ca_subset("AO", ...), which can interleave irreps:
+            // C_somo' = (1 - C_docc C_docc^T S) C_aocc.
+            auto docc_overlap_aocc = linalg::triplet(
+                C_docc, reference_wavefunction_->S(), C_aocc, true, false, false);
+            auto C_somo_projected = C_aocc->clone();
+            C_somo_projected->subtract(linalg::doublet(C_docc, docc_overlap_aocc));
+
+            auto S_somo = linalg::triplet(C_somo_projected, reference_wavefunction_->S(),
+                                          C_somo_projected, true, false, false);
+            auto U_somo = std::make_shared<Matrix>("SOMO subspace eigenvectors", naocc, naocc);
+            auto s_somo = std::make_shared<Vector>("SOMO subspace eigenvalues", naocc);
+            S_somo->diagonalize(U_somo, s_somo, descending);
+
+            auto X_somo = std::make_shared<Matrix>("SOMO orthogonalizer", naocc, nsomo);
+            for (int u = 0; u < nsomo; ++u) {
+                const double eigenvalue = s_somo->get(u);
+                if (eigenvalue <= options_.get_double("S_CUT")) {
+                    throw PSIEXCEPTION("Unable to separate the active ROHF DOCC and SOMO subspaces");
+                }
+                for (int p = 0; p < naocc; ++p) {
+                    X_somo->set(p, u, U_somo->get(p, u) / std::sqrt(eigenvalue));
+                }
+            }
+            C_somo = linalg::doublet(C_somo_projected, X_somo);
+        }
+
+        auto L_docc = localize_block(C_docc);
+        auto L_somo = localize_block(C_somo);
+        C_lmo_ = std::make_shared<Matrix>("Localized Active ROHF Orbitals", nbf, naocc);
+        for (int mu = 0; mu < nbf; ++mu) {
+            for (int i = 0; i < nbocc; ++i) C_lmo_->set(mu, i, L_docc->get(mu, i));
+            for (int u = 0; u < nsomo; ++u) C_lmo_->set(mu, nbocc + u, L_somo->get(mu, u));
+        }
     }
     timer_off("Local MOs");
 

--- a/psi4/src/psi4/dlpno/dlpno.cc
+++ b/psi4/src/psi4/dlpno/dlpno.cc
@@ -591,6 +591,21 @@ void DLPNO::compute_dipole_ints() {
     // transition-dipole domains are needed for the SOMOs here.
     const int ndipole_occ = open_shell ? nbocc : naocc;
 
+    // The inactive/external part of the high-spin Dyall Hamiltonian uses the
+    // spin-free ROHF Fock matrix (Saitow et al., Eq. 9).  For a high-spin
+    // determinant this is exactly (F_alpha + F_beta) / 2, giving J - K / 2
+    // for each SOMO.  Keep the original matrices in the RHF path so its
+    // arithmetic remains unchanged.
+    auto F_lmo_dipole = F_lmo_;
+    auto F_pao_dipole = F_pao_;
+    if (open_shell) {
+        auto F_rohf = reference_wavefunction_->Fa()->clone();
+        F_rohf->add(reference_wavefunction_->Fb());
+        F_rohf->scale(0.5);
+        F_lmo_dipole = linalg::triplet(C_lmo_, F_rohf, C_lmo_, true, false, false);
+        F_pao_dipole = linalg::triplet(C_pao_, F_rohf, C_pao_, true, false, false);
+    }
+
     const auto ao_dipole = MintsHelper(basisset_, options_).ao_dipole();
 
     auto lmo_lmo_dipx = linalg::triplet(C_lmo_, ao_dipole[0], C_lmo_, true, false, false);
@@ -626,7 +641,7 @@ void DLPNO::compute_dipole_ints() {
 
         auto C_pao_i = submatrix_cols(*C_pao_, pao_inds);
         auto S_pao_i = submatrix_rows_and_cols(*S_pao_, pao_inds, pao_inds);
-        auto F_pao_i = submatrix_rows_and_cols(*F_pao_, pao_inds, pao_inds);
+        auto F_pao_i = submatrix_rows_and_cols(*F_pao_dipole, pao_inds, pao_inds);
 
         SharedMatrix X_pao_i;
         SharedVector e_pao_i;
@@ -688,7 +703,8 @@ void DLPNO::compute_dipole_ints() {
                     num_linear *= num_linear;
 
                     double denom =
-                        (lmo_pao_e[i]->get(u) + lmo_pao_e[j]->get(v)) - (F_lmo_->get(i, i) + F_lmo_->get(j, j));
+                        (lmo_pao_e[i]->get(u) + lmo_pao_e[j]->get(v)) -
+                        (F_lmo_dipole->get(i, i) + F_lmo_dipole->get(j, j));
 
                     dipole_pair_e_temp += (num_actual / denom);
                     dipole_pair_e_bound_temp += (num_linear / denom);

--- a/psi4/src/psi4/dlpno/dlpno.h
+++ b/psi4/src/psi4/dlpno/dlpno.h
@@ -48,6 +48,50 @@ namespace dlpno {
 
 enum class DLPNOMethod { MP2, CCSD, CCSD_T };
 
+/**
+ * @enum SpinCase
+ *
+ * @brief An enum class to represent alpha and beta spin cases
+ *
+ */
+enum class SpinCase { Alpha = 0, Beta = 1 };
+
+/**
+  *
+  * @enum DoubleSpinCase
+  *
+  * @brief Denotes a doubles spin case alpha, beta, alpha/beta
+  */
+enum class DoubleSpinCase { AA = 0, AB = 1, BB = 2 };
+
+/**
+ * @brief Converts a pair of SpinCases to a DoubleSpinCase
+ */
+constexpr DoubleSpinCase to_double_spin(SpinCase spin1, SpinCase spin2) {
+   if (static_cast<int>(spin1) == 0 && static_cast<int>(spin2) == 0) {
+      return DoubleSpinCase::AA;
+   } else if (static_cast<int>(spin1) == 0 && static_cast<int>(spin2) == 1) {
+      return DoubleSpinCase::AB;
+   } else if (static_cast<int>(spin1) == 1 && static_cast<int>(spin2) == 0) { // TODO: Handle this smarter in the future
+      return DoubleSpinCase::AB;
+   } else {
+      return DoubleSpinCase::BB;
+   }
+}
+
+/**
+ * @brief Converts a DoubleSpinCase to a pair of SpinCase
+ */
+constexpr std::pair<SpinCase,SpinCase> get_spin_pair(DoubleSpinCase double_spin_case) {
+   if (static_cast<int>(double_spin_case) == 0) {
+      return std::make_pair(SpinCase::Alpha, SpinCase::Alpha);
+   } else if (static_cast<int>(double_spin_case) == 1) {
+      return std::make_pair(SpinCase::Alpha, SpinCase::Beta);
+   } else {
+      return std::make_pair(SpinCase::Beta, SpinCase::Beta);
+   }
+}
+
 // Equations refer to Pinski et al. (JCP 143, 034108, 2015; DOI: 10.1063/1.4926879)
 
 class DLPNO : public Wavefunction {
@@ -97,10 +141,15 @@ class DLPNO : public Wavefunction {
     /// localized molecular orbitals (LMOs)
     SharedMatrix C_lmo_;
     SharedMatrix F_lmo_;
+    SharedMatrix F_lmo_a_;
+    SharedMatrix F_lmo_b_;
 
     /// projected atomic orbitals (PAOs)
     SharedMatrix C_pao_;
     SharedMatrix F_pao_;
+    SharedMatrix F_pao_a_;
+    SharedMatrix F_pao_b_;
+    SharedMatrix F_lmo_pao_; //< needed for non-canonical Brueckner orbitals
     SharedMatrix S_pao_;
 
     /// differential overlap integrals (EQ 4)
@@ -433,6 +482,78 @@ class PSI_API DLPNOCCSD : public DLPNO {
     ~DLPNOCCSD() override;
 
     double compute_energy() override;
+};
+
+class PSI_API RO_DLPNOCCSD : public DLPNOCCSD {
+   protected:
+    // T1 amplitudes over A, B
+    std::array<std::vector<SharedMatrix>, 2> T_ia_spin_;
+    // T1 amplitudes projected into every pair domain, over A, B
+    std::array<std::vector<SharedMatrix>, 2> T_n_ij_spin_;
+    // T2 amplitudes over AA, AB, BB
+    std::array<std::vector<SharedMatrix>, 3> T_iajb_spin_;
+
+    // Spin-resolved T1-transformed DF integrals
+    std::array<std::vector<SharedMatrix>, 2> i_Qk_t1_spin_;
+    std::array<std::vector<SharedMatrix>, 2> i_Qa_t1_spin_;
+
+    // Bare and T1-transformed spin Fock blocks
+    std::array<std::vector<SharedMatrix>, 2> F_pno_spin_;
+    std::array<SharedMatrix, 2> Fki_tilde_spin_;
+    std::array<std::vector<SharedMatrix>, 2> Fkc_tilde_spin_;
+    std::array<std::vector<SharedMatrix>, 2> Fai_tilde_spin_;
+    std::array<std::vector<SharedMatrix>, 2> Fab_tilde_spin_;
+
+    /// extend PAO and PNO rank for each pair by nsomo (for open-shell case)... that is, by nalpha - nbeta
+    /// see: https://doi.org/10.1063/1.4981521
+    void extend_virtual_by_somo();
+    /// Get the correct spin-case for doubles amplitudes
+    SharedMatrix T_iajb_spin_helper(const int ij, const SpinCase& sigma1, const SpinCase& sigma2);
+    /// A helper funcion to zero matrix elements by spin case for X_ia-like elements
+    void spin_enforcer(std::vector<SharedMatrix>& X_ia, const SpinCase &sigma);
+    /// A helper function to zero matrix elements by spin case for X_iajb-like elements
+    void double_spin_enforcer(std::vector<SharedMatrix>& X_iajb, const DoubleSpinCase &double_sigma, bool reverse_ab=false);
+    /// A helper function to enforce spin in matrix elements in matrix elements that look like qo
+    void matrix_spin_enforcer_qo(SharedMatrix &X, const int &ij, const SpinCase &sigma);
+    /// A helper function to enforce spin in matrix elements in matrix elements that look like qv
+    void matrix_spin_enforcer_qv(SharedMatrix &X, const SpinCase &sigma);
+    /// A helper function to enforce spin in matrix elements in the occupied-occupied block of a matrix, given pair ij
+    void matrix_spin_enforcer_oo(SharedMatrix &X, const int &ij, const SpinCase &sigma);
+    /// A helper function to enforce spin in matrix elements in the virtual-virtual block of a matrix
+    void matrix_spin_enforcer_vv(SharedMatrix &X, const SpinCase &sigma);
+    /// Project alpha and beta singles amplitudes into every pair domain
+    void form_projected_singles();
+    /// Form spin-resolved T1-transformed DF integrals
+    void t1_ints_spin();
+    /// Form spin-resolved T1-transformed Fock intermediates
+    void t1_fock_spin();
+    /// computes singles residuals in RO LCCSD equations
+    void compute_R_ia(std::array<std::vector<SharedMatrix>, 2>& R_ia, std::array<std::vector<std::vector<SharedMatrix>>, 2>& R_ia_buffer);
+    /// computes doubles residuals in RO LCCSD equations
+    void compute_R_iajb(std::array<std::vector<SharedMatrix>, 3>& R_iajb, std::array<std::vector<SharedMatrix>, 3>& Rn_iajb);
+
+    /// TODO: Uncomment functions as they are defined
+    /// Jiang and Toth Eq. 13
+    std::array<std::vector<SharedMatrix>, 3> compute_beta();
+    /// Jiang and Toth Eq. 14
+    std::array<std::array<std::vector<SharedMatrix>, 2>, 2> compute_gamma();
+    /// Jiang and Toth Eq. 16
+    std::array<std::array<std::vector<SharedMatrix>, 2>, 2> compute_delta();
+    /// Jiang and Toth Eq. 17
+    std::array<std::vector<SharedMatrix>, 2> compute_Fbc_double_tilde();
+    /// Jiang and Toth Eq. 18
+    std::array<SharedMatrix, 2> compute_Fki_double_tilde();
+
+    /// iteratively solves local CCSD equations for restricted open-shell case
+    void lccsd_iterations();
+    /// computes DLPNO-CCSD energy for restricted open-shell case (decoupled from compute_energy in case Brueckner orbitals are requested)
+    double compute_dlpno_ccsd_energy();
+
+    public:
+     RO_DLPNOCCSD(SharedWavefunction ref_wfn, Options& options);
+     ~RO_DLPNOCCSD() override;
+
+     double compute_energy() override;
 };
 
 // Equations refer to Jiang et al. (JCP 161, 082502, 2024; DOI: 10.1063/5.0219963)

--- a/psi4/src/psi4/dlpno/dlpno.h
+++ b/psi4/src/psi4/dlpno/dlpno.h
@@ -181,6 +181,9 @@ class DLPNO : public Wavefunction {
     std::vector<SharedMatrix> X_pno_;   ///< global PAO -> canonical PNO transforms
     std::vector<SharedVector> e_pno_;   ///< PNO orbital energies
     std::vector<int> n_pno_;       ///< number of pnos
+    /// true once the PNO space has been augmented by the SOMOs (open-shell only).  Quantities
+    /// cached by recompute_pnos() are stale in that case and must be rebuilt in the new basis.
+    bool somo_augmented_ = false;
     std::vector<double> occ_pno_;       ///< lowest PNO occupation number per PNO
     std::vector<double> trace_pno_;     ///< total trace(Dij) recovered per PNO
     std::vector<double> e_ratio_pno_;   ///< percentage of correlation energy recovered by PNOs

--- a/psi4/src/psi4/dlpno/dlpno.h
+++ b/psi4/src/psi4/dlpno/dlpno.h
@@ -39,6 +39,7 @@
 #include "psi4/psifiles.h"
 
 #include <map>
+#include <array>
 #include <tuple>
 #include <string>
 #include <unordered_map>
@@ -490,6 +491,7 @@ class PSI_API DLPNOCCSD : public DLPNO {
 class PSI_API RO_DLPNOCCSD : public DLPNOCCSD {
    protected:
     using SpinPairMatrixBlocks = std::array<std::array<std::vector<SharedMatrix>, 2>, 2>;
+    using SpinPairEnergies = std::array<std::vector<double>, 3>;
 
     // T1 amplitudes over A, B
     std::array<std::vector<SharedMatrix>, 2> T_ia_spin_;
@@ -497,6 +499,14 @@ class PSI_API RO_DLPNOCCSD : public DLPNOCCSD {
     std::array<std::vector<SharedMatrix>, 2> T_n_ij_spin_;
     // T2 amplitudes over AA, AB, BB
     std::array<std::vector<SharedMatrix>, 3> T_iajb_spin_;
+    // Fixed spin-adapted SROLMP2 amplitudes.  These initialize every RCCSD
+    // pair and remain fixed for weak pairs, so that weak pairs can couple to
+    // strong-pair RCCSD amplitudes (and are available to a future ROHF (T)).
+    std::array<std::vector<SharedMatrix>, 3> T_iajb_srolmp2_spin_;
+
+    // Physical AA, AB, and BB pair-energy components obtained from the one
+    // spin-free SROMP2 amplitude set used to select the common spatial PNOs.
+    SpinPairEnergies sromp2_pair_energies_;
 
     // Spin-resolved T1-transformed DF integrals
     std::array<std::vector<SharedMatrix>, 2> i_Qk_t1_spin_;
@@ -508,6 +518,28 @@ class PSI_API RO_DLPNOCCSD : public DLPNOCCSD {
     std::array<std::vector<SharedMatrix>, 2> Fkc_tilde_spin_;
     std::array<std::vector<SharedMatrix>, 2> Fai_tilde_spin_;
     std::array<std::vector<SharedMatrix>, 2> Fab_tilde_spin_;
+
+    /// ROHF/SROMP2 versions of the pair-prescreening pipeline.  These hide
+    /// the closed-shell implementations intentionally (the base functions
+    /// are non-virtual, and templated functions cannot be virtual).
+    template<bool crude> void pair_prescreening();
+    template<bool crude> std::vector<double> compute_pair_energies();
+    template<bool crude> double filter_pairs(const std::vector<double>& e_ijs);
+    std::vector<double> pno_lmp2_iterations();
+    void recompute_pnos();
+
+    /// Evaluate semicanonical spin-adapted pair energies in the current PAO
+    /// domains without changing the common (closed-shell-form) PNO selector.
+    std::vector<double> compute_semicanonical_sromp2_pair_energies(bool print_header);
+    /// Recompute physical spin-channel energies from the current common
+    /// SROMP2 amplitudes in the PNO basis.
+    std::vector<double> update_sromp2_pair_energies();
+    /// Cache the spin-adapted amplitudes in the pre-SOMO-augmentation PNO
+    /// space for use as fixed weak-pair amplitudes in RCCSD.
+    void cache_srolmp2_spin_amplitudes();
+    /// Restore fixed weak amplitudes after DIIS, which otherwise has no
+    /// knowledge of the strong/weak distinction.
+    void restore_srolmp2_weak_amplitudes();
 
     /// extend PAO and PNO rank for each pair by nsomo (for open-shell case)... that is, by nalpha - nbeta
     /// see: https://doi.org/10.1063/1.4981521

--- a/psi4/src/psi4/dlpno/dlpno.h
+++ b/psi4/src/psi4/dlpno/dlpno.h
@@ -486,6 +486,8 @@ class PSI_API DLPNOCCSD : public DLPNO {
 
 class PSI_API RO_DLPNOCCSD : public DLPNOCCSD {
    protected:
+    using SpinPairMatrixBlocks = std::array<std::array<std::vector<SharedMatrix>, 2>, 2>;
+
     // T1 amplitudes over A, B
     std::array<std::vector<SharedMatrix>, 2> T_ia_spin_;
     // T1 amplitudes projected into every pair domain, over A, B
@@ -537,8 +539,8 @@ class PSI_API RO_DLPNOCCSD : public DLPNOCCSD {
     std::array<std::vector<SharedMatrix>, 3> compute_beta();
     /// Jiang and Toth Eq. 14
     std::array<std::array<std::vector<SharedMatrix>, 2>, 2> compute_gamma();
-    /// Jiang and Toth Eq. 16
-    std::array<std::array<std::vector<SharedMatrix>, 2>, 2> compute_delta();
+    /// Jiang and Toth Eqs. 15 and 16 (unbarred and barred delta, respectively)
+    std::array<SpinPairMatrixBlocks, 2> compute_delta();
     /// Jiang and Toth Eq. 17
     std::array<std::vector<SharedMatrix>, 2> compute_Fbc_double_tilde();
     /// Jiang and Toth Eq. 18

--- a/psi4/src/psi4/dlpno/dlpno.h
+++ b/psi4/src/psi4/dlpno/dlpno.h
@@ -524,6 +524,9 @@ class PSI_API RO_DLPNOCCSD : public DLPNOCCSD {
     void matrix_spin_enforcer_qv(SharedMatrix &X, const SpinCase &sigma);
     /// A helper function to enforce spin in matrix elements in the occupied-occupied block of a matrix, given pair ij
     void matrix_spin_enforcer_oo(SharedMatrix &X, const int &ij, const SpinCase &sigma);
+    /// Enforce potentially different spin cases on the row and column occupied indices
+    void matrix_spin_enforcer_oo(SharedMatrix &X, const int &ij, const SpinCase &row_sigma,
+                                 const SpinCase &col_sigma);
     /// A helper function to enforce spin in matrix elements in the virtual-virtual block of a matrix
     void matrix_spin_enforcer_vv(SharedMatrix &X, const SpinCase &sigma);
     /// Project alpha and beta singles amplitudes into every pair domain

--- a/psi4/src/psi4/dlpno/dlpno.h
+++ b/psi4/src/psi4/dlpno/dlpno.h
@@ -66,6 +66,13 @@ enum class SpinCase { Alpha = 0, Beta = 1 };
 enum class DoubleSpinCase { AA = 0, AB = 1, BB = 2 };
 
 /**
+ * @enum TripleSpinCase
+ *
+ * @brief Denotes the four unique triples spin cases.
+ */
+enum class TripleSpinCase { AAA = 0, AAB = 1, BBA = 2, BBB = 3 };
+
+/**
  * @brief Converts a pair of SpinCases to a DoubleSpinCase
  */
 constexpr DoubleSpinCase to_double_spin(SpinCase spin1, SpinCase spin2) {
@@ -91,6 +98,21 @@ constexpr std::pair<SpinCase,SpinCase> get_spin_pair(DoubleSpinCase double_spin_
    } else {
       return std::make_pair(SpinCase::Beta, SpinCase::Beta);
    }
+}
+
+/**
+ * @brief Converts a TripleSpinCase to three SpinCases
+ */
+constexpr std::array<SpinCase, 3> get_spin_triple(TripleSpinCase triple_spin_case) {
+    if (triple_spin_case == TripleSpinCase::AAA) {
+        return {SpinCase::Alpha, SpinCase::Alpha, SpinCase::Alpha};
+    } else if (triple_spin_case == TripleSpinCase::AAB) {
+        return {SpinCase::Alpha, SpinCase::Alpha, SpinCase::Beta};
+    } else if (triple_spin_case == TripleSpinCase::BBA) {
+        return {SpinCase::Beta, SpinCase::Beta, SpinCase::Alpha};
+    } else {
+        return {SpinCase::Beta, SpinCase::Beta, SpinCase::Beta};
+    }
 }
 
 // Equations refer to Pinski et al. (JCP 143, 034108, 2015; DOI: 10.1063/1.4926879)
@@ -688,6 +710,66 @@ class PSI_API DLPNOCCSD_T : public DLPNOCCSD {
    public:
     DLPNOCCSD_T(SharedWavefunction ref_wfn, Options& options);
     ~DLPNOCCSD_T() override;
+
+    double compute_energy() override;
+};
+
+class PSI_API RO_DLPNOCCSD_T : public RO_DLPNOCCSD {
+   protected:
+    // Common sparsity information for all four triples spin cases.  Unlike the
+    // closed-shell implementation, the occupied triples retain their oriented
+    // ordering because mixed-spin amplitudes are not fully permutation symmetric.
+    SparseMap lmotriplet_to_ribfs_ro_;
+    SparseMap lmotriplet_to_lmos_ro_;
+    SparseMap lmotriplet_to_paos_ro_;
+    std::vector<std::tuple<int, int, int>> ijk_to_i_j_k_ro_;
+    std::array<std::unordered_map<int, int>, 4> i_j_k_to_ijk_spin_;
+    std::array<std::vector<bool>, 4> active_ijk_spin_;
+
+    // Triples intermediates and amplitudes over AAA, AAB, BBA, and BBB.
+    std::array<std::vector<SharedMatrix>, 4> W_iajbkc_spin_;
+    std::array<std::vector<SharedMatrix>, 4> V_iajbkc_spin_;
+    std::array<std::vector<SharedMatrix>, 4> T_iajbkc_spin_;
+
+    // A common spatial TNO basis is used for all spin cases; only its Fock
+    // representation and orbital energies are spin resolved.
+    std::vector<SharedMatrix> X_tno_ro_;
+    std::array<std::vector<SharedMatrix>, 2> F_tno_spin_;
+    std::vector<int> n_tno_ro_;
+
+    // Per-spin and spin-summed triplet energies used in screening/iterations.
+    std::array<std::vector<double>, 4> e_ijk_spin_;
+    std::vector<double> e_ijk_ro_;
+    std::vector<double> tno_scale_ro_;
+    std::vector<bool> is_strong_triplet_ro_;
+
+    bool write_intermediates_ro_ = false;
+    bool write_amplitudes_ro_ = false;
+
+    std::array<double, 4> de_lccsd_t_screened_spin_ro_{};
+    double de_lccsd_t_screened_ro_ = 0.0;
+    double e_lccsd_t_ro_ = 0.0;
+    double E_T_ro_ = 0.0;
+
+    void ro_triples_sparsity(bool prescreening);
+    void ro_sort_triplets(double e_total);
+    void ro_tno_transform(double tno_tolerance);
+    void ro_estimate_memory();
+
+    double compute_ro_lccsd_t0(bool save_memory = false);
+    double compute_ro_t_iteration_energy();
+    double ro_lccsd_t_iterations();
+
+    SharedMatrix ro_matmul_3d(SharedMatrix A, SharedMatrix X, int dim_old, int dim_new);
+    SharedMatrix ro_triples_permuter(const SharedMatrix& X, TripleSpinCase spin, int i, int j, int k);
+    void triples_spin_enforcer(SharedMatrix& X, TripleSpinCase spin, int i, int j, int k);
+
+    void ro_print_header();
+    void ro_print_results();
+
+   public:
+    RO_DLPNOCCSD_T(SharedWavefunction ref_wfn, Options& options);
+    ~RO_DLPNOCCSD_T() override;
 
     double compute_energy() override;
 };

--- a/psi4/src/psi4/dlpno/dlpno.h
+++ b/psi4/src/psi4/dlpno/dlpno.h
@@ -582,6 +582,15 @@ class PSI_API RO_DLPNOCCSD : public DLPNOCCSD {
     /// Jiang and Toth Eq. 18
     std::array<SharedMatrix, 2> compute_Fki_double_tilde();
 
+    /// ROHF-specific memory estimate.  The base implementation is
+    /// intentionally non-virtual, so this is dispatched from the ROHF
+    /// compute-energy path by name hiding.
+    void estimate_memory();
+    /// Print the ROHF/SROMP2 method header and orbital-space dimensions.
+    void print_header();
+    /// Print spin-resolved diagnostics and final ROHF-DLPNO-CCSD energies.
+    void print_results();
+
     /// iteratively solves local CCSD equations for restricted open-shell case
     void lccsd_iterations();
     /// computes DLPNO-CCSD energy for restricted open-shell case (decoupled from compute_energy in case Brueckner orbitals are requested)

--- a/psi4/src/psi4/dlpno/dlpno.h
+++ b/psi4/src/psi4/dlpno/dlpno.h
@@ -744,7 +744,12 @@ class PSI_API RO_DLPNOCCSD_T : public RO_DLPNOCCSD {
     std::vector<bool> is_strong_triplet_ro_;
 
     bool write_intermediates_ro_ = false;
+    // Keep the immutable current Jacobi generation independent from the
+    // storage selected for the generation under construction.  This allows
+    // current T amplitudes to remain in memory while next T is streamed to
+    // disk, avoiding repeated disk reads of Fock-coupled neighbors.
     bool write_amplitudes_ro_ = false;
+    bool write_next_amplitudes_ro_ = false;
 
     std::array<double, 4> de_lccsd_t_screened_spin_ro_{};
     double de_lccsd_t_screened_ro_ = 0.0;

--- a/psi4/src/psi4/dlpno/dlpno.h
+++ b/psi4/src/psi4/dlpno/dlpno.h
@@ -579,8 +579,6 @@ class PSI_API RO_DLPNOCCSD : public DLPNOCCSD {
     std::array<std::array<std::vector<SharedMatrix>, 2>, 2> compute_gamma();
     /// Jiang and Toth Eqs. 15 and 16 (unbarred and barred delta, respectively)
     std::array<SpinPairMatrixBlocks, 2> compute_delta();
-    /// Jiang and Toth Eq. 17
-    std::array<std::vector<SharedMatrix>, 2> compute_Fbc_double_tilde();
     /// Jiang and Toth Eq. 18
     std::array<SharedMatrix, 2> compute_Fki_double_tilde();
 

--- a/psi4/src/psi4/dlpno/dlpno.h
+++ b/psi4/src/psi4/dlpno/dlpno.h
@@ -139,6 +139,26 @@ class DLPNO : public Wavefunction {
     SharedMatrix full_metric_;
     std::vector<double> J_metric_shell_diag_; ///< used in AO ERI screening
 
+    // => Prepared restricted reference <= //
+
+    /// True when an unrestricted input has been converted to a common-spatial-orbital QRO determinant.
+    bool qro_reference_ = false;
+    /// True once the input reference quantities (and, for UHF, QRO quantities) are ready for use.
+    bool reference_prepared_ = false;
+    /// Input SCF energy.  This remains the value of the SCF TOTAL ENERGY variable for provenance.
+    double input_scf_energy_ = 0.0;
+    /// Determinant energy used to normal order the correlation problem (SCF for RHF/ROHF, QRO for UHF).
+    double reference_energy_ = 0.0;
+    /// Common alpha-occupied, active-alpha, and active-beta orbital spaces used by the local machinery.
+    SharedMatrix C_reference_occ_;
+    SharedMatrix C_reference_active_a_;
+    SharedMatrix C_reference_active_b_;
+    /// Spin-resolved Fock matrices belonging to the determinant used by the correlation problem.
+    SharedMatrix F_reference_a_;
+    SharedMatrix F_reference_b_;
+    /// UHF natural occupations used to diagnose the UHF -> QRO projection.
+    SharedVector qro_noons_;
+
     /// localized molecular orbitals (LMOs)
     SharedMatrix C_lmo_;
     SharedMatrix F_lmo_;
@@ -268,6 +288,11 @@ class DLPNO : public Wavefunction {
     std::shared_ptr<PSIO> psio_;
 
     void common_init();
+
+    /// Prepare common restricted orbitals and spin Focks; constructs QROs when the input reference is UHF.
+    void prepare_reference();
+    /// Build a high-spin QRO determinant from an unrestricted input without modifying the input wavefunction.
+    void build_qro_reference();
 
     // Helper functions
     void C_DGESV_wrapper(SharedMatrix A, SharedMatrix B);

--- a/psi4/src/psi4/dlpno/ro_triples.cc
+++ b/psi4/src/psi4/dlpno/ro_triples.cc
@@ -1,0 +1,1496 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Psi4: an open-source quantum chemistry software package
+ *
+ * Copyright (c) 2007-2026 The Psi4 Developers.
+ *
+ * The copyrights for code used from other parties are included in the corresponding files.
+ *
+ * This file is part of Psi4.
+ *
+ * Psi4 is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, version 3.
+ *
+ * Psi4 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with Psi4; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * @END LICENSE
+ */
+
+#include "dlpno.h"
+#include "sparse.h"
+
+#include "psi4/libmints/basisset.h"
+#include "psi4/libmints/matrix.h"
+#include "psi4/libmints/molecule.h"
+#include "psi4/libmints/vector.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/exception.h"
+#include "psi4/libpsi4util/process.h"
+#include "psi4/libqt/qt.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <ctime>
+#include <sstream>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace psi {
+namespace dlpno {
+
+namespace {
+
+constexpr std::array<SpinCase, 2> kSpins = {SpinCase::Alpha, SpinCase::Beta};
+constexpr std::array<TripleSpinCase, 4> kTripleSpins = {TripleSpinCase::AAA, TripleSpinCase::AAB, TripleSpinCase::BBA,
+                                                        TripleSpinCase::BBB};
+
+const char* triple_spin_label(TripleSpinCase spin) {
+    switch (spin) {
+        case TripleSpinCase::AAA:
+            return "AAA";
+        case TripleSpinCase::AAB:
+            return "AAB";
+        case TripleSpinCase::BBA:
+            return "BBA";
+        case TripleSpinCase::BBB:
+            return "BBB";
+    }
+    return "UNKNOWN";
+}
+
+inline int triple_key(int i, int j, int k, int naocc) { return i * naocc * naocc + j * naocc + k; }
+
+inline double cube_get(const SharedMatrix& X, int n, int a, int b, int c) { return X->get(a, b * n + c); }
+
+inline void cube_set(const SharedMatrix& X, int n, int a, int b, int c, double value) { X->set(a, b * n + c, value); }
+
+inline void cube_add(const SharedMatrix& X, int n, int a, int b, int c, double value) {
+    X->add(0, a, b * n + c, value);
+}
+
+}  // namespace
+
+RO_DLPNOCCSD_T::RO_DLPNOCCSD_T(SharedWavefunction ref_wfn, Options& options) : RO_DLPNOCCSD(ref_wfn, options) {}
+
+RO_DLPNOCCSD_T::~RO_DLPNOCCSD_T() = default;
+
+void RO_DLPNOCCSD_T::ro_print_header() {
+    const bool t0_only = options_.get_bool("T0_APPROXIMATION");
+    const std::string triples_algorithm = t0_only ? "SEMICANONICAL (T0)" : "ITERATIVE (T)";
+    const double t_cut_tno = options_.get_double("T_CUT_TNO");
+
+    outfile->Printf("   --------------------------------------------\n");
+    outfile->Printf("                 RO-DLPNO-CCSD(T)              \n");
+    outfile->Printf("   --------------------------------------------\n\n");
+    outfile->Printf("  Open-shell triples equations: DOI 10.1063/1.5127550\n");
+    outfile->Printf("  DLPNO convergence set to %s.\n\n", options_.get_str("PNO_CONVERGENCE").c_str());
+    outfile->Printf("  Detailed DLPNO triples thresholds and cutoffs:\n");
+    outfile->Printf("    ALGORITHM                    = %6s\n", triples_algorithm.c_str());
+    outfile->Printf("    T_CUT_TNO (T0)              = %6.3e\n", t_cut_tno);
+    outfile->Printf("    T_CUT_DO_TRIPLES (T0)       = %6.3e\n", options_.get_double("T_CUT_DO_TRIPLES"));
+    outfile->Printf("    T_CUT_MKN_TRIPLES (T0)      = %6.3e\n", options_.get_double("T_CUT_MKN_TRIPLES"));
+    outfile->Printf("    T_CUT_TRIPLES_WEAK (T0)     = %6.3e\n", options_.get_double("T_CUT_TRIPLES_WEAK"));
+    outfile->Printf("    T_CUT_TNO_PRE (T0)          = %6.3e\n", options_.get_double("T_CUT_TNO_PRE"));
+    outfile->Printf("    T_CUT_DO_TRIPLES_PRE (T0)   = %6.3e\n", options_.get_double("T_CUT_DO_TRIPLES_PRE"));
+    outfile->Printf("    T_CUT_MKN_TRIPLES_PRE (T0)  = %6.3e\n", options_.get_double("T_CUT_MKN_TRIPLES_PRE"));
+    if (!t0_only) {
+        outfile->Printf("    T_CUT_TNO_STRONG (T)        = %6.3e\n",
+                        t_cut_tno * options_.get_double("T_CUT_TNO_STRONG_SCALE"));
+        outfile->Printf("    T_CUT_TNO_WEAK (T)          = %6.3e\n",
+                        t_cut_tno * options_.get_double("T_CUT_TNO_WEAK_SCALE"));
+        outfile->Printf("    F_CUT_T (T)                 = %6.3e\n", options_.get_double("F_CUT_T"));
+        outfile->Printf("    T_CUT_ITER (T)              = %6.3e\n", options_.get_double("T_CUT_ITER"));
+    }
+    outfile->Printf("    MIN_TNOS                    = %6d\n", options_.get_int("MIN_TNOS"));
+    outfile->Printf("    TRIPLES_MAX_WEAK_PAIRS      = %6d\n\n", options_.get_int("TRIPLES_MAX_WEAK_PAIRS"));
+}
+
+SharedMatrix RO_DLPNOCCSD_T::ro_matmul_3d(SharedMatrix A, SharedMatrix X, int dim_old, int dim_new) {
+    // A'[i,j,k] = A[I,J,K] X[I,i] X[J,j] X[K,k], with A stored as i x (j*k).
+    auto A_new = linalg::doublet(X, A, false, false);
+    A_new->reshape(dim_new * dim_old, dim_old);
+    A_new = linalg::doublet(A_new, X, false, true);
+
+    auto A_transposed = std::make_shared<Matrix>(dim_new * dim_new, dim_old);
+    for (int index = 0; index < dim_new * dim_new * dim_old; ++index) {
+        const int a = index / (dim_new * dim_old);
+        const int b = (index / dim_old) % dim_new;
+        const int c = index % dim_old;
+        A_transposed->set(a * dim_new + b, c, A_new->get(a * dim_old + c, b));
+    }
+
+    A_transposed = linalg::doublet(A_transposed, X, false, true);
+    auto result = std::make_shared<Matrix>(dim_new, dim_new * dim_new);
+    for (int a = 0; a < dim_new; ++a) {
+        for (int b = 0; b < dim_new; ++b) {
+            for (int c = 0; c < dim_new; ++c) {
+                result->set(a, b * dim_new + c, A_transposed->get(a * dim_new + c, b));
+            }
+        }
+    }
+    return result;
+}
+
+SharedMatrix RO_DLPNOCCSD_T::ro_triples_permuter(const SharedMatrix& X, TripleSpinCase spin, int i, int j, int k) {
+    const int n = X->nrow();
+    auto result = X->clone();
+
+    if (spin == TripleSpinCase::AAB || spin == TripleSpinCase::BBA) {
+        if (i <= j) return result;
+        for (int a = 0; a < n; ++a) {
+            for (int b = 0; b < n; ++b) {
+                for (int c = 0; c < n; ++c) cube_set(result, n, a, b, c, cube_get(X, n, b, a, c));
+            }
+        }
+        return result;
+    }
+
+    int permutation = 5;
+    if (i <= j && j <= k) {
+        permutation = 0;
+    } else if (i <= k && k <= j) {
+        permutation = 1;
+    } else if (j <= i && i <= k) {
+        permutation = 2;
+    } else if (j <= k && k <= i) {
+        permutation = 3;
+    } else if (k <= i && i <= j) {
+        permutation = 4;
+    }
+
+    for (int a = 0; a < n; ++a) {
+        for (int b = 0; b < n; ++b) {
+            for (int c = 0; c < n; ++c) {
+                double value = 0.0;
+                if (permutation == 0) value = cube_get(X, n, a, b, c);
+                if (permutation == 1) value = cube_get(X, n, a, c, b);
+                if (permutation == 2) value = cube_get(X, n, b, a, c);
+                if (permutation == 3) value = cube_get(X, n, b, c, a);
+                if (permutation == 4) value = cube_get(X, n, c, a, b);
+                if (permutation == 5) value = cube_get(X, n, c, b, a);
+                cube_set(result, n, a, b, c, value);
+            }
+        }
+    }
+    return result;
+}
+
+void RO_DLPNOCCSD_T::triples_spin_enforcer(SharedMatrix& X, TripleSpinCase spin, int i, int j, int k) {
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = naocc - nbocc;
+    const auto spins = get_spin_triple(spin);
+    const std::array<int, 3> occupied = {i, j, k};
+
+    if (i == j || ((spin == TripleSpinCase::AAA || spin == TripleSpinCase::BBB) && (i == k || j == k))) {
+        X->zero();
+        return;
+    }
+    for (int axis = 0; axis < 3; ++axis) {
+        if (spins[axis] == SpinCase::Beta && occupied[axis] >= nbocc) {
+            X->zero();
+            return;
+        }
+    }
+
+    if (nsomo == 0) return;
+    const int n = X->nrow();
+    const int alpha_virtual_end = n - nsomo;
+    for (int a = 0; a < n; ++a) {
+        for (int b = 0; b < n; ++b) {
+            for (int c = 0; c < n; ++c) {
+                if ((spins[0] == SpinCase::Alpha && a >= alpha_virtual_end) ||
+                    (spins[1] == SpinCase::Alpha && b >= alpha_virtual_end) ||
+                    (spins[2] == SpinCase::Alpha && c >= alpha_virtual_end)) {
+                    cube_set(X, n, a, b, c, 0.0);
+                }
+            }
+        }
+    }
+}
+
+void RO_DLPNOCCSD_T::ro_triples_sparsity(bool prescreening) {
+    timer_on("RO Triples Sparsity");
+
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nbf = basisset_->nbf();
+    const int npao = C_pao_->ncol();
+    const int natom = molecule_->natom();
+
+    auto rebuild_maps = [&]() {
+        for (auto& map : i_j_k_to_ijk_spin_) map.clear();
+        for (int ijk = 0; ijk < static_cast<int>(ijk_to_i_j_k_ro_.size()); ++ijk) {
+            int i, j, k;
+            std::tie(i, j, k) = ijk_to_i_j_k_ro_[ijk];
+            for (TripleSpinCase spin : kTripleSpins) {
+                const int ts = static_cast<int>(spin);
+                if (!active_ijk_spin_[ts][ijk]) continue;
+                auto& map = i_j_k_to_ijk_spin_[ts];
+                if (spin == TripleSpinCase::AAB || spin == TripleSpinCase::BBA) {
+                    map[triple_key(i, j, k, naocc)] = ijk;
+                    map[triple_key(j, i, k, naocc)] = ijk;
+                } else {
+                    const std::array<std::array<int, 3>, 6> permutations = {
+                        std::array<int, 3>{i, j, k}, std::array<int, 3>{i, k, j}, std::array<int, 3>{j, i, k},
+                        std::array<int, 3>{j, k, i}, std::array<int, 3>{k, i, j}, std::array<int, 3>{k, j, i}};
+                    for (const auto& p : permutations) map[triple_key(p[0], p[1], p[2], naocc)] = ijk;
+                }
+            }
+        }
+    };
+
+    if (prescreening) {
+        ijk_to_i_j_k_ro_.clear();
+        for (auto& active : active_ijk_spin_) active.clear();
+
+        const int max_weak_pairs = options_.get_int("TRIPLES_MAX_WEAK_PAIRS");
+        for (int i = 0; i < naocc; ++i) {
+            for (int j = i + 1; j < naocc; ++j) {
+                const int ij = i_j_to_ij_[i][j];
+                if (ij == -1) continue;
+                for (int k : lmopair_to_lmos_[ij]) {
+                    const int ik = i_j_to_ij_[i][k];
+                    const int jk = i_j_to_ij_[j][k];
+                    if (ik == -1 || jk == -1) continue;
+
+                    int weak_pair_count = 0;
+                    if (i_j_to_ij_weak_[i][j] != -1) ++weak_pair_count;
+                    if (i_j_to_ij_weak_[i][k] != -1) ++weak_pair_count;
+                    if (i_j_to_ij_weak_[j][k] != -1) ++weak_pair_count;
+                    if (weak_pair_count > max_weak_pairs) continue;
+
+                    std::array<bool, 4> active = {j < k,                   // AAA: i < j < k
+                                                  k < nbocc,               // AAB: i < j, k beta occupied
+                                                  i < nbocc && j < nbocc,  // BBA: i < j beta occupied, k alpha occupied
+                                                  j < k && k < nbocc};     // BBB: i < j < k beta occupied
+
+                    if (!std::any_of(active.begin(), active.end(), [](bool value) { return value; })) continue;
+                    ijk_to_i_j_k_ro_.emplace_back(i, j, k);
+                    for (int ts = 0; ts < 4; ++ts) active_ijk_spin_[ts].push_back(active[ts]);
+                }
+            }
+        }
+    } else {
+        const double energy_cutoff = options_.get_double("T_CUT_TRIPLES_WEAK");
+        de_lccsd_t_screened_ro_ = 0.0;
+        de_lccsd_t_screened_spin_ro_.fill(0.0);
+
+        std::vector<std::tuple<int, int, int>> retained_triplets;
+        std::array<std::vector<bool>, 4> retained_active;
+        for (int old_ijk = 0; old_ijk < static_cast<int>(ijk_to_i_j_k_ro_.size()); ++old_ijk) {
+            if (std::fabs(e_ijk_ro_[old_ijk]) < energy_cutoff) {
+                for (TripleSpinCase spin : kTripleSpins) {
+                    const int ts = static_cast<int>(spin);
+                    if (!active_ijk_spin_[ts][old_ijk]) continue;
+                    de_lccsd_t_screened_ro_ += e_ijk_spin_[ts][old_ijk];
+                    de_lccsd_t_screened_spin_ro_[ts] += e_ijk_spin_[ts][old_ijk];
+                }
+                continue;
+            }
+
+            retained_triplets.push_back(ijk_to_i_j_k_ro_[old_ijk]);
+            for (int ts = 0; ts < 4; ++ts) retained_active[ts].push_back(active_ijk_spin_[ts][old_ijk]);
+        }
+        ijk_to_i_j_k_ro_ = std::move(retained_triplets);
+        active_ijk_spin_ = std::move(retained_active);
+    }
+
+    rebuild_maps();
+
+    const int ntriplets = ijk_to_i_j_k_ro_.size();
+    tno_scale_ro_.assign(ntriplets, 1.0);
+
+    SparseMap lmo_to_ribfs(naocc);
+    SparseMap lmo_to_paos(naocc);
+    const double mkn_cutoff = options_.get_double(prescreening ? "T_CUT_MKN_TRIPLES_PRE" : "T_CUT_MKN_TRIPLES");
+    const double doi_cutoff = options_.get_double(prescreening ? "T_CUT_DO_TRIPLES_PRE" : "T_CUT_DO_TRIPLES");
+
+    for (int i = 0; i < naocc; ++i) {
+        std::vector<double> mulliken_population(natom, 0.0);
+        auto orbital_density = reference_wavefunction_->S()->clone();
+        for (int mu = 0; mu < nbf; ++mu) {
+            orbital_density->scale_row(0, mu, C_lmo_->get(mu, i));
+            orbital_density->scale_column(0, mu, C_lmo_->get(mu, i));
+        }
+        for (int mu = 0; mu < nbf; ++mu) {
+            const int center_mu = basisset_->function_to_center(mu);
+            const double p_mu_mu = orbital_density->get(mu, mu);
+            for (int nu = 0; nu < nbf; ++nu) {
+                const int center_nu = basisset_->function_to_center(nu);
+                const double p_nu_nu = orbital_density->get(nu, nu);
+                const double denominator = p_mu_mu + p_nu_nu;
+                if (std::fabs(denominator) < 1.0e-16) continue;
+                const double p_mu_nu = orbital_density->get(mu, nu);
+                mulliken_population[center_mu] += p_mu_nu * p_mu_mu / denominator;
+                mulliken_population[center_nu] += p_mu_nu * p_nu_nu / denominator;
+            }
+        }
+        for (int atom = 0; atom < natom; ++atom) {
+            if (std::fabs(mulliken_population[atom]) <= mkn_cutoff) continue;
+            lmo_to_ribfs[i] = merge_lists(lmo_to_ribfs[i], atom_to_ribf_[atom]);
+        }
+
+        std::vector<int> selected_paos;
+        for (int u = 0; u < nbf; ++u) {
+            if (std::fabs(DOI_iu_->get(i, u)) > doi_cutoff) selected_paos.push_back(u);
+        }
+        lmo_to_paos[i] = contract_lists(selected_paos, atom_to_bf_);
+        // The appended SOMOs are mandatory beta virtuals and must be present in every triples domain.
+        for (int u = nbf; u < npao; ++u) lmo_to_paos[i].push_back(u);
+    }
+
+    lmotriplet_to_ribfs_ro_.assign(ntriplets, {});
+    lmotriplet_to_lmos_ro_.assign(ntriplets, {});
+    lmotriplet_to_paos_ro_.assign(ntriplets, {});
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ijk = 0; ijk < ntriplets; ++ijk) {
+        int i, j, k;
+        std::tie(i, j, k) = ijk_to_i_j_k_ro_[ijk];
+        lmotriplet_to_ribfs_ro_[ijk] = merge_lists(lmo_to_ribfs[i], merge_lists(lmo_to_ribfs[j], lmo_to_ribfs[k]));
+        lmotriplet_to_paos_ro_[ijk] = merge_lists(lmo_to_paos[i], merge_lists(lmo_to_paos[j], lmo_to_paos[k]));
+        for (int l = 0; l < naocc; ++l) {
+            if (i_j_to_ij_[i][l] != -1 && i_j_to_ij_[j][l] != -1 && i_j_to_ij_[k][l] != -1)
+                lmotriplet_to_lmos_ro_[ijk].push_back(l);
+        }
+    }
+
+    std::array<int, 4> case_counts{};
+    for (int ts = 0; ts < 4; ++ts) {
+        case_counts[ts] = std::count(active_ijk_spin_[ts].begin(), active_ijk_spin_[ts].end(), true);
+    }
+    outfile->Printf("    Retained oriented RO triplets: AAA %d, AAB %d, BBA %d, BBB %d (%d shared domains)\n",
+                    case_counts[0], case_counts[1], case_counts[2], case_counts[3], ntriplets);
+
+    timer_off("RO Triples Sparsity");
+}
+
+void RO_DLPNOCCSD_T::ro_sort_triplets(double total_energy) {
+    timer_on("RO Sort Triplets");
+    const int ntriplets = ijk_to_i_j_k_ro_.size();
+    std::vector<std::pair<int, double>> ranked(ntriplets);
+    for (int ijk = 0; ijk < ntriplets; ++ijk) ranked[ijk] = {ijk, e_ijk_ro_[ijk]};
+    std::sort(ranked.begin(), ranked.end(),
+              [](const auto& lhs, const auto& rhs) { return std::fabs(lhs.second) > std::fabs(rhs.second); });
+
+    const double strong_scale = options_.get_double("T_CUT_TNO_STRONG_SCALE");
+    const double weak_scale = options_.get_double("T_CUT_TNO_WEAK_SCALE");
+    is_strong_triplet_ro_.assign(ntriplets, false);
+    tno_scale_ro_.assign(ntriplets, weak_scale);
+
+    double accumulated = 0.0;
+    int nstrong = 0;
+    const double target = 0.9 * std::fabs(total_energy);
+    for (const auto& [ijk, energy] : ranked) {
+        is_strong_triplet_ro_[ijk] = true;
+        tno_scale_ro_[ijk] = strong_scale;
+        accumulated += std::fabs(energy);
+        ++nstrong;
+        if (accumulated >= target) break;
+    }
+    outfile->Printf("    Number of strong RO triplet domains: %d of %d\n\n", nstrong, ntriplets);
+    timer_off("RO Sort Triplets");
+}
+
+void RO_DLPNOCCSD_T::ro_tno_transform(double tno_tolerance) {
+    timer_on("RO TNO Transform");
+
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = naocc - nbocc;
+    const int ntriplets = ijk_to_i_j_k_ro_.size();
+    const int min_tnos = options_.get_int("MIN_TNOS");
+
+    X_tno_ro_.assign(ntriplets, nullptr);
+    n_tno_ro_.assign(ntriplets, 0);
+    for (auto& fock : F_tno_spin_) fock.assign(ntriplets, nullptr);
+
+    auto F_pao_average = F_pao_a_->clone();
+    F_pao_average->add(F_pao_b_);
+    F_pao_average->scale(0.5);
+
+#pragma omp parallel for schedule(dynamic, 1)
+    for (int ijk = 0; ijk < ntriplets; ++ijk) {
+        int i, j, k;
+        std::tie(i, j, k) = ijk_to_i_j_k_ro_[ijk];
+        const auto& domain = lmotriplet_to_paos_ro_[ijk];
+        const int npao = domain.size();
+        const int nexternal_pao = npao - nsomo;
+
+        auto retain_somo_block = [&]() {
+            if (nsomo == 0 || npao < nsomo) return;
+            auto X_tno = std::make_shared<Matrix>(npao, nsomo);
+            for (int s = 0; s < nsomo; ++s) X_tno->set(npao - nsomo + s, s, 1.0);
+            X_tno_ro_[ijk] = X_tno;
+            n_tno_ro_[ijk] = nsomo;
+            const std::array<SharedMatrix, 2> F_pao_spin = {F_pao_a_, F_pao_b_};
+            for (SpinCase sigma : kSpins) {
+                const int s = static_cast<int>(sigma);
+                auto F_domain = submatrix_rows_and_cols(*F_pao_spin[s], domain, domain);
+                F_tno_spin_[s][ijk] = linalg::triplet(X_tno, F_domain, X_tno, true, false, false);
+                matrix_spin_enforcer_vv(F_tno_spin_[s][ijk], sigma);
+            }
+        };
+
+        if (nexternal_pao <= 0) {
+            retain_somo_block();
+            continue;
+        }
+
+        const std::vector<int> external_domain(domain.begin(), domain.begin() + nexternal_pao);
+        auto S_external = submatrix_rows_and_cols(*S_pao_, external_domain, external_domain);
+        auto F_external = submatrix_rows_and_cols(*F_pao_average, external_domain, external_domain);
+
+        SharedMatrix X_canonical_pao;
+        SharedVector e_canonical_pao;
+        std::tie(X_canonical_pao, e_canonical_pao) = orthocanonicalizer(S_external, F_external);
+        auto F_canonical_pao = linalg::triplet(X_canonical_pao, F_external, X_canonical_pao, true, false, false);
+        const int ncanonical = X_canonical_pao->ncol();
+        if (ncanonical == 0) {
+            retain_somo_block();
+            continue;
+        }
+
+        auto pair_density = [&](int pair) {
+            const int npno = n_pno_[pair];
+            auto density = std::make_shared<Matrix>(npno, npno);
+            density->zero();
+
+            auto add_density = [&](const SharedMatrix& amplitudes, double scale) {
+                auto left = linalg::doublet(amplitudes, amplitudes, false, true);
+                auto right = linalg::doublet(amplitudes, amplitudes, true, false);
+                left->add(right);
+                left->scale(scale);
+                density->add(left);
+            };
+
+            // The spin trace includes both mixed-spin orientations and exactly recovers the established restricted
+            // density D(T) + 1/2 D(T - T^T) when the alpha and beta amplitudes coincide.
+            add_density(T_iajb_spin_[static_cast<int>(DoubleSpinCase::AA)][pair], 0.25);
+            add_density(T_iajb_spin_[static_cast<int>(DoubleSpinCase::AB)][pair], 0.5);
+            add_density(T_iajb_spin_helper(pair, SpinCase::Beta, SpinCase::Alpha), 0.5);
+            add_density(T_iajb_spin_[static_cast<int>(DoubleSpinCase::BB)][pair], 0.25);
+            auto& pair_indices = ij_to_i_j_[pair];
+            if (pair_indices.first == pair_indices.second) density->scale(0.5);
+            return density;
+        };
+
+        auto project_pair_density = [&](int pair) {
+            auto density = pair_density(pair);
+            auto S_pair_external = submatrix_rows_and_cols(*S_pao_, lmopair_to_paos_[pair], external_domain);
+            S_pair_external = linalg::doublet(S_pair_external, X_canonical_pao);
+            auto S_pno_external = linalg::doublet(X_pno_[pair], S_pair_external, true, false);
+            return linalg::triplet(S_pno_external, density, S_pno_external, true, false, false);
+        };
+
+        const int ij = i_j_to_ij_[i][j];
+        const int jk = i_j_to_ij_[j][k];
+        const int ik = i_j_to_ij_[i][k];
+        auto triplet_density = project_pair_density(ij);
+        triplet_density->add(project_pair_density(jk));
+        triplet_density->add(project_pair_density(ik));
+        triplet_density->scale(1.0 / 3.0);
+
+        auto X_density = std::make_shared<Matrix>(ncanonical, ncanonical);
+        auto occupations = std::make_shared<Vector>(ncanonical);
+        triplet_density->diagonalize(*X_density, *occupations, descending);
+
+        const int min_external = std::max(1, min_tnos - nsomo);
+        int nexternal_tno = 0;
+        for (int a = 0; a < ncanonical; ++a) {
+            if (std::fabs(occupations->get(a)) >= tno_scale_ro_[ijk] * tno_tolerance || a < min_external)
+                ++nexternal_tno;
+        }
+        nexternal_tno = std::min(ncanonical, std::max(1, nexternal_tno));
+
+        Dimension zero(1);
+        Dimension selected_dimension(1);
+        selected_dimension.fill(nexternal_tno);
+        auto X_selected = X_density->get_block({zero, X_density->rowspi()}, {zero, selected_dimension});
+
+        SharedMatrix canonical_rotation;
+        SharedVector selected_energies;
+        std::tie(canonical_rotation, selected_energies) = canonicalizer(X_selected, F_canonical_pao);
+        X_selected = linalg::doublet(X_selected, canonical_rotation);
+        auto X_external_tno = linalg::doublet(X_canonical_pao, X_selected);
+
+        const int ntno = nexternal_tno + nsomo;
+        auto X_tno = std::make_shared<Matrix>(npao, ntno);
+        for (int u = 0; u < nexternal_pao; ++u) {
+            for (int a = 0; a < nexternal_tno; ++a) X_tno->set(u, a, X_external_tno->get(u, a));
+        }
+        // Preserve the SOMO block as explicit trailing orbitals so all existing spin masks remain exact.
+        for (int s = 0; s < nsomo; ++s) X_tno->set(nexternal_pao + s, nexternal_tno + s, 1.0);
+
+        X_tno_ro_[ijk] = X_tno;
+        n_tno_ro_[ijk] = ntno;
+        const std::array<SharedMatrix, 2> F_pao_spin = {F_pao_a_, F_pao_b_};
+        for (SpinCase sigma : kSpins) {
+            const int s = static_cast<int>(sigma);
+            auto F_domain = submatrix_rows_and_cols(*F_pao_spin[s], domain, domain);
+            F_tno_spin_[s][ijk] = linalg::triplet(X_tno, F_domain, X_tno, true, false, false);
+            matrix_spin_enforcer_vv(F_tno_spin_[s][ijk], sigma);
+        }
+    }
+
+    if (ntriplets == 0) {
+        outfile->Printf("    No RO triples survived screening.\n\n");
+        timer_off("RO TNO Transform");
+        return;
+    }
+    int total = 0;
+    int minimum = C_pao_->ncol();
+    int maximum = 0;
+    for (int ntno : n_tno_ro_) {
+        total += ntno;
+        minimum = std::min(minimum, ntno);
+        maximum = std::max(maximum, ntno);
+    }
+    outfile->Printf("    RO TNOs per shared triplet domain: avg %d, min %d, max %d\n\n", total / ntriplets, minimum,
+                    maximum);
+    timer_off("RO TNO Transform");
+}
+
+double RO_DLPNOCCSD_T::compute_ro_lccsd_t0(bool save_memory) {
+    timer_on("RO LCCSD(T0)");
+
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = naocc - nbocc;
+    const int ntriplets = ijk_to_i_j_k_ro_.size();
+
+    for (int ts = 0; ts < 4; ++ts) {
+        e_ijk_spin_[ts].assign(ntriplets, 0.0);
+        if (save_memory) {
+            W_iajbkc_spin_[ts].assign(ntriplets, nullptr);
+            V_iajbkc_spin_[ts].assign(ntriplets, nullptr);
+            T_iajbkc_spin_[ts].assign(ntriplets, nullptr);
+        }
+    }
+    e_ijk_ro_.assign(ntriplets, 0.0);
+
+    const std::array<SharedMatrix, 2> F_lmo_spin = {F_lmo_a_, F_lmo_b_};
+    const std::array<SharedMatrix, 2> F_lmo_pao_spin = {
+        linalg::triplet(C_lmo_, F_reference_a_, C_pao_, true, false, false),
+        linalg::triplet(C_lmo_, F_reference_b_, C_pao_, true, false, false)};
+
+    std::vector<std::pair<int, size_t>> ranked(ntriplets);
+#pragma omp parallel for
+    for (int ijk = 0; ijk < ntriplets; ++ijk) {
+        const size_t npao = lmotriplet_to_paos_ro_[ijk].size();
+        const size_t naux = lmotriplet_to_ribfs_ro_[ijk].size();
+        const size_t ntno = n_tno_ro_[ijk];
+        ranked[ijk] = {ijk, naux * ntno * npao * (npao + ntno)};
+    }
+    std::sort(ranked.begin(), ranked.end(), [](const auto& lhs, const auto& rhs) { return lhs.second > rhs.second; });
+
+    double total_energy = 0.0;
+    std::time_t start_time = std::time(nullptr);
+
+#pragma omp parallel for schedule(dynamic, 1) reduction(+ : total_energy)
+    for (int rank = 0; rank < ntriplets; ++rank) {
+        const int ijk = ranked[rank].first;
+        int i, j, k;
+        std::tie(i, j, k) = ijk_to_i_j_k_ro_[ijk];
+        const std::array<int, 3> occupied = {i, j, k};
+        const int ntno = n_tno_ro_[ijk];
+        if (ntno == 0) continue;
+
+        const int nlmo = lmotriplet_to_lmos_ro_[ijk].size();
+        const int npao = lmotriplet_to_paos_ro_[ijk].size();
+        const int naux = lmotriplet_to_ribfs_ro_[ijk].size();
+
+        std::array<SharedMatrix, 3> q_ov;
+        std::array<SharedMatrix, 3> q_oo;
+        for (int p = 0; p < 3; ++p) {
+            q_ov[p] = std::make_shared<Matrix>(naux, npao);
+            q_oo[p] = std::make_shared<Matrix>(naux, nlmo);
+        }
+        auto q_vv = std::make_shared<Matrix>(naux, ntno * ntno);
+
+        for (int q_local = 0; q_local < naux; ++q_local) {
+            const int q = lmotriplet_to_ribfs_ro_[ijk][q_local];
+            const int center = ribasis_->function_to_center(q);
+            for (int l_local = 0; l_local < nlmo; ++l_local) {
+                const int l = lmotriplet_to_lmos_ro_[ijk][l_local];
+                for (int p = 0; p < 3; ++p) {
+                    q_oo[p]->set(q_local, l_local,
+                                 qij_[q]->get(riatom_to_lmos_ext_dense_[center][occupied[p]],
+                                              riatom_to_lmos_ext_dense_[center][l]));
+                }
+            }
+            for (int u_local = 0; u_local < npao; ++u_local) {
+                const int u = lmotriplet_to_paos_ro_[ijk][u_local];
+                for (int p = 0; p < 3; ++p) {
+                    q_ov[p]->set(q_local, u_local,
+                                 qia_[q]->get(riatom_to_lmos_ext_dense_[center][occupied[p]],
+                                              riatom_to_paos_ext_dense_[center][u]));
+                }
+            }
+
+            auto q_vv_pao = std::make_shared<Matrix>(npao, npao);
+            for (int u_local = 0; u_local < npao; ++u_local) {
+                const int u = lmotriplet_to_paos_ro_[ijk][u_local];
+                for (int v_local = 0; v_local < npao; ++v_local) {
+                    const int v = lmotriplet_to_paos_ro_[ijk][v_local];
+                    const int uv = riatom_to_pao_pairs_dense_[center][u][v];
+                    if (uv != -1) q_vv_pao->set(u_local, v_local, qab_[q]->get(uv, 0));
+                }
+            }
+            q_vv_pao = linalg::triplet(X_tno_ro_[ijk], q_vv_pao, X_tno_ro_[ijk], true, false, false);
+            ::memcpy(q_vv->get_pointer() + q_local * ntno * ntno, q_vv_pao->get_pointer(),
+                     ntno * ntno * sizeof(double));
+        }
+
+        for (int p = 0; p < 3; ++p) q_ov[p] = linalg::doublet(q_ov[p], X_tno_ro_[ijk]);
+        std::array<SharedMatrix, 3> q_ov_metric = {q_ov[0]->clone(), q_ov[1]->clone(), q_ov[2]->clone()};
+        auto metric =
+            submatrix_rows_and_cols(*full_metric_, lmotriplet_to_ribfs_ro_[ijk], lmotriplet_to_ribfs_ro_[ijk]);
+        for (int p = 0; p < 3; ++p) C_DGESV_wrapper(metric->clone(), q_ov_metric[p]);
+        metric->power(0.5, 1.0e-14);
+        for (int p = 0; p < 3; ++p) {
+            C_DGESV_wrapper(metric->clone(), q_ov[p]);
+            C_DGESV_wrapper(metric->clone(), q_oo[p]);
+        }
+
+        // These twelve spatial integral blocks are formed once and reused by every spin case.
+        std::array<SharedMatrix, 3> K_ovvv;
+        for (int p = 0; p < 3; ++p) K_ovvv[p] = linalg::doublet(q_ov_metric[p], q_vv, true, false);
+
+        std::array<std::array<SharedMatrix, 3>, 3> K_ooov{};
+        K_ooov[0][1] = linalg::doublet(q_oo[0], q_ov[1], true, false);
+        K_ooov[1][0] = linalg::doublet(q_oo[1], q_ov[0], true, false);
+        K_ooov[2][1] = linalg::doublet(q_oo[2], q_ov[1], true, false);
+        K_ooov[1][2] = linalg::doublet(q_oo[1], q_ov[2], true, false);
+        K_ooov[0][2] = linalg::doublet(q_oo[0], q_ov[2], true, false);
+        K_ooov[2][0] = linalg::doublet(q_oo[2], q_ov[0], true, false);
+
+        std::array<std::array<SharedMatrix, 3>, 3> K_ovov{};
+        K_ovov[0][1] = linalg::doublet(q_ov[0], q_ov[1], true, false);
+        K_ovov[1][0] = K_ovov[0][1]->transpose();
+        K_ovov[0][2] = linalg::doublet(q_ov[0], q_ov[2], true, false);
+        K_ovov[2][0] = K_ovov[0][2]->transpose();
+        K_ovov[1][2] = linalg::doublet(q_ov[1], q_ov[2], true, false);
+        K_ovov[2][1] = K_ovov[1][2]->transpose();
+
+        std::unordered_map<long long, SharedMatrix> projected_pairs;
+        auto project_pair = [&](int p, int q, SpinCase spin_p, SpinCase spin_q) -> SharedMatrix {
+            const long long key = (((static_cast<long long>(p) * naocc + q) * 2 + static_cast<int>(spin_p)) * 2 +
+                                   static_cast<int>(spin_q));
+            auto found = projected_pairs.find(key);
+            if (found != projected_pairs.end()) return found->second;
+
+            auto projected = std::make_shared<Matrix>(ntno, ntno);
+            if ((spin_p == SpinCase::Beta && p >= nbocc) || (spin_q == SpinCase::Beta && q >= nbocc)) {
+                projected_pairs[key] = projected;
+                return projected;
+            }
+            const int pair = i_j_to_ij_[p][q];
+            if (pair == -1) {
+                projected_pairs[key] = projected;
+                return projected;
+            }
+            auto S_pair_triplet = submatrix_rows_and_cols(*S_pao_, lmopair_to_paos_[pair], lmotriplet_to_paos_ro_[ijk]);
+            S_pair_triplet = linalg::doublet(S_pair_triplet, X_tno_ro_[ijk]);
+            auto S_pno_triplet = linalg::doublet(X_pno_[pair], S_pair_triplet, true, false);
+            projected = linalg::triplet(S_pno_triplet, T_iajb_spin_helper(pair, spin_p, spin_q), S_pno_triplet, true,
+                                        false, false);
+            const int alpha_end = ntno - nsomo;
+            if (spin_p == SpinCase::Alpha) {
+                for (int a = alpha_end; a < ntno; ++a) projected->zero_row(0, a);
+            }
+            if (spin_q == SpinCase::Alpha) {
+                for (int b = alpha_end; b < ntno; ++b) projected->zero_column(0, b);
+            }
+            projected_pairs[key] = projected;
+            return projected;
+        };
+
+        std::unordered_map<long long, SharedMatrix> projected_singles;
+        auto project_single = [&](int p, SpinCase spin) -> SharedMatrix {
+            const long long key = static_cast<long long>(p) * 2 + static_cast<int>(spin);
+            auto found = projected_singles.find(key);
+            if (found != projected_singles.end()) return found->second;
+            auto projected = std::make_shared<Matrix>(ntno, 1);
+            if (spin == SpinCase::Beta && p >= nbocc) {
+                projected_singles[key] = projected;
+                return projected;
+            }
+            const int pp = i_j_to_ij_[p][p];
+            auto S_pair_triplet = submatrix_rows_and_cols(*S_pao_, lmopair_to_paos_[pp], lmotriplet_to_paos_ro_[ijk]);
+            S_pair_triplet = linalg::doublet(S_pair_triplet, X_tno_ro_[ijk]);
+            auto S_pno_triplet = linalg::doublet(X_pno_[pp], S_pair_triplet, true, false);
+            projected = linalg::doublet(S_pno_triplet, T_ia_spin_[static_cast<int>(spin)][p], true, false);
+            if (spin == SpinCase::Alpha) {
+                for (int a = ntno - nsomo; a < ntno; ++a) projected->set(a, 0, 0.0);
+            }
+            projected_singles[key] = projected;
+            return projected;
+        };
+
+        std::unordered_map<long long, SharedMatrix> projected_fia;
+        auto project_fia = [&](int p, SpinCase spin) -> SharedMatrix {
+            const long long key = static_cast<long long>(p) * 2 + static_cast<int>(spin);
+            auto found = projected_fia.find(key);
+            if (found != projected_fia.end()) return found->second;
+            auto projected = std::make_shared<Matrix>(ntno, 1);
+            if (spin == SpinCase::Beta && p >= nbocc) {
+                projected_fia[key] = projected;
+                return projected;
+            }
+            auto Fia_domain = submatrix_rows_and_cols(*F_lmo_pao_spin[static_cast<int>(spin)], std::vector<int>{p},
+                                                      lmotriplet_to_paos_ro_[ijk]);
+            Fia_domain = linalg::doublet(Fia_domain, X_tno_ro_[ijk]);
+            projected = Fia_domain->transpose();
+            if (spin == SpinCase::Alpha) {
+                for (int a = ntno - nsomo; a < ntno; ++a) projected->set(a, 0, 0.0);
+            }
+            projected_fia[key] = projected;
+            return projected;
+        };
+
+        auto pure_parent = [&](int p, int q, int r, SpinCase spin) {
+            auto parent = std::make_shared<Matrix>(ntno, ntno * ntno);
+            const auto T_qr = project_pair(occupied[q], occupied[r], spin, spin);
+            for (int a = 0; a < ntno; ++a) {
+                for (int b = 0; b < ntno; ++b) {
+                    for (int c = 0; c < ntno; ++c) {
+                        double value = 0.0;
+                        for (int d = 0; d < ntno; ++d) {
+                            value -= K_ovvv[p]->get(c, b * ntno + d) * T_qr->get(d, a);
+                            value -= K_ovvv[p]->get(b, c * ntno + d) * T_qr->get(a, d);
+                        }
+                        cube_set(parent, ntno, a, b, c, value);
+                    }
+                }
+            }
+            for (int l_local = 0; l_local < nlmo; ++l_local) {
+                const int l = lmotriplet_to_lmos_ro_[ijk][l_local];
+                const auto T_pl = project_pair(occupied[p], l, spin, spin);
+                for (int a = 0; a < ntno; ++a) {
+                    const double h_qr = K_ooov[q][r]->get(l_local, a);
+                    const double h_rq = K_ooov[r][q]->get(l_local, a);
+                    for (int b = 0; b < ntno; ++b) {
+                        for (int c = 0; c < ntno; ++c) {
+                            cube_add(parent, ntno, a, b, c, h_qr * T_pl->get(c, b) + h_rq * T_pl->get(b, c));
+                        }
+                    }
+                }
+            }
+            return parent;
+        };
+
+        auto form_pure_w = [&](SpinCase spin) {
+            const std::array<std::array<int, 3>, 3> occupied_permutations = {
+                std::array<int, 3>{0, 1, 2}, std::array<int, 3>{1, 0, 2}, std::array<int, 3>{2, 1, 0}};
+            const std::array<double, 3> signs = {1.0, -1.0, -1.0};
+            std::array<SharedMatrix, 3> parents;
+            for (int p = 0; p < 3; ++p) {
+                parents[p] = pure_parent(occupied_permutations[p][0], occupied_permutations[p][1],
+                                         occupied_permutations[p][2], spin);
+            }
+            auto W = std::make_shared<Matrix>(ntno, ntno * ntno);
+            for (int a = 0; a < ntno; ++a) {
+                for (int b = 0; b < ntno; ++b) {
+                    for (int c = 0; c < ntno; ++c) {
+                        double value = 0.0;
+                        for (int p = 0; p < 3; ++p) {
+                            value +=
+                                signs[p] * (cube_get(parents[p], ntno, a, b, c) - cube_get(parents[p], ntno, b, a, c) -
+                                            cube_get(parents[p], ntno, c, b, a));
+                        }
+                        cube_set(W, ntno, a, b, c, value);
+                    }
+                }
+            }
+            return W;
+        };
+
+        auto pure_v_parent = [&](int p, int q, int r, SpinCase spin) {
+            auto parent = std::make_shared<Matrix>(ntno, ntno * ntno);
+            const auto T_p = project_single(occupied[p], spin);
+            const auto F_p = project_fia(occupied[p], spin);
+            const auto T_qr = project_pair(occupied[q], occupied[r], spin, spin);
+            for (int a = 0; a < ntno; ++a) {
+                for (int b = 0; b < ntno; ++b) {
+                    for (int c = 0; c < ntno; ++c) {
+                        const double value = (K_ovov[q][r]->get(b, c) - K_ovov[q][r]->get(c, b)) * T_p->get(a, 0) +
+                                             F_p->get(a, 0) * T_qr->get(b, c);
+                        cube_set(parent, ntno, a, b, c, value);
+                    }
+                }
+            }
+            return parent;
+        };
+
+        auto form_pure_v = [&](SpinCase spin) {
+            const std::array<std::array<int, 3>, 3> occupied_permutations = {
+                std::array<int, 3>{0, 1, 2}, std::array<int, 3>{1, 0, 2}, std::array<int, 3>{2, 1, 0}};
+            const std::array<double, 3> signs = {1.0, -1.0, -1.0};
+            std::array<SharedMatrix, 3> parents;
+            for (int p = 0; p < 3; ++p) {
+                parents[p] = pure_v_parent(occupied_permutations[p][0], occupied_permutations[p][1],
+                                           occupied_permutations[p][2], spin);
+            }
+            auto V = std::make_shared<Matrix>(ntno, ntno * ntno);
+            for (int a = 0; a < ntno; ++a) {
+                for (int b = 0; b < ntno; ++b) {
+                    for (int c = 0; c < ntno; ++c) {
+                        double value = 0.0;
+                        for (int p = 0; p < 3; ++p) {
+                            value +=
+                                signs[p] * (cube_get(parents[p], ntno, a, b, c) - cube_get(parents[p], ntno, b, a, c) -
+                                            cube_get(parents[p], ntno, c, b, a));
+                        }
+                        cube_set(V, ntno, a, b, c, value);
+                    }
+                }
+            }
+            return V;
+        };
+
+        auto mixed_pij_block = [&](int p, int q, SpinCase like, SpinCase opposite) {
+            constexpr int r = 2;
+            auto block = std::make_shared<Matrix>(ntno, ntno * ntno);
+            const auto T_qr = project_pair(occupied[q], occupied[r], like, opposite);
+            const auto T_pr = project_pair(occupied[p], occupied[r], like, opposite);
+            for (int a = 0; a < ntno; ++a) {
+                for (int b = 0; b < ntno; ++b) {
+                    for (int c = 0; c < ntno; ++c) {
+                        double value = 0.0;
+                        for (int d = 0; d < ntno; ++d) {
+                            value += K_ovvv[p]->get(a, b * ntno + d) * T_qr->get(d, c);
+                            value += K_ovvv[q]->get(b, c * ntno + d) * T_pr->get(a, d);
+                            value += K_ovvv[p]->get(a, c * ntno + d) * T_qr->get(b, d);
+                            value += K_ovvv[q]->get(b, a * ntno + d) * T_pr->get(d, c);
+                        }
+                        cube_set(block, ntno, a, b, c, value);
+                    }
+                }
+            }
+            for (int l_local = 0; l_local < nlmo; ++l_local) {
+                const int l = lmotriplet_to_lmos_ro_[ijk][l_local];
+                const auto T_pl_like = project_pair(occupied[p], l, like, like);
+                const auto T_ql_mixed = project_pair(occupied[q], l, like, opposite);
+                const auto T_pl_mixed = project_pair(occupied[p], l, like, opposite);
+                for (int a = 0; a < ntno; ++a) {
+                    for (int b = 0; b < ntno; ++b) {
+                        for (int c = 0; c < ntno; ++c) {
+                            cube_add(block, ntno, a, b, c,
+                                     -K_ooov[q][r]->get(l_local, c) * T_pl_like->get(a, b) -
+                                         K_ooov[r][p]->get(l_local, a) * T_ql_mixed->get(b, c) -
+                                         K_ooov[r][q]->get(l_local, b) * T_pl_mixed->get(a, c));
+                        }
+                    }
+                }
+            }
+            return block;
+        };
+
+        auto mixed_pab_block = [&](SpinCase like, SpinCase opposite) {
+            constexpr int p = 0, q = 1, r = 2;
+            auto block = std::make_shared<Matrix>(ntno, ntno * ntno);
+            const auto T_pq = project_pair(occupied[p], occupied[q], like, like);
+            for (int a = 0; a < ntno; ++a) {
+                for (int b = 0; b < ntno; ++b) {
+                    for (int c = 0; c < ntno; ++c) {
+                        double value = 0.0;
+                        for (int d = 0; d < ntno; ++d) value += K_ovvv[r]->get(c, b * ntno + d) * T_pq->get(a, d);
+                        cube_set(block, ntno, a, b, c, value);
+                    }
+                }
+            }
+            for (int l_local = 0; l_local < nlmo; ++l_local) {
+                const int l = lmotriplet_to_lmos_ro_[ijk][l_local];
+                const auto T_lr = project_pair(l, occupied[r], like, opposite);
+                for (int a = 0; a < ntno; ++a) {
+                    for (int b = 0; b < ntno; ++b) {
+                        for (int c = 0; c < ntno; ++c) {
+                            cube_add(block, ntno, a, b, c,
+                                     -K_ooov[q][p]->get(l_local, a) * T_lr->get(b, c) -
+                                         K_ooov[p][q]->get(l_local, b) * T_lr->get(a, c));
+                        }
+                    }
+                }
+            }
+            return block;
+        };
+
+        auto form_mixed_w = [&](SpinCase like, SpinCase opposite) {
+            const auto direct = mixed_pij_block(0, 1, like, opposite);
+            const auto exchanged = mixed_pij_block(1, 0, like, opposite);
+            const auto particle = mixed_pab_block(like, opposite);
+            auto W = std::make_shared<Matrix>(ntno, ntno * ntno);
+            for (int a = 0; a < ntno; ++a) {
+                for (int b = 0; b < ntno; ++b) {
+                    for (int c = 0; c < ntno; ++c) {
+                        cube_set(W, ntno, a, b, c,
+                                 cube_get(direct, ntno, a, b, c) - cube_get(exchanged, ntno, a, b, c) +
+                                     cube_get(particle, ntno, a, b, c) - cube_get(particle, ntno, b, a, c));
+                    }
+                }
+            }
+            return W;
+        };
+
+        auto mixed_v_pij_block = [&](int p, int q, SpinCase like, SpinCase opposite) {
+            constexpr int r = 2;
+            auto block = std::make_shared<Matrix>(ntno, ntno * ntno);
+            const auto T_p = project_single(occupied[p], like);
+            const auto T_q = project_single(occupied[q], like);
+            const auto T_r = project_single(occupied[r], opposite);
+            const auto F_p = project_fia(occupied[p], like);
+            const auto F_q = project_fia(occupied[q], like);
+            const auto T_qr = project_pair(occupied[q], occupied[r], like, opposite);
+            const auto T_pr = project_pair(occupied[p], occupied[r], like, opposite);
+            for (int a = 0; a < ntno; ++a) {
+                for (int b = 0; b < ntno; ++b) {
+                    for (int c = 0; c < ntno; ++c) {
+                        const double value = K_ovov[q][r]->get(b, c) * T_p->get(a, 0) +
+                                             K_ovov[p][r]->get(a, c) * T_q->get(b, 0) +
+                                             K_ovov[p][q]->get(a, b) * T_r->get(c, 0) +
+                                             F_p->get(a, 0) * T_qr->get(b, c) + F_q->get(b, 0) * T_pr->get(a, c);
+                        cube_set(block, ntno, a, b, c, value);
+                    }
+                }
+            }
+            return block;
+        };
+
+        auto form_mixed_v = [&](SpinCase like, SpinCase opposite) {
+            constexpr int p = 0, q = 1, r = 2;
+            const auto direct = mixed_v_pij_block(p, q, like, opposite);
+            const auto exchanged = mixed_v_pij_block(q, p, like, opposite);
+            const auto F_r = project_fia(occupied[r], opposite);
+            const auto T_pq = project_pair(occupied[p], occupied[q], like, like);
+            const auto T_p = project_single(occupied[p], like);
+            auto V = std::make_shared<Matrix>(ntno, ntno * ntno);
+            for (int a = 0; a < ntno; ++a) {
+                for (int b = 0; b < ntno; ++b) {
+                    for (int c = 0; c < ntno; ++c) {
+                        cube_set(V, ntno, a, b, c,
+                                 cube_get(direct, ntno, a, b, c) - cube_get(exchanged, ntno, a, b, c) +
+                                     F_r->get(c, 0) * T_pq->get(a, b) + K_ovov[q][r]->get(b, c) * T_p->get(a, 0));
+                    }
+                }
+            }
+            return V;
+        };
+
+        for (TripleSpinCase spin : kTripleSpins) {
+            const int ts = static_cast<int>(spin);
+            if (!active_ijk_spin_[ts][ijk]) continue;
+            const auto spins = get_spin_triple(spin);
+
+            SharedMatrix W;
+            SharedMatrix V;
+            if (spin == TripleSpinCase::AAA) {
+                W = form_pure_w(SpinCase::Alpha);
+                V = form_pure_v(SpinCase::Alpha);
+            } else if (spin == TripleSpinCase::BBB) {
+                W = form_pure_w(SpinCase::Beta);
+                V = form_pure_v(SpinCase::Beta);
+            } else {
+                const SpinCase like = spins[0];
+                const SpinCase opposite = spins[2];
+                W = form_mixed_w(like, opposite);
+                V = form_mixed_v(like, opposite);
+            }
+            W->set_name(std::string("RO W ") + triple_spin_label(spin) + " " + std::to_string(ijk));
+            V->set_name(std::string("RO V ") + triple_spin_label(spin) + " " + std::to_string(ijk));
+            triples_spin_enforcer(W, spin, i, j, k);
+            triples_spin_enforcer(V, spin, i, j, k);
+
+            auto T = W->clone();
+            T->set_name(std::string("RO T ") + triple_spin_label(spin) + " " + std::to_string(ijk));
+            for (int a = 0; a < ntno; ++a) {
+                for (int b = 0; b < ntno; ++b) {
+                    for (int c = 0; c < ntno; ++c) {
+                        const std::array<int, 3> virtuals = {a, b, c};
+                        bool allowed = true;
+                        for (int axis = 0; axis < 3; ++axis) {
+                            if (spins[axis] == SpinCase::Alpha && virtuals[axis] >= ntno - nsomo) allowed = false;
+                        }
+                        if (!allowed) {
+                            cube_set(T, ntno, a, b, c, 0.0);
+                            continue;
+                        }
+                        const double denominator = F_lmo_spin[static_cast<int>(spins[0])]->get(i, i) +
+                                                   F_lmo_spin[static_cast<int>(spins[1])]->get(j, j) +
+                                                   F_lmo_spin[static_cast<int>(spins[2])]->get(k, k) -
+                                                   F_tno_spin_[static_cast<int>(spins[0])][ijk]->get(a, a) -
+                                                   F_tno_spin_[static_cast<int>(spins[1])][ijk]->get(b, b) -
+                                                   F_tno_spin_[static_cast<int>(spins[2])][ijk]->get(c, c);
+                        cube_set(T, ntno, a, b, c,
+                                 std::fabs(denominator) > 1.0e-14 ? cube_get(W, ntno, a, b, c) / denominator : 0.0);
+                    }
+                }
+            }
+            triples_spin_enforcer(T, spin, i, j, k);
+
+            const double prefactor =
+                (spin == TripleSpinCase::AAA || spin == TripleSpinCase::BBB) ? 1.0 / 6.0 : 1.0 / 2.0;
+            auto W_plus_V = W->clone();
+            W_plus_V->add(V);
+            e_ijk_spin_[ts][ijk] = prefactor * W_plus_V->vector_dot(T);
+            e_ijk_ro_[ijk] += e_ijk_spin_[ts][ijk];
+            total_energy += e_ijk_spin_[ts][ijk];
+
+            if (!save_memory) continue;
+            if (write_intermediates_ro_) {
+#pragma omp critical(ro_triples_psio)
+                {
+                    W->save(psio_, PSIF_DLPNO_TRIPLES, psi::Matrix::SubBlocks);
+                    V->save(psio_, PSIF_DLPNO_TRIPLES, psi::Matrix::SubBlocks);
+                }
+            } else {
+                W_iajbkc_spin_[ts][ijk] = W;
+                V_iajbkc_spin_[ts][ijk] = V;
+            }
+            if (write_amplitudes_ro_) {
+#pragma omp critical(ro_triples_psio)
+                T->save(psio_, PSIF_DLPNO_TRIPLES, psi::Matrix::SubBlocks);
+            } else {
+                T_iajbkc_spin_[ts][ijk] = T;
+            }
+        }
+    }
+
+    outfile->Printf("    RO semicanonical (T0) completed in %d s\n\n",
+                    static_cast<int>(std::time(nullptr) - start_time));
+    timer_off("RO LCCSD(T0)");
+    return total_energy;
+}
+
+void RO_DLPNOCCSD_T::ro_estimate_memory() {
+    size_t cube_elements = 0;
+    for (int ijk = 0; ijk < static_cast<int>(ijk_to_i_j_k_ro_.size()); ++ijk) {
+        const size_t n = n_tno_ro_[ijk];
+        const size_t elements = n * n * n;
+        for (int ts = 0; ts < 4; ++ts) {
+            if (active_ijk_spin_[ts][ijk]) cube_elements += elements;
+        }
+    }
+
+    write_intermediates_ro_ = options_.get_bool("WRITE_TRIPLES_INTERMEDIATES");
+    write_amplitudes_ro_ = options_.get_bool("WRITE_TRIPLES_AMPLITUDES");
+    size_t intermediate_memory = write_intermediates_ro_ ? 0 : 2 * cube_elements;
+    // Jacobi iterations retain an immutable current generation while constructing the next one.
+    size_t amplitude_memory = write_amplitudes_ro_ ? 0 : 2 * cube_elements;
+    size_t total_words = qij_memory_ + qia_memory_ + qab_memory_ + intermediate_memory + amplitude_memory;
+
+    if (toggle_memory_ && !write_intermediates_ro_ && total_words * sizeof(double) > 0.9 * memory_) {
+        write_intermediates_ro_ = true;
+        total_words -= intermediate_memory;
+        intermediate_memory = 0;
+    }
+    if (toggle_memory_ && !write_amplitudes_ro_ && total_words * sizeof(double) > 0.9 * memory_) {
+        write_amplitudes_ro_ = true;
+        total_words -= amplitude_memory;
+        amplitude_memory = 0;
+    }
+    if (toggle_memory_ && total_words * sizeof(double) > 0.9 * memory_)
+        throw PSIEXCEPTION("Too little memory for the RO-DLPNO-(T) intermediates");
+
+    constexpr double bytes_to_gb = 1.0e-9;
+    outfile->Printf("\n  ==> RO-DLPNO-(T) Memory Requirements <==\n\n");
+    outfile->Printf("    Spin-resolved W/V/T generations: %.3f [GB]\n",
+                    (intermediate_memory + amplitude_memory) * sizeof(double) * bytes_to_gb);
+    outfile->Printf("    Total estimated memory    : %.3f [GB]\n", total_words * sizeof(double) * bytes_to_gb);
+    outfile->Printf("    Total memory available    : %.3f [GB]\n\n", memory_ * bytes_to_gb);
+    if (write_intermediates_ro_) outfile->Printf("    Writing RO W and V intermediates to disk.\n");
+    if (write_amplitudes_ro_) outfile->Printf("    Writing RO T amplitudes to disk.\n");
+    outfile->Printf("\n");
+}
+
+double RO_DLPNOCCSD_T::compute_ro_t_iteration_energy() {
+    timer_on("RO Compute (T) Energy");
+    const int ntriplets = ijk_to_i_j_k_ro_.size();
+    for (auto& energies : e_ijk_spin_) energies.assign(ntriplets, 0.0);
+    e_ijk_ro_.assign(ntriplets, 0.0);
+
+    double total_energy = 0.0;
+#pragma omp parallel for schedule(dynamic, 1) reduction(+ : total_energy)
+    for (int ijk = 0; ijk < ntriplets; ++ijk) {
+        const int ntno = n_tno_ro_[ijk];
+        if (ntno == 0) continue;
+        for (TripleSpinCase spin : kTripleSpins) {
+            const int ts = static_cast<int>(spin);
+            if (!active_ijk_spin_[ts][ijk]) continue;
+
+            auto load_matrix = [&](const char* kind, bool from_disk,
+                                   const std::array<std::vector<SharedMatrix>, 4>& matrices) {
+                if (!from_disk) return matrices[ts][ijk];
+                auto matrix = std::make_shared<Matrix>(
+                    std::string("RO ") + kind + " " + triple_spin_label(spin) + " " + std::to_string(ijk), ntno,
+                    ntno * ntno);
+#pragma omp critical(ro_triples_psio)
+                matrix->load(psio_, PSIF_DLPNO_TRIPLES, psi::Matrix::SubBlocks);
+                return matrix;
+            };
+
+            auto W = load_matrix("W", write_intermediates_ro_, W_iajbkc_spin_);
+            auto V = load_matrix("V", write_intermediates_ro_, V_iajbkc_spin_);
+            auto T = load_matrix("T", write_amplitudes_ro_, T_iajbkc_spin_);
+            auto W_plus_V = W->clone();
+            W_plus_V->add(V);
+            const double prefactor =
+                (spin == TripleSpinCase::AAA || spin == TripleSpinCase::BBB) ? 1.0 / 6.0 : 1.0 / 2.0;
+            e_ijk_spin_[ts][ijk] = prefactor * W_plus_V->vector_dot(T);
+            e_ijk_ro_[ijk] += e_ijk_spin_[ts][ijk];
+            total_energy += e_ijk_spin_[ts][ijk];
+        }
+    }
+    timer_off("RO Compute (T) Energy");
+    return total_energy;
+}
+
+double RO_DLPNOCCSD_T::ro_lccsd_t_iterations() {
+    timer_on("RO LCCSD(T) Iterations");
+
+    const int naocc = nalpha_ - nfrzc();
+    const int nbocc = nbeta_ - nfrzc();
+    const int nsomo = naocc - nbocc;
+    const int ntriplets = ijk_to_i_j_k_ro_.size();
+    const std::array<SharedMatrix, 2> F_lmo_spin = {F_lmo_a_, F_lmo_b_};
+    const double fock_cutoff = options_.get_double("F_CUT_T");
+    const double iteration_cutoff = options_.get_double("T_CUT_ITER");
+
+    outfile->Printf("\n  ==> Iterative RO-DLPNO-(T) <==\n\n");
+    outfile->Printf("                         (T) Energy      Delta E       Max R     Time (s)\n");
+
+    std::array<std::vector<double>, 4> old_spin_energies;
+    for (auto& energies : old_spin_energies) energies.assign(ntriplets, 0.0);
+    double current_energy = 0.0;
+    for (const auto& energies : e_ijk_spin_)
+        for (double energy : energies) current_energy += energy;
+
+    const int max_iterations = options_.get_int("DLPNO_MAXITER");
+    bool energy_converged = false;
+    bool residual_converged = false;
+    int iteration = 1;
+
+    while (!(energy_converged && residual_converged)) {
+        const std::time_t iteration_start = std::time(nullptr);
+        std::array<std::vector<double>, 4> residual_rms;
+        for (auto& residuals : residual_rms) residuals.assign(ntriplets, 0.0);
+        auto next_amplitudes = T_iajbkc_spin_;
+        std::array<std::vector<char>, 4> amplitude_updated;
+        for (auto& updated : amplitude_updated) updated.assign(ntriplets, 0);
+
+#pragma omp parallel for schedule(dynamic, 1)
+        for (int ijk = 0; ijk < ntriplets; ++ijk) {
+            int i, j, k;
+            std::tie(i, j, k) = ijk_to_i_j_k_ro_[ijk];
+            const std::array<int, 3> occupied = {i, j, k};
+            const int ntno = n_tno_ro_[ijk];
+            if (ntno == 0) continue;
+
+            for (TripleSpinCase spin : kTripleSpins) {
+                const int ts = static_cast<int>(spin);
+                if (!active_ijk_spin_[ts][ijk]) continue;
+                if (iteration > 1 && std::fabs(e_ijk_spin_[ts][ijk] - old_spin_energies[ts][ijk]) <
+                                         std::fabs(old_spin_energies[ts][ijk] * iteration_cutoff))
+                    continue;
+
+                auto load_matrix = [&](const char* kind, bool from_disk,
+                                       const std::array<std::vector<SharedMatrix>, 4>& matrices, int index) {
+                    if (!from_disk) return matrices[ts][index];
+                    const int n = n_tno_ro_[index];
+                    auto matrix = std::make_shared<Matrix>(
+                        std::string("RO ") + kind + " " + triple_spin_label(spin) + " " + std::to_string(index), n,
+                        n * n);
+#pragma omp critical(ro_triples_psio)
+                    matrix->load(psio_, PSIF_DLPNO_TRIPLES, psi::Matrix::SubBlocks);
+                    return matrix;
+                };
+
+                auto W = load_matrix("W", write_intermediates_ro_, W_iajbkc_spin_, ijk);
+                auto T = load_matrix("T", write_amplitudes_ro_, T_iajbkc_spin_, ijk)->clone();
+                auto residual = W->clone();
+                residual->set_name("RO triples residual");
+                const auto spins = get_spin_triple(spin);
+
+                // Full virtual Fock action in the common RO TNO basis.  Its diagonal gives the T0 denominator;
+                // retaining the off-diagonal part makes the iterative result invariant to the common spatial basis.
+                const auto F_a = F_tno_spin_[static_cast<int>(spins[0])][ijk];
+                const auto F_b = F_tno_spin_[static_cast<int>(spins[1])][ijk];
+                const auto F_c = F_tno_spin_[static_cast<int>(spins[2])][ijk];
+                const double occupied_diagonal = F_lmo_spin[static_cast<int>(spins[0])]->get(i, i) +
+                                                 F_lmo_spin[static_cast<int>(spins[1])]->get(j, j) +
+                                                 F_lmo_spin[static_cast<int>(spins[2])]->get(k, k);
+                for (int a = 0; a < ntno; ++a) {
+                    for (int b = 0; b < ntno; ++b) {
+                        for (int c = 0; c < ntno; ++c) {
+                            double value = -occupied_diagonal * cube_get(T, ntno, a, b, c);
+                            for (int d = 0; d < ntno; ++d) {
+                                value += F_a->get(a, d) * cube_get(T, ntno, d, b, c);
+                                value += F_b->get(b, d) * cube_get(T, ntno, a, d, c);
+                                value += F_c->get(c, d) * cube_get(T, ntno, a, b, d);
+                            }
+                            cube_add(residual, ntno, a, b, c, value);
+                        }
+                    }
+                }
+
+                // Off-diagonal occupied Fock couplings preserve the spin carried by the replaced slot.
+                for (int axis = 0; axis < 3; ++axis) {
+                    const int s = static_cast<int>(spins[axis]);
+                    const int noccupied = spins[axis] == SpinCase::Alpha ? naocc : nbocc;
+                    for (int l = 0; l < noccupied; ++l) {
+                        if (l == occupied[axis]) continue;
+                        const double coupling = F_lmo_spin[s]->get(l, occupied[axis]);
+                        if (std::fabs(coupling) < fock_cutoff) continue;
+
+                        auto requested = occupied;
+                        requested[axis] = l;
+                        const int key = triple_key(requested[0], requested[1], requested[2], naocc);
+                        const auto neighbor_position = i_j_k_to_ijk_spin_[ts].find(key);
+                        if (neighbor_position == i_j_k_to_ijk_spin_[ts].end()) continue;
+                        const int neighbor = neighbor_position->second;
+                        if (n_tno_ro_[neighbor] == 0) continue;
+
+                        auto neighbor_T = load_matrix("T", write_amplitudes_ro_, T_iajbkc_spin_, neighbor);
+                        neighbor_T = ro_triples_permuter(neighbor_T, spin, requested[0], requested[1], requested[2]);
+
+                        auto overlap = submatrix_rows_and_cols(*S_pao_, lmotriplet_to_paos_ro_[ijk],
+                                                               lmotriplet_to_paos_ro_[neighbor]);
+                        overlap = linalg::triplet(X_tno_ro_[ijk], overlap, X_tno_ro_[neighbor], true, false, false);
+                        auto projected_neighbor =
+                            ro_matmul_3d(neighbor_T, overlap, n_tno_ro_[neighbor], n_tno_ro_[ijk]);
+                        C_DAXPY(ntno * ntno * ntno, -coupling, projected_neighbor->get_pointer(), 1,
+                                residual->get_pointer(), 1);
+                    }
+                }
+
+                triples_spin_enforcer(residual, spin, i, j, k);
+                double residual_squared = 0.0;
+                size_t allowed_elements = 0;
+                for (int a = 0; a < ntno; ++a) {
+                    for (int b = 0; b < ntno; ++b) {
+                        for (int c = 0; c < ntno; ++c) {
+                            const std::array<int, 3> virtuals = {a, b, c};
+                            bool allowed = true;
+                            for (int axis = 0; axis < 3; ++axis) {
+                                if (spins[axis] == SpinCase::Alpha && virtuals[axis] >= ntno - nsomo) allowed = false;
+                            }
+                            if (!allowed) continue;
+                            const double residual_element = cube_get(residual, ntno, a, b, c);
+                            residual_squared += residual_element * residual_element;
+                            ++allowed_elements;
+                            const double denominator =
+                                F_a->get(a, a) + F_b->get(b, b) + F_c->get(c, c) - occupied_diagonal;
+                            if (std::fabs(denominator) > 1.0e-14)
+                                cube_add(T, ntno, a, b, c, -residual_element / denominator);
+                        }
+                    }
+                }
+                triples_spin_enforcer(T, spin, i, j, k);
+                residual_rms[ts][ijk] = allowed_elements == 0 ? 0.0 : std::sqrt(residual_squared / allowed_elements);
+                amplitude_updated[ts][ijk] = 1;
+
+                if (write_amplitudes_ro_) {
+                    T->set_name(std::string("RO T next ") + triple_spin_label(spin) + " " + std::to_string(ijk));
+#pragma omp critical(ro_triples_psio)
+                    T->save(psio_, PSIF_DLPNO_TRIPLES, psi::Matrix::SubBlocks);
+                } else {
+                    next_amplitudes[ts][ijk] = T;
+                }
+            }
+        }
+
+        // Jacobi semantics require every residual to read the same amplitude generation.  Promote the completed
+        // generation only after all triplets have finished reading their neighbors.
+        if (write_amplitudes_ro_) {
+            for (TripleSpinCase spin : kTripleSpins) {
+                const int ts = static_cast<int>(spin);
+                for (int ijk = 0; ijk < ntriplets; ++ijk) {
+                    if (!amplitude_updated[ts][ijk]) continue;
+                    const int ntno = n_tno_ro_[ijk];
+                    auto T = std::make_shared<Matrix>(
+                        std::string("RO T next ") + triple_spin_label(spin) + " " + std::to_string(ijk), ntno,
+                        ntno * ntno);
+                    T->load(psio_, PSIF_DLPNO_TRIPLES, psi::Matrix::SubBlocks);
+                    T->set_name(std::string("RO T ") + triple_spin_label(spin) + " " + std::to_string(ijk));
+                    T->save(psio_, PSIF_DLPNO_TRIPLES, psi::Matrix::SubBlocks);
+                }
+            }
+        } else {
+            T_iajbkc_spin_ = std::move(next_amplitudes);
+        }
+
+        const double previous_energy = current_energy;
+        old_spin_energies = e_ijk_spin_;
+        current_energy = compute_ro_t_iteration_energy();
+
+        double max_residual = 0.0;
+        for (const auto& residuals : residual_rms)
+            for (double value : residuals) max_residual = std::max(max_residual, value);
+
+        energy_converged = std::fabs(current_energy - previous_energy) < options_.get_double("E_CONVERGENCE");
+        residual_converged = max_residual < options_.get_double("R_CONVERGENCE");
+        outfile->Printf("  @RO-LCCSD(T) iter %3d: %16.12f %10.3e %10.3e %8d\n", iteration, current_energy,
+                        current_energy - previous_energy, max_residual,
+                        static_cast<int>(std::time(nullptr) - iteration_start));
+
+        if (++iteration > max_iterations + 1) throw PSIEXCEPTION("Maximum RO-DLPNO-(T) iterations exceeded");
+    }
+
+    timer_off("RO LCCSD(T) Iterations");
+    return current_energy;
+}
+
+double RO_DLPNOCCSD_T::compute_energy() {
+    timer_on("RO-DLPNO-CCSD(T)");
+
+    // The RO-specific CCSD path prepares common orbitals, augments every virtual domain by the SOMOs, and leaves the
+    // converged spin-resolved T1/T2 amplitudes available to the triples correction.
+    RO_DLPNOCCSD::compute_dlpno_ccsd_energy();
+
+    // Release the CCSD-only integral, overlap, and dressed-intermediate caches before allocating triples cubes.
+    K_mibj_.clear();
+    J_ijmb_.clear();
+    L_mibj_.clear();
+    L_iajb_.clear();
+    J_ikac_non_proj_.clear();
+    K_iakc_non_proj_.clear();
+    K_ivvv_.clear();
+    Qma_ij_.clear();
+    Qab_ij_.clear();
+    i_Qk_ij_.clear();
+    i_Qa_ij_.clear();
+    i_Qk_t1_.clear();
+    i_Qa_t1_.clear();
+    S_pno_ij_kj_.clear();
+    S_pno_ij_nn_.clear();
+    S_pno_ij_mn_.clear();
+    Fkc_.clear();
+    Fai_.clear();
+    Fab_.clear();
+    T_n_ij_.clear();
+    for (auto& block : T_n_ij_spin_) block.clear();
+    for (auto& block : i_Qk_t1_spin_) block.clear();
+    for (auto& block : i_Qa_t1_spin_) block.clear();
+    for (auto& block : F_pno_spin_) block.clear();
+    for (auto& block : Fkc_tilde_spin_) block.clear();
+    for (auto& block : Fai_tilde_spin_) block.clear();
+    for (auto& block : Fab_tilde_spin_) block.clear();
+    for (auto& block : Fki_tilde_spin_) block.reset();
+    K_iajb_.clear();
+    T_iajb_.clear();
+    Tt_iajb_.clear();
+    T_ia_.clear();
+    for (auto& block : T_iajb_srolmp2_spin_) block.clear();
+    Fkj_.reset();
+
+    psio_->open(PSIF_DLPNO_TRIPLES, PSIO_OPEN_NEW);
+    ro_print_header();
+
+    const double tno_pre = options_.get_double("T_CUT_TNO_PRE");
+    const double tno_cutoff = options_.get_double("T_CUT_TNO");
+
+    outfile->Printf("\n   Starting spin-resolved RO triplet prescreening...\n");
+    ro_triples_sparsity(true);
+    ro_tno_transform(tno_pre);
+    compute_ro_lccsd_t0();
+
+    outfile->Printf("\n   Continuing with RO triplets above %6.3e Eh...\n", options_.get_double("T_CUT_TRIPLES_WEAK"));
+    ro_triples_sparsity(false);
+    outfile->Printf("    Screened RO triplet contribution: %.12f\n\n", de_lccsd_t_screened_ro_);
+    ro_tno_transform(tno_cutoff);
+    const double accurate_t0 = compute_ro_lccsd_t0();
+
+    auto sum_current_spin_energies = [&]() {
+        std::array<double, 4> sums{};
+        for (int ts = 0; ts < 4; ++ts) {
+            sums[ts] = de_lccsd_t_screened_spin_ro_[ts];
+            for (double energy : e_ijk_spin_[ts]) sums[ts] += energy;
+        }
+        return sums;
+    };
+    std::array<double, 4> final_spin_energy = sum_current_spin_energies();
+    e_lccsd_t_ro_ = e_lccsd_ + accurate_t0 + de_lccsd_t_screened_ro_;
+
+    outfile->Printf("    RO-DLPNO-CCSD(T0) correlation energy: %16.12f\n", e_lccsd_t_ro_);
+    outfile->Printf("      DLPNO-CCSD contribution:            %16.12f\n", e_lccsd_);
+    outfile->Printf("      RO-DLPNO-(T0) contribution:         %16.12f\n", accurate_t0);
+    outfile->Printf("      Screened triplet contribution:      %16.12f\n\n", de_lccsd_t_screened_ro_);
+
+    if (!options_.get_bool("T0_APPROXIMATION")) {
+        outfile->Printf("\n  ==> Computing Full Iterative RO-DLPNO-(T) <==\n\n");
+        ro_sort_triplets(accurate_t0);
+        ro_tno_transform(tno_cutoff);
+        ro_estimate_memory();
+
+        const double loose_t0 = compute_ro_lccsd_t0(true);
+        std::array<double, 4> loose_t0_spin{};
+        for (int ts = 0; ts < 4; ++ts)
+            for (double energy : e_ijk_spin_[ts]) loose_t0_spin[ts] += energy;
+
+        E_T_ro_ = ro_lccsd_t_iterations();
+        std::array<double, 4> iterative_spin{};
+        for (int ts = 0; ts < 4; ++ts)
+            for (double energy : e_ijk_spin_[ts]) iterative_spin[ts] += energy;
+
+        const double iterative_increment = E_T_ro_ - loose_t0;
+        e_lccsd_t_ro_ += iterative_increment;
+        for (int ts = 0; ts < 4; ++ts) final_spin_energy[ts] += iterative_spin[ts] - loose_t0_spin[ts];
+
+        outfile->Printf("    RO-DLPNO-(T0), iterative TNO space: %16.12f\n", loose_t0);
+        outfile->Printf("    RO-DLPNO-(T),  iterative TNO space: %16.12f\n", E_T_ro_);
+        outfile->Printf("    Net iterative triples increment:    %16.12f\n\n", iterative_increment);
+    }
+
+    const double triples_energy = e_lccsd_t_ro_ - e_lccsd_;
+    const double correlation_energy = e_lccsd_t_ro_ + de_weak_ + de_lmp2_eliminated_ + de_dipole_ + de_pno_total_;
+    const double total_energy = reference_energy_ + correlation_energy;
+
+    set_scalar_variable("CURRENT REFERENCE ENERGY", reference_energy_);
+    set_scalar_variable("CCSD(T) CORRELATION ENERGY", correlation_energy);
+    set_scalar_variable("CURRENT CORRELATION ENERGY", correlation_energy);
+    set_scalar_variable("CCSD(T) TOTAL ENERGY", total_energy);
+    set_scalar_variable("CURRENT ENERGY", total_energy);
+    set_scalar_variable("(T) CORRECTION ENERGY", triples_energy);
+    set_scalar_variable("AAA (T) CORRECTION ENERGY", final_spin_energy[0]);
+    set_scalar_variable("AAB (T) CORRECTION ENERGY", final_spin_energy[1]);
+    set_scalar_variable("ABB (T) CORRECTION ENERGY", final_spin_energy[2]);
+    set_scalar_variable("BBB (T) CORRECTION ENERGY", final_spin_energy[3]);
+    set_scalar_variable("DLPNO SEMICANONICAL (T0) ENERGY", accurate_t0 + de_lccsd_t_screened_ro_);
+    set_scalar_variable("DLPNO SCREENED TRIPLETS ENERGY", de_lccsd_t_screened_ro_);
+
+    ro_print_results();
+    psio_->close(PSIF_DLPNO_TRIPLES, 0);
+    timer_off("RO-DLPNO-CCSD(T)");
+    return total_energy;
+}
+
+void RO_DLPNOCCSD_T::ro_print_results() {
+    const double triples = e_lccsd_t_ro_ - e_lccsd_;
+    const double ccsd_correlation = e_lccsd_ + de_weak_ + de_lmp2_eliminated_ + de_pno_total_ + de_dipole_;
+    const double total_correlation = ccsd_correlation + triples;
+    outfile->Printf("\n  Total RO-DLPNO-CCSD(T) Correlation Energy: %16.12f\n", total_correlation);
+    outfile->Printf("    RO-DLPNO-CCSD contribution:              %16.12f\n", ccsd_correlation);
+    outfile->Printf("    RO-DLPNO-(T) contribution:               %16.12f\n", triples);
+    outfile->Printf("      AAA: %16.12f\n", scalar_variable("AAA (T) CORRECTION ENERGY"));
+    outfile->Printf("      AAB: %16.12f\n", scalar_variable("AAB (T) CORRECTION ENERGY"));
+    outfile->Printf("      ABB: %16.12f\n", scalar_variable("ABB (T) CORRECTION ENERGY"));
+    outfile->Printf("      BBB: %16.12f\n", scalar_variable("BBB (T) CORRECTION ENERGY"));
+    outfile->Printf("    Screened triplet contribution:           %16.12f\n", de_lccsd_t_screened_ro_);
+    outfile->Printf("\n  @Total RO-DLPNO-CCSD(T) Energy: %16.12f\n\n", reference_energy_ + total_correlation);
+}
+
+}  // namespace dlpno
+}  // namespace psi

--- a/psi4/src/psi4/dlpno/ro_triples.cc
+++ b/psi4/src/psi4/dlpno/ro_triples.cc
@@ -621,6 +621,9 @@ double RO_DLPNOCCSD_T::compute_ro_lccsd_t0(bool save_memory) {
         }
         auto q_vv = std::make_shared<Matrix>(naux, ntno * ntno);
 
+        // Reuse the PAO work buffer for every auxiliary function.  The old
+        // path allocated a new npao-by-npao matrix for every q_local.
+        auto q_vv_pao = std::make_shared<Matrix>(npao, npao);
         for (int q_local = 0; q_local < naux; ++q_local) {
             const int q = lmotriplet_to_ribfs_ro_[ijk][q_local];
             const int center = ribasis_->function_to_center(q);
@@ -641,7 +644,7 @@ double RO_DLPNOCCSD_T::compute_ro_lccsd_t0(bool save_memory) {
                 }
             }
 
-            auto q_vv_pao = std::make_shared<Matrix>(npao, npao);
+            q_vv_pao->zero();
             for (int u_local = 0; u_local < npao; ++u_local) {
                 const int u = lmotriplet_to_paos_ro_[ijk][u_local];
                 for (int v_local = 0; v_local < npao; ++v_local) {
@@ -650,20 +653,62 @@ double RO_DLPNOCCSD_T::compute_ro_lccsd_t0(bool save_memory) {
                     if (uv != -1) q_vv_pao->set(u_local, v_local, qab_[q]->get(uv, 0));
                 }
             }
-            q_vv_pao = linalg::triplet(X_tno_ro_[ijk], q_vv_pao, X_tno_ro_[ijk], true, false, false);
-            ::memcpy(q_vv->get_pointer() + q_local * ntno * ntno, q_vv_pao->get_pointer(),
+            auto q_vv_tno =
+                linalg::triplet(X_tno_ro_[ijk], q_vv_pao, X_tno_ro_[ijk], true, false, false);
+            ::memcpy(q_vv->get_pointer() + q_local * ntno * ntno, q_vv_tno->get_pointer(),
                      ntno * ntno * sizeof(double));
         }
 
         for (int p = 0; p < 3; ++p) q_ov[p] = linalg::doublet(q_ov[p], X_tno_ro_[ijk]);
-        std::array<SharedMatrix, 3> q_ov_metric = {q_ov[0]->clone(), q_ov[1]->clone(), q_ov[2]->clone()};
         auto metric =
             submatrix_rows_and_cols(*full_metric_, lmotriplet_to_ribfs_ro_[ijk], lmotriplet_to_ribfs_ro_[ijk]);
-        for (int p = 0; p < 3; ++p) C_DGESV_wrapper(metric->clone(), q_ov_metric[p]);
+
+        // Factor the Coulomb metric once for all three occupied rows instead
+        // of repeating the same DGESV factorization for each right-hand side.
+        auto q_ov_metric_rhs = std::make_shared<Matrix>(naux, 3 * ntno);
+        for (int q_local = 0; q_local < naux; ++q_local) {
+            for (int p = 0; p < 3; ++p) {
+                ::memcpy(q_ov_metric_rhs->get_pointer() + q_local * 3 * ntno + p * ntno,
+                         q_ov[p]->get_pointer() + q_local * ntno, ntno * sizeof(double));
+            }
+        }
+        C_DGESV_wrapper(metric->clone(), q_ov_metric_rhs);
+        std::array<SharedMatrix, 3> q_ov_metric;
+        for (int p = 0; p < 3; ++p) q_ov_metric[p] = std::make_shared<Matrix>(naux, ntno);
+        for (int q_local = 0; q_local < naux; ++q_local) {
+            for (int p = 0; p < 3; ++p) {
+                ::memcpy(q_ov_metric[p]->get_pointer() + q_local * ntno,
+                         q_ov_metric_rhs->get_pointer() + q_local * 3 * ntno + p * ntno,
+                         ntno * sizeof(double));
+            }
+        }
+
         metric->power(0.5, 1.0e-14);
-        for (int p = 0; p < 3; ++p) {
-            C_DGESV_wrapper(metric->clone(), q_ov[p]);
-            C_DGESV_wrapper(metric->clone(), q_oo[p]);
+
+        // The inverse-square-root metric transform has six right-hand-side
+        // blocks.  Solve them together so DGESV performs one factorization.
+        const int metric_rhs_stride = ntno + nlmo;
+        auto metric_rhs = std::make_shared<Matrix>(naux, 3 * metric_rhs_stride);
+        for (int q_local = 0; q_local < naux; ++q_local) {
+            for (int p = 0; p < 3; ++p) {
+                const int offset = p * metric_rhs_stride;
+                ::memcpy(metric_rhs->get_pointer() + q_local * 3 * metric_rhs_stride + offset,
+                         q_ov[p]->get_pointer() + q_local * ntno, ntno * sizeof(double));
+                ::memcpy(metric_rhs->get_pointer() + q_local * 3 * metric_rhs_stride + offset + ntno,
+                         q_oo[p]->get_pointer() + q_local * nlmo, nlmo * sizeof(double));
+            }
+        }
+        C_DGESV_wrapper(metric->clone(), metric_rhs);
+        for (int q_local = 0; q_local < naux; ++q_local) {
+            for (int p = 0; p < 3; ++p) {
+                const int offset = p * metric_rhs_stride;
+                ::memcpy(q_ov[p]->get_pointer() + q_local * ntno,
+                         metric_rhs->get_pointer() + q_local * 3 * metric_rhs_stride + offset,
+                         ntno * sizeof(double));
+                ::memcpy(q_oo[p]->get_pointer() + q_local * nlmo,
+                         metric_rhs->get_pointer() + q_local * 3 * metric_rhs_stride + offset + ntno,
+                         nlmo * sizeof(double));
+            }
         }
 
         // These twelve spatial integral blocks are formed once and reused by every spin case.
@@ -1069,50 +1114,112 @@ double RO_DLPNOCCSD_T::compute_ro_lccsd_t0(bool save_memory) {
         }
     }
 
-    outfile->Printf("    RO semicanonical (T0) completed in %d s\n\n",
-                    static_cast<int>(std::time(nullptr) - start_time));
+    if (save_memory) {
+        outfile->Printf("    RO iterative triples initialization completed in %d s\n\n",
+                        static_cast<int>(std::time(nullptr) - start_time));
+    } else {
+        outfile->Printf("    RO semicanonical (T0) completed in %d s\n\n",
+                        static_cast<int>(std::time(nullptr) - start_time));
+    }
     timer_off("RO LCCSD(T0)");
     return total_energy;
 }
 
 void RO_DLPNOCCSD_T::ro_estimate_memory() {
     size_t cube_elements = 0;
+    size_t max_cube_elements = 0;
+    size_t active_spin_blocks = 0;
     for (int ijk = 0; ijk < static_cast<int>(ijk_to_i_j_k_ro_.size()); ++ijk) {
         const size_t n = n_tno_ro_[ijk];
         const size_t elements = n * n * n;
         for (int ts = 0; ts < 4; ++ts) {
-            if (active_ijk_spin_[ts][ijk]) cube_elements += elements;
+            if (active_ijk_spin_[ts][ijk]) {
+                cube_elements += elements;
+                max_cube_elements = std::max(max_cube_elements, elements);
+                ++active_spin_blocks;
+            }
         }
     }
 
     write_intermediates_ro_ = options_.get_bool("WRITE_TRIPLES_INTERMEDIATES");
     write_amplitudes_ro_ = options_.get_bool("WRITE_TRIPLES_AMPLITUDES");
-    size_t intermediate_memory = write_intermediates_ro_ ? 0 : 2 * cube_elements;
-    // Jacobi iterations retain an immutable current generation while constructing the next one.
-    size_t amplitude_memory = write_amplitudes_ro_ ? 0 : 2 * cube_elements;
-    size_t total_words = qij_memory_ + qia_memory_ + qab_memory_ + intermediate_memory + amplitude_memory;
+    // An explicit request to write amplitudes places both Jacobi generations
+    // on disk.  Automatic memory control may instead select the hybrid mode
+    // with current T resident and only next T on disk.
+    write_next_amplitudes_ro_ = write_amplitudes_ro_;
 
-    if (toggle_memory_ && !write_intermediates_ro_ && total_words * sizeof(double) > 0.9 * memory_) {
+    const size_t integral_memory = qij_memory_ + qia_memory_ + qab_memory_;
+    const size_t w_memory = cube_elements;
+    const size_t v_memory = cube_elements;
+    const size_t current_t_memory = cube_elements;
+    const size_t next_t_memory = cube_elements;
+
+    size_t nthreads = 1;
+#ifdef _OPENMP
+    nthreads = static_cast<size_t>(omp_get_max_threads());
+#endif
+    // Per worker, allow room for W, a cloned T, the residual, neighbor
+    // permutation/projection buffers, and the transient promoted T block.
+    // This is deliberately conservative; persistent generations are counted
+    // separately below.
+    constexpr size_t workspace_cubes_per_thread = 8;
+    const size_t workspace_memory = nthreads * workspace_cubes_per_thread * max_cube_elements;
+
+    const size_t all_in_core_memory =
+        integral_memory + w_memory + v_memory + current_t_memory + next_t_memory + workspace_memory;
+    size_t resident_memory = integral_memory + workspace_memory;
+    if (!write_intermediates_ro_) resident_memory += w_memory + v_memory;
+    if (!write_amplitudes_ro_) resident_memory += current_t_memory;
+    if (!write_next_amplitudes_ro_) resident_memory += next_t_memory;
+
+    const auto exceeds_memory = [&]() {
+        return static_cast<double>(resident_memory) * sizeof(double) > 0.9 * static_cast<double>(memory_);
+    };
+
+    // Immutable W/V are consumed once per block and are therefore the
+    // highest-throughput tensors to spill.  Preserve current T in memory as
+    // long as possible because every residual can request several neighbor
+    // amplitudes.
+    if (toggle_memory_ && !write_intermediates_ro_ && exceeds_memory()) {
         write_intermediates_ro_ = true;
-        total_words -= intermediate_memory;
-        intermediate_memory = 0;
+        resident_memory -= w_memory + v_memory;
     }
-    if (toggle_memory_ && !write_amplitudes_ro_ && total_words * sizeof(double) > 0.9 * memory_) {
+    if (toggle_memory_ && !write_next_amplitudes_ro_ && exceeds_memory()) {
+        write_next_amplitudes_ro_ = true;
+        resident_memory -= next_t_memory;
+    }
+    if (toggle_memory_ && !write_amplitudes_ro_ && exceeds_memory()) {
         write_amplitudes_ro_ = true;
-        total_words -= amplitude_memory;
-        amplitude_memory = 0;
+        write_next_amplitudes_ro_ = true;
+        resident_memory -= current_t_memory;
     }
-    if (toggle_memory_ && total_words * sizeof(double) > 0.9 * memory_)
+    if (toggle_memory_ && exceeds_memory())
         throw PSIEXCEPTION("Too little memory for the RO-DLPNO-(T) intermediates");
 
     constexpr double bytes_to_gb = 1.0e-9;
+    const auto words_to_gb = [&](size_t words) { return words * sizeof(double) * bytes_to_gb; };
     outfile->Printf("\n  ==> RO-DLPNO-(T) Memory Requirements <==\n\n");
-    outfile->Printf("    Spin-resolved W/V/T generations: %.3f [GB]\n",
-                    (intermediate_memory + amplitude_memory) * sizeof(double) * bytes_to_gb);
-    outfile->Printf("    Total estimated memory    : %.3f [GB]\n", total_words * sizeof(double) * bytes_to_gb);
-    outfile->Printf("    Total memory available    : %.3f [GB]\n\n", memory_ * bytes_to_gb);
+    outfile->Printf("    Active spin-resolved T cubes : %zu\n", active_spin_blocks);
+    outfile->Printf("    Integral storage              : %8.3f [GB]\n", words_to_gb(integral_memory));
+    outfile->Printf("    W generation                  : %8.3f [GB]\n", words_to_gb(w_memory));
+    outfile->Printf("    V generation                  : %8.3f [GB]\n", words_to_gb(v_memory));
+    outfile->Printf("    Current T generation          : %8.3f [GB]\n", words_to_gb(current_t_memory));
+    outfile->Printf("    Next T generation             : %8.3f [GB]\n", words_to_gb(next_t_memory));
+    outfile->Printf("    Thread workspace allowance    : %8.3f [GB] (%zu threads)\n",
+                    words_to_gb(workspace_memory), nthreads);
+    outfile->Printf("    All-in-core requirement       : %8.3f [GB]\n", words_to_gb(all_in_core_memory));
+    outfile->Printf("    Selected resident memory      : %8.3f [GB]\n", words_to_gb(resident_memory));
+    outfile->Printf("    Automatic memory limit (90%%)  : %8.3f [GB]\n", 0.9 * memory_ * bytes_to_gb);
+    outfile->Printf("    Total memory available        : %8.3f [GB]\n\n", memory_ * bytes_to_gb);
     if (write_intermediates_ro_) outfile->Printf("    Writing RO W and V intermediates to disk.\n");
-    if (write_amplitudes_ro_) outfile->Printf("    Writing RO T amplitudes to disk.\n");
+    if (write_amplitudes_ro_) {
+        outfile->Printf("    Writing current and next RO T generations to disk.\n");
+    } else if (write_next_amplitudes_ro_) {
+        outfile->Printf("    Keeping current RO T amplitudes in memory.\n");
+        outfile->Printf("    Writing only the next RO T Jacobi generation to disk.\n");
+    } else {
+        outfile->Printf("    Keeping both RO T Jacobi generations in memory.\n");
+    }
     outfile->Printf("\n");
 }
 
@@ -1187,7 +1294,8 @@ double RO_DLPNOCCSD_T::ro_lccsd_t_iterations() {
         const std::time_t iteration_start = std::time(nullptr);
         std::array<std::vector<double>, 4> residual_rms;
         for (auto& residuals : residual_rms) residuals.assign(ntriplets, 0.0);
-        auto next_amplitudes = T_iajbkc_spin_;
+        std::array<std::vector<SharedMatrix>, 4> next_amplitudes;
+        if (!write_next_amplitudes_ro_) next_amplitudes = T_iajbkc_spin_;
         std::array<std::vector<char>, 4> amplitude_updated;
         for (auto& updated : amplitude_updated) updated.assign(ntriplets, 0);
 
@@ -1302,7 +1410,7 @@ double RO_DLPNOCCSD_T::ro_lccsd_t_iterations() {
                 residual_rms[ts][ijk] = allowed_elements == 0 ? 0.0 : std::sqrt(residual_squared / allowed_elements);
                 amplitude_updated[ts][ijk] = 1;
 
-                if (write_amplitudes_ro_) {
+                if (write_next_amplitudes_ro_) {
                     T->set_name(std::string("RO T next ") + triple_spin_label(spin) + " " + std::to_string(ijk));
 #pragma omp critical(ro_triples_psio)
                     T->save(psio_, PSIF_DLPNO_TRIPLES, psi::Matrix::SubBlocks);
@@ -1314,7 +1422,7 @@ double RO_DLPNOCCSD_T::ro_lccsd_t_iterations() {
 
         // Jacobi semantics require every residual to read the same amplitude generation.  Promote the completed
         // generation only after all triplets have finished reading their neighbors.
-        if (write_amplitudes_ro_) {
+        if (write_next_amplitudes_ro_) {
             for (TripleSpinCase spin : kTripleSpins) {
                 const int ts = static_cast<int>(spin);
                 for (int ijk = 0; ijk < ntriplets; ++ijk) {
@@ -1325,7 +1433,15 @@ double RO_DLPNOCCSD_T::ro_lccsd_t_iterations() {
                         ntno * ntno);
                     T->load(psio_, PSIF_DLPNO_TRIPLES, psi::Matrix::SubBlocks);
                     T->set_name(std::string("RO T ") + triple_spin_label(spin) + " " + std::to_string(ijk));
-                    T->save(psio_, PSIF_DLPNO_TRIPLES, psi::Matrix::SubBlocks);
+                    if (write_amplitudes_ro_) {
+                        T->save(psio_, PSIF_DLPNO_TRIPLES, psi::Matrix::SubBlocks);
+                    } else {
+                        // All residuals have completed, so replacing one
+                        // current block at a time preserves Jacobi semantics
+                        // without ever materializing a second in-core
+                        // generation.
+                        T_iajbkc_spin_[ts][ijk] = T;
+                    }
                 }
             }
         } else {

--- a/psi4/src/psi4/dlpno/wrapper.cc
+++ b/psi4/src/psi4/dlpno/wrapper.cc
@@ -47,8 +47,14 @@ SharedWavefunction dlpno(SharedWavefunction ref_wfn, Options& options) {
         } else {
             throw PSIEXCEPTION("Requested DLPNO method is not yet available!");
         }
+    } else if (options.get_str("REFERENCE") == "ROHF") {
+        if (options.get_str("DLPNO_ALGORITHM") == "CCSD") {
+            dlpno = std::make_shared<RO_DLPNOCCSD>(ref_wfn, options);
+        } else {
+            throw PSIEXCEPTION("Requested DLPNO method is not yet available for ROHF reference!");
+        }
     } else {
-        throw PSIEXCEPTION("DLPNO requires closed-shell reference"); 
+        throw PSIEXCEPTION("DLPNO methods currently only support restricted orbitals! TODO: Implement QROs\n");
     }
 
     return dlpno;

--- a/psi4/src/psi4/dlpno/wrapper.cc
+++ b/psi4/src/psi4/dlpno/wrapper.cc
@@ -50,6 +50,8 @@ SharedWavefunction dlpno(SharedWavefunction ref_wfn, Options& options) {
     } else if (options.get_str("REFERENCE") == "ROHF") {
         if (options.get_str("DLPNO_ALGORITHM") == "CCSD") {
             dlpno = std::make_shared<RO_DLPNOCCSD>(ref_wfn, options);
+        } else if (options.get_str("DLPNO_ALGORITHM") == "CCSD(T)") {
+            dlpno = std::make_shared<RO_DLPNOCCSD_T>(ref_wfn, options);
         } else {
             throw PSIEXCEPTION("Requested DLPNO method is not yet available for ROHF reference!");
         }

--- a/psi4/src/psi4/dlpno/wrapper.cc
+++ b/psi4/src/psi4/dlpno/wrapper.cc
@@ -53,8 +53,15 @@ SharedWavefunction dlpno(SharedWavefunction ref_wfn, Options& options) {
         } else {
             throw PSIEXCEPTION("Requested DLPNO method is not yet available for ROHF reference!");
         }
+    } else if (options.get_str("REFERENCE") == "UHF") {
+        if (options.get_str("DLPNO_ALGORITHM") == "CCSD") {
+            dlpno = std::make_shared<RO_DLPNOCCSD>(ref_wfn, options);
+        } else {
+            throw PSIEXCEPTION(
+                "UHF references are supported only for DLPNO-CCSD through the UHF -> QRO transformation.");
+        }
     } else {
-        throw PSIEXCEPTION("DLPNO methods currently only support restricted orbitals! TODO: Implement QROs\n");
+        throw PSIEXCEPTION("Requested DLPNO reference is not supported.\n");
     }
 
     return dlpno;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,7 @@ foreach(test_name aediis-1
                   pywrap-db3
                   pywrap-molecule rasci-c2-active rasci-h2o
                   rasci-ne rasscf-sp remp-energy1 remp-energy2 rodlpnocc-1 rodlpnocc-2 rodlpnocc-3
+                  uhfqrodlpnocc-1 uhfqrodlpnocc-2
                   sad-scf-type sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 sapt-dft-api sapt-dft-lrc
                   sapt-exch-disp-inf sapt-exch-ind-inf sapt-exch-ind30-inf
                   sapt7 sapt8 scf-bz2 scf-dipder scf-guess scf-guess-read1 scf-upcast-custom-basis

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,8 +89,8 @@ foreach(test_name aediis-1
                   pywrap-checkrun-rohf pywrap-checkrun-uhf pywrap-db1
                   pywrap-db3
                   pywrap-molecule rasci-c2-active rasci-h2o
-                  rasci-ne rasscf-sp sad-scf-type sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 sapt-dft-api sapt-dft-lrc
-                  remp-energy1 remp-energy2
+                  rasci-ne rasscf-sp remp-energy1 remp-energy2 rodlpnocc-1 rodlpnocc-2 rodlpnocc-3
+                  sad-scf-type sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 sapt-dft-api sapt-dft-lrc
                   sapt-exch-disp-inf sapt-exch-ind-inf sapt-exch-ind30-inf
                   sapt7 sapt8 scf-bz2 scf-dipder scf-guess scf-guess-read1 scf-upcast-custom-basis
                   scf-guess-read2 scf-guess-read3 scf1 scf-occ scf2 scf3 scf4 scf5 scf6

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,7 +89,7 @@ foreach(test_name aediis-1
                   pywrap-checkrun-rohf pywrap-checkrun-uhf pywrap-db1
                   pywrap-db3
                   pywrap-molecule rasci-c2-active rasci-h2o
-                  rasci-ne rasscf-sp remp-energy1 remp-energy2 rodlpnocc-1 rodlpnocc-2 rodlpnocc-3
+                  rasci-ne rasscf-sp remp-energy1 remp-energy2 rodlpnocc-1 rodlpnocc-2 rodlpnocc-3 rodlpnocc-4
                   uhfqrodlpnocc-1 uhfqrodlpnocc-2
                   sad-scf-type sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 sapt-dft-api sapt-dft-lrc
                   sapt-exch-disp-inf sapt-exch-ind-inf sapt-exch-ind30-inf

--- a/tests/rodlpnocc-1/CMakeLists.txt
+++ b/tests/rodlpnocc-1/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(rodlpnocc-1 "psi;dlpno;cc;smoke")

--- a/tests/rodlpnocc-1/input.dat
+++ b/tests/rodlpnocc-1/input.dat
@@ -1,0 +1,42 @@
+#! Full-space ROHF DLPNO-CCSD regression for triplet O2
+#! Zero pair and PNO cutoffs recover the canonical DF-CCSD limit
+#! This also tests the completely in-core DLPNO algorithm
+
+ref_scf                  =   -149.62517883242350             #TEST
+ref_roccsd_corl          =     -0.38235440818800             #TEST
+ref_roccsd_tot           =   -150.00753324061150             #TEST
+
+molecule o2 {
+0 3
+O
+O 1 1.16
+symmetry c1
+}
+
+set basis aug-cc-pvdz
+set freeze_core false
+set scf_type direct
+set e_convergence 1.0e-8
+set r_convergence 1.0e-8
+set t_cut_pno 0.0
+set t_cut_pno_mp2 0.0
+set t_cut_pairs 0.0
+set t_cut_do 0.0
+set t_cut_mkn 0.0
+set t_cut_tno 0.0
+set t_cut_do_triples 0.0
+set t_cut_mkn_triples 0.0
+set dlpno_toggle_memory false
+set reference rohf
+
+print('   Testing ROHF DLPNO-CCSD on triplet O2 ...')
+val = energy('dlpno-ccsd')
+
+compare_values(ref_scf, variable('SCF TOTAL ENERGY'), 7, 'scf ref')                       #TEST
+compare_values(ref_roccsd_corl, variable('CCSD CORRELATION ENERGY'), 7, 'ccsd corl')     #TEST
+compare_values(ref_roccsd_tot, variable('CCSD TOTAL ENERGY'), 7, 'ccsd total')           #TEST
+compare_values(ref_scf, variable('CURRENT REFERENCE ENERGY'), 7, 'current ref')          #TEST
+compare_values(ref_roccsd_corl, variable('CURRENT CORRELATION ENERGY'), 7, 'current corl') #TEST
+compare_values(ref_roccsd_tot, variable('CURRENT ENERGY'), 7, 'current total')           #TEST
+compare_values(ref_roccsd_tot, val, 7, 'dlpno-ccsd return')                              #TEST
+clean()

--- a/tests/rodlpnocc-1/output.ref
+++ b/tests/rodlpnocc-1/output.ref
@@ -1,0 +1,772 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.12a1.dev46 
+
+                         Git: Rev {ro_dlpno_113} 80caaaa 
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, D. L. Poole, T. Győri, E. C. Mitchell, J. P. Pederson,
+    and A. M. Wallace
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    https://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Sunday, 30 August 2026 07:30PM
+
+    Process ID: 3053
+    Host:       Androlomews-MacBook-Pro.local
+    PSIDATADIR: /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    8
+    Addons:     adcc, a̶m̶b̶i̶t̶, bse, c̶c̶t̶3̶, c̶f̶o̶u̶r̶, c̶h̶e̶m̶p̶s̶2̶, cppe, ddx, dftd3, dftd4, d̶k̶h̶,
+                e̶c̶p̶i̶n̶t̶, einsums, f̶o̶r̶t̶e̶, g̶a̶u̶x̶c̶, gcp, gdma, geometric,
+                g̶p̶u̶_̶d̶f̶c̶c̶, i̶n̶t̶e̶g̶r̶a̶t̶o̶r̶x̶x̶, ipi, libefp, mdi, m̶p̶2̶d̶,
+                m̶r̶c̶c̶, o̶o̶o̶, o̶p̶e̶n̶f̶e̶r̶m̶i̶o̶n̶p̶s̶i̶4̶, p̶c̶m̶s̶o̶l̶v̶e̶r̶,
+                p̶s̶i̶4̶f̶o̶c̶k̶c̶i̶, p̶s̶i̶x̶a̶s̶, pyeinsums, qcmanybody, r̶e̶s̶p̶,
+                s̶i̶m̶i̶n̶t̶, s̶n̶s̶m̶p̶2̶, v̶2̶r̶d̶m̶_̶c̶a̶s̶s̶c̶f̶
+
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Full-space ROHF DLPNO-CCSD regression for triplet O2
+#! Zero pair and PNO cutoffs recover the canonical DF-CCSD limit
+#! This also tests the completely in-core DLPNO algorithm
+
+ref_scf                  =   -149.62517883242350             #TEST
+ref_roccsd_corl          =     -0.38235440818800             #TEST
+ref_roccsd_tot           =   -150.00753324061150             #TEST
+
+molecule o2 {
+0 3
+O
+O 1 1.16
+symmetry c1
+}
+
+set basis aug-cc-pvdz
+set freeze_core false
+set scf_type direct
+set e_convergence 1.0e-8
+set r_convergence 1.0e-8
+set t_cut_pno 0.0
+set t_cut_pno_mp2 0.0
+set t_cut_pairs 0.0
+set t_cut_do 0.0
+set t_cut_mkn 0.0
+set t_cut_tno 0.0
+set t_cut_do_triples 0.0
+set t_cut_mkn_triples 0.0
+set dlpno_toggle_memory false
+set reference rohf
+
+print('   Testing ROHF DLPNO-CCSD on triplet O2 ...')
+val = energy('dlpno-ccsd')
+
+compare_values(ref_scf, variable('SCF TOTAL ENERGY'), 7, 'scf ref')                       #TEST
+compare_values(ref_roccsd_corl, variable('CCSD CORRELATION ENERGY'), 7, 'ccsd corl')     #TEST
+compare_values(ref_roccsd_tot, variable('CCSD TOTAL ENERGY'), 7, 'ccsd total')           #TEST
+compare_values(ref_scf, variable('CURRENT REFERENCE ENERGY'), 7, 'current ref')          #TEST
+compare_values(ref_roccsd_corl, variable('CURRENT CORRELATION ENERGY'), 7, 'current corl') #TEST
+compare_values(ref_roccsd_tot, variable('CURRENT ENERGY'), 7, 'current total')           #TEST
+compare_values(ref_roccsd_tot, val, 7, 'dlpno-ccsd return')                              #TEST
+clean()
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on Androlomews-MacBook-Pro.local
+*** at Sun Aug 30 19:30:17 2026
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   254 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             ROHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.580000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.580000000000    15.994914619570
+
+  Running in c1 symmetry.
+
+  Rotational constants: A = ************  B =      1.56649  C =      1.56649 [cm^-1]
+  Rotational constants: A = ************  B =  46962.29263  C =  46962.29263 [MHz]
+  Nuclear repulsion =   29.195984036965520
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DIRECT.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 18
+    Number of basis functions: 46
+    Number of Cartesian functions: 50
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   270 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+  Starting with a DF guess...
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.003 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 56
+    Number of basis functions: 172
+    Number of Cartesian functions: 202
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 6.1192045937E-04.
+  Reciprocal condition number of the overlap matrix is 1.5184810677E-04.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         46      46 
+   -------------------------
+    Total      46      46
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter SAD:  -149.01477380239766   -1.49015e+02   0.00000e+00 
+   @DF-ROHF iter   1:  -149.60462027860854   -5.89846e-01   3.60816e-03 DIIS
+   @DF-ROHF iter   2:  -149.62297782656481   -1.83575e-02   1.15521e-03 DIIS
+   @DF-ROHF iter   3:  -149.62470456965266   -1.72674e-03   2.04206e-04 DIIS
+   @DF-ROHF iter   4:  -149.62479070728216   -8.61376e-05   5.14270e-05 DIIS
+   @DF-ROHF iter   5:  -149.62479805948541   -7.35220e-06   5.86308e-06 DIIS
+   @DF-ROHF iter   6:  -149.62479816471196   -1.05227e-07   6.83435e-07 DIIS
+   @DF-ROHF iter   7:  -149.62479816612182   -1.40986e-09   1.09002e-07 DIIS
+   @DF-ROHF iter   8:  -149.62479816616076   -3.89377e-11   1.72592e-08 DIIS
+   @DF-ROHF iter   9:  -149.62479816616181   -1.05160e-12   1.55612e-09 DIIS
+
+  DF guess converged.
+
+  ==> DirectJK: Integral-Direct J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           8
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
+
+   @ROHF iter  10:  -149.62517842133764   -1.49625e+02   1.90011e-05 DIIS
+   @ROHF iter  11:  -149.62517881768485   -3.96347e-07   3.10615e-06 DIIS
+   @ROHF iter  12:  -149.62517883102777   -1.33429e-08   9.04709e-07 DIIS
+   @ROHF iter  13:  -149.62517883233392   -1.30615e-09   2.07044e-07 DIIS
+   @ROHF iter  14:  -149.62517883241918   -8.52651e-11   3.69888e-08 DIIS
+   @ROHF iter  15:  -149.62517883242322   -4.03588e-12   3.47803e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.732436     2A    -20.731305     3A     -1.704316  
+       4A     -1.088187     5A     -0.753204     6A     -0.728981  
+       7A     -0.728981  
+
+    Singly Occupied:                                                      
+
+       8A     -0.193196     9A     -0.193196  
+
+    Virtual:                                                              
+
+      10A      0.123398    11A      0.172953    12A      0.185521  
+      13A      0.185521    14A      0.243779    15A      0.243779  
+      16A      0.247754    17A      0.400239    18A      0.593930  
+      19A      0.826253    20A      0.826253    21A      0.978009  
+      22A      1.051063    23A      1.051063    24A      1.173158  
+      25A      1.173158    26A      1.207712    27A      1.288259  
+      28A      1.288259    29A      1.317210    30A      1.317210  
+      31A      1.415356    32A      1.538188    33A      1.690740  
+      34A      1.690740    35A      2.459079    36A      3.087881  
+      37A      3.087881    38A      3.357065    39A      3.357065  
+      40A      3.408304    41A      3.600440    42A      3.600440  
+      43A      3.623607    44A      4.091402    45A      4.091402  
+      46A      4.283376  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     7 ]
+    SOCC [     2 ]
+    NA   [     9 ]
+    NB   [     7 ]
+
+  @ROHF Final Energy:  -149.62517883242322
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             29.1959840369655197
+    One-Electron Energy =                -263.6780482576259601
+    Two-Electron Energy =                  84.8568853882372451
+    Total Energy =                       -149.6251788324232166
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.0000000            0.0000000           -0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on Androlomews-MacBook-Pro.local at Sun Aug 30 19:30:18 2026
+Module time:
+	user time   =       2.18 seconds =       0.04 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       2.18 seconds =       0.04 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on Androlomews-MacBook-Pro.local
+*** at Sun Aug 30 19:30:18 2026
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //             DLPNO-CCSD            //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1-2 entry O          line   204 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+
+   --------------------------------------------------
+          ROHF T1-Transformed DLPNO-CCSD            
+                    by Andy Jiang                    
+       Closed-shell engine: DOI 10.1063/5.0219963   
+   --------------------------------------------------
+
+  Reference                    : ROHF
+  PNO selector                 : spin-independent SROMP2
+  SOMO treatment               : appended to every pair space
+  DLPNO convergence            : NORMAL
+
+  Detailed DLPNO thresholds and cutoffs:
+    T_CUT_PNO        = 0.0000e+00 
+    T_DIAG_SCALE     = 3.0000e-02 
+    T_CORE_SCALE     = 1.0000e-02 
+    T_CUT_TRACE      = 9.9000e-01 
+    T_CUT_ENERGY     = 9.9000e-01 
+    T_CUT_PAIRS      = 0.0000e+00 
+    T_CUT_PAIRS_MP2  = 0.0000e+00 
+    T_CUT_PRE        = 0.0000e+00 
+    T_CUT_DO_PRE     = 3.0000e-02 
+    T_CUT_MKN        = 0.0000e+00 
+    T_CUT_PNO_MP2    = 0.0000e+00 
+    T_CUT_TRACE_MP2  = 9.9900e-01 
+    T_CUT_ENERGY_MP2 = 9.9700e-01 
+    T_CUT_DO         = 0.0000e+00 
+    T_CUT_DO_IJ      = 1.0000e-05 
+    T_CUT_DO_UV      = 1.0000e-05 
+    T_CUT_CLMO       = 1.0000e-04 
+    T_CUT_CPAO       = 1.0000e-04 
+    S_CUT            = 1.0000e-08 
+    F_CUT            = 1.0000e-05 
+    INTS_TOL (AO)    = 1.0000e-10 
+    MIN_PNOS         =      5   
+
+  ==> ROHF Orbital-Space Information <==
+
+   -----------------------------------------------------------------------------
+    NBF  NFRZC  ACT-A  ACT-B  DOCC  SOMO  VIRT-A  VIRT-B  NAUX
+   -----------------------------------------------------------------------------
+     46      0      9      7     7     2      37      39   144
+   -----------------------------------------------------------------------------
+
+  ==> Boys Localizer <==
+
+    Convergence =   1.000E-12
+    Maxiter     =        1000
+
+    Iteration                   Metric       Residual
+    @Boys    0   6.9475176596239041E-14              -
+    @Boys    1   6.0589363949278923E+00   8.721009E+13
+    @Boys    2   7.8584128493693726E+00   2.969954E-01
+    @Boys    3   8.0194111118089602E+00   2.048738E-02
+    @Boys    4   8.0236168239826817E+00   5.244415E-04
+    @Boys    5   8.0239484299614805E+00   4.132874E-05
+    @Boys    6   8.0239554215561224E+00   8.713409E-07
+    @Boys    7   8.0239555452322477E+00   1.541336E-08
+    @Boys    8   8.0239555546077863E+00   1.168443E-09
+    @Boys    9   8.0239555550535044E+00   5.554843E-11
+    @Boys   10   8.0239555550737496E+00   2.523087E-12
+    @Boys   11   8.0239555550748669E+00   1.392491E-13
+
+    Boys Localizer converged.
+
+  ==> Boys Localizer <==
+
+    Convergence =   1.000E-12
+    Maxiter     =        1000
+
+    Iteration                   Metric       Residual
+    @Boys    0   1.7706152529388977E-20              -
+    @Boys    1   1.7708602557380535E-20   1.383716E-04
+    @Boys    2   1.7708602557379391E-20   6.457432E-14
+
+    Boys Localizer converged.
+
+    Retained 15 SOMO-containing pairs through dipole prescreening.
+  ==> Crude Prescreening (Determines Semicanonical-MP2 Pairs) <==
+
+    T_CUT_MKN set to 0.000e+00
+    T_CUT_DO  set to 0.000e+00
+
+  ==> Forming Local MO Domains <==
+
+    Auxiliary BFs per Local MO:
+      Average =  144 AUX BFs (2 atoms)
+      Min     =  144 AUX BFs (2 atoms)
+      Max     =  144 AUX BFs (2 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   46 PAOs (2 atoms)
+      Min     =   46 PAOs (2 atoms)
+      Max     =   46 PAOs (2 atoms)
+
+    Local MOs per Local MO:
+      Average =    9 LMOs
+      Min     =    9 LMOs
+      Max     =    9 LMOs
+ 
+    Screened 0 of 81 LMO pairs (0.00 %)
+             0 pairs met overlap criteria
+             9 pairs met energy criteria
+ 
+    Screened LMO pair energy =  0.000000000000 
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =  144 AUX BFs (2 atoms)
+      Min     =  144 AUX BFs (2 atoms)
+      Max     =  144 AUX BFs (2 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    9 LMOs
+      Min     =    9 LMOs
+      Max     =    9 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   46 PAOs (2 atoms)
+      Min     =   46 PAOs (2 atoms)
+      Max     =   46 PAOs (2 atoms)
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Initial SROMP2 prescreening of pairs <==
+
+  ==> Spin-Restricted Open-Shell Semicanonical MP2 Pair Prescreening <==
+
+    Eliminated Pairs (SC-SROMP2)       = 0
+    Surviving Pairs                    = 81
+    Surviving Pairs / Non-dipole Pairs = (100.00 %)
+    Eliminated Pair dE                 = 0.000000000000
+
+  ==> Refined Prescreening (Determines Strong and Weak Pairs) <==
+
+    T_CUT_MKN reset to 0.000e+00
+    T_CUT_DO  reset to 0.000e+00
+
+  ==> Forming Local MO Domains <==
+
+    Auxiliary BFs per Local MO:
+      Average =  144 AUX BFs (2 atoms)
+      Min     =  144 AUX BFs (2 atoms)
+      Max     =  144 AUX BFs (2 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   46 PAOs (2 atoms)
+      Min     =   46 PAOs (2 atoms)
+      Max     =   46 PAOs (2 atoms)
+
+    Local MOs per Local MO:
+      Average =    9 LMOs
+      Min     =    9 LMOs
+      Max     =    9 LMOs
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =  144 AUX BFs (2 atoms)
+      Min     =  144 AUX BFs (2 atoms)
+      Max     =  144 AUX BFs (2 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    9 LMOs
+      Min     =    9 LMOs
+      Max     =    9 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   46 PAOs (2 atoms)
+      Min     =   46 PAOs (2 atoms)
+      Max     =   46 PAOs (2 atoms)
+
+    Coefficient sparsity in AO -> LMO transform:   0.00 % 
+    Coefficient sparsity in AO -> PAO transform:   0.00 % 
+    Coefficient sparsity in combined transforms:   0.00 % 
+
+    Storing transformed LMO/LMO, LMO/PAO, and PAO/PAO integrals in sparse format.
+    Required memory: 0.003 GiB (0.00 % reduction from dense format) 
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Determining Strong and Weak Pairs with SROLMP2 <==
+
+  ==> Forming Pair Natural Orbitals (for LMP2) <==
+  
+    Natural Orbitals per Local MO pair:
+      Avg:  37 NOs 
+      Min:  37 NOs 
+      Max:  37 NOs 
+
+      Avg Occ Number Tol: 8.170e-10 
+      Min Occ Number Tol: -6.025e-19 
+      Max Occ Number Tol: 1.344e-08 
+
+      Avg Trace Sum: 1.000000 
+      Min Trace Sum: 1.000000 
+      Max Trace Sum: 1.000000 
+
+      Avg Energy Ratio: 1.000000 
+      Min Energy Ratio: 1.000000 
+      Max Energy Ratio: 1.000000 
+
+    PNO truncation energy = 0.000000000000
+    SROMP2 spin-adapted PNO truncation energy = 0.000000000000
+
+  ==> PNO-LMP2 Memory Estimate <== 
+
+    (q | i a) [AUX, LMO, PAO]  :    0.000 [GB]
+    X^{PNO}_{u_{ij} a_{ij}}    :    0.001 [GB]
+    (i a_{ij} | j b_{ij})      :    0.001 [GB]
+    T_{ij}^{a_{ij} b_{ij}}     :    0.001 [GB]
+    U_{ij}^{a_{ij} b_{ij}}     :    0.001 [GB]
+    PNO overlaps               :    0.005 [GB]
+    Total Memory Required      :    0.009 [GB]
+    Total Memory Given         :    0.524 [GB]
+
+
+  ==> Iterative Local MP2 with Pair Natural Orbitals (PNOs) <==
+
+    E_CONVERGENCE = 1.00e-10
+    R_CONVERGENCE = 1.00e-10
+
+                         Corr. Energy    Delta E     Max R     Time (s)
+  @PNO-LMP2 iter   1:  -0.380274694578 -3.803e-01  1.445e-03        0
+  @PNO-LMP2 iter   2:  -0.386261934746 -5.987e-03  3.372e-04        0
+  @PNO-LMP2 iter   3:  -0.386602834445 -3.409e-04  7.950e-05        0
+  @PNO-LMP2 iter   4:  -0.386676643856 -7.381e-05  1.487e-05        0
+  @PNO-LMP2 iter   5:  -0.386686937737 -1.029e-05  2.655e-06        0
+  @PNO-LMP2 iter   6:  -0.386687740208 -8.025e-07  6.593e-07        0
+  @PNO-LMP2 iter   7:  -0.386687493031  2.472e-07  1.421e-07        0
+  @PNO-LMP2 iter   8:  -0.386687388217  1.048e-07  4.398e-08        0
+  @PNO-LMP2 iter   9:  -0.386687394867 -6.650e-09  8.570e-09        0
+  @PNO-LMP2 iter  10:  -0.386687390534  4.333e-09  2.208e-09        0
+  @PNO-LMP2 iter  11:  -0.386687389455  1.079e-09  5.338e-10        0
+  @PNO-LMP2 iter  12:  -0.386687389223  2.316e-10  1.286e-10        0
+  @PNO-LMP2 iter  13:  -0.386687389210  1.295e-11  4.667e-11        0
+    Final spin-adapted SROLMP2 correlation energy = -0.266420092835
+
+  ==> Final Strong and Weak Pairs <==
+
+    Weak Pairs                      = 0
+    Strong Pairs                    = 81
+    Strong Pairs / Total Pairs      = (100.00 %)
+  
+  Total DLPNO-MP2 Correlation Energy:  -0.266420092835 
+    MP2 Correlation Energy:            -0.266420092835 
+    Semicanonical MP2 Correction:       0.000000000000 
+    Dipole Correction:                  0.000000000000 
+    PNO Truncation Correction:          0.000000000000 
+
+
+  @Total DLPNO-MP2 Energy: -149.891598925258 
+
+   * WARNING: This answer will likely vary from one obtained by a energy('dlpno-mp2') call
+                due to lack of a semi-canonical MP2 prescreening step in DLPNO-MP2, as well
+                as slightly tighter cutoffs utilized to increase accuracy in the context of CC!!!
+
+
+  ==> Forming Pair Natural Orbitals (for LCCSD) <==
+  
+    Natural Orbitals per Local MO pair:
+      Avg:  37 NOs 
+      Min:  37 NOs 
+      Max:  37 NOs 
+
+      Avg Occ Number Tol: 1.269e-09 
+      Min Occ Number Tol: -1.259e-19 
+      Max Occ Number Tol: 1.344e-08 
+
+      Avg Trace Sum: 1.000000 
+      Min Trace Sum: 1.000000 
+      Max Trace Sum: 1.000000 
+
+      Avg Energy Ratio: 1.000000 
+      Min Energy Ratio: 1.000000 
+      Max Energy Ratio: 1.000000 
+
+    LMP2 Weak Pair energy = 0.000000000000
+    PNO truncation energy = 0.000000000000
+    Spin-adapted SROLMP2 weak-pair energy = 0.000000000000
+    Spin-adapted total PNO truncation energy = 0.000000000000
+
+    Auxiliary BFs per Local MO:
+      Average =  144 AUX BFs (2 atoms)
+      Min     =  144 AUX BFs (2 atoms)
+      Max     =  144 AUX BFs (2 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   48 PAOs (2 atoms)
+      Min     =   48 PAOs (2 atoms)
+      Max     =   48 PAOs (2 atoms)
+
+    Local MOs per Local MO:
+      Average =    9 LMOs
+      Min     =    9 LMOs
+      Max     =    9 LMOs
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =  144 AUX BFs (2 atoms)
+      Min     =  144 AUX BFs (2 atoms)
+      Max     =  144 AUX BFs (2 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    9 LMOs
+      Min     =    9 LMOs
+      Max     =    9 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   48 PAOs (2 atoms)
+      Min     =   48 PAOs (2 atoms)
+      Max     =   48 PAOs (2 atoms)
+
+  ==> Transforming 3-Index Integrals to LMO/LMO basis <==
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Transforming 3-Index Integrals to PAO/PAO basis <==
+
+    * PAO/PAO Integral Memory After Screening: 0.001 [GiB]
+
+  ==> ROHF-DLPNO-CCSD Memory Requirements <== 
+
+    *** Spin-Independent Spatial Quantities ***
+    (q | i j) [AUX, LMO]          :    0.000 [GB]
+    (q | i a) [AUX, LMO, PAO]     :    0.000 [GB]
+    (q | a b) [AUX, PAO]          :    0.001 [GB]
+    (k_{ij}, c_{ij}) integrals    :    0.001 [GB]
+    (a_{ij}, b_{ij}) integrals    :    0.004 [GB]
+    Non-projected two-ext. ERIs   :    0.018 [GB]
+    Three-external ERIs           :    0.038 [GB]
+    Spatial DF PNO tensors        :    0.106 [GB]
+
+    *** ROHF Spin-Resolved Iteration Quantities ***
+    RCCSD + SROLMP2 T2 blocks     :    0.006 [GB]
+    R2 and non-symmetric R2       :    0.006 [GB]
+    Spin Fock pair blocks         :    0.003 [GB]
+    Global spin Fock blocks       :    0.000 [GB]
+    Projected spin T1 blocks      :    0.000 [GB]
+    T1-transformed spin DF blocks :    0.009 [GB]
+    PNO overlaps                  :    0.026 [GB]
+    DIIS history (maximum)        :    0.030 [GB]
+
+    Maximum ERI buffer per thread :    0.005 [GB]
+    Maximum CC buffer per thread  :    0.004 [GB]
+    Total Memory Required (ERIs)  :    0.210 [GB]
+    Total Memory Required (RCCSD) :    0.297 [GB]
+    Total Memory Given            :    0.524 [GB]
+
+    Using high-memory PNO overlap algorithm...
+
+    Keeping (Q_{ij}|m_{ij} a_{ij}) tensors in RAM.
+    Keeping (Q_{ij}|a_{ij} b_{ij}) tensors in RAM.
+
+    Computing integrals in the PNO basis from PAO integrals...
+
+    Integral Computation Complete!!! Time Elapsed:    0 seconds
+
+
+  ==> Restricted Open Shell Local CCSD <==
+
+    E_CONVERGENCE = 1.00e-08
+    R_CONVERGENCE = 1.00e-08
+
+                      Corr. Energy    Delta E     Max R1     Max R2     Time (s)
+  @LCCSD iter   1:  -0.371179358238 -3.712e-01  7.391e-03  1.377e-03        0
+  @LCCSD iter   2:  -0.379670827056 -8.491e-03  3.676e-03  3.557e-04        1
+  @LCCSD iter   3:  -0.381359595645 -1.689e-03  1.028e-03  1.974e-04        0
+  @LCCSD iter   4:  -0.382051416356 -6.918e-04  1.125e-03  7.342e-05        1
+  @LCCSD iter   5:  -0.382299083399 -2.477e-04  3.508e-04  3.858e-05        0
+  @LCCSD iter   6:  -0.382342440111 -4.336e-05  1.433e-04  1.709e-05        0
+  @LCCSD iter   7:  -0.382347314518 -4.874e-06  3.538e-05  7.759e-06        1
+  @LCCSD iter   8:  -0.382357352633 -1.004e-05  2.207e-05  3.900e-06        0
+  @LCCSD iter   9:  -0.382354841058  2.512e-06  9.755e-06  1.838e-06        1
+  @LCCSD iter  10:  -0.382355240473 -3.994e-07  2.794e-06  8.799e-07        0
+  @LCCSD iter  11:  -0.382355023320  2.172e-07  3.045e-06  3.559e-07        0
+  @LCCSD iter  12:  -0.382354625093  3.982e-07  1.456e-06  1.762e-07        1
+  @LCCSD iter  13:  -0.382354546574  7.852e-08  7.561e-07  5.011e-08        0
+  @LCCSD iter  14:  -0.382354482710  6.386e-08  2.484e-07  2.450e-08        1
+  @LCCSD iter  15:  -0.382354437953  4.476e-08  1.817e-07  1.419e-08        0
+  @LCCSD iter  16:  -0.382354426963  1.099e-08  9.362e-08  9.149e-09        0
+  @LCCSD iter  17:  -0.382354416005  1.096e-08  2.848e-08  7.028e-09        1
+  @LCCSD iter  18:  -0.382354412676  3.329e-09  1.997e-08  4.711e-09        0
+  @LCCSD iter  19:  -0.382354410604  2.073e-09  1.302e-08  3.174e-09        0
+  @LCCSD iter  20:  -0.382354410125  4.787e-10  6.544e-09  1.628e-09        1
+
+  ROHF T1 Diagnostic: 0.00726354 
+  
+  Total ROHF-DLPNO-CCSD Correlation Energy:  -0.382354410125 
+    Strong-Pair RCCSD Contribution:          -0.382354410125 
+    SROLMP2 Weak-Pair Contribution:           0.000000000000 
+    Semicanonical SROMP2 Correction:          0.000000000000 
+    ROHF Dipole-Pair Correction:              0.000000000000 
+    PNO Truncation Correction:                0.000000000000 
+
+
+  @Total ROHF-DLPNO-CCSD Energy: -150.007533242548 
+    *** Spin-adapted and SOMO-safe. A thousand hallelujahs!!! 
+
+
+*** tstop() called on Androlomews-MacBook-Pro.local at Sun Aug 30 19:30:26 2026
+Module time:
+	user time   =      63.94 seconds =       1.07 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =          8 seconds =       0.13 minutes
+Total time:
+	user time   =      66.12 seconds =       1.10 minutes
+	system time =       0.40 seconds =       0.01 minutes
+	total time  =          9 seconds =       0.15 minutes
+    scf ref...............................................................................PASSED
+    ccsd corl.............................................................................PASSED
+    ccsd total............................................................................PASSED
+    current ref...........................................................................PASSED
+    current corl..........................................................................PASSED
+    current total.........................................................................PASSED
+    dlpno-ccsd return.....................................................................PASSED
+
+    Psi4 stopped on: Sunday, 30 August 2026 07:30PM
+    Psi4 wall time for execution: 0:00:08.38
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/rodlpnocc-1/test_input.py
+++ b/tests/rodlpnocc-1/test_input.py
@@ -1,0 +1,5 @@
+from addons import *
+
+@ctest_labeler("dlpno;cc;smoke")
+def test_rodlpnocc_1():
+    ctest_runner(__file__)

--- a/tests/rodlpnocc-2/CMakeLists.txt
+++ b/tests/rodlpnocc-2/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(rodlpnocc-2 "psi;dlpno;cc;quick")

--- a/tests/rodlpnocc-2/input.dat
+++ b/tests/rodlpnocc-2/input.dat
@@ -1,0 +1,43 @@
+#! Full-space ROHF DLPNO-CCSD regression for triplet methylene
+#! Geometry from Allen, Sargent, and Schaefer
+#! Zero pair and PNO cutoffs recover the canonical DF-CCSD limit
+
+ref_scf                  =    -38.92287607721545             #TEST
+ref_roccsd_corl          =     -0.12482089891700             #TEST
+ref_roccsd_tot           =    -39.04769697613245             #TEST
+
+molecule ch2 {
+0 3
+C
+H 1 1.0756
+H 1 1.0756 2 133.94
+symmetry c1
+}
+
+set basis aug-cc-pvdz
+set freeze_core false
+set scf_type direct
+set e_convergence 1.0e-8
+set r_convergence 1.0e-8
+set t_cut_pno 0.0
+set t_cut_pno_mp2 0.0
+set t_cut_pairs 0.0
+set t_cut_do 0.0
+set t_cut_mkn 0.0
+set t_cut_tno 0.0
+set t_cut_do_triples 0.0
+set t_cut_mkn_triples 0.0
+set dlpno_toggle_memory false
+set reference rohf
+
+print('   Testing ROHF DLPNO-CCSD on triplet CH2 ...')
+val = energy('dlpno-ccsd')
+
+compare_values(ref_scf, variable('SCF TOTAL ENERGY'), 7, 'scf ref')                       #TEST
+compare_values(ref_roccsd_corl, variable('CCSD CORRELATION ENERGY'), 7, 'ccsd corl')     #TEST
+compare_values(ref_roccsd_tot, variable('CCSD TOTAL ENERGY'), 7, 'ccsd total')           #TEST
+compare_values(ref_scf, variable('CURRENT REFERENCE ENERGY'), 7, 'current ref')          #TEST
+compare_values(ref_roccsd_corl, variable('CURRENT CORRELATION ENERGY'), 7, 'current corl') #TEST
+compare_values(ref_roccsd_tot, variable('CURRENT ENERGY'), 7, 'current total')           #TEST
+compare_values(ref_roccsd_tot, val, 7, 'dlpno-ccsd return')                              #TEST
+clean()

--- a/tests/rodlpnocc-2/output.ref
+++ b/tests/rodlpnocc-2/output.ref
@@ -1,0 +1,759 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.12a1.dev46 
+
+                         Git: Rev {ro_dlpno_113} 80caaaa 
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, D. L. Poole, T. Győri, E. C. Mitchell, J. P. Pederson,
+    and A. M. Wallace
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    https://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Sunday, 30 August 2026 07:30PM
+
+    Process ID: 3068
+    Host:       Androlomews-MacBook-Pro.local
+    PSIDATADIR: /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    8
+    Addons:     adcc, a̶m̶b̶i̶t̶, bse, c̶c̶t̶3̶, c̶f̶o̶u̶r̶, c̶h̶e̶m̶p̶s̶2̶, cppe, ddx, dftd3, dftd4, d̶k̶h̶,
+                e̶c̶p̶i̶n̶t̶, einsums, f̶o̶r̶t̶e̶, g̶a̶u̶x̶c̶, gcp, gdma, geometric,
+                g̶p̶u̶_̶d̶f̶c̶c̶, i̶n̶t̶e̶g̶r̶a̶t̶o̶r̶x̶x̶, ipi, libefp, mdi, m̶p̶2̶d̶,
+                m̶r̶c̶c̶, o̶o̶o̶, o̶p̶e̶n̶f̶e̶r̶m̶i̶o̶n̶p̶s̶i̶4̶, p̶c̶m̶s̶o̶l̶v̶e̶r̶,
+                p̶s̶i̶4̶f̶o̶c̶k̶c̶i̶, p̶s̶i̶x̶a̶s̶, pyeinsums, qcmanybody, r̶e̶s̶p̶,
+                s̶i̶m̶i̶n̶t̶, s̶n̶s̶m̶p̶2̶, v̶2̶r̶d̶m̶_̶c̶a̶s̶s̶c̶f̶
+
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Full-space ROHF DLPNO-CCSD regression for triplet methylene
+#! Geometry from Allen, Sargent, and Schaefer
+#! Zero pair and PNO cutoffs recover the canonical DF-CCSD limit
+
+ref_scf                  =    -38.92287607721545             #TEST
+ref_roccsd_corl          =     -0.12482089891700             #TEST
+ref_roccsd_tot           =    -39.04769697613245             #TEST
+
+molecule ch2 {
+0 3
+C
+H 1 1.0756
+H 1 1.0756 2 133.94
+symmetry c1
+}
+
+set basis aug-cc-pvdz
+set freeze_core false
+set scf_type direct
+set e_convergence 1.0e-8
+set r_convergence 1.0e-8
+set t_cut_pno 0.0
+set t_cut_pno_mp2 0.0
+set t_cut_pairs 0.0
+set t_cut_do 0.0
+set t_cut_mkn 0.0
+set t_cut_tno 0.0
+set t_cut_do_triples 0.0
+set t_cut_mkn_triples 0.0
+set dlpno_toggle_memory false
+set reference rohf
+
+print('   Testing ROHF DLPNO-CCSD on triplet CH2 ...')
+val = energy('dlpno-ccsd')
+
+compare_values(ref_scf, variable('SCF TOTAL ENERGY'), 7, 'scf ref')                       #TEST
+compare_values(ref_roccsd_corl, variable('CCSD CORRELATION ENERGY'), 7, 'ccsd corl')     #TEST
+compare_values(ref_roccsd_tot, variable('CCSD TOTAL ENERGY'), 7, 'ccsd total')           #TEST
+compare_values(ref_scf, variable('CURRENT REFERENCE ENERGY'), 7, 'current ref')          #TEST
+compare_values(ref_roccsd_corl, variable('CURRENT CORRELATION ENERGY'), 7, 'current corl') #TEST
+compare_values(ref_roccsd_tot, variable('CURRENT ENERGY'), 7, 'current total')           #TEST
+compare_values(ref_roccsd_tot, val, 7, 'dlpno-ccsd return')                              #TEST
+clean()
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on Androlomews-MacBook-Pro.local
+*** at Sun Aug 30 19:30:42 2026
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line   182 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-3 entry H          line    40 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             ROHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000     0.000000000000    -0.060515415317    12.000000000000
+         H            0.000000000000    -0.989874831596     0.360273341393     1.007825032230
+         H            0.000000000000     0.989874831596     0.360273341393     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     55.16773  B =      8.53534  C =      7.39172 [cm^-1]
+  Rotational constants: A = 1653886.90254  B = 255883.03806  C = 221598.21256 [MHz]
+  Nuclear repulsion =    6.171094313241209
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 8
+  Nalpha       = 5
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DIRECT.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 19
+    Number of basis functions: 41
+    Number of Cartesian functions: 43
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   154 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    70 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+  Starting with a DF guess...
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 52
+    Number of basis functions: 150
+    Number of Cartesian functions: 171
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 9.0654983062E-04.
+  Reciprocal condition number of the overlap matrix is 1.6133758254E-04.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         41      41 
+   -------------------------
+    Total      41      41
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter SAD:   -38.13775190259834   -3.81378e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -38.90962058538540   -7.71869e-01   2.25396e-03 DIIS
+   @DF-ROHF iter   2:   -38.92142678573634   -1.18062e-02   6.92143e-04 DIIS
+   @DF-ROHF iter   3:   -38.92269220756930   -1.26542e-03   2.32359e-04 DIIS
+   @DF-ROHF iter   4:   -38.92285526554011   -1.63058e-04   5.62580e-05 DIIS
+   @DF-ROHF iter   5:   -38.92286243959626   -7.17406e-06   2.61655e-05 DIIS
+   @DF-ROHF iter   6:   -38.92286497645115   -2.53685e-06   7.45716e-06 DIIS
+   @DF-ROHF iter   7:   -38.92286517892506   -2.02474e-07   1.39479e-06 DIIS
+   @DF-ROHF iter   8:   -38.92286518685783   -7.93277e-09   4.25813e-07 DIIS
+   @DF-ROHF iter   9:   -38.92286518741361   -5.55772e-10   7.90519e-08 DIIS
+   @DF-ROHF iter  10:   -38.92286518743151   -1.79057e-11   2.47454e-08 DIIS
+   @DF-ROHF iter  11:   -38.92286518743327   -1.76215e-12   4.97999e-09 DIIS
+
+  DF guess converged.
+
+  ==> DirectJK: Integral-Direct J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           8
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
+
+   @ROHF iter  12:   -38.92287607225671   -3.89229e+01   2.23290e-06 DIIS
+   @ROHF iter  13:   -38.92287607713813   -4.88141e-09   2.09083e-07 DIIS
+   @ROHF iter  14:   -38.92287607720716   -6.90363e-11   5.52960e-08 DIIS
+   @ROHF iter  15:   -38.92287607721373   -6.56541e-12   2.51019e-08 DIIS
+   @ROHF iter  16:   -38.92287607721541   -1.67688e-12   7.89649e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -11.250905     2A     -0.854873     3A     -0.604465  
+
+    Singly Occupied:                                                      
+
+       4A     -0.149721     5A     -0.109376  
+
+    Virtual:                                                              
+
+       6A      0.039405     7A      0.056503     8A      0.118181  
+       9A      0.124802    10A      0.161109    11A      0.179336  
+      12A      0.256809    13A      0.312005    14A      0.354838  
+      15A      0.414157    16A      0.429658    17A      0.464710  
+      18A      0.508093    19A      0.524651    20A      0.532326  
+      21A      0.552808    22A      0.622100    23A      0.649696  
+      24A      0.656629    25A      0.900967    26A      0.905035  
+      27A      0.989941    28A      1.103058    29A      1.433984  
+      30A      1.539280    31A      1.641353    32A      1.650664  
+      33A      1.707522    34A      1.774254    35A      2.019621  
+      36A      2.024714    37A      2.329434    38A      2.339873  
+      39A      2.393006    40A      2.845372    41A      3.049510  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     3 ]
+    SOCC [     2 ]
+    NA   [     5 ]
+    NB   [     3 ]
+
+  @ROHF Final Energy:   -38.92287607721541
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              6.1710943132412091
+    One-Electron Energy =                 -63.8994440549382858
+    Two-Electron Energy =                  18.8054736644816671
+    Total Energy =                        -38.9228760772154061
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.4448214            0.6754905            0.2306691
+ Magnitude           :                                                    0.2306691
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on Androlomews-MacBook-Pro.local at Sun Aug 30 19:30:42 2026
+Module time:
+	user time   =       1.70 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.70 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+*** tstart() called on Androlomews-MacBook-Pro.local
+*** at Sun Aug 30 19:30:42 2026
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //             DLPNO-CCSD            //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry C          line   112 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    30 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+
+   --------------------------------------------------
+          ROHF T1-Transformed DLPNO-CCSD            
+                    by Andy Jiang                    
+       Closed-shell engine: DOI 10.1063/5.0219963   
+   --------------------------------------------------
+
+  Reference                    : ROHF
+  PNO selector                 : spin-independent SROMP2
+  SOMO treatment               : appended to every pair space
+  DLPNO convergence            : NORMAL
+
+  Detailed DLPNO thresholds and cutoffs:
+    T_CUT_PNO        = 0.0000e+00 
+    T_DIAG_SCALE     = 3.0000e-02 
+    T_CORE_SCALE     = 1.0000e-02 
+    T_CUT_TRACE      = 9.9000e-01 
+    T_CUT_ENERGY     = 9.9000e-01 
+    T_CUT_PAIRS      = 0.0000e+00 
+    T_CUT_PAIRS_MP2  = 0.0000e+00 
+    T_CUT_PRE        = 0.0000e+00 
+    T_CUT_DO_PRE     = 3.0000e-02 
+    T_CUT_MKN        = 0.0000e+00 
+    T_CUT_PNO_MP2    = 0.0000e+00 
+    T_CUT_TRACE_MP2  = 9.9900e-01 
+    T_CUT_ENERGY_MP2 = 9.9700e-01 
+    T_CUT_DO         = 0.0000e+00 
+    T_CUT_DO_IJ      = 1.0000e-05 
+    T_CUT_DO_UV      = 1.0000e-05 
+    T_CUT_CLMO       = 1.0000e-04 
+    T_CUT_CPAO       = 1.0000e-04 
+    S_CUT            = 1.0000e-08 
+    F_CUT            = 1.0000e-05 
+    INTS_TOL (AO)    = 1.0000e-10 
+    MIN_PNOS         =      5   
+
+  ==> ROHF Orbital-Space Information <==
+
+   -----------------------------------------------------------------------------
+    NBF  NFRZC  ACT-A  ACT-B  DOCC  SOMO  VIRT-A  VIRT-B  NAUX
+   -----------------------------------------------------------------------------
+     41      0      5      3     3     2      36      38   118
+   -----------------------------------------------------------------------------
+
+  ==> Boys Localizer <==
+
+    Convergence =   1.000E-12
+    Maxiter     =        1000
+
+    Iteration                   Metric       Residual
+    @Boys    0   2.8850607081347168E-01              -
+    @Boys    1   3.4153437665632440E+00   1.083803E+01
+    @Boys    2   3.4159404557893378E+00   1.747084E-04
+    @Boys    3   3.4159405439648385E+00   2.581295E-08
+    @Boys    4   3.4159405439650796E+00   7.059269E-14
+
+    Boys Localizer converged.
+
+  ==> Boys Localizer <==
+
+    Convergence =   1.000E-12
+    Maxiter     =        1000
+
+    Iteration                   Metric       Residual
+    @Boys    0   4.7753262210820602E-01              -
+    @Boys    1   5.6092489122090661E-01   1.746316E-01
+    @Boys    2   5.6092489122090661E-01   0.000000E+00
+
+    Boys Localizer converged.
+
+    Retained 7 SOMO-containing pairs through dipole prescreening.
+  ==> Crude Prescreening (Determines Semicanonical-MP2 Pairs) <==
+
+    T_CUT_MKN set to 0.000e+00
+    T_CUT_DO  set to 0.000e+00
+
+  ==> Forming Local MO Domains <==
+
+    Auxiliary BFs per Local MO:
+      Average =  118 AUX BFs (3 atoms)
+      Min     =  118 AUX BFs (3 atoms)
+      Max     =  118 AUX BFs (3 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   41 PAOs (3 atoms)
+      Min     =   41 PAOs (3 atoms)
+      Max     =   41 PAOs (3 atoms)
+
+    Local MOs per Local MO:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+ 
+    Screened 0 of 25 LMO pairs (0.00 %)
+             0 pairs met overlap criteria
+             5 pairs met energy criteria
+ 
+    Screened LMO pair energy =  0.000000000000 
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =  118 AUX BFs (3 atoms)
+      Min     =  118 AUX BFs (3 atoms)
+      Max     =  118 AUX BFs (3 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   41 PAOs (3 atoms)
+      Min     =   41 PAOs (3 atoms)
+      Max     =   41 PAOs (3 atoms)
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Initial SROMP2 prescreening of pairs <==
+
+  ==> Spin-Restricted Open-Shell Semicanonical MP2 Pair Prescreening <==
+
+    Eliminated Pairs (SC-SROMP2)       = 0
+    Surviving Pairs                    = 25
+    Surviving Pairs / Non-dipole Pairs = (100.00 %)
+    Eliminated Pair dE                 = 0.000000000000
+
+  ==> Refined Prescreening (Determines Strong and Weak Pairs) <==
+
+    T_CUT_MKN reset to 0.000e+00
+    T_CUT_DO  reset to 0.000e+00
+
+  ==> Forming Local MO Domains <==
+
+    Auxiliary BFs per Local MO:
+      Average =  118 AUX BFs (3 atoms)
+      Min     =  118 AUX BFs (3 atoms)
+      Max     =  118 AUX BFs (3 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   41 PAOs (3 atoms)
+      Min     =   41 PAOs (3 atoms)
+      Max     =   41 PAOs (3 atoms)
+
+    Local MOs per Local MO:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =  118 AUX BFs (3 atoms)
+      Min     =  118 AUX BFs (3 atoms)
+      Max     =  118 AUX BFs (3 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   41 PAOs (3 atoms)
+      Min     =   41 PAOs (3 atoms)
+      Max     =   41 PAOs (3 atoms)
+
+    Coefficient sparsity in AO -> LMO transform:   0.00 % 
+    Coefficient sparsity in AO -> PAO transform:   0.00 % 
+    Coefficient sparsity in combined transforms:   0.00 % 
+
+    Storing transformed LMO/LMO, LMO/PAO, and PAO/PAO integrals in sparse format.
+    Required memory: 0.002 GiB (0.00 % reduction from dense format) 
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Determining Strong and Weak Pairs with SROLMP2 <==
+
+  ==> Forming Pair Natural Orbitals (for LMP2) <==
+  
+    Natural Orbitals per Local MO pair:
+      Avg:  36 NOs 
+      Min:  36 NOs 
+      Max:  36 NOs 
+
+      Avg Occ Number Tol: 1.488e-09 
+      Min Occ Number Tol: 9.835e-19 
+      Max Occ Number Tol: 1.107e-08 
+
+      Avg Trace Sum: 1.000000 
+      Min Trace Sum: 1.000000 
+      Max Trace Sum: 1.000000 
+
+      Avg Energy Ratio: 1.000000 
+      Min Energy Ratio: 1.000000 
+      Max Energy Ratio: 1.000000 
+
+    PNO truncation energy = -0.000000000000
+    SROMP2 spin-adapted PNO truncation energy = -0.000000000000
+
+  ==> PNO-LMP2 Memory Estimate <== 
+
+    (q | i a) [AUX, LMO, PAO]  :    0.000 [GB]
+    X^{PNO}_{u_{ij} a_{ij}}    :    0.000 [GB]
+    (i a_{ij} | j b_{ij})      :    0.000 [GB]
+    T_{ij}^{a_{ij} b_{ij}}     :    0.000 [GB]
+    U_{ij}^{a_{ij} b_{ij}}     :    0.000 [GB]
+    PNO overlaps               :    0.001 [GB]
+    Total Memory Required      :    0.003 [GB]
+    Total Memory Given         :    0.524 [GB]
+
+
+  ==> Iterative Local MP2 with Pair Natural Orbitals (PNOs) <==
+
+    E_CONVERGENCE = 1.00e-10
+    R_CONVERGENCE = 1.00e-10
+
+                         Corr. Energy    Delta E     Max R     Time (s)
+  @PNO-LMP2 iter   1:  -0.196617625154 -1.966e-01  7.061e-04        0
+  @PNO-LMP2 iter   2:  -0.197531575489 -9.140e-04  7.339e-05        0
+  @PNO-LMP2 iter   3:  -0.197556385962 -2.481e-05  1.069e-05        0
+  @PNO-LMP2 iter   4:  -0.197558705663 -2.320e-06  8.430e-07        0
+  @PNO-LMP2 iter   5:  -0.197558813667 -1.080e-07  8.801e-08        0
+  @PNO-LMP2 iter   6:  -0.197558822827 -9.159e-09  1.052e-08        0
+  @PNO-LMP2 iter   7:  -0.197558821377  1.449e-09  1.603e-09        0
+  @PNO-LMP2 iter   8:  -0.197558821367  1.083e-11  1.765e-10        0
+  @PNO-LMP2 iter   9:  -0.197558821273  9.327e-11  2.434e-11        0
+    Final spin-adapted SROLMP2 correlation energy = -0.094742185282
+
+  ==> Final Strong and Weak Pairs <==
+
+    Weak Pairs                      = 0
+    Strong Pairs                    = 25
+    Strong Pairs / Total Pairs      = (100.00 %)
+  
+  Total DLPNO-MP2 Correlation Energy:  -0.094742185282 
+    MP2 Correlation Energy:            -0.094742185282 
+    Semicanonical MP2 Correction:       0.000000000000 
+    Dipole Correction:                  0.000000000000 
+    PNO Truncation Correction:         -0.000000000000 
+
+
+  @Total DLPNO-MP2 Energy: -39.017618262497 
+
+   * WARNING: This answer will likely vary from one obtained by a energy('dlpno-mp2') call
+                due to lack of a semi-canonical MP2 prescreening step in DLPNO-MP2, as well
+                as slightly tighter cutoffs utilized to increase accuracy in the context of CC!!!
+
+
+  ==> Forming Pair Natural Orbitals (for LCCSD) <==
+  
+    Natural Orbitals per Local MO pair:
+      Avg:  36 NOs 
+      Min:  36 NOs 
+      Max:  36 NOs 
+
+      Avg Occ Number Tol: 1.857e-09 
+      Min Occ Number Tol: 1.580e-16 
+      Max Occ Number Tol: 1.067e-08 
+
+      Avg Trace Sum: 1.000000 
+      Min Trace Sum: 1.000000 
+      Max Trace Sum: 1.000000 
+
+      Avg Energy Ratio: 1.000000 
+      Min Energy Ratio: 1.000000 
+      Max Energy Ratio: 1.000000 
+
+    LMP2 Weak Pair energy = 0.000000000000
+    PNO truncation energy = 0.000000000000
+    Spin-adapted SROLMP2 weak-pair energy = 0.000000000000
+    Spin-adapted total PNO truncation energy = 0.000000000000
+
+    Auxiliary BFs per Local MO:
+      Average =  118 AUX BFs (3 atoms)
+      Min     =  118 AUX BFs (3 atoms)
+      Max     =  118 AUX BFs (3 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   43 PAOs (3 atoms)
+      Min     =   43 PAOs (3 atoms)
+      Max     =   43 PAOs (3 atoms)
+
+    Local MOs per Local MO:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =  118 AUX BFs (3 atoms)
+      Min     =  118 AUX BFs (3 atoms)
+      Max     =  118 AUX BFs (3 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   43 PAOs (3 atoms)
+      Min     =   43 PAOs (3 atoms)
+      Max     =   43 PAOs (3 atoms)
+
+  ==> Transforming 3-Index Integrals to LMO/LMO basis <==
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Transforming 3-Index Integrals to PAO/PAO basis <==
+
+    * PAO/PAO Integral Memory After Screening: 0.001 [GiB]
+
+  ==> ROHF-DLPNO-CCSD Memory Requirements <== 
+
+    *** Spin-Independent Spatial Quantities ***
+    (q | i j) [AUX, LMO]          :    0.000 [GB]
+    (q | i a) [AUX, LMO, PAO]     :    0.000 [GB]
+    (q | a b) [AUX, PAO]          :    0.001 [GB]
+    (k_{ij}, c_{ij}) integrals    :    0.000 [GB]
+    (a_{ij}, b_{ij}) integrals    :    0.001 [GB]
+    Non-projected two-ext. ERIs   :    0.003 [GB]
+    Three-external ERIs           :    0.011 [GB]
+    Spatial DF PNO tensors        :    0.025 [GB]
+
+    *** ROHF Spin-Resolved Iteration Quantities ***
+    RCCSD + SROLMP2 T2 blocks     :    0.002 [GB]
+    R2 and non-symmetric R2       :    0.002 [GB]
+    Spin Fock pair blocks         :    0.001 [GB]
+    Global spin Fock blocks       :    0.000 [GB]
+    Projected spin T1 blocks      :    0.000 [GB]
+    T1-transformed spin DF blocks :    0.002 [GB]
+    PNO overlaps                  :    0.003 [GB]
+    DIIS history (maximum)        :    0.009 [GB]
+
+    Maximum ERI buffer per thread :    0.003 [GB]
+    Maximum CC buffer per thread  :    0.003 [GB]
+    Total Memory Required (ERIs)  :    0.069 [GB]
+    Total Memory Required (RCCSD) :    0.089 [GB]
+    Total Memory Given            :    0.524 [GB]
+
+    Using high-memory PNO overlap algorithm...
+
+    Keeping (Q_{ij}|m_{ij} a_{ij}) tensors in RAM.
+    Keeping (Q_{ij}|a_{ij} b_{ij}) tensors in RAM.
+
+    Computing integrals in the PNO basis from PAO integrals...
+
+    Integral Computation Complete!!! Time Elapsed:    0 seconds
+
+
+  ==> Restricted Open Shell Local CCSD <==
+
+    E_CONVERGENCE = 1.00e-08
+    R_CONVERGENCE = 1.00e-08
+
+                      Corr. Energy    Delta E     Max R1     Max R2     Time (s)
+  @LCCSD iter   1:  -0.119737836149 -1.197e-01  5.623e-03  1.384e-03        0
+  @LCCSD iter   2:  -0.123274804032 -3.537e-03  2.200e-03  4.020e-04        0
+  @LCCSD iter   3:  -0.124507766390 -1.233e-03  5.986e-04  1.266e-04        0
+  @LCCSD iter   4:  -0.124745619751 -2.379e-04  2.317e-04  4.015e-05        0
+  @LCCSD iter   5:  -0.124805444505 -5.982e-05  7.566e-05  1.768e-05        1
+  @LCCSD iter   6:  -0.124816330341 -1.089e-05  2.603e-05  6.573e-06        0
+  @LCCSD iter   7:  -0.124819692800 -3.362e-06  7.379e-06  2.210e-06        0
+  @LCCSD iter   8:  -0.124820294453 -6.017e-07  3.476e-06  7.619e-07        0
+  @LCCSD iter   9:  -0.124820506727 -2.123e-07  1.290e-06  2.931e-07        0
+  @LCCSD iter  10:  -0.124820701616 -1.949e-07  3.746e-07  1.326e-07        0
+  @LCCSD iter  11:  -0.124820806703 -1.051e-07  1.137e-07  5.766e-08        0
+  @LCCSD iter  12:  -0.124820862703 -5.600e-08  4.721e-08  2.639e-08        0
+  @LCCSD iter  13:  -0.124820887077 -2.437e-08  2.641e-08  1.165e-08        0
+  @LCCSD iter  14:  -0.124820895489 -8.412e-09  1.490e-08  5.185e-09        0
+  @LCCSD iter  15:  -0.124820898488 -2.999e-09  6.970e-09  2.117e-09        0
+
+  ROHF T1 Diagnostic: 0.00962114 
+  
+  Total ROHF-DLPNO-CCSD Correlation Energy:  -0.124820898488 
+    Strong-Pair RCCSD Contribution:          -0.124820898488 
+    SROLMP2 Weak-Pair Contribution:           0.000000000000 
+    Semicanonical SROMP2 Correction:          0.000000000000 
+    ROHF Dipole-Pair Correction:              0.000000000000 
+    PNO Truncation Correction:                0.000000000000 
+
+
+  @Total ROHF-DLPNO-CCSD Energy: -39.047696975704 
+    *** Spin-adapted and SOMO-safe. A thousand hallelujahs!!! 
+
+
+*** tstop() called on Androlomews-MacBook-Pro.local at Sun Aug 30 19:30:43 2026
+Module time:
+	user time   =       8.23 seconds =       0.14 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       9.93 seconds =       0.17 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+    scf ref...............................................................................PASSED
+    ccsd corl.............................................................................PASSED
+    ccsd total............................................................................PASSED
+    current ref...........................................................................PASSED
+    current corl..........................................................................PASSED
+    current total.........................................................................PASSED
+    dlpno-ccsd return.....................................................................PASSED
+
+    Psi4 stopped on: Sunday, 30 August 2026 07:30PM
+    Psi4 wall time for execution: 0:00:01.33
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/rodlpnocc-2/test_input.py
+++ b/tests/rodlpnocc-2/test_input.py
@@ -1,0 +1,5 @@
+from addons import *
+
+@ctest_labeler("dlpno;cc;quick")
+def test_rodlpnocc_2():
+    ctest_runner(__file__)

--- a/tests/rodlpnocc-3/CMakeLists.txt
+++ b/tests/rodlpnocc-3/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(rodlpnocc-3 "psi;dlpno;cc;quick")

--- a/tests/rodlpnocc-3/input.dat
+++ b/tests/rodlpnocc-3/input.dat
@@ -1,0 +1,45 @@
+#! Full-space ROHF DLPNO-CCSD regression for the methyl radical
+#! Zero pair and PNO cutoffs recover the canonical DF-CCSD limit
+#! Cartesian coordinates are in bohr
+
+ref_scf                  =    -39.56165780069830             #TEST
+ref_roccsd_corl          =     -0.16196608056500             #TEST
+ref_roccsd_tot           =    -39.72362388126330             #TEST
+
+molecule ch3 {
+0 2
+C    0.00000000000000      0.00000000000000      0.00000000000000
+H    1.02022495761968     -1.76708146174709      0.00000000000000
+H    1.02022495761968      1.76708146174709      0.00000000000000
+H   -2.04044991523936      0.00000000000000      0.00000000000000
+units bohr
+symmetry c1
+}
+
+set basis aug-cc-pvdz
+set freeze_core false
+set scf_type direct
+set e_convergence 1.0e-8
+set r_convergence 1.0e-8
+set t_cut_pno 0.0
+set t_cut_pno_mp2 0.0
+set t_cut_pairs 0.0
+set t_cut_do 0.0
+set t_cut_mkn 0.0
+set t_cut_tno 0.0
+set t_cut_do_triples 0.0
+set t_cut_mkn_triples 0.0
+set dlpno_toggle_memory false
+set reference rohf
+
+print('   Testing ROHF DLPNO-CCSD on the methyl radical ...')
+val = energy('dlpno-ccsd')
+
+compare_values(ref_scf, variable('SCF TOTAL ENERGY'), 7, 'scf ref')                       #TEST
+compare_values(ref_roccsd_corl, variable('CCSD CORRELATION ENERGY'), 7, 'ccsd corl')     #TEST
+compare_values(ref_roccsd_tot, variable('CCSD TOTAL ENERGY'), 7, 'ccsd total')           #TEST
+compare_values(ref_scf, variable('CURRENT REFERENCE ENERGY'), 7, 'current ref')          #TEST
+compare_values(ref_roccsd_corl, variable('CURRENT CORRELATION ENERGY'), 7, 'current corl') #TEST
+compare_values(ref_roccsd_tot, variable('CURRENT ENERGY'), 7, 'current total')           #TEST
+compare_values(ref_roccsd_tot, val, 7, 'dlpno-ccsd return')                              #TEST
+clean()

--- a/tests/rodlpnocc-3/output.ref
+++ b/tests/rodlpnocc-3/output.ref
@@ -1,0 +1,757 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.12a1.dev46 
+
+                         Git: Rev {ro_dlpno_113} 80caaaa 
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, D. L. Poole, T. Győri, E. C. Mitchell, J. P. Pederson,
+    and A. M. Wallace
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    https://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Sunday, 30 August 2026 07:31PM
+
+    Process ID: 3081
+    Host:       Androlomews-MacBook-Pro.local
+    PSIDATADIR: /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    8
+    Addons:     adcc, a̶m̶b̶i̶t̶, bse, c̶c̶t̶3̶, c̶f̶o̶u̶r̶, c̶h̶e̶m̶p̶s̶2̶, cppe, ddx, dftd3, dftd4, d̶k̶h̶,
+                e̶c̶p̶i̶n̶t̶, einsums, f̶o̶r̶t̶e̶, g̶a̶u̶x̶c̶, gcp, gdma, geometric,
+                g̶p̶u̶_̶d̶f̶c̶c̶, i̶n̶t̶e̶g̶r̶a̶t̶o̶r̶x̶x̶, ipi, libefp, mdi, m̶p̶2̶d̶,
+                m̶r̶c̶c̶, o̶o̶o̶, o̶p̶e̶n̶f̶e̶r̶m̶i̶o̶n̶p̶s̶i̶4̶, p̶c̶m̶s̶o̶l̶v̶e̶r̶,
+                p̶s̶i̶4̶f̶o̶c̶k̶c̶i̶, p̶s̶i̶x̶a̶s̶, pyeinsums, qcmanybody, r̶e̶s̶p̶,
+                s̶i̶m̶i̶n̶t̶, s̶n̶s̶m̶p̶2̶, v̶2̶r̶d̶m̶_̶c̶a̶s̶s̶c̶f̶
+
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Full-space ROHF DLPNO-CCSD regression for the methyl radical
+#! Zero pair and PNO cutoffs recover the canonical DF-CCSD limit
+#! Cartesian coordinates are in bohr
+
+ref_scf                  =    -39.56165780069830             #TEST
+ref_roccsd_corl          =     -0.16196608056500             #TEST
+ref_roccsd_tot           =    -39.72362388126330             #TEST
+
+molecule ch3 {
+0 2
+C    0.00000000000000      0.00000000000000      0.00000000000000
+H    1.02022495761968     -1.76708146174709      0.00000000000000
+H    1.02022495761968      1.76708146174709      0.00000000000000
+H   -2.04044991523936      0.00000000000000      0.00000000000000
+units bohr
+symmetry c1
+}
+
+set basis aug-cc-pvdz
+set freeze_core false
+set scf_type direct
+set e_convergence 1.0e-8
+set r_convergence 1.0e-8
+set t_cut_pno 0.0
+set t_cut_pno_mp2 0.0
+set t_cut_pairs 0.0
+set t_cut_do 0.0
+set t_cut_mkn 0.0
+set t_cut_tno 0.0
+set t_cut_do_triples 0.0
+set t_cut_mkn_triples 0.0
+set dlpno_toggle_memory false
+set reference rohf
+
+print('   Testing ROHF DLPNO-CCSD on the methyl radical ...')
+val = energy('dlpno-ccsd')
+
+compare_values(ref_scf, variable('SCF TOTAL ENERGY'), 7, 'scf ref')                       #TEST
+compare_values(ref_roccsd_corl, variable('CCSD CORRELATION ENERGY'), 7, 'ccsd corl')     #TEST
+compare_values(ref_roccsd_tot, variable('CCSD TOTAL ENERGY'), 7, 'ccsd total')           #TEST
+compare_values(ref_scf, variable('CURRENT REFERENCE ENERGY'), 7, 'current ref')          #TEST
+compare_values(ref_roccsd_corl, variable('CURRENT CORRELATION ENERGY'), 7, 'current corl') #TEST
+compare_values(ref_roccsd_tot, variable('CURRENT ENERGY'), 7, 'current total')           #TEST
+compare_values(ref_roccsd_tot, val, 7, 'dlpno-ccsd return')                              #TEST
+clean()
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on Androlomews-MacBook-Pro.local
+*** at Sun Aug 30 19:31:09 2026
+
+   => Loading Basis Set <=
+
+    Name: AUG-CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line   182 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz.gbs 
+    atoms 2-4 entry H          line    40 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             ROHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: D3h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000     0.000000000000    -0.000000000000    12.000000000000
+         H           -0.000000000000     0.000000000000    -2.040449915239     1.007825032230
+         H            1.767081461747     0.000000000000     1.020224957620     1.007825032230
+         H           -1.767081461747     0.000000000000     1.020224957620     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      9.56458  B =      9.56458  C =      4.78229 [cm^-1]
+  Rotational constants: A = 286738.92683  B = 286738.92683  C = 143369.46342 [MHz]
+  Nuclear repulsion =    9.670441141533319
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DIRECT.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: AUG-CC-PVDZ
+    Blend: AUG-CC-PVDZ
+    Number of shells: 24
+    Number of basis functions: 50
+    Number of Cartesian functions: 52
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   154 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+    atoms 2-4 entry H          line    70 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz-jkfit.gbs 
+
+  Starting with a DF guess...
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.004 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (AUG-CC-PVDZ AUX)
+    Blend: AUG-CC-PVDZ-JKFIT
+    Number of shells: 64
+    Number of basis functions: 182
+    Number of Cartesian functions: 206
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 8.9698536260E-04.
+  Reciprocal condition number of the overlap matrix is 1.2570203870E-04.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         50      50 
+   -------------------------
+    Total      50      50
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-ROHF iter SAD:   -38.85227089937575   -3.88523e+01   0.00000e+00 
+   @DF-ROHF iter   1:   -39.53212518455143   -6.79854e-01   3.13625e-03 DIIS
+   @DF-ROHF iter   2:   -39.55713233167776   -2.50071e-02   1.19109e-03 DIIS
+   @DF-ROHF iter   3:   -39.56128555505966   -4.15322e-03   2.51660e-04 DIIS
+   @DF-ROHF iter   4:   -39.56162631479540   -3.40760e-04   5.42924e-05 DIIS
+   @DF-ROHF iter   5:   -39.56164450314299   -1.81883e-05   1.32712e-05 DIIS
+   @DF-ROHF iter   6:   -39.56164545315067   -9.50008e-07   1.71577e-06 DIIS
+   @DF-ROHF iter   7:   -39.56164547122082   -1.80701e-08   3.78842e-07 DIIS
+   @DF-ROHF iter   8:   -39.56164547189640   -6.75577e-10   2.89169e-08 DIIS
+   @DF-ROHF iter   9:   -39.56164547190050   -4.09983e-12   2.39676e-09 DIIS
+
+  DF guess converged.
+
+  ==> DirectJK: Integral-Direct J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           8
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
+
+   @ROHF iter  10:   -39.56165779459347   -3.95617e+01   1.94011e-06 DIIS
+   @ROHF iter  11:   -39.56165780060225   -6.00878e-09   1.97550e-07 DIIS
+   @ROHF iter  12:   -39.56165780069166   -8.94147e-11   3.74934e-08 DIIS
+   @ROHF iter  13:   -39.56165780069712   -5.45697e-12   1.69766e-08 DIIS
+   @ROHF iter  14:   -39.56165780069824   -1.12266e-12   2.83648e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -11.233199     2A     -0.902202     3A     -0.573648  
+       4A     -0.573648  
+
+    Singly Occupied:                                                      
+
+       5A     -0.110498  
+
+    Virtual:                                                              
+
+       6A      0.038310     7A      0.060105     8A      0.060105  
+       9A      0.125411    10A      0.151266    11A      0.151266  
+      12A      0.177366    13A      0.287147    14A      0.287147  
+      15A      0.301702    16A      0.370776    17A      0.370776  
+      18A      0.446176    19A      0.446176    20A      0.498929  
+      21A      0.509828    22A      0.552890    23A      0.570695  
+      24A      0.570695    25A      0.572222    26A      0.632483  
+      27A      0.632483    28A      0.666212    29A      0.666212  
+      30A      0.944775    31A      0.951249    32A      1.125878  
+      33A      1.125878    34A      1.455810    35A      1.455810  
+      36A      1.540231    37A      1.540231    38A      1.766782  
+      39A      1.834164    40A      1.976792    41A      1.985861  
+      42A      1.985861    43A      2.125903    44A      2.287923  
+      45A      2.287923    46A      2.490770    47A      2.490770  
+      48A      2.833966    49A      3.019215    50A      3.019215  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+    NA   [     5 ]
+    NB   [     4 ]
+
+  @ROHF Final Energy:   -39.56165780069824
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.6704411415333187
+    One-Electron Energy =                 -71.5251642787677042
+    Two-Electron Energy =                  22.2930653365361415
+    Total Energy =                        -39.5616578006982422
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.0000000            0.0000000           -0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on Androlomews-MacBook-Pro.local at Sun Aug 30 19:31:09 2026
+Module time:
+	user time   =       2.23 seconds =       0.04 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.23 seconds =       0.04 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+*** tstart() called on Androlomews-MacBook-Pro.local
+*** at Sun Aug 30 19:31:09 2026
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //             DLPNO-CCSD            //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (AUG-CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry C          line   112 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+    atoms 2-4 entry H          line    30 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/aug-cc-pvdz-ri.gbs 
+
+   --------------------------------------------------
+          ROHF T1-Transformed DLPNO-CCSD            
+                    by Andy Jiang                    
+       Closed-shell engine: DOI 10.1063/5.0219963   
+   --------------------------------------------------
+
+  Reference                    : ROHF
+  PNO selector                 : spin-independent SROMP2
+  SOMO treatment               : appended to every pair space
+  DLPNO convergence            : NORMAL
+
+  Detailed DLPNO thresholds and cutoffs:
+    T_CUT_PNO        = 0.0000e+00 
+    T_DIAG_SCALE     = 3.0000e-02 
+    T_CORE_SCALE     = 1.0000e-02 
+    T_CUT_TRACE      = 9.9000e-01 
+    T_CUT_ENERGY     = 9.9000e-01 
+    T_CUT_PAIRS      = 0.0000e+00 
+    T_CUT_PAIRS_MP2  = 0.0000e+00 
+    T_CUT_PRE        = 0.0000e+00 
+    T_CUT_DO_PRE     = 3.0000e-02 
+    T_CUT_MKN        = 0.0000e+00 
+    T_CUT_PNO_MP2    = 0.0000e+00 
+    T_CUT_TRACE_MP2  = 9.9900e-01 
+    T_CUT_ENERGY_MP2 = 9.9700e-01 
+    T_CUT_DO         = 0.0000e+00 
+    T_CUT_DO_IJ      = 1.0000e-05 
+    T_CUT_DO_UV      = 1.0000e-05 
+    T_CUT_CLMO       = 1.0000e-04 
+    T_CUT_CPAO       = 1.0000e-04 
+    S_CUT            = 1.0000e-08 
+    F_CUT            = 1.0000e-05 
+    INTS_TOL (AO)    = 1.0000e-10 
+    MIN_PNOS         =      5   
+
+  ==> ROHF Orbital-Space Information <==
+
+   -----------------------------------------------------------------------------
+    NBF  NFRZC  ACT-A  ACT-B  DOCC  SOMO  VIRT-A  VIRT-B  NAUX
+   -----------------------------------------------------------------------------
+     50      0      5      4     4     1      45      46   141
+   -----------------------------------------------------------------------------
+
+  ==> Boys Localizer <==
+
+    Convergence =   1.000E-12
+    Maxiter     =        1000
+
+    Iteration                   Metric       Residual
+    @Boys    0   5.1077059698922933E-01              -
+    @Boys    1   2.4638430044196076E+00   3.823776E+00
+    @Boys    2   5.6421920301953215E+00   1.289997E+00
+    @Boys    3   5.7288941326759870E+00   1.536674E-02
+    @Boys    4   5.7293559866586108E+00   8.061835E-05
+    @Boys    5   5.7293600477493696E+00   7.088215E-07
+    @Boys    6   5.7293600496056580E+00   3.239958E-10
+    @Boys    7   5.7293600496148063E+00   1.596729E-12
+    @Boys    8   5.7293600496149217E+00   2.015290E-14
+
+    Boys Localizer converged.
+
+    Retained 4 SOMO-containing pairs through dipole prescreening.
+  ==> Crude Prescreening (Determines Semicanonical-MP2 Pairs) <==
+
+    T_CUT_MKN set to 0.000e+00
+    T_CUT_DO  set to 0.000e+00
+
+  ==> Forming Local MO Domains <==
+
+    Auxiliary BFs per Local MO:
+      Average =  141 AUX BFs (4 atoms)
+      Min     =  141 AUX BFs (4 atoms)
+      Max     =  141 AUX BFs (4 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   50 PAOs (4 atoms)
+      Min     =   50 PAOs (4 atoms)
+      Max     =   50 PAOs (4 atoms)
+
+    Local MOs per Local MO:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+ 
+    Screened 0 of 25 LMO pairs (0.00 %)
+             0 pairs met overlap criteria
+             5 pairs met energy criteria
+ 
+    Screened LMO pair energy =  0.000000000000 
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =  141 AUX BFs (4 atoms)
+      Min     =  141 AUX BFs (4 atoms)
+      Max     =  141 AUX BFs (4 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   50 PAOs (4 atoms)
+      Min     =   50 PAOs (4 atoms)
+      Max     =   50 PAOs (4 atoms)
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Initial SROMP2 prescreening of pairs <==
+
+  ==> Spin-Restricted Open-Shell Semicanonical MP2 Pair Prescreening <==
+
+    Eliminated Pairs (SC-SROMP2)       = 0
+    Surviving Pairs                    = 25
+    Surviving Pairs / Non-dipole Pairs = (100.00 %)
+    Eliminated Pair dE                 = 0.000000000000
+
+  ==> Refined Prescreening (Determines Strong and Weak Pairs) <==
+
+    T_CUT_MKN reset to 0.000e+00
+    T_CUT_DO  reset to 0.000e+00
+
+  ==> Forming Local MO Domains <==
+
+    Auxiliary BFs per Local MO:
+      Average =  141 AUX BFs (4 atoms)
+      Min     =  141 AUX BFs (4 atoms)
+      Max     =  141 AUX BFs (4 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   50 PAOs (4 atoms)
+      Min     =   50 PAOs (4 atoms)
+      Max     =   50 PAOs (4 atoms)
+
+    Local MOs per Local MO:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =  141 AUX BFs (4 atoms)
+      Min     =  141 AUX BFs (4 atoms)
+      Max     =  141 AUX BFs (4 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   50 PAOs (4 atoms)
+      Min     =   50 PAOs (4 atoms)
+      Max     =   50 PAOs (4 atoms)
+
+    Coefficient sparsity in AO -> LMO transform:   0.00 % 
+    Coefficient sparsity in AO -> PAO transform:   0.00 % 
+    Coefficient sparsity in combined transforms:   0.00 % 
+
+    Storing transformed LMO/LMO, LMO/PAO, and PAO/PAO integrals in sparse format.
+    Required memory: 0.003 GiB (0.00 % reduction from dense format) 
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Determining Strong and Weak Pairs with SROLMP2 <==
+
+  ==> Forming Pair Natural Orbitals (for LMP2) <==
+  
+    Natural Orbitals per Local MO pair:
+      Avg:  45 NOs 
+      Min:  45 NOs 
+      Max:  45 NOs 
+
+      Avg Occ Number Tol: 8.938e-11 
+      Min Occ Number Tol: -5.040e-19 
+      Max Occ Number Tol: 1.811e-09 
+
+      Avg Trace Sum: 1.000000 
+      Min Trace Sum: 1.000000 
+      Max Trace Sum: 1.000000 
+
+      Avg Energy Ratio: 1.000000 
+      Min Energy Ratio: 1.000000 
+      Max Energy Ratio: 1.000000 
+
+    PNO truncation energy = 0.000000000000
+    SROMP2 spin-adapted PNO truncation energy = 0.000000000000
+
+  ==> PNO-LMP2 Memory Estimate <== 
+
+    (q | i a) [AUX, LMO, PAO]  :    0.000 [GB]
+    X^{PNO}_{u_{ij} a_{ij}}    :    0.000 [GB]
+    (i a_{ij} | j b_{ij})      :    0.000 [GB]
+    T_{ij}^{a_{ij} b_{ij}}     :    0.000 [GB]
+    U_{ij}^{a_{ij} b_{ij}}     :    0.000 [GB]
+    PNO overlaps               :    0.001 [GB]
+    Total Memory Required      :    0.003 [GB]
+    Total Memory Given         :    0.524 [GB]
+
+
+  ==> Iterative Local MP2 with Pair Natural Orbitals (PNOs) <==
+
+    E_CONVERGENCE = 1.00e-10
+    R_CONVERGENCE = 1.00e-10
+
+                         Corr. Energy    Delta E     Max R     Time (s)
+  @PNO-LMP2 iter   1:  -0.186725494307 -1.867e-01  6.182e-04        0
+  @PNO-LMP2 iter   2:  -0.188062150428 -1.337e-03  7.928e-05        0
+  @PNO-LMP2 iter   3:  -0.188102743328 -4.059e-05  1.362e-05        1
+  @PNO-LMP2 iter   4:  -0.188108529994 -5.787e-06  1.457e-06        0
+  @PNO-LMP2 iter   5:  -0.188108986353 -4.564e-07  1.607e-07        0
+  @PNO-LMP2 iter   6:  -0.188109024713 -3.836e-08  1.978e-08        0
+  @PNO-LMP2 iter   7:  -0.188109025979 -1.265e-09  2.818e-09        0
+  @PNO-LMP2 iter   8:  -0.188109026203 -2.246e-10  5.047e-10        0
+  @PNO-LMP2 iter   9:  -0.188109026017  1.868e-10  6.191e-11        0
+  @PNO-LMP2 iter  10:  -0.188109026010  6.187e-12  7.662e-12        0
+    Final spin-adapted SROLMP2 correlation energy = -0.133910158801
+
+  ==> Final Strong and Weak Pairs <==
+
+    Weak Pairs                      = 0
+    Strong Pairs                    = 25
+    Strong Pairs / Total Pairs      = (100.00 %)
+  
+  Total DLPNO-MP2 Correlation Energy:  -0.133910158801 
+    MP2 Correlation Energy:            -0.133910158801 
+    Semicanonical MP2 Correction:       0.000000000000 
+    Dipole Correction:                  0.000000000000 
+    PNO Truncation Correction:          0.000000000000 
+
+
+  @Total DLPNO-MP2 Energy: -39.695567959500 
+
+   * WARNING: This answer will likely vary from one obtained by a energy('dlpno-mp2') call
+                due to lack of a semi-canonical MP2 prescreening step in DLPNO-MP2, as well
+                as slightly tighter cutoffs utilized to increase accuracy in the context of CC!!!
+
+
+  ==> Forming Pair Natural Orbitals (for LCCSD) <==
+  
+    Natural Orbitals per Local MO pair:
+      Avg:  45 NOs 
+      Min:  45 NOs 
+      Max:  45 NOs 
+
+      Avg Occ Number Tol: 9.966e-11 
+      Min Occ Number Tol: -8.696e-19 
+      Max Occ Number Tol: 1.811e-09 
+
+      Avg Trace Sum: 1.000000 
+      Min Trace Sum: 1.000000 
+      Max Trace Sum: 1.000000 
+
+      Avg Energy Ratio: 1.000000 
+      Min Energy Ratio: 1.000000 
+      Max Energy Ratio: 1.000000 
+
+    LMP2 Weak Pair energy = 0.000000000000
+    PNO truncation energy = -0.000000000000
+    Spin-adapted SROLMP2 weak-pair energy = 0.000000000000
+    Spin-adapted total PNO truncation energy = 0.000000000000
+
+    Auxiliary BFs per Local MO:
+      Average =  141 AUX BFs (4 atoms)
+      Min     =  141 AUX BFs (4 atoms)
+      Max     =  141 AUX BFs (4 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   51 PAOs (4 atoms)
+      Min     =   51 PAOs (4 atoms)
+      Max     =   51 PAOs (4 atoms)
+
+    Local MOs per Local MO:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =  141 AUX BFs (4 atoms)
+      Min     =  141 AUX BFs (4 atoms)
+      Max     =  141 AUX BFs (4 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   51 PAOs (4 atoms)
+      Min     =   51 PAOs (4 atoms)
+      Max     =   51 PAOs (4 atoms)
+
+  ==> Transforming 3-Index Integrals to LMO/LMO basis <==
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Transforming 3-Index Integrals to PAO/PAO basis <==
+
+    * PAO/PAO Integral Memory After Screening: 0.001 [GiB]
+
+  ==> ROHF-DLPNO-CCSD Memory Requirements <== 
+
+    *** Spin-Independent Spatial Quantities ***
+    (q | i j) [AUX, LMO]          :    0.000 [GB]
+    (q | i a) [AUX, LMO, PAO]     :    0.000 [GB]
+    (q | a b) [AUX, PAO]          :    0.001 [GB]
+    (k_{ij}, c_{ij}) integrals    :    0.000 [GB]
+    (a_{ij}, b_{ij}) integrals    :    0.002 [GB]
+    Non-projected two-ext. ERIs   :    0.004 [GB]
+    Three-external ERIs           :    0.019 [GB]
+    Spatial DF PNO tensors        :    0.043 [GB]
+
+    *** ROHF Spin-Resolved Iteration Quantities ***
+    RCCSD + SROLMP2 T2 blocks     :    0.003 [GB]
+    R2 and non-symmetric R2       :    0.003 [GB]
+    Spin Fock pair blocks         :    0.001 [GB]
+    Global spin Fock blocks       :    0.000 [GB]
+    Projected spin T1 blocks      :    0.000 [GB]
+    T1-transformed spin DF blocks :    0.003 [GB]
+    PNO overlaps                  :    0.004 [GB]
+    DIIS history (maximum)        :    0.013 [GB]
+
+    Maximum ERI buffer per thread :    0.006 [GB]
+    Maximum CC buffer per thread  :    0.006 [GB]
+    Total Memory Required (ERIs)  :    0.116 [GB]
+    Total Memory Required (RCCSD) :    0.146 [GB]
+    Total Memory Given            :    0.524 [GB]
+
+    Using high-memory PNO overlap algorithm...
+
+    Keeping (Q_{ij}|m_{ij} a_{ij}) tensors in RAM.
+    Keeping (Q_{ij}|a_{ij} b_{ij}) tensors in RAM.
+
+    Computing integrals in the PNO basis from PAO integrals...
+
+    Integral Computation Complete!!! Time Elapsed:    0 seconds
+
+
+  ==> Restricted Open Shell Local CCSD <==
+
+    E_CONVERGENCE = 1.00e-08
+    R_CONVERGENCE = 1.00e-08
+
+                      Corr. Energy    Delta E     Max R1     Max R2     Time (s)
+  @LCCSD iter   1:  -0.156788098974 -1.568e-01  4.072e-03  1.122e-03        0
+  @LCCSD iter   2:  -0.160513914770 -3.726e-03  2.173e-03  3.147e-04        0
+  @LCCSD iter   3:  -0.161711334447 -1.197e-03  3.212e-04  9.180e-05        0
+  @LCCSD iter   4:  -0.161913782353 -2.024e-04  1.358e-04  3.616e-05        0
+  @LCCSD iter   5:  -0.161953213289 -3.943e-05  3.726e-05  1.717e-05        0
+  @LCCSD iter   6:  -0.161960690468 -7.477e-06  1.339e-05  7.438e-06        0
+  @LCCSD iter   7:  -0.161963253677 -2.563e-06  5.725e-06  2.847e-06        0
+  @LCCSD iter   8:  -0.161964637591 -1.384e-06  2.417e-06  1.066e-06        1
+  @LCCSD iter   9:  -0.161965350314 -7.127e-07  1.230e-06  3.399e-07        0
+  @LCCSD iter  10:  -0.161965747558 -3.972e-07  5.104e-07  1.227e-07        0
+  @LCCSD iter  11:  -0.161965956498 -2.089e-07  1.518e-07  4.883e-08        0
+  @LCCSD iter  12:  -0.161966033182 -7.668e-08  5.289e-08  2.312e-08        0
+  @LCCSD iter  13:  -0.161966065878 -3.270e-08  2.094e-08  1.258e-08        0
+  @LCCSD iter  14:  -0.161966079577 -1.370e-08  1.260e-08  7.412e-09        0
+  @LCCSD iter  15:  -0.161966085039 -5.462e-09  4.806e-09  3.890e-09        0
+
+  ROHF T1 Diagnostic: 0.00482499 
+  
+  Total ROHF-DLPNO-CCSD Correlation Energy:  -0.161966085039 
+    Strong-Pair RCCSD Contribution:          -0.161966085039 
+    SROLMP2 Weak-Pair Contribution:           0.000000000000 
+    Semicanonical SROMP2 Correction:          0.000000000000 
+    ROHF Dipole-Pair Correction:              0.000000000000 
+    PNO Truncation Correction:                0.000000000000 
+
+
+  @Total ROHF-DLPNO-CCSD Energy: -39.723623885737 
+    *** Spin-adapted and SOMO-safe. A thousand hallelujahs!!! 
+
+
+*** tstop() called on Androlomews-MacBook-Pro.local at Sun Aug 30 19:31:11 2026
+Module time:
+	user time   =      14.92 seconds =       0.25 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      17.15 seconds =       0.29 minutes
+	system time =       0.24 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+    scf ref...............................................................................PASSED
+    ccsd corl.............................................................................PASSED
+    ccsd total............................................................................PASSED
+    current ref...........................................................................PASSED
+    current corl..........................................................................PASSED
+    current total.........................................................................PASSED
+    dlpno-ccsd return.....................................................................PASSED
+
+    Psi4 stopped on: Sunday, 30 August 2026 07:31PM
+    Psi4 wall time for execution: 0:00:02.21
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/rodlpnocc-3/test_input.py
+++ b/tests/rodlpnocc-3/test_input.py
@@ -1,0 +1,5 @@
+from addons import *
+
+@ctest_labeler("dlpno;cc;quick")
+def test_rodlpnocc_3():
+    ctest_runner(__file__)

--- a/tests/rodlpnocc-4/CMakeLists.txt
+++ b/tests/rodlpnocc-4/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(rodlpnocc-4 "psi;dlpno;cc;quick")

--- a/tests/rodlpnocc-4/input.dat
+++ b/tests/rodlpnocc-4/input.dat
@@ -1,0 +1,82 @@
+#! Full-space iterative ROHF DLPNO-CCSD(T) regression for the CN radical
+#! Canonical reference components are from cc8a. Opening every local cutoff
+#! makes this a compact oracle for the AAA, AAB, ABB, and BBB triples blocks.
+
+ref_scf   = -92.195556565280143  #TEST
+ref_ccsd  =  -0.281342908789723  #TEST
+ref_aaa   =  -0.000197427882648  #TEST
+ref_aab   =  -0.007154863588219  #TEST
+ref_abb   =  -0.006445976029399  #TEST
+ref_bbb   =  -0.000175823746097  #TEST
+ref_t     =  -0.013974091246363  #TEST
+ref_total = -92.490873565316235  #TEST
+
+molecule cn {
+0 2
+C  0.000000000000  0.000000000000   1.195736583480
+N  0.000000000000  0.000000000000  -1.024692078304
+units bohr
+symmetry c1
+}
+
+set {
+  reference rohf
+  basis cc-pVDZ
+  docc [6]
+  socc [1]
+  freeze_core true
+  scf_type direct
+
+  e_convergence 1.0e-10
+  r_convergence 1.0e-9
+  d_convergence 1.0e-9
+  dlpno_maxiter 100
+  dlpno_toggle_memory false
+
+  t_cut_pno 0.0
+  t_cut_pno_mp2 0.0
+  t_cut_pairs 0.0
+  t_cut_pairs_mp2 0.0
+  t_cut_do 0.0
+  t_cut_mkn 0.0
+  t_cut_pre 0.0
+  t_cut_do_pre 0.0
+  t_cut_do_ij 0.0
+  t_cut_clmo 0.0
+  t_cut_cpao 0.0
+  f_cut 0.0
+
+  t0_approximation false
+  t_cut_tno 0.0
+  t_cut_tno_pre 0.0
+  t_cut_do_triples 0.0
+  t_cut_do_triples_pre 0.0
+  t_cut_mkn_triples 0.0
+  t_cut_mkn_triples_pre 0.0
+  t_cut_triples_weak 0.0
+  triples_max_weak_pairs 3
+  f_cut_t 0.0
+  t_cut_iter 0.0
+}
+
+print('   Testing full-space iterative ROHF DLPNO-CCSD(T) on CN ...')
+val = energy('dlpno-ccsd(t)')
+
+e_aaa = variable('AAA (T) CORRECTION ENERGY')
+e_aab = variable('AAB (T) CORRECTION ENERGY')
+e_abb = variable('ABB (T) CORRECTION ENERGY')
+e_bbb = variable('BBB (T) CORRECTION ENERGY')
+e_t = variable('(T) CORRECTION ENERGY')
+
+compare_values(ref_scf, variable('SCF TOTAL ENERGY'), 8, 'scf ref')                   #TEST
+compare_values(ref_ccsd, variable('CCSD CORRELATION ENERGY'), 6, 'ccsd correlation') #TEST
+compare_values(ref_aaa, e_aaa, 6, 'AAA triples contribution')                        #TEST
+compare_values(ref_aab, e_aab, 6, 'AAB triples contribution')                        #TEST
+compare_values(ref_abb, e_abb, 6, 'ABB triples contribution')                        #TEST
+compare_values(ref_bbb, e_bbb, 6, 'BBB triples contribution')                        #TEST
+compare_values(ref_t, e_t, 6, 'iterative triples correction')                        #TEST
+compare_values(e_t, e_aaa + e_aab + e_abb + e_bbb, 10, 'spin-component sum')         #TEST
+compare_values(ref_total, variable('CCSD(T) TOTAL ENERGY'), 6, 'ccsd(t) total')       #TEST
+compare_values(ref_total, variable('CURRENT ENERGY'), 6, 'current total')             #TEST
+compare_values(ref_total, val, 6, 'dlpno-ccsd(t) return')                             #TEST
+clean()

--- a/tests/rodlpnocc-4/test_input.py
+++ b/tests/rodlpnocc-4/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+
+@ctest_labeler("dlpno;cc;quick")
+def test_rodlpnocc_4():
+    ctest_runner(__file__)

--- a/tests/uhfqrodlpnocc-1/CMakeLists.txt
+++ b/tests/uhfqrodlpnocc-1/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(uhfqrodlpnocc-1 "psi;dlpno;cc;quick")

--- a/tests/uhfqrodlpnocc-1/input.dat
+++ b/tests/uhfqrodlpnocc-1/input.dat
@@ -1,0 +1,48 @@
+#! UHF-to-QRO DLPNO-CCSD regression for triplet O2
+#! Tests the prepared QRO reference invariants and energy bookkeeping.
+
+molecule o2 {
+0 3
+O
+O 1 1.16
+symmetry c1
+}
+
+set basis cc-pvdz
+set freeze_core false
+set scf_type direct
+set e_convergence 1.0e-8
+set r_convergence 1.0e-8
+set t_cut_pno 0.0
+set t_cut_pno_mp2 0.0
+set t_cut_pairs 0.0
+set t_cut_do 0.0
+set t_cut_mkn 0.0
+set dlpno_toggle_memory false
+set reference uhf
+
+print('   Testing UHF-to-QRO DLPNO-CCSD on triplet O2 ...')
+input_uhf, uhf_wfn = energy('scf', return_wfn=True)
+ca_before = uhf_wfn.Ca().clone()
+cb_before = uhf_wfn.Cb().clone()
+fa_before = uhf_wfn.Fa().clone()
+fb_before = uhf_wfn.Fb().clone()
+val = energy('dlpno-ccsd', ref_wfn=uhf_wfn)
+
+qro_ref = variable('QRO REFERENCE ENERGY')
+corr = variable('CCSD CORRELATION ENERGY')
+total = variable('CCSD TOTAL ENERGY')
+
+compare_values(input_uhf, variable('SCF TOTAL ENERGY'), 10, 'input UHF provenance')           #TEST
+compare_values(qro_ref, variable('CURRENT REFERENCE ENERGY'), 10, 'current QRO reference')   #TEST
+compare_values(qro_ref + corr, total, 10, 'QRO reference plus correlation')                  #TEST
+compare_values(total, variable('CURRENT ENERGY'), 10, 'current total')                       #TEST
+compare_values(total, val, 10, 'dlpno-ccsd return')                                         #TEST
+compare_values(9.0, variable('QRO ALPHA ELECTRONS'), 8, 'QRO alpha electron count')          #TEST
+compare_values(7.0, variable('QRO BETA ELECTRONS'), 8, 'QRO beta electron count')            #TEST
+compare_values(0.0, variable('QRO ORTHONORMALITY ERROR'), 7, 'QRO orthonormality')           #TEST
+compare_matrices(ca_before, uhf_wfn.Ca(), 12, 'input UHF alpha orbitals unchanged')           #TEST
+compare_matrices(cb_before, uhf_wfn.Cb(), 12, 'input UHF beta orbitals unchanged')            #TEST
+compare_matrices(fa_before, uhf_wfn.Fa(), 12, 'input UHF alpha Fock unchanged')               #TEST
+compare_matrices(fb_before, uhf_wfn.Fb(), 12, 'input UHF beta Fock unchanged')                #TEST
+clean()

--- a/tests/uhfqrodlpnocc-1/output.ref
+++ b/tests/uhfqrodlpnocc-1/output.ref
@@ -1,0 +1,823 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.12a1.dev48 
+
+                         Git: Rev {ro_dlpno_113} 3e08d3c 
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, D. L. Poole, T. Győri, E. C. Mitchell, J. P. Pederson,
+    and A. M. Wallace
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    https://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Monday, 31 August 2026 11:44AM
+
+    Process ID: 8928
+    Host:       Androlomews-MacBook-Pro.local
+    PSIDATADIR: /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    8
+    Addons:     adcc, a̶m̶b̶i̶t̶, bse, c̶c̶t̶3̶, c̶f̶o̶u̶r̶, c̶h̶e̶m̶p̶s̶2̶, cppe, ddx, dftd3, dftd4, d̶k̶h̶,
+                e̶c̶p̶i̶n̶t̶, einsums, f̶o̶r̶t̶e̶, g̶a̶u̶x̶c̶, gcp, gdma, geometric,
+                g̶p̶u̶_̶d̶f̶c̶c̶, i̶n̶t̶e̶g̶r̶a̶t̶o̶r̶x̶x̶, ipi, libefp, mdi, m̶p̶2̶d̶,
+                m̶r̶c̶c̶, o̶o̶o̶, o̶p̶e̶n̶f̶e̶r̶m̶i̶o̶n̶p̶s̶i̶4̶, p̶c̶m̶s̶o̶l̶v̶e̶r̶,
+                p̶s̶i̶4̶f̶o̶c̶k̶c̶i̶, p̶s̶i̶x̶a̶s̶, pyeinsums, qcmanybody, r̶e̶s̶p̶,
+                s̶i̶m̶i̶n̶t̶, s̶n̶s̶m̶p̶2̶, v̶2̶r̶d̶m̶_̶c̶a̶s̶s̶c̶f̶
+
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! UHF-to-QRO DLPNO-CCSD regression for triplet O2
+#! Tests the prepared QRO reference invariants and energy bookkeeping.
+
+molecule o2 {
+0 3
+O
+O 1 1.16
+symmetry c1
+}
+
+set basis cc-pvdz
+set freeze_core false
+set scf_type direct
+set e_convergence 1.0e-8
+set r_convergence 1.0e-8
+set t_cut_pno 0.0
+set t_cut_pno_mp2 0.0
+set t_cut_pairs 0.0
+set t_cut_do 0.0
+set t_cut_mkn 0.0
+set dlpno_toggle_memory false
+set reference uhf
+
+print('   Testing UHF-to-QRO DLPNO-CCSD on triplet O2 ...')
+input_uhf, uhf_wfn = energy('scf', return_wfn=True)
+ca_before = uhf_wfn.Ca().clone()
+cb_before = uhf_wfn.Cb().clone()
+fa_before = uhf_wfn.Fa().clone()
+fb_before = uhf_wfn.Fb().clone()
+val = energy('dlpno-ccsd', ref_wfn=uhf_wfn)
+
+qro_ref = variable('QRO REFERENCE ENERGY')
+corr = variable('CCSD CORRELATION ENERGY')
+total = variable('CCSD TOTAL ENERGY')
+
+compare_values(input_uhf, variable('SCF TOTAL ENERGY'), 10, 'input UHF provenance')           #TEST
+compare_values(qro_ref, variable('CURRENT REFERENCE ENERGY'), 10, 'current QRO reference')   #TEST
+compare_values(qro_ref + corr, total, 10, 'QRO reference plus correlation')                  #TEST
+compare_values(total, variable('CURRENT ENERGY'), 10, 'current total')                       #TEST
+compare_values(total, val, 10, 'dlpno-ccsd return')                                         #TEST
+compare_values(9.0, variable('QRO ALPHA ELECTRONS'), 8, 'QRO alpha electron count')          #TEST
+compare_values(7.0, variable('QRO BETA ELECTRONS'), 8, 'QRO beta electron count')            #TEST
+compare_values(0.0, variable('QRO ORTHONORMALITY ERROR'), 7, 'QRO orthonormality')           #TEST
+compare_matrices(ca_before, uhf_wfn.Ca(), 12, 'input UHF alpha orbitals unchanged')           #TEST
+compare_matrices(cb_before, uhf_wfn.Cb(), 12, 'input UHF beta orbitals unchanged')            #TEST
+compare_matrices(fa_before, uhf_wfn.Fa(), 12, 'input UHF alpha Fock unchanged')               #TEST
+compare_matrices(fb_before, uhf_wfn.Fb(), 12, 'input UHF beta Fock unchanged')                #TEST
+clean()
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on Androlomews-MacBook-Pro.local
+*** at Mon Aug 31 11:44:55 2026
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry O          line   198 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 3:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.580000000000    15.994914619570
+         O            0.000000000000     0.000000000000     0.580000000000    15.994914619570
+
+  Running in c1 symmetry.
+
+  Rotational constants: A = ************  B =      1.56649  C =      1.56649 [cm^-1]
+  Rotational constants: A = ************  B =  46962.29263  C =  46962.29263 [MHz]
+  Nuclear repulsion =   29.195984036965520
+
+  Charge       = 0
+  Multiplicity = 3
+  Electrons    = 16
+  Nalpha       = 9
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DIRECT.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-06
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 28
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry O          line   221 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  Starting with a DF guess...
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 48
+    Number of basis functions: 140
+    Number of Cartesian functions: 162
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.6334605313E-02.
+  Reciprocal condition number of the overlap matrix is 5.6588345735E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         28      28 
+   -------------------------
+    Total      28      28
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:  -149.01276128271837   -1.49013e+02   0.00000e+00 
+   @DF-UHF iter   1:  -149.59268728231942   -5.79926e-01   1.03370e-02 ADIIS/DIIS
+   @DF-UHF iter   2:  -149.62718890929031   -3.45016e-02   3.06944e-03 ADIIS/DIIS
+   @DF-UHF iter   3:  -149.63094822274584   -3.75931e-03   1.16713e-03 ADIIS/DIIS
+   @DF-UHF iter   4:  -149.63181775957861   -8.69537e-04   2.75414e-04 ADIIS/DIIS
+   @DF-UHF iter   5:  -149.63186503724253   -4.72777e-05   6.45212e-05 DIIS
+   @DF-UHF iter   6:  -149.63186769468541   -2.65744e-06   3.90221e-06 DIIS
+   @DF-UHF iter   7:  -149.63186770324188   -8.55647e-09   8.17442e-07 DIIS
+
+  DF guess converged.
+
+  ==> DirectJK: Integral-Direct J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           8
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
+
+   @UHF iter   8:  -149.63226297792542   -1.49632e+02   3.73167e-05 DIIS
+   @UHF iter   9:  -149.63226331534867   -3.37423e-07   6.69261e-06 DIIS
+   @UHF iter  10:  -149.63226332858284   -1.32342e-08   1.69289e-06 DIIS
+   @UHF iter  11:  -149.63226332956754   -9.84699e-10   3.12078e-07 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   3.041620553E-02
+   @S^2 Expected:                2.000000000E+00
+   @S^2 Observed:                2.030416206E+00
+   @S   Expected:                1.000000000E+00
+   @S   Observed:                1.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -20.741033     2A    -20.740244     3A     -1.759587  
+       4A     -1.183539     5A     -0.854733     6A     -0.854733  
+       7A     -0.773287     8A     -0.528588     9A     -0.528588  
+
+    Alpha Virtual:                                                        
+
+      10A      0.489058    11A      1.053195    12A      1.053195  
+      13A      1.086848    14A      1.121364    15A      1.166822  
+      16A      1.166822    17A      1.303747    18A      1.983957  
+      19A      2.368232    20A      2.368232    21A      2.598667  
+      22A      2.598667    23A      2.964837    24A      2.964837  
+      25A      3.283903    26A      3.730209    27A      3.730209  
+      28A      4.177560  
+
+    Beta Occupied:                                                        
+
+       1A    -20.686758     2A    -20.685349     3A     -1.634800  
+       4A     -0.977910     5A     -0.708121     6A     -0.595609  
+       7A     -0.595609  
+
+    Beta Virtual:                                                         
+
+       8A      0.136777     9A      0.136777    10A      0.563384  
+      11A      1.121779    12A      1.136124    13A      1.168038  
+      14A      1.168038    15A      1.294757    16A      1.294757  
+      17A      1.338267    18A      2.037528    19A      2.445730  
+      20A      2.445730    21A      2.713527    22A      2.713527  
+      23A      3.113479    24A      3.113479    25A      3.355845  
+      26A      3.806837    27A      3.806837    28A      4.221687  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     7 ]
+    SOCC [     2 ]
+    NA   [     9 ]
+    NB   [     7 ]
+
+  @UHF Final Energy:  -149.63226332956754
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             29.1959840369655197
+    One-Electron Energy =                -263.8080277768603423
+    Two-Electron Energy =                  84.9797804103273222
+    Total Energy =                       -149.6322633295675075
+
+  UHF NO Occupations:
+  HONO-2 :    7  A 1.9943254
+  HONO-1 :    8  A 1.0000000
+  HONO-0 :    9  A 1.0000000
+  LUNO+0 :   10  A 0.0056746
+  LUNO+1 :   11  A 0.0056746
+  LUNO+2 :   12  A 0.0030843
+  LUNO+3 :   13  A 0.0007346
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.0000000            0.0000000           -0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on Androlomews-MacBook-Pro.local at Mon Aug 31 11:44:55 2026
+Module time:
+	user time   =       1.64 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.64 seconds =       0.03 minutes
+	system time =       0.09 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+Scratch directory: /tmp/
+
+*** tstart() called on Androlomews-MacBook-Pro.local
+*** at Mon Aug 31 11:44:55 2026
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //             DLPNO-CCSD            //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1-2 entry O          line   235 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+
+
+  ==> UHF -> Quasi-Restricted Orbital Transformation <==
+
+    The UHF natural orbitals are being transformed to a common QRO basis.
+    DLPNO-CCSD will use the QRO determinant and its spin Fock matrices.
+    The reported total energy is E(QRO reference) + E(CCSD correlation).
+
+    Input UHF SCF energy:          -149.632263329568
+    QRO determinant energy:        -149.613099403939
+    QRO - UHF energy:                 0.019163925629
+    QRO orthonormality error:              2.652e-14
+    QRO electron counts:        alpha = 9.00000000, beta = 7.00000000
+    Last DOMO occupation:             1.994325436517
+    First SOMO occupation:            1.000000000000
+    Last SOMO occupation:             1.000000000000
+    First virtual occupation:         0.005674563483
+
+    QROs are not converged ROHF orbitals; nonzero occupied-virtual Fock
+    elements and their singles contributions are retained.
+
+   --------------------------------------------------
+     Restricted Open-Shell T1-Transformed DLPNO-CCSD
+                    by Andy Jiang                    
+       Closed-shell engine: DOI 10.1063/5.0219963   
+   --------------------------------------------------
+
+  Reference                    : UHF -> QRO
+  Correlation reference energy : QRO determinant
+  Input UHF SCF energy          :    -149.632263329568
+  QRO reference energy          :    -149.613099403939
+  PNO selector                 : spin-independent SROMP2
+  SOMO treatment               : appended to every pair space
+  DLPNO convergence            : NORMAL
+
+  Detailed DLPNO thresholds and cutoffs:
+    T_CUT_PNO        = 0.0000e+00 
+    T_DIAG_SCALE     = 3.0000e-02 
+    T_CORE_SCALE     = 1.0000e-02 
+    T_CUT_TRACE      = 9.9000e-01 
+    T_CUT_ENERGY     = 9.9000e-01 
+    T_CUT_PAIRS      = 0.0000e+00 
+    T_CUT_PAIRS_MP2  = 0.0000e+00 
+    T_CUT_PRE        = 0.0000e+00 
+    T_CUT_DO_PRE     = 3.0000e-02 
+    T_CUT_MKN        = 0.0000e+00 
+    T_CUT_PNO_MP2    = 0.0000e+00 
+    T_CUT_TRACE_MP2  = 9.9900e-01 
+    T_CUT_ENERGY_MP2 = 9.9700e-01 
+    T_CUT_DO         = 0.0000e+00 
+    T_CUT_DO_IJ      = 1.0000e-05 
+    T_CUT_DO_UV      = 1.0000e-05 
+    T_CUT_CLMO       = 1.0000e-04 
+    T_CUT_CPAO       = 1.0000e-04 
+    S_CUT            = 1.0000e-08 
+    F_CUT            = 1.0000e-05 
+    INTS_TOL (AO)    = 1.0000e-10 
+    MIN_PNOS         =      5   
+
+  ==> ROHF Orbital-Space Information <==
+
+   -----------------------------------------------------------------------------
+    NBF  NFRZC  ACT-A  ACT-B  DOCC  SOMO  VIRT-A  VIRT-B  NAUX
+   -----------------------------------------------------------------------------
+     28      0      9      7     7     2      19      21   112
+   -----------------------------------------------------------------------------
+
+  ==> Boys Localizer <==
+
+    Convergence =   1.000E-12
+    Maxiter     =        1000
+
+    Iteration                   Metric       Residual
+    @Boys    0   1.0299222668575875E-18              -
+    @Boys    1   6.0684822862569838E+00   5.892175E+18
+    @Boys    2   7.8934025337213329E+00   3.007210E-01
+    @Boys    3   8.0573728740395083E+00   2.077309E-02
+    @Boys    4   8.0617393291233661E+00   5.419204E-04
+    @Boys    5   8.0620618898713996E+00   4.001131E-05
+    @Boys    6   8.0620677231765043E+00   7.235500E-07
+    @Boys    7   8.0620678169554889E+00   1.163213E-08
+    @Boys    8   8.0620678238430177E+00   8.543129E-10
+    @Boys    9   8.0620678241305033E+00   3.565904E-11
+    @Boys   10   8.0620678241426642E+00   1.508414E-12
+    @Boys   11   8.0620678241433641E+00   8.681204E-14
+
+    Boys Localizer converged.
+
+  ==> Boys Localizer <==
+
+    Convergence =   1.000E-12
+    Maxiter     =        1000
+
+    Iteration                   Metric       Residual
+    @Boys    0   1.0565663475757997E-25              -
+    @Boys    1   1.0647254195078662E-25   7.722252E-03
+    @Boys    2   1.0647254191298718E-25   3.550159E-10
+    @Boys    3   1.0647254191298718E-25   0.000000E+00
+
+    Boys Localizer converged.
+
+    Retained 15 SOMO-containing pairs through dipole prescreening.
+  ==> Crude Prescreening (Determines Semicanonical-MP2 Pairs) <==
+
+    T_CUT_MKN set to 0.000e+00
+    T_CUT_DO  set to 0.000e+00
+
+  ==> Forming Local MO Domains <==
+
+    Auxiliary BFs per Local MO:
+      Average =  112 AUX BFs (2 atoms)
+      Min     =  112 AUX BFs (2 atoms)
+      Max     =  112 AUX BFs (2 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   28 PAOs (2 atoms)
+      Min     =   28 PAOs (2 atoms)
+      Max     =   28 PAOs (2 atoms)
+
+    Local MOs per Local MO:
+      Average =    9 LMOs
+      Min     =    9 LMOs
+      Max     =    9 LMOs
+ 
+    Screened 0 of 81 LMO pairs (0.00 %)
+             0 pairs met overlap criteria
+             9 pairs met energy criteria
+ 
+    Screened LMO pair energy =  0.000000000000 
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =  112 AUX BFs (2 atoms)
+      Min     =  112 AUX BFs (2 atoms)
+      Max     =  112 AUX BFs (2 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    9 LMOs
+      Min     =    9 LMOs
+      Max     =    9 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   28 PAOs (2 atoms)
+      Min     =   28 PAOs (2 atoms)
+      Max     =   28 PAOs (2 atoms)
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Initial SROMP2 prescreening of pairs <==
+
+  ==> Spin-Restricted Open-Shell Semicanonical MP2 Pair Prescreening <==
+
+    Eliminated Pairs (SC-SROMP2)       = 0
+    Surviving Pairs                    = 81
+    Surviving Pairs / Non-dipole Pairs = (100.00 %)
+    Eliminated Pair dE                 = 0.000000000000
+
+  ==> Refined Prescreening (Determines Strong and Weak Pairs) <==
+
+    T_CUT_MKN reset to 0.000e+00
+    T_CUT_DO  reset to 0.000e+00
+
+  ==> Forming Local MO Domains <==
+
+    Auxiliary BFs per Local MO:
+      Average =  112 AUX BFs (2 atoms)
+      Min     =  112 AUX BFs (2 atoms)
+      Max     =  112 AUX BFs (2 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   28 PAOs (2 atoms)
+      Min     =   28 PAOs (2 atoms)
+      Max     =   28 PAOs (2 atoms)
+
+    Local MOs per Local MO:
+      Average =    9 LMOs
+      Min     =    9 LMOs
+      Max     =    9 LMOs
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =  112 AUX BFs (2 atoms)
+      Min     =  112 AUX BFs (2 atoms)
+      Max     =  112 AUX BFs (2 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    9 LMOs
+      Min     =    9 LMOs
+      Max     =    9 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   28 PAOs (2 atoms)
+      Min     =   28 PAOs (2 atoms)
+      Max     =   28 PAOs (2 atoms)
+
+    Coefficient sparsity in AO -> LMO transform:   0.00 % 
+    Coefficient sparsity in AO -> PAO transform:   0.00 % 
+    Coefficient sparsity in combined transforms:   0.00 % 
+
+    Storing transformed LMO/LMO, LMO/PAO, and PAO/PAO integrals in sparse format.
+    Required memory: 0.001 GiB (0.00 % reduction from dense format) 
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Determining Strong and Weak Pairs with SROLMP2 <==
+
+  ==> Forming Pair Natural Orbitals (for LMP2) <==
+  
+    Natural Orbitals per Local MO pair:
+      Avg:  19 NOs 
+      Min:  19 NOs 
+      Max:  19 NOs 
+
+      Avg Occ Number Tol: 1.762e-07 
+      Min Occ Number Tol: -2.447e-19 
+      Max Occ Number Tol: 1.304e-06 
+
+      Avg Trace Sum: 1.000000 
+      Min Trace Sum: 1.000000 
+      Max Trace Sum: 1.000000 
+
+      Avg Energy Ratio: 1.000000 
+      Min Energy Ratio: 1.000000 
+      Max Energy Ratio: 1.000000 
+
+    PNO truncation energy = 0.000000000000
+    SROMP2 spin-adapted PNO truncation energy = 0.000000000000
+
+  ==> PNO-LMP2 Memory Estimate <== 
+
+    (q | i a) [AUX, LMO, PAO]  :    0.000 [GB]
+    X^{PNO}_{u_{ij} a_{ij}}    :    0.000 [GB]
+    (i a_{ij} | j b_{ij})      :    0.000 [GB]
+    T_{ij}^{a_{ij} b_{ij}}     :    0.000 [GB]
+    U_{ij}^{a_{ij} b_{ij}}     :    0.000 [GB]
+    PNO overlaps               :    0.001 [GB]
+    Total Memory Required      :    0.002 [GB]
+    Total Memory Given         :    0.524 [GB]
+
+
+  ==> Iterative Local MP2 with Pair Natural Orbitals (PNOs) <==
+
+    E_CONVERGENCE = 1.00e-10
+    R_CONVERGENCE = 1.00e-10
+
+                         Corr. Energy    Delta E     Max R     Time (s)
+  @PNO-LMP2 iter   1:  -0.354075877362 -3.541e-01  2.705e-03        0
+  @PNO-LMP2 iter   2:  -0.359469320201 -5.393e-03  6.424e-04        0
+  @PNO-LMP2 iter   3:  -0.359724992359 -2.557e-04  1.460e-04        0
+  @PNO-LMP2 iter   4:  -0.359772988698 -4.800e-05  2.720e-05        0
+  @PNO-LMP2 iter   5:  -0.359779736656 -6.748e-06  4.225e-06        0
+  @PNO-LMP2 iter   6:  -0.359780086701 -3.500e-07  7.229e-07        0
+  @PNO-LMP2 iter   7:  -0.359779848824  2.379e-07  1.337e-07        0
+  @PNO-LMP2 iter   8:  -0.359779814004  3.482e-08  3.170e-08        0
+  @PNO-LMP2 iter   9:  -0.359779814567 -5.623e-10  5.672e-09        1
+  @PNO-LMP2 iter  10:  -0.359779813163  1.403e-09  8.439e-10        0
+  @PNO-LMP2 iter  11:  -0.359779812917  2.461e-10  1.451e-10        0
+  @PNO-LMP2 iter  12:  -0.359779812893  2.432e-11  3.190e-11        0
+    Final spin-adapted SROLMP2 correlation energy = -0.248165166829
+
+  ==> Final Strong and Weak Pairs <==
+
+    Weak Pairs                      = 0
+    Strong Pairs                    = 81
+    Strong Pairs / Total Pairs      = (100.00 %)
+  
+  Total DLPNO-MP2 Correlation Energy:  -0.248165166829 
+    MP2 Correlation Energy:            -0.248165166829 
+    Semicanonical MP2 Correction:       0.000000000000 
+    Dipole Correction:                  0.000000000000 
+    PNO Truncation Correction:          0.000000000000 
+
+
+  @Total DLPNO-MP2 Energy: -149.861264570768 
+
+   * WARNING: This answer will likely vary from one obtained by a energy('dlpno-mp2') call
+                due to lack of a semi-canonical MP2 prescreening step in DLPNO-MP2, as well
+                as slightly tighter cutoffs utilized to increase accuracy in the context of CC!!!
+
+
+  ==> Forming Pair Natural Orbitals (for LCCSD) <==
+  
+    Natural Orbitals per Local MO pair:
+      Avg:  19 NOs 
+      Min:  19 NOs 
+      Max:  19 NOs 
+
+      Avg Occ Number Tol: 2.016e-07 
+      Min Occ Number Tol: -2.220e-19 
+      Max Occ Number Tol: 1.502e-06 
+
+      Avg Trace Sum: 1.000000 
+      Min Trace Sum: 1.000000 
+      Max Trace Sum: 1.000000 
+
+      Avg Energy Ratio: 1.000000 
+      Min Energy Ratio: 1.000000 
+      Max Energy Ratio: 1.000000 
+
+    LMP2 Weak Pair energy = 0.000000000000
+    PNO truncation energy = 0.000000000000
+    Spin-adapted SROLMP2 weak-pair energy = 0.000000000000
+    Spin-adapted total PNO truncation energy = 0.000000000000
+
+    Auxiliary BFs per Local MO:
+      Average =  112 AUX BFs (2 atoms)
+      Min     =  112 AUX BFs (2 atoms)
+      Max     =  112 AUX BFs (2 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   30 PAOs (2 atoms)
+      Min     =   30 PAOs (2 atoms)
+      Max     =   30 PAOs (2 atoms)
+
+    Local MOs per Local MO:
+      Average =    9 LMOs
+      Min     =    9 LMOs
+      Max     =    9 LMOs
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =  112 AUX BFs (2 atoms)
+      Min     =  112 AUX BFs (2 atoms)
+      Max     =  112 AUX BFs (2 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    9 LMOs
+      Min     =    9 LMOs
+      Max     =    9 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   30 PAOs (2 atoms)
+      Min     =   30 PAOs (2 atoms)
+      Max     =   30 PAOs (2 atoms)
+
+  ==> Transforming 3-Index Integrals to LMO/LMO basis <==
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Transforming 3-Index Integrals to PAO/PAO basis <==
+
+    * PAO/PAO Integral Memory After Screening: 0.000 [GiB]
+
+  ==> ROHF-DLPNO-CCSD Memory Requirements <== 
+
+    *** Spin-Independent Spatial Quantities ***
+    (q | i j) [AUX, LMO]          :    0.000 [GB]
+    (q | i a) [AUX, LMO, PAO]     :    0.000 [GB]
+    (q | a b) [AUX, PAO]          :    0.000 [GB]
+    (k_{ij}, c_{ij}) integrals    :    0.000 [GB]
+    (a_{ij}, b_{ij}) integrals    :    0.001 [GB]
+    Non-projected two-ext. ERIs   :    0.005 [GB]
+    Three-external ERIs           :    0.006 [GB]
+    Spatial DF PNO tensors        :    0.030 [GB]
+
+    *** ROHF Spin-Resolved Iteration Quantities ***
+    RCCSD + SROLMP2 T2 blocks     :    0.002 [GB]
+    R2 and non-symmetric R2       :    0.002 [GB]
+    Spin Fock pair blocks         :    0.001 [GB]
+    Global spin Fock blocks       :    0.000 [GB]
+    Projected spin T1 blocks      :    0.000 [GB]
+    T1-transformed spin DF blocks :    0.004 [GB]
+    PNO overlaps                  :    0.008 [GB]
+    DIIS history (maximum)        :    0.009 [GB]
+
+    Maximum ERI buffer per thread :    0.001 [GB]
+    Maximum CC buffer per thread  :    0.001 [GB]
+    Total Memory Required (ERIs)  :    0.055 [GB]
+    Total Memory Required (RCCSD) :    0.081 [GB]
+    Total Memory Given            :    0.524 [GB]
+
+    Using high-memory PNO overlap algorithm...
+
+    Keeping (Q_{ij}|m_{ij} a_{ij}) tensors in RAM.
+    Keeping (Q_{ij}|a_{ij} b_{ij}) tensors in RAM.
+
+    Computing integrals in the PNO basis from PAO integrals...
+
+    Integral Computation Complete!!! Time Elapsed:    0 seconds
+
+
+  ==> Restricted Open Shell Local CCSD <==
+
+    E_CONVERGENCE = 1.00e-08
+    R_CONVERGENCE = 1.00e-08
+
+                      Corr. Energy    Delta E     Max R1     Max R2     Time (s)
+  @LCCSD iter   1:  -0.352417093264 -3.524e-01  1.087e-02  2.410e-03        0
+  @LCCSD iter   2:  -0.359871094455 -7.454e-03  4.942e-03  7.319e-04        0
+  @LCCSD iter   3:  -0.361476270794 -1.605e-03  1.422e-03  3.991e-04        0
+  @LCCSD iter   4:  -0.362095440344 -6.192e-04  4.231e-04  1.606e-04        0
+  @LCCSD iter   5:  -0.362180827051 -8.539e-05  1.957e-04  7.597e-05        0
+  @LCCSD iter   6:  -0.362191303745 -1.048e-05  4.677e-05  3.365e-05        0
+  @LCCSD iter   7:  -0.362198943672 -7.640e-06  1.370e-05  1.418e-05        0
+  @LCCSD iter   8:  -0.362196798639  2.145e-06  6.238e-06  4.605e-06        1
+  @LCCSD iter   9:  -0.362197983224 -1.185e-06  4.745e-06  1.498e-06        0
+  @LCCSD iter  10:  -0.362198418916 -4.357e-07  1.306e-06  6.253e-07        0
+  @LCCSD iter  11:  -0.362198678251 -2.593e-07  7.150e-07  2.586e-07        0
+  @LCCSD iter  12:  -0.362198830553 -1.523e-07  2.700e-07  1.220e-07        0
+  @LCCSD iter  13:  -0.362198887004 -5.645e-08  1.017e-07  5.941e-08        0
+  @LCCSD iter  14:  -0.362198916748 -2.974e-08  4.318e-08  3.346e-08        0
+  @LCCSD iter  15:  -0.362198928302 -1.155e-08  1.983e-08  1.700e-08        0
+  @LCCSD iter  16:  -0.362198930045 -1.743e-09  8.280e-09  7.126e-09        1
+
+  ROHF T1 Diagnostic: 0.00551172 
+  
+  Total Restricted-Open-Shell DLPNO-CCSD Correlation Energy:  -0.362198930045 
+    Strong-Pair RCCSD Contribution:          -0.362198930045 
+    SROLMP2 Weak-Pair Contribution:           0.000000000000 
+    Semicanonical SROMP2 Correction:          0.000000000000 
+    Open-Shell Dipole-Pair Correction:         0.000000000000 
+    PNO Truncation Correction:                0.000000000000 
+
+
+  @Total Restricted-Open-Shell DLPNO-CCSD Energy: -149.975298333984 
+    (QRO reference -149.613099403939 + correlation  -0.362198930045)
+    *** Spin-adapted and SOMO-safe. A thousand hallelujahs!!! 
+
+
+*** tstop() called on Androlomews-MacBook-Pro.local at Mon Aug 31 11:44:58 2026
+Module time:
+	user time   =      17.20 seconds =       0.29 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =      19.01 seconds =       0.32 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          3 seconds =       0.05 minutes
+    input UHF provenance..................................................................PASSED
+    current QRO reference.................................................................PASSED
+    QRO reference plus correlation........................................................PASSED
+    current total.........................................................................PASSED
+    dlpno-ccsd return.....................................................................PASSED
+    QRO alpha electron count..............................................................PASSED
+    QRO beta electron count...............................................................PASSED
+    QRO orthonormality....................................................................PASSED
+    input UHF alpha orbitals unchanged....................................................PASSED
+    input UHF beta orbitals unchanged.....................................................PASSED
+    input UHF alpha Fock unchanged........................................................PASSED
+    input UHF beta Fock unchanged.........................................................PASSED
+
+    Psi4 stopped on: Monday, 31 August 2026 11:44AM
+    Psi4 wall time for execution: 0:00:02.46
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/uhfqrodlpnocc-1/test_input.py
+++ b/tests/uhfqrodlpnocc-1/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+
+@ctest_labeler("dlpno;cc;quick")
+def test_uhfqrodlpnocc_1():
+    ctest_runner(__file__)

--- a/tests/uhfqrodlpnocc-2/CMakeLists.txt
+++ b/tests/uhfqrodlpnocc-2/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(uhfqrodlpnocc-2 "psi;dlpno;cc;quick")

--- a/tests/uhfqrodlpnocc-2/input.dat
+++ b/tests/uhfqrodlpnocc-2/input.dat
@@ -1,0 +1,48 @@
+#! Collapsed closed-shell consistency limit for UHF-to-QRO DLPNO-CCSD
+#! Full pair and PNO spaces make the result directly comparable to RHF.
+
+molecule h2o {
+0 1
+O
+H 1 0.957
+H 1 0.957 2 104.5
+symmetry c1
+}
+
+set basis cc-pvdz
+set freeze_core false
+set scf_type direct
+set e_convergence 1.0e-8
+set r_convergence 1.0e-8
+set t_cut_pno 0.0
+set t_cut_pno_mp2 0.0
+set t_cut_pairs 0.0
+set t_cut_do 0.0
+set t_cut_mkn 0.0
+set dlpno_toggle_memory false
+
+set reference rhf
+print('   Computing the RHF DLPNO-CCSD closed-shell reference ...')
+rhf_total = energy('dlpno-ccsd')
+rhf_ref = variable('SCF TOTAL ENERGY')
+rhf_corr = variable('CCSD CORRELATION ENERGY')
+clean()
+
+set reference uhf
+print('   Testing the collapsed UHF-to-QRO DLPNO-CCSD limit ...')
+qro_total = energy('dlpno-ccsd')
+input_uhf = variable('SCF TOTAL ENERGY')
+qro_ref = variable('QRO REFERENCE ENERGY')
+qro_corr = variable('CCSD CORRELATION ENERGY')
+
+compare_values(rhf_ref, input_uhf, 8, 'collapsed UHF SCF energy')                            #TEST
+compare_values(rhf_ref, qro_ref, 8, 'collapsed QRO reference energy')                       #TEST
+compare_values(rhf_corr, qro_corr, 7, 'collapsed QRO correlation energy')                   #TEST
+compare_values(rhf_total, qro_total, 7, 'collapsed QRO total energy')                       #TEST
+compare_values(qro_ref + qro_corr, qro_total, 10, 'QRO reference plus correlation')         #TEST
+compare_values(qro_ref, variable('CURRENT REFERENCE ENERGY'), 10, 'current QRO reference')  #TEST
+compare_values(5.0, variable('QRO ALPHA ELECTRONS'), 8, 'QRO alpha electron count')          #TEST
+compare_values(5.0, variable('QRO BETA ELECTRONS'), 8, 'QRO beta electron count')            #TEST
+compare_values(0.0, variable('QRO UHF SPIN DENSITY NORM'), 7, 'collapsed spin density')      #TEST
+compare_values(0.0, variable('QRO ORTHONORMALITY ERROR'), 7, 'QRO orthonormality')           #TEST
+clean()

--- a/tests/uhfqrodlpnocc-2/output.ref
+++ b/tests/uhfqrodlpnocc-2/output.ref
@@ -1,0 +1,1463 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.12a1.dev48 
+
+                         Git: Rev {ro_dlpno_113} 3e08d3c 
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, D. L. Poole, T. Győri, E. C. Mitchell, J. P. Pederson,
+    and A. M. Wallace
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    https://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Monday, 31 August 2026 11:46AM
+
+    Process ID: 8943
+    Host:       Androlomews-MacBook-Pro.local
+    PSIDATADIR: /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    8
+    Addons:     adcc, a̶m̶b̶i̶t̶, bse, c̶c̶t̶3̶, c̶f̶o̶u̶r̶, c̶h̶e̶m̶p̶s̶2̶, cppe, ddx, dftd3, dftd4, d̶k̶h̶,
+                e̶c̶p̶i̶n̶t̶, einsums, f̶o̶r̶t̶e̶, g̶a̶u̶x̶c̶, gcp, gdma, geometric,
+                g̶p̶u̶_̶d̶f̶c̶c̶, i̶n̶t̶e̶g̶r̶a̶t̶o̶r̶x̶x̶, ipi, libefp, mdi, m̶p̶2̶d̶,
+                m̶r̶c̶c̶, o̶o̶o̶, o̶p̶e̶n̶f̶e̶r̶m̶i̶o̶n̶p̶s̶i̶4̶, p̶c̶m̶s̶o̶l̶v̶e̶r̶,
+                p̶s̶i̶4̶f̶o̶c̶k̶c̶i̶, p̶s̶i̶x̶a̶s̶, pyeinsums, qcmanybody, r̶e̶s̶p̶,
+                s̶i̶m̶i̶n̶t̶, s̶n̶s̶m̶p̶2̶, v̶2̶r̶d̶m̶_̶c̶a̶s̶s̶c̶f̶
+
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Collapsed closed-shell consistency limit for UHF-to-QRO DLPNO-CCSD
+#! Full pair and PNO spaces make the result directly comparable to RHF.
+
+molecule h2o {
+0 1
+O
+H 1 0.957
+H 1 0.957 2 104.5
+symmetry c1
+}
+
+set basis cc-pvdz
+set freeze_core false
+set scf_type direct
+set e_convergence 1.0e-8
+set r_convergence 1.0e-8
+set t_cut_pno 0.0
+set t_cut_pno_mp2 0.0
+set t_cut_pairs 0.0
+set t_cut_do 0.0
+set t_cut_mkn 0.0
+set dlpno_toggle_memory false
+
+set reference rhf
+print('   Computing the RHF DLPNO-CCSD closed-shell reference ...')
+rhf_total = energy('dlpno-ccsd')
+rhf_ref = variable('SCF TOTAL ENERGY')
+rhf_corr = variable('CCSD CORRELATION ENERGY')
+clean()
+
+set reference uhf
+print('   Testing the collapsed UHF-to-QRO DLPNO-CCSD limit ...')
+qro_total = energy('dlpno-ccsd')
+input_uhf = variable('SCF TOTAL ENERGY')
+qro_ref = variable('QRO REFERENCE ENERGY')
+qro_corr = variable('CCSD CORRELATION ENERGY')
+
+compare_values(rhf_ref, input_uhf, 8, 'collapsed UHF SCF energy')                            #TEST
+compare_values(rhf_ref, qro_ref, 8, 'collapsed QRO reference energy')                       #TEST
+compare_values(rhf_corr, qro_corr, 7, 'collapsed QRO correlation energy')                   #TEST
+compare_values(rhf_total, qro_total, 7, 'collapsed QRO total energy')                       #TEST
+compare_values(qro_ref + qro_corr, qro_total, 10, 'QRO reference plus correlation')         #TEST
+compare_values(qro_ref, variable('CURRENT REFERENCE ENERGY'), 10, 'current QRO reference')  #TEST
+compare_values(5.0, variable('QRO ALPHA ELECTRONS'), 8, 'QRO alpha electron count')          #TEST
+compare_values(5.0, variable('QRO BETA ELECTRONS'), 8, 'QRO beta electron count')            #TEST
+compare_values(0.0, variable('QRO UHF SPIN DENSITY NORM'), 7, 'collapsed spin density')      #TEST
+compare_values(0.0, variable('QRO ORTHONORMALITY ERROR'), 7, 'QRO orthonormality')           #TEST
+clean()
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on Androlomews-MacBook-Pro.local
+*** at Mon Aug 31 11:46:34 2026
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065570021889    15.994914619570
+         H            0.000000000000    -0.756689922073     0.520321915104     1.007825032230
+         H            0.000000000000     0.756689922073     0.520321915104     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.43416  B =     14.60648  C =      9.53165 [cm^-1]
+  Rotational constants: A = 822455.52651  B = 437891.14479  C = 285751.53189 [MHz]
+  Nuclear repulsion =    9.196933714281483
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DIRECT.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  Starting with a DF guess...
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis functions: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.4162833904E-02.
+  Reciprocal condition number of the overlap matrix is 9.2080850101E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -75.51187233988479   -7.55119e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.95408986630436   -4.42218e-01   1.74098e-02 DIIS/ADIIS
+   @DF-RHF iter   2:   -76.00736316501451   -5.32733e-02   9.93601e-03 DIIS/ADIIS
+   @DF-RHF iter   3:   -76.02631695536589   -1.89538e-02   1.06509e-03 DIIS/ADIIS
+   @DF-RHF iter   4:   -76.02676727938004   -4.50324e-04   2.07817e-04 DIIS/ADIIS
+   @DF-RHF iter   5:   -76.02678633953960   -1.90602e-05   3.81948e-05 DIIS
+   @DF-RHF iter   6:   -76.02678724955996   -9.10020e-07   6.05530e-06 DIIS
+   @DF-RHF iter   7:   -76.02678727505682   -2.54969e-08   8.40107e-07 DIIS
+   @DF-RHF iter   8:   -76.02678727556165   -5.04826e-10   1.95216e-07 DIIS
+   @DF-RHF iter   9:   -76.02678727559324   -3.15907e-11   3.31793e-08 DIIS
+   @DF-RHF iter  10:   -76.02678727559403   -7.95808e-13   2.73628e-09 DIIS
+
+  DF guess converged.
+
+  ==> DirectJK: Integral-Direct J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           8
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
+
+   @RHF iter  11:   -76.02680816114379   -7.60268e+01   6.93232e-06 DIIS
+   @RHF iter  12:   -76.02680817338572   -1.22419e-08   1.11869e-06 DIIS
+   @RHF iter  13:   -76.02680817376591   -3.80197e-10   2.18535e-07 DIIS
+   @RHF iter  14:   -76.02680817377974   -1.38272e-11   6.33259e-08 DIIS
+   @RHF iter  15:   -76.02680817378086   -1.12266e-12   2.56515e-08 DIIS
+   @RHF iter  16:   -76.02680817378099   -1.27898e-13   2.35070e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550390     2A     -1.336826     3A     -0.699406  
+       4A     -0.566646     5A     -0.493169  
+
+    Virtual:                                                              
+
+       6A      0.185609     7A      0.256291     8A      0.789452  
+       9A      0.854627    10A      1.163500    11A      1.200384  
+      12A      1.253301    13A      1.444438    14A      1.476370  
+      15A      1.674656    16A      1.867219    17A      1.935269  
+      18A      2.453470    19A      2.491061    20A      3.285961  
+      21A      3.339124    22A      3.510949    23A      3.866084  
+      24A      4.147878  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+    NA   [     5 ]
+    NB   [     5 ]
+
+  @RHF Final Energy:   -76.02680817378099
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1969337142814833
+    One-Electron Energy =                -123.1546097106768514
+    Two-Electron Energy =                  37.9308678226143670
+    Total Energy =                        -76.0268081737810064
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.1662417            0.9752568            0.8090151
+ Magnitude           :                                                    0.8090151
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on Androlomews-MacBook-Pro.local at Mon Aug 31 11:46:34 2026
+Module time:
+	user time   =       1.56 seconds =       0.03 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.56 seconds =       0.03 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+*** tstart() called on Androlomews-MacBook-Pro.local
+*** at Mon Aug 31 11:46:34 2026
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //             DLPNO-CCSD            //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   235 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+
+   --------------------------------------------
+                    DLPNO-CCSD                 
+                   by Andy Jiang               
+              DOI: 10.1063/5.0219963           
+   --------------------------------------------
+
+  DLPNO convergence set to NORMAL.
+
+  Detailed DLPNO thresholds and cutoffs:
+    T_CUT_PNO        = 0.0000e+00 
+    T_DIAG_SCALE     = 3.0000e-02 
+    T_CORE_SCALE     = 1.0000e-02 
+    T_CUT_TRACE      = 9.9000e-01 
+    T_CUT_ENERGY     = 9.9000e-01 
+    T_CUT_PAIRS      = 0.0000e+00 
+    T_CUT_PAIRS_MP2  = 0.0000e+00 
+    T_CUT_PRE        = 0.0000e+00 
+    T_CUT_DO_PRE     = 3.0000e-02 
+    T_CUT_MKN        = 0.0000e+00 
+    T_CUT_PNO_MP2    = 0.0000e+00 
+    T_CUT_TRACE_MP2  = 9.9900e-01 
+    T_CUT_ENERGY_MP2 = 9.9700e-01 
+    T_CUT_DO         = 0.0000e+00 
+    T_CUT_DO_IJ      = 1.0000e-05 
+    T_CUT_DO_UV      = 1.0000e-05 
+    T_CUT_CLMO       = 1.0000e-04 
+    T_CUT_CPAO       = 1.0000e-04 
+    S_CUT            = 1.0000e-08 
+    F_CUT            = 1.0000e-05 
+    INTS_TOL (AO)    = 1.0000e-10 
+    MIN_PNOS         =      5   
+
+
+  ==> Basis Set Information <==
+
+   ----------------------------------------------
+      NBF   NFRZC   NACT   NDOCC   NVIR   NAUX   
+   ----------------------------------------------
+       24      0      5       5      19     84
+   ----------------------------------------------
+
+  ==> Boys Localizer <==
+
+    Convergence =   1.000E-12
+    Maxiter     =        1000
+
+    Iteration                   Metric       Residual
+    @Boys    0   1.9569019761943135E-01              -
+    @Boys    1   2.2027151483626293E+00   1.025613E+01
+    @Boys    2   2.5561954287196551E+00   1.604748E-01
+    @Boys    3   2.5653807054973110E+00   3.593339E-03
+    @Boys    4   2.5668644190518650E+00   5.783600E-04
+    @Boys    5   2.5671502259210968E+00   1.113447E-04
+    @Boys    6   2.5672230665627174E+00   2.837413E-05
+    @Boys    7   2.5672358476952044E+00   4.978583E-06
+    @Boys    8   2.5672381205774402E+00   8.853422E-07
+    @Boys    9   2.5672384369721155E+00   1.232432E-07
+    @Boys   10   2.5672384999652658E+00   2.453732E-08
+    @Boys   11   2.5672385055035258E+00   2.157283E-09
+    @Boys   12   2.5672385067060759E+00   4.684216E-10
+    @Boys   13   2.5672385069829531E+00   1.078502E-10
+    @Boys   14   2.5672385070131307E+00   1.175490E-11
+    @Boys   15   2.5672385070179673E+00   1.883960E-12
+    @Boys   16   2.5672385070192241E+00   4.895425E-13
+
+    Boys Localizer converged.
+
+  ==> Crude Prescreening (Determines Semicanonical-MP2 Pairs) <==
+
+    T_CUT_MKN set to 0.000e+00
+    T_CUT_DO  set to 0.000e+00
+
+  ==> Forming Local MO Domains <==
+
+    Auxiliary BFs per Local MO:
+      Average =   84 AUX BFs (3 atoms)
+      Min     =   84 AUX BFs (3 atoms)
+      Max     =   84 AUX BFs (3 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   24 PAOs (3 atoms)
+      Min     =   24 PAOs (3 atoms)
+      Max     =   24 PAOs (3 atoms)
+
+    Local MOs per Local MO:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+ 
+    Screened 0 of 25 LMO pairs (0.00 %)
+             0 pairs met overlap criteria
+             5 pairs met energy criteria
+ 
+    Screened LMO pair energy =  0.000000000000 
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =   84 AUX BFs (3 atoms)
+      Min     =   84 AUX BFs (3 atoms)
+      Max     =   84 AUX BFs (3 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   24 PAOs (3 atoms)
+      Min     =   24 PAOs (3 atoms)
+      Max     =   24 PAOs (3 atoms)
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Initial semi-canonical MP2 prescreening of pairs <==
+
+  ==> Semi-Canonical MP2 Pair Prescreening <==
+
+    Eliminated Pairs (SC-LMP2)         = 0
+    Surviving Pairs                    = 25
+    Surviving Pairs / Non-dipole Pairs = (100.00 %)
+    Eliminated Pair dE                 = 0.000000000000
+
+  ==> Refined Prescreening (Determines Strong and Weak Pairs) <==
+
+    T_CUT_MKN reset to 0.000e+00
+    T_CUT_DO  reset to 0.000e+00
+
+  ==> Forming Local MO Domains <==
+
+    Auxiliary BFs per Local MO:
+      Average =   84 AUX BFs (3 atoms)
+      Min     =   84 AUX BFs (3 atoms)
+      Max     =   84 AUX BFs (3 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   24 PAOs (3 atoms)
+      Min     =   24 PAOs (3 atoms)
+      Max     =   24 PAOs (3 atoms)
+
+    Local MOs per Local MO:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =   84 AUX BFs (3 atoms)
+      Min     =   84 AUX BFs (3 atoms)
+      Max     =   84 AUX BFs (3 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   24 PAOs (3 atoms)
+      Min     =   24 PAOs (3 atoms)
+      Max     =   24 PAOs (3 atoms)
+
+    Coefficient sparsity in AO -> LMO transform:   0.00 % 
+    Coefficient sparsity in AO -> PAO transform:   0.00 % 
+    Coefficient sparsity in combined transforms:   0.00 % 
+
+    Storing transformed LMO/LMO, LMO/PAO, and PAO/PAO integrals in sparse format.
+    Required memory: 0.000 GiB (0.00 % reduction from dense format) 
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Determining Strong and Weak Pairs (Refined Prescreening Step) <==
+
+  ==> Forming Pair Natural Orbitals (for LMP2) <==
+  
+    Natural Orbitals per Local MO pair:
+      Avg:  19 NOs 
+      Min:  19 NOs 
+      Max:  19 NOs 
+
+      Avg Occ Number Tol: 5.692e-08 
+      Min Occ Number Tol: 2.083e-14 
+      Max Occ Number Tol: 2.465e-07 
+
+      Avg Trace Sum: 1.000000 
+      Min Trace Sum: 1.000000 
+      Max Trace Sum: 1.000000 
+
+      Avg Energy Ratio: 1.000000 
+      Min Energy Ratio: 1.000000 
+      Max Energy Ratio: 1.000000 
+
+    PNO truncation energy = 0.000000000000
+
+  ==> PNO-LMP2 Memory Estimate <== 
+
+    (q | i a) [AUX, LMO, PAO]  :    0.000 [GB]
+    X^{PNO}_{u_{ij} a_{ij}}    :    0.000 [GB]
+    (i a_{ij} | j b_{ij})      :    0.000 [GB]
+    T_{ij}^{a_{ij} b_{ij}}     :    0.000 [GB]
+    U_{ij}^{a_{ij} b_{ij}}     :    0.000 [GB]
+    PNO overlaps               :    0.000 [GB]
+    Total Memory Required      :    0.001 [GB]
+    Total Memory Given         :    0.524 [GB]
+
+
+  ==> Iterative Local MP2 with Pair Natural Orbitals (PNOs) <==
+
+    E_CONVERGENCE = 1.00e-10
+    R_CONVERGENCE = 1.00e-10
+
+                         Corr. Energy    Delta E     Max R     Time (s)
+  @PNO-LMP2 iter   1:  -0.199698507529 -1.997e-01  3.898e-03        0
+  @PNO-LMP2 iter   2:  -0.203569525951 -3.871e-03  9.470e-04        0
+  @PNO-LMP2 iter   3:  -0.203858601690 -2.891e-04  3.340e-04        0
+  @PNO-LMP2 iter   4:  -0.203930268877 -7.167e-05  6.834e-05        0
+  @PNO-LMP2 iter   5:  -0.203934348561 -4.080e-06  1.637e-05        0
+  @PNO-LMP2 iter   6:  -0.203933465697  8.829e-07  2.760e-06        0
+  @PNO-LMP2 iter   7:  -0.203933173373  2.923e-07  7.493e-07        0
+  @PNO-LMP2 iter   8:  -0.203933001518  1.719e-07  2.604e-07        0
+  @PNO-LMP2 iter   9:  -0.203933005399 -3.881e-09  6.144e-08        0
+  @PNO-LMP2 iter  10:  -0.203933001579  3.820e-09  1.362e-08        0
+  @PNO-LMP2 iter  11:  -0.203933000931  6.486e-10  2.766e-09        0
+  @PNO-LMP2 iter  12:  -0.203933000697  2.332e-10  6.242e-10        0
+  @PNO-LMP2 iter  13:  -0.203933000668  2.923e-11  2.071e-10        0
+  @PNO-LMP2 iter  14:  -0.203933000676 -7.974e-12  5.278e-11        0
+
+  ==> Final Strong and Weak Pairs <==
+
+    Weak Pairs                      = 0
+    Strong Pairs                    = 25
+    Strong Pairs / Total Pairs      = (100.00 %)
+  
+  Total DLPNO-MP2 Correlation Energy:  -0.203933000676 
+    MP2 Correlation Energy:            -0.203933000676 
+    Semicanonical MP2 Correction:       0.000000000000 
+    Dipole Correction:                  0.000000000000 
+    PNO Truncation Correction:          0.000000000000 
+
+
+  @Total DLPNO-MP2 Energy: -76.230741174457 
+
+   * WARNING: This answer will likely vary from one obtained by a energy('dlpno-mp2') call
+                due to lack of a semi-canonical MP2 prescreening step in DLPNO-MP2, as well
+                as slightly tighter cutoffs utilized to increase accuracy in the context of CC!!!
+
+
+    Auxiliary BFs per Local MO:
+      Average =   84 AUX BFs (3 atoms)
+      Min     =   84 AUX BFs (3 atoms)
+      Max     =   84 AUX BFs (3 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   24 PAOs (3 atoms)
+      Min     =   24 PAOs (3 atoms)
+      Max     =   24 PAOs (3 atoms)
+
+    Local MOs per Local MO:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =   84 AUX BFs (3 atoms)
+      Min     =   84 AUX BFs (3 atoms)
+      Max     =   84 AUX BFs (3 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   24 PAOs (3 atoms)
+      Min     =   24 PAOs (3 atoms)
+      Max     =   24 PAOs (3 atoms)
+
+  ==> Forming Pair Natural Orbitals (for LCCSD) <==
+  
+    Natural Orbitals per Local MO pair:
+      Avg:  19 NOs 
+      Min:  19 NOs 
+      Max:  19 NOs 
+
+      Avg Occ Number Tol: 8.136e-08 
+      Min Occ Number Tol: 1.681e-12 
+      Max Occ Number Tol: 3.467e-07 
+
+      Avg Trace Sum: 1.000000 
+      Min Trace Sum: 1.000000 
+      Max Trace Sum: 1.000000 
+
+      Avg Energy Ratio: 1.000000 
+      Min Energy Ratio: 1.000000 
+      Max Energy Ratio: 1.000000 
+
+    LMP2 Weak Pair energy = 0.000000000000
+    PNO truncation energy = 0.000000000000
+
+  ==> Transforming 3-Index Integrals to LMO/LMO basis <==
+
+  ==> Transforming 3-Index Integrals to PAO/PAO basis <==
+
+    * PAO/PAO Integral Memory After Screening: 0.000 [GiB]
+
+  ==> DLPNO-CCSD Memory Requirements <== 
+
+    *** Common Quantities ***
+    (q | i j) [AUX, LMO]          :    0.000 [GB]
+    (q | i a) [AUX, LMO, PAO]     :    0.000 [GB]
+    (q | a b) [AUX, PAO]          :    0.000 [GB]
+    (k_{ij}, l_{ij})-like         :    0.000 [GB]
+    (k_{ij}, c_{ij})-like         :    0.000 [GB]
+    (a_{ij}, b_{ij})-like         :    0.001 [GB]
+    (a_{ij}, c_{kj})-like         :    0.001 [GB]
+    (i a_{ij} | b_{ij}, c_{ij})   :    0.001 [GB]
+    (Q_{ij} | k_{ij} i)           :    0.000 [GB]
+    (Q_{ij} | a_{ij} i)           :    0.001 [GB]
+    (Q_{ij} | m_{ij} a_{ij})      :    0.001 [GB]
+    (Q_{ij} | a_{ij} b_{ij})      :    0.004 [GB]
+
+    *** Maximum ERI buffer space of 0.001 [GB] per pair, over 8 threads...
+
+    Buffer Space for ERIs         :    0.006 [GB]
+    Total Memory Required (ERIs)  :    0.014 [GB]
+
+    *** Quantities for LCCSD Iterations ***
+    PNO overlaps                  :    0.001 [GB]
+
+    *** Maximum CCSD buffer space of 0.001 [GB] per pair, over 8 threads...
+
+    Buffer Space for Iterations   :    0.005 [GB]
+    Total Memory Required (LCCSD) :    0.014 [GB]
+
+    Total Memory Given            :    0.524 [GB]
+
+    Using high memory PNO overlap algorithm... 
+
+    Storing (Q_{ij}|m_{ij} a_{ij}) integrals in RAM... 
+
+    Storing (Q_{ij}|a_{ij} b_{ij}) integrals in RAM... 
+
+    Computing integrals in the PNO basis from PAO integrals...
+
+    Integral Computation Complete!!! Time Elapsed:    0 seconds
+
+
+  ==> Local CCSD <==
+
+    E_CONVERGENCE = 1.00e-08
+    R_CONVERGENCE = 1.00e-08
+
+                      Corr. Energy    Delta E     Max R1     Max R2     Time (s)
+  @LCCSD iter   1:  -0.209413989380 -2.094e-01  4.337e-03  2.180e-03        0
+  @LCCSD iter   2:  -0.212091337914 -2.677e-03  1.631e-03  7.541e-04        0
+  @LCCSD iter   3:  -0.213057813377 -9.665e-04  4.150e-04  2.901e-04        0
+  @LCCSD iter   4:  -0.213315969056 -2.582e-04  2.517e-04  9.436e-05        0
+  @LCCSD iter   5:  -0.213387830837 -7.186e-05  1.450e-04  3.277e-05        0
+  @LCCSD iter   6:  -0.213405770769 -1.794e-05  5.198e-05  1.119e-05        0
+  @LCCSD iter   7:  -0.213407669503 -1.899e-06  4.139e-05  4.188e-06        0
+  @LCCSD iter   8:  -0.213408798631 -1.129e-06  2.013e-05  1.793e-06        0
+  @LCCSD iter   9:  -0.213409160341 -3.617e-07  7.824e-06  7.958e-07        0
+  @LCCSD iter  10:  -0.213409422711 -2.624e-07  4.181e-06  3.199e-07        0
+  @LCCSD iter  11:  -0.213409412261  1.045e-08  7.419e-07  1.667e-07        0
+  @LCCSD iter  12:  -0.213409437834 -2.557e-08  1.833e-07  8.543e-08        0
+  @LCCSD iter  13:  -0.213409453665 -1.583e-08  2.385e-07  3.354e-08        0
+  @LCCSD iter  14:  -0.213409455777 -2.113e-09  4.457e-08  1.272e-08        0
+  @LCCSD iter  15:  -0.213409457499 -1.721e-09  2.003e-08  4.737e-09        0
+  @LCCSD iter  16:  -0.213409458325 -8.259e-10  1.026e-08  2.389e-09        0
+  @LCCSD iter  17:  -0.213409458263  6.170e-11  1.187e-08  9.506e-10        0
+  @LCCSD iter  18:  -0.213409458357 -9.352e-11  3.506e-09  5.699e-10        0
+
+  T1 Diagnostic: 0.00524674 
+  
+  Total DLPNO-CCSD Correlation Energy:  -0.213409458357 
+    CCSD Correlation Energy:            -0.213409458357 
+    Weak Pair Contribution:              0.000000000000 
+    Semicanonical MP2 Correction:        0.000000000000 
+    Dipole Pair Correction:              0.000000000000 
+    PNO Truncation Correction:           0.000000000000 
+
+
+  @Total DLPNO-CCSD Energy: -76.240217632138 
+    *** Wow, that was fast! A thousand hallelujahs!!! 
+
+
+*** tstop() called on Androlomews-MacBook-Pro.local at Mon Aug 31 11:46:34 2026
+Module time:
+	user time   =       1.20 seconds =       0.02 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.77 seconds =       0.05 minutes
+	system time =       0.10 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on Androlomews-MacBook-Pro.local
+*** at Mon Aug 31 11:46:34 2026
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        8 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065570021889    15.994914619570
+         H            0.000000000000    -0.756689922073     0.520321915104     1.007825032230
+         H            0.000000000000     0.756689922073     0.520321915104     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.43416  B =     14.60648  C =      9.53165 [cm^-1]
+  Rotational constants: A = 822455.52651  B = 437891.14479  C = 285751.53189 [MHz]
+  Nuclear repulsion =    9.196933714281487
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DIRECT.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   221 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  Starting with a DF guess...
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               8
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 42
+    Number of basis functions: 116
+    Number of Cartesian functions: 131
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 3.4162833904E-02.
+  Reciprocal condition number of the overlap matrix is 9.2080850101E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:   -75.51187233988644   -7.55119e+01   0.00000e+00 
+   @DF-UHF iter   1:   -75.95408986630642   -4.42218e-01   1.74098e-02 DIIS/ADIIS
+   @DF-UHF iter   2:   -76.00736316501666   -5.32733e-02   9.93601e-03 DIIS/ADIIS
+   @DF-UHF iter   3:   -76.02631695536805   -1.89538e-02   1.06509e-03 DIIS/ADIIS
+   @DF-UHF iter   4:   -76.02676727938217   -4.50324e-04   2.07817e-04 DIIS/ADIIS
+   @DF-UHF iter   5:   -76.02678633954174   -1.90602e-05   3.81948e-05 DIIS
+   @DF-UHF iter   6:   -76.02678724956208   -9.10020e-07   6.05530e-06 DIIS
+   @DF-UHF iter   7:   -76.02678727505901   -2.54969e-08   8.40107e-07 DIIS
+   @DF-UHF iter   8:   -76.02678727556373   -5.04727e-10   1.95216e-07 DIIS
+   @DF-UHF iter   9:   -76.02678727559534   -3.16049e-11   3.31793e-08 DIIS
+   @DF-UHF iter  10:   -76.02678727559612   -7.81597e-13   2.73628e-09 DIIS
+
+  DF guess converged.
+
+  ==> DirectJK: Integral-Direct J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Integrals threads:           8
+    Screening Type:           CSAM
+    Screening Cutoff:        1E-12
+    Incremental Fock:           No
+
+   @UHF iter  11:   -76.02680816114383   -7.60268e+01   6.93232e-06 DIIS
+   @UHF iter  12:   -76.02680817338590   -1.22421e-08   1.11869e-06 DIIS
+   @UHF iter  13:   -76.02680817376610   -3.80197e-10   2.18535e-07 DIIS
+   @UHF iter  14:   -76.02680817377983   -1.37277e-11   6.33259e-08 DIIS
+   @UHF iter  15:   -76.02680817378108   -1.25056e-12   2.56515e-08 DIIS
+   @UHF iter  16:   -76.02680817378121   -1.27898e-13   2.35070e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   8.881784197E-16
+   @S^2 Expected:                0.000000000E+00
+   @S^2 Observed:                8.881784197E-16
+   @S   Expected:                0.000000000E+00
+   @S   Observed:                0.000000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -20.550390     2A     -1.336826     3A     -0.699406  
+       4A     -0.566646     5A     -0.493169  
+
+    Alpha Virtual:                                                        
+
+       6A      0.185609     7A      0.256291     8A      0.789452  
+       9A      0.854627    10A      1.163500    11A      1.200384  
+      12A      1.253301    13A      1.444438    14A      1.476370  
+      15A      1.674656    16A      1.867219    17A      1.935269  
+      18A      2.453470    19A      2.491061    20A      3.285961  
+      21A      3.339124    22A      3.510949    23A      3.866084  
+      24A      4.147878  
+
+    Beta Occupied:                                                        
+
+       1A    -20.550390     2A     -1.336826     3A     -0.699406  
+       4A     -0.566646     5A     -0.493169  
+
+    Beta Virtual:                                                         
+
+       6A      0.185609     7A      0.256291     8A      0.789452  
+       9A      0.854627    10A      1.163500    11A      1.200384  
+      12A      1.253301    13A      1.444438    14A      1.476370  
+      15A      1.674656    16A      1.867219    17A      1.935269  
+      18A      2.453470    19A      2.491061    20A      3.285961  
+      21A      3.339124    22A      3.510949    23A      3.866084  
+      24A      4.147878  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+    SOCC [     0 ]
+    NA   [     5 ]
+    NB   [     5 ]
+
+  @UHF Final Energy:   -76.02680817378121
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1969337142814869
+    One-Electron Energy =                -123.1546097106771640
+    Two-Electron Energy =                  37.9308678226144806
+    Total Energy =                        -76.0268081737812054
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 2.0000000
+  HONO-1 :    4  A 2.0000000
+  HONO-0 :    5  A 2.0000000
+  LUNO+0 :    6  A 0.0000000
+  LUNO+1 :    7  A 0.0000000
+  LUNO+2 :    8  A 0.0000000
+  LUNO+3 :    9  A 0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Y            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Z            :         -0.1662417            0.9752568            0.8090151
+ Magnitude           :                                                    0.8090151
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on Androlomews-MacBook-Pro.local at Mon Aug 31 11:46:35 2026
+Module time:
+	user time   =       1.53 seconds =       0.03 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       4.50 seconds =       0.07 minutes
+	system time =       0.14 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on Androlomews-MacBook-Pro.local
+*** at Mon Aug 31 11:46:35 2026
+
+
+  //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>//
+  //             DLPNO-CCSD            //
+  //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<//
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   235 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+    atoms 2-3 entry H          line    19 file /Users/andyjiang/github/psi4/objdir_p4dev/stage/share/psi4/basis/cc-pvdz-ri.gbs 
+
+
+  ==> UHF -> Quasi-Restricted Orbital Transformation <==
+
+    The UHF natural orbitals are being transformed to a common QRO basis.
+    DLPNO-CCSD will use the QRO determinant and its spin Fock matrices.
+    The reported total energy is E(QRO reference) + E(CCSD correlation).
+
+    Input UHF SCF energy:           -76.026808173781
+    QRO determinant energy:         -76.026808173781
+    QRO - UHF energy:                 0.000000000000
+    QRO orthonormality error:              2.120e-14
+    QRO electron counts:        alpha = 5.00000000, beta = 5.00000000
+    Last DOMO occupation:             2.000000000000
+    First virtual occupation:         0.000000000000
+
+    QROs are not converged ROHF orbitals; nonzero occupied-virtual Fock
+    elements and their singles contributions are retained.
+
+   --------------------------------------------------
+     Restricted Open-Shell T1-Transformed DLPNO-CCSD
+                    by Andy Jiang                    
+       Closed-shell engine: DOI 10.1063/5.0219963   
+   --------------------------------------------------
+
+  Reference                    : UHF -> QRO
+  Correlation reference energy : QRO determinant
+  Input UHF SCF energy          :     -76.026808173781
+  QRO reference energy          :     -76.026808173781
+  PNO selector                 : spin-independent SROMP2
+  SOMO treatment               : appended to every pair space
+  DLPNO convergence            : NORMAL
+
+  Detailed DLPNO thresholds and cutoffs:
+    T_CUT_PNO        = 0.0000e+00 
+    T_DIAG_SCALE     = 3.0000e-02 
+    T_CORE_SCALE     = 1.0000e-02 
+    T_CUT_TRACE      = 9.9000e-01 
+    T_CUT_ENERGY     = 9.9000e-01 
+    T_CUT_PAIRS      = 0.0000e+00 
+    T_CUT_PAIRS_MP2  = 0.0000e+00 
+    T_CUT_PRE        = 0.0000e+00 
+    T_CUT_DO_PRE     = 3.0000e-02 
+    T_CUT_MKN        = 0.0000e+00 
+    T_CUT_PNO_MP2    = 0.0000e+00 
+    T_CUT_TRACE_MP2  = 9.9900e-01 
+    T_CUT_ENERGY_MP2 = 9.9700e-01 
+    T_CUT_DO         = 0.0000e+00 
+    T_CUT_DO_IJ      = 1.0000e-05 
+    T_CUT_DO_UV      = 1.0000e-05 
+    T_CUT_CLMO       = 1.0000e-04 
+    T_CUT_CPAO       = 1.0000e-04 
+    S_CUT            = 1.0000e-08 
+    F_CUT            = 1.0000e-05 
+    INTS_TOL (AO)    = 1.0000e-10 
+    MIN_PNOS         =      5   
+
+  ==> ROHF Orbital-Space Information <==
+
+   -----------------------------------------------------------------------------
+    NBF  NFRZC  ACT-A  ACT-B  DOCC  SOMO  VIRT-A  VIRT-B  NAUX
+   -----------------------------------------------------------------------------
+     24      0      5      5     5     0      19      19    84
+   -----------------------------------------------------------------------------
+
+  ==> Boys Localizer <==
+
+    Convergence =   1.000E-12
+    Maxiter     =        1000
+
+    Iteration                   Metric       Residual
+    @Boys    0   1.9569019761943099E-01              -
+    @Boys    1   2.2027151483626408E+00   1.025613E+01
+    @Boys    2   2.5561954287196600E+00   1.604748E-01
+    @Boys    3   2.5653807054973163E+00   3.593339E-03
+    @Boys    4   2.5668644190518703E+00   5.783600E-04
+    @Boys    5   2.5671502259211016E+00   1.113447E-04
+    @Boys    6   2.5672230665627227E+00   2.837413E-05
+    @Boys    7   2.5672358476952097E+00   4.978583E-06
+    @Boys    8   2.5672381205774455E+00   8.853422E-07
+    @Boys    9   2.5672384369721204E+00   1.232432E-07
+    @Boys   10   2.5672384999652715E+00   2.453732E-08
+    @Boys   11   2.5672385055035312E+00   2.157283E-09
+    @Boys   12   2.5672385067060817E+00   4.684218E-10
+    @Boys   13   2.5672385069829593E+00   1.078504E-10
+    @Boys   14   2.5672385070131361E+00   1.175456E-11
+    @Boys   15   2.5672385070179731E+00   1.884133E-12
+    @Boys   16   2.5672385070192298E+00   4.895425E-13
+
+    Boys Localizer converged.
+
+  ==> Crude Prescreening (Determines Semicanonical-MP2 Pairs) <==
+
+    T_CUT_MKN set to 0.000e+00
+    T_CUT_DO  set to 0.000e+00
+
+  ==> Forming Local MO Domains <==
+
+    Auxiliary BFs per Local MO:
+      Average =   84 AUX BFs (3 atoms)
+      Min     =   84 AUX BFs (3 atoms)
+      Max     =   84 AUX BFs (3 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   24 PAOs (3 atoms)
+      Min     =   24 PAOs (3 atoms)
+      Max     =   24 PAOs (3 atoms)
+
+    Local MOs per Local MO:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+ 
+    Screened 0 of 25 LMO pairs (0.00 %)
+             0 pairs met overlap criteria
+             5 pairs met energy criteria
+ 
+    Screened LMO pair energy =  0.000000000000 
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =   84 AUX BFs (3 atoms)
+      Min     =   84 AUX BFs (3 atoms)
+      Max     =   84 AUX BFs (3 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   24 PAOs (3 atoms)
+      Min     =   24 PAOs (3 atoms)
+      Max     =   24 PAOs (3 atoms)
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Initial SROMP2 prescreening of pairs <==
+
+  ==> Spin-Restricted Open-Shell Semicanonical MP2 Pair Prescreening <==
+
+    Eliminated Pairs (SC-SROMP2)       = 0
+    Surviving Pairs                    = 25
+    Surviving Pairs / Non-dipole Pairs = (100.00 %)
+    Eliminated Pair dE                 = 0.000000000000
+
+  ==> Refined Prescreening (Determines Strong and Weak Pairs) <==
+
+    T_CUT_MKN reset to 0.000e+00
+    T_CUT_DO  reset to 0.000e+00
+
+  ==> Forming Local MO Domains <==
+
+    Auxiliary BFs per Local MO:
+      Average =   84 AUX BFs (3 atoms)
+      Min     =   84 AUX BFs (3 atoms)
+      Max     =   84 AUX BFs (3 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   24 PAOs (3 atoms)
+      Min     =   24 PAOs (3 atoms)
+      Max     =   24 PAOs (3 atoms)
+
+    Local MOs per Local MO:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =   84 AUX BFs (3 atoms)
+      Min     =   84 AUX BFs (3 atoms)
+      Max     =   84 AUX BFs (3 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   24 PAOs (3 atoms)
+      Min     =   24 PAOs (3 atoms)
+      Max     =   24 PAOs (3 atoms)
+
+    Coefficient sparsity in AO -> LMO transform:   0.00 % 
+    Coefficient sparsity in AO -> PAO transform:   0.00 % 
+    Coefficient sparsity in combined transforms:   0.00 % 
+
+    Storing transformed LMO/LMO, LMO/PAO, and PAO/PAO integrals in sparse format.
+    Required memory: 0.000 GiB (0.00 % reduction from dense format) 
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Determining Strong and Weak Pairs with SROLMP2 <==
+
+  ==> Forming Pair Natural Orbitals (for LMP2) <==
+  
+    Natural Orbitals per Local MO pair:
+      Avg:  19 NOs 
+      Min:  19 NOs 
+      Max:  19 NOs 
+
+      Avg Occ Number Tol: 5.692e-08 
+      Min Occ Number Tol: 2.083e-14 
+      Max Occ Number Tol: 2.465e-07 
+
+      Avg Trace Sum: 1.000000 
+      Min Trace Sum: 1.000000 
+      Max Trace Sum: 1.000000 
+
+      Avg Energy Ratio: 1.000000 
+      Min Energy Ratio: 1.000000 
+      Max Energy Ratio: 1.000000 
+
+    PNO truncation energy = 0.000000000000
+    SROMP2 spin-adapted PNO truncation energy = 0.000000000000
+
+  ==> PNO-LMP2 Memory Estimate <== 
+
+    (q | i a) [AUX, LMO, PAO]  :    0.000 [GB]
+    X^{PNO}_{u_{ij} a_{ij}}    :    0.000 [GB]
+    (i a_{ij} | j b_{ij})      :    0.000 [GB]
+    T_{ij}^{a_{ij} b_{ij}}     :    0.000 [GB]
+    U_{ij}^{a_{ij} b_{ij}}     :    0.000 [GB]
+    PNO overlaps               :    0.000 [GB]
+    Total Memory Required      :    0.001 [GB]
+    Total Memory Given         :    0.524 [GB]
+
+
+  ==> Iterative Local MP2 with Pair Natural Orbitals (PNOs) <==
+
+    E_CONVERGENCE = 1.00e-10
+    R_CONVERGENCE = 1.00e-10
+
+                         Corr. Energy    Delta E     Max R     Time (s)
+  @PNO-LMP2 iter   1:  -0.199698507537 -1.997e-01  3.898e-03        0
+  @PNO-LMP2 iter   2:  -0.203569525961 -3.871e-03  9.470e-04        0
+  @PNO-LMP2 iter   3:  -0.203858601701 -2.891e-04  3.340e-04        0
+  @PNO-LMP2 iter   4:  -0.203930268888 -7.167e-05  6.834e-05        0
+  @PNO-LMP2 iter   5:  -0.203934348572 -4.080e-06  1.637e-05        0
+  @PNO-LMP2 iter   6:  -0.203933465708  8.829e-07  2.760e-06        0
+  @PNO-LMP2 iter   7:  -0.203933173384  2.923e-07  7.493e-07        0
+  @PNO-LMP2 iter   8:  -0.203933001529  1.719e-07  2.604e-07        0
+  @PNO-LMP2 iter   9:  -0.203933005410 -3.881e-09  6.144e-08        0
+  @PNO-LMP2 iter  10:  -0.203933001590  3.820e-09  1.362e-08        0
+  @PNO-LMP2 iter  11:  -0.203933000942  6.486e-10  2.766e-09        0
+  @PNO-LMP2 iter  12:  -0.203933000709  2.332e-10  6.242e-10        0
+  @PNO-LMP2 iter  13:  -0.203933000679  2.923e-11  2.071e-10        0
+  @PNO-LMP2 iter  14:  -0.203933000687 -7.975e-12  5.278e-11        0
+    Final spin-adapted SROLMP2 correlation energy = -0.203933000687
+
+  ==> Final Strong and Weak Pairs <==
+
+    Weak Pairs                      = 0
+    Strong Pairs                    = 25
+    Strong Pairs / Total Pairs      = (100.00 %)
+  
+  Total DLPNO-MP2 Correlation Energy:  -0.203933000687 
+    MP2 Correlation Energy:            -0.203933000687 
+    Semicanonical MP2 Correction:       0.000000000000 
+    Dipole Correction:                  0.000000000000 
+    PNO Truncation Correction:          0.000000000000 
+
+
+  @Total DLPNO-MP2 Energy: -76.230741174468 
+
+   * WARNING: This answer will likely vary from one obtained by a energy('dlpno-mp2') call
+                due to lack of a semi-canonical MP2 prescreening step in DLPNO-MP2, as well
+                as slightly tighter cutoffs utilized to increase accuracy in the context of CC!!!
+
+
+  ==> Forming Pair Natural Orbitals (for LCCSD) <==
+  
+    Natural Orbitals per Local MO pair:
+      Avg:  19 NOs 
+      Min:  19 NOs 
+      Max:  19 NOs 
+
+      Avg Occ Number Tol: 8.136e-08 
+      Min Occ Number Tol: 1.681e-12 
+      Max Occ Number Tol: 3.467e-07 
+
+      Avg Trace Sum: 1.000000 
+      Min Trace Sum: 1.000000 
+      Max Trace Sum: 1.000000 
+
+      Avg Energy Ratio: 1.000000 
+      Min Energy Ratio: 1.000000 
+      Max Energy Ratio: 1.000000 
+
+    LMP2 Weak Pair energy = 0.000000000000
+    PNO truncation energy = 0.000000000000
+    Spin-adapted SROLMP2 weak-pair energy = 0.000000000000
+    Spin-adapted total PNO truncation energy = 0.000000000000
+
+    Auxiliary BFs per Local MO:
+      Average =   84 AUX BFs (3 atoms)
+      Min     =   84 AUX BFs (3 atoms)
+      Max     =   84 AUX BFs (3 atoms)
+  
+    Projected AOs per Local MO:
+      Average =   24 PAOs (3 atoms)
+      Min     =   24 PAOs (3 atoms)
+      Max     =   24 PAOs (3 atoms)
+
+    Local MOs per Local MO:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+
+  ==> Merging LMO Domains into LMO Pair Domains <==
+  
+    Auxiliary BFs per Local MO pair:
+      Average =   84 AUX BFs (3 atoms)
+      Min     =   84 AUX BFs (3 atoms)
+      Max     =   84 AUX BFs (3 atoms)
+  
+    Local MOs per Local MO pair:
+      Average =    5 LMOs
+      Min     =    5 LMOs
+      Max     =    5 LMOs
+  
+    Projected AOs per Local MO pair:
+      Average =   24 PAOs (3 atoms)
+      Min     =   24 PAOs (3 atoms)
+      Max     =   24 PAOs (3 atoms)
+
+  ==> Transforming 3-Index Integrals to LMO/LMO basis <==
+
+  ==> Transforming 3-Index Integrals to LMO/PAO basis <==
+
+  ==> Transforming 3-Index Integrals to PAO/PAO basis <==
+
+    * PAO/PAO Integral Memory After Screening: 0.000 [GiB]
+
+  ==> ROHF-DLPNO-CCSD Memory Requirements <== 
+
+    *** Spin-Independent Spatial Quantities ***
+    (q | i j) [AUX, LMO]          :    0.000 [GB]
+    (q | i a) [AUX, LMO, PAO]     :    0.000 [GB]
+    (q | a b) [AUX, PAO]          :    0.000 [GB]
+    (k_{ij}, c_{ij}) integrals    :    0.000 [GB]
+    (a_{ij}, b_{ij}) integrals    :    0.000 [GB]
+    Non-projected two-ext. ERIs   :    0.001 [GB]
+    Three-external ERIs           :    0.001 [GB]
+    Spatial DF PNO tensors        :    0.005 [GB]
+
+    *** ROHF Spin-Resolved Iteration Quantities ***
+    RCCSD + SROLMP2 T2 blocks     :    0.000 [GB]
+    R2 and non-symmetric R2       :    0.000 [GB]
+    Spin Fock pair blocks         :    0.000 [GB]
+    Global spin Fock blocks       :    0.000 [GB]
+    Projected spin T1 blocks      :    0.000 [GB]
+    T1-transformed spin DF blocks :    0.001 [GB]
+    PNO overlaps                  :    0.001 [GB]
+    DIIS history (maximum)        :    0.002 [GB]
+
+    Maximum ERI buffer per thread :    0.001 [GB]
+    Maximum CC buffer per thread  :    0.001 [GB]
+    Total Memory Required (ERIs)  :    0.014 [GB]
+    Total Memory Required (RCCSD) :    0.019 [GB]
+    Total Memory Given            :    0.524 [GB]
+
+    Using high-memory PNO overlap algorithm...
+
+    Keeping (Q_{ij}|m_{ij} a_{ij}) tensors in RAM.
+    Keeping (Q_{ij}|a_{ij} b_{ij}) tensors in RAM.
+
+    Computing integrals in the PNO basis from PAO integrals...
+
+    Integral Computation Complete!!! Time Elapsed:    0 seconds
+
+
+  ==> Restricted Open Shell Local CCSD <==
+
+    E_CONVERGENCE = 1.00e-08
+    R_CONVERGENCE = 1.00e-08
+
+                      Corr. Energy    Delta E     Max R1     Max R2     Time (s)
+  @LCCSD iter   1:  -0.209413989425 -2.094e-01  4.337e-03  2.180e-03        0
+  @LCCSD iter   2:  -0.212211019748 -2.797e-03  1.631e-03  7.541e-04        0
+  @LCCSD iter   3:  -0.213088283101 -8.773e-04  4.904e-04  2.710e-04        0
+  @LCCSD iter   4:  -0.213334863528 -2.466e-04  2.317e-04  8.992e-05        0
+  @LCCSD iter   5:  -0.213399413361 -6.455e-05  1.561e-04  3.430e-05        0
+  @LCCSD iter   6:  -0.213408299090 -8.886e-06  5.067e-05  1.208e-05        0
+  @LCCSD iter   7:  -0.213407906550  3.925e-07  4.386e-05  4.626e-06        0
+  @LCCSD iter   8:  -0.213408033394 -1.268e-07  2.014e-05  1.816e-06        0
+  @LCCSD iter   9:  -0.213408788170 -7.548e-07  7.540e-06  8.287e-07        0
+  @LCCSD iter  10:  -0.213409212490 -4.243e-07  4.316e-06  3.201e-07        0
+  @LCCSD iter  11:  -0.213409323387 -1.109e-07  5.073e-07  1.667e-07        0
+  @LCCSD iter  12:  -0.213409402930 -7.954e-08  1.725e-07  9.643e-08        0
+  @LCCSD iter  13:  -0.213409437860 -3.493e-08  1.928e-07  4.175e-08        0
+  @LCCSD iter  14:  -0.213409450059 -1.220e-08  7.040e-08  1.319e-08        0
+  @LCCSD iter  15:  -0.213409455830 -5.771e-09  1.167e-08  4.085e-09        0
+  @LCCSD iter  16:  -0.213409457362 -1.532e-09  7.608e-09  2.152e-09        0
+
+  ROHF T1 Diagnostic: 0.00524674 
+  
+  Total Restricted-Open-Shell DLPNO-CCSD Correlation Energy:  -0.213409457362 
+    Strong-Pair RCCSD Contribution:          -0.213409457362 
+    SROLMP2 Weak-Pair Contribution:           0.000000000000 
+    Semicanonical SROMP2 Correction:          0.000000000000 
+    Open-Shell Dipole-Pair Correction:         0.000000000000 
+    PNO Truncation Correction:                0.000000000000 
+
+
+  @Total Restricted-Open-Shell DLPNO-CCSD Energy: -76.240217631143 
+    (QRO reference -76.026808173781 + correlation  -0.213409457362)
+    *** Spin-adapted and SOMO-safe. A thousand hallelujahs!!! 
+
+
+*** tstop() called on Androlomews-MacBook-Pro.local at Mon Aug 31 11:46:35 2026
+Module time:
+	user time   =       3.89 seconds =       0.06 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       8.39 seconds =       0.14 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+    collapsed UHF SCF energy..............................................................PASSED
+    collapsed QRO reference energy........................................................PASSED
+    collapsed QRO correlation energy......................................................PASSED
+    collapsed QRO total energy............................................................PASSED
+    QRO reference plus correlation........................................................PASSED
+    current QRO reference.................................................................PASSED
+    QRO alpha electron count..............................................................PASSED
+    QRO beta electron count...............................................................PASSED
+    collapsed spin density................................................................PASSED
+    QRO orthonormality....................................................................PASSED
+
+    Psi4 stopped on: Monday, 31 August 2026 11:46AM
+    Psi4 wall time for execution: 0:00:01.12
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/uhfqrodlpnocc-2/test_input.py
+++ b/tests/uhfqrodlpnocc-2/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+
+@ctest_labeler("dlpno;cc;quick")
+def test_uhfqrodlpnocc_2():
+    ctest_runner(__file__)


### PR DESCRIPTION
## Description

This draft PR introduces an initial restricted open-shell (ROHF), T1-transformed DLPNO-CCSD implementation. It extends Psi4’s existing closed-shell DLPNO-CCSD code with spin-resolved amplitudes, intermediates, and residual equations.

The immediate goal is to establish a development baseline for numerical validation of the strong-pair CCSD equations. Open-shell weak-pair, semicanonical-MP2, and dipole-pair treatments remain future work.

**Update 8/31: Full stack DLPNO-CCSD implemented (strong pairs, ROMP2 screening, dipole screening) and (T)... at least CCSD residual equations confirmed to be valid. (T) likely valid but needs more testing since we are using Scuseria's formulaton that ignores off-diagonal a/b Fock matrix couplings (non-orbital invariant). Other components subject to testing.**

## User API & Changelog headlines

* Adds preliminary DLPNO-CCSD support for `REFERENCE ROHF`.
* Retains the existing RHF implementation and behavior.
* UHF references are supported through UHF -> QRO transformation

## Dev notes & details

* Adds `RO_DLPNOCCSD`, derived from the existing `DLPNOCCSD` implementation.
* Introduces spin-resolved singles amplitudes for alpha and beta spin.
* Introduces doubles amplitudes for alpha-alpha, alpha-beta, and beta-beta spin cases.
* Implements spin-resolved T1-transformed density-fitting integrals and Fock intermediates.
* Implements the corresponding singles and doubles residual equations and supporting beta, gamma, delta, and twice-transformed Fock intermediates.
* Augments pair PAO and PNO spaces with the singly occupied molecular orbitals.
* Adds helpers that enforce the valid occupied and virtual spaces for each spin case.
* Updates local-domain sparsity and PAO-pair handling for the SOMO-augmented virtual space.
* Routes ROHF DLPNO-CCSD calculations through the existing Python driver and DLPNO wrapper.
* Preserves the existing closed-shell DLPNO-CCSD path.
* This remains an under-development implementation. Numerical validation and the open-shell treatments of weak pairs, semicanonical-MP2 pairs, and dipole pairs are not yet complete.

## Questions

* [ ] Is deriving `RO_DLPNOCCSD` from the existing closed-shell class the preferred long-term organization?
* [ ] Are the SOMO augmentation and spin-enforcement conventions consistent with Psi4’s preferred ROHF orbital conventions?
* [ ] Which small open-shell systems and reference results would be most useful for the initial regression tests?
* [ ] Should the incomplete pair-correction paths be explicitly disabled for ROHF until their spin-resolved forms are implemented?

## AI

* [x] AI assisted with translating the working equations into C++, porting the implementation to the current Psi4 branch, compiler-error triage, and code review. The human author remains responsible for validating the equations, numerical results, and submitted implementation. **No novel intellectual work was performed through AI, as we used a template from an old branch of ROHF-DLPNO-CEPA0 at (https://github.com/andyj10224/psi4/tree/ro_dlpno_ccsd), a fully derived set of PNO-basis equations from a manuscript draft, and a working Python copy of these equations)**

## Progress Checks
* [x] Working code/equations for T1-Transformed Open-Shell CCSD equations (Strong Pairs)
* [x] Working code for open-shell LMP2 equations (Weak Pairs)
* [x] Working code for open-shell semi-canonical MP2 equations (Screened Pairs)
* [x] Working code for dipole estimate (Dipole Pairs)
* [x] Implement ROHF Triples Terms for (T)

## Checklist

* [ ] Tests added for the new ROHF pathway
* [ ] Numerical results validated against canonical open-shell CCSD equations
* [ ] Docstring or narrative documentation updated if needed
* [x] Open-shell weak-pair treatment implemented
* [x] Open-shell semicanonical-MP2 pair treatment implemented
* [x] Open-shell dipole-pair treatment implemented

## Status

* [ ] Ready for review
* [ ] Ready for merge

This PR should remain in Draft status while numerical validation and the remaining open-shell pair treatments are in progress.
