### PR TITLE
Remove obsolete "removed in 1.4" OCC/PSIMRCC option shims

### DIFF
--- a/psi4/src/psi4/occ/occwave.cc
+++ b/psi4/src/psi4/occ/occwave.cc
@@ -110,20 +110,7 @@ void OCCWave::common_init() {
     oeprop_ = options_.get_str("OEPROP");
     // comput_s2_=options_.get_str("COMPUT_S2");
 
-    if (options_["DO_LEVEL_SHIFT"].has_changed() || options_["LEVEL_SHIFT"].has_changed()) {
-        outfile->Printf(
-            "\t'Level shifting' was removed from OCC in 1.4. Contact a developer for more information.\n\n");
-    }
-    if (options_["MP2_SOS_SCALE"].has_changed() || options_["MP2_SOS_SCALE2"].has_changed() ||
-        options_["CEPA_SOS_SCALE"].has_changed() || options_["MP2_OS_SCALE"].has_changed() ||
-        options_["CEPA_OS_SCALE"].has_changed() || options_["MP2_SS_SCALE"].has_changed() ||
-        options_["CEPA_SS_SCALE"].has_changed()) {
-        outfile->Printf(
-            "\tSpin-scaling in OCC changed in 1.4. Psi variables use canonical scaling. You can supply custom values "
-            "with OS_SCALE and SS_SCALE.\n\n");
-    }
-    if (options_["DO_SCS"].has_changed() || options_["DO_SOS"].has_changed() || options_["SCS_TYPE"].has_changed() ||
-        options_["SOS_TYPE"].has_changed()) {
+    if (options_["SCS_TYPE"].has_changed() || options_["SOS_TYPE"].has_changed()) {
         outfile->Printf(
             "\tSpin-scaling in OCC changed in 1.4. Leave options to the energy call. Just pass in the method name, "
             "like scs-mp2.\n\n");

--- a/psi4/src/psi4/psimrcc/main.cc
+++ b/psi4/src/psi4/psimrcc/main.cc
@@ -80,10 +80,6 @@ SharedWavefunction psimrcc(SharedWavefunction ref_wfn, Options &options) {
 
     auto wfn = std::make_shared<PSIMRCCWfn>(ref_wfn, options);
 
-    if (options["PERTURB_CBS"].has_changed() || options["PERTURB_CBS_COUPLING"].has_changed()) {
-        outfile->Printf("\tPerturbative CBS was removed in 1.4. Using unpublished features is a bad habit.\n\n");
-    }
-
     wfn->compute_energy();
 
     return wfn;

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -2832,10 +2832,6 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_bool("COUPLING_TERMS", true);
         /*- Do print the effective Hamiltonian? -*/
         options.add_bool("HEFF_PRINT", false);
-        /*- Removed in 1.4. Will raise an error in 1.5. -*/
-        options.add_bool("PERTURB_CBS", false);
-        /*- Removed in 1.4. Will raise an error in 1.5. -*/
-        options.add_bool("PERTURB_CBS_COUPLING", true);
         /*- Do use Tikhonow regularization in (T) computations? !expert -*/
         options.add_bool("TIKHONOW_TRIPLES", false);
         /*- The type of perturbation theory computation to perform -*/
@@ -3151,22 +3147,6 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("MAX_MOGRAD_CONVERGENCE", 1e-4);
         /*- Maximum step size in orbital-optimization procedure -*/
         options.add_double("MO_STEP_MAX", 0.5);
-        /*- Removed in 1.4. Will raise an error in 1.5. -*/
-        options.add_double("LEVEL_SHIFT", 0.02);
-        /*- Removed in 1.4. Will raise an error in 1.5. -*/
-        options.add_double("MP2_OS_SCALE", 6.0 / 5.0);
-        /*- Removed in 1.4. Will raise an error in 1.5. -*/
-        options.add_double("MP2_SS_SCALE", 1.0 / 3.0);
-        /*- Removed in 1.4. Will raise an error in 1.5. -*/
-        options.add_double("MP2_SOS_SCALE", 1.3);
-        /*- Removed in 1.4. Will raise an error in 1.5. -*/
-        options.add_double("MP2_SOS_SCALE2", 1.2);
-        /*- Removed in 1.4. Will raise an error in 1.5. -*/
-        options.add_double("CEPA_OS_SCALE", 1.27);
-        /*- Removed in 1.4. Will raise an error in 1.5. -*/
-        options.add_double("CEPA_SS_SCALE", 1.13);
-        /*- Removed in 1.4. Will raise an error in 1.5. -*/
-        options.add_double("CEPA_SOS_SCALE", 1.3);
         /*- A custom scaling parameter for opposite-spin terms in OCC. The result goes to a CUSTOM SCS variable, exact name method-dependent. -*/
         options.add_double("OS_SCALE", 1);
         /*- A custom scaling parameter for same-spin terms in OCC. The result goes to a CUSTOM SCS variable, exact name method-dependent. -*/
@@ -3211,14 +3191,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
 
         /*- Do compute natural orbitals? -*/
         options.add_bool("NAT_ORBS", false);
-        /*- Removed in 1.4. Will raise an error in 1.5. -*/
-        options.add_bool("DO_LEVEL_SHIFT", true);
         /*- Do print OCC orbital energies? -*/
         options.add_bool("OCC_ORBS_PRINT", false);
-        /*- Removed in 1.4. Will raise an error in 1.5. Pass the method name, like scs-mp2, to energy instead. -*/
-        options.add_bool("DO_SCS", false);
-        /*- Removed in 1.4. Will raise an error in 1.5. Pass the method name, like scs-mp2, to energy instead. -*/
-        options.add_bool("DO_SOS", false);
         /*- Do write coefficient matrices to external files for direct reading MOs in a subsequent job? -*/
         options.add_bool("MO_WRITE", false);
         /*- Do read coefficient matrices from external files of a previous OMP2 or OMP3 computation? -*/


### PR DESCRIPTION
Thirteen options carrying `/*- Removed in 1.4. Will raise an error in 1.5. -*/` were still registered at v1.11, and the promised "raise an error" was never implemented — they were enforced only as a warn-only `Printf` with the value ignored. Per the no-stub policy, remove them outright. Scoped strictly to the **OCC** and **PSIMRCC** namespaces.

**`read_options.cc`**
- OCC: `LEVEL_SHIFT`, `MP2_OS_SCALE`, `MP2_SS_SCALE`, `MP2_SOS_SCALE`, `MP2_SOS_SCALE2`, `CEPA_OS_SCALE`, `CEPA_SS_SCALE`, `CEPA_SOS_SCALE`, `DO_LEVEL_SHIFT`, `DO_SCS`, `DO_SOS`
- PSIMRCC: `PERTURB_CBS`, `PERTURB_CBS_COUPLING`

**`occ/occwave.cc`** — drop the two warn blocks for the removed level-shift and spin-scaling options. The third block is **kept** for the still-live `SCS_TYPE`/`SOS_TYPE` options (only their two removed companions `DO_SCS`/`DO_SOS` are dropped from its condition).

**`psimrcc/main.cc`** — drop the `PERTURB_CBS` warn block.

The identically-named **DFOCC** options (`DO_SCS`/`DO_SOS`/`DO_LEVEL_SHIFT`/`MP2_*_SCALE`) are live (set via `proc.py`'s `['DFOCC', …]`) and are untouched — only the OCC-namespace copies are removed. Verified that the 11 OCC options are referenced only in the removed `occwave.cc` warn blocks and `PERTURB_CBS` only in the removed `main.cc` block.

No functional change; the removed options only printed a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
