### PR TITLE
Add fixed-reference variant to the DirectJK incremental Fock build

### DIFF
--- a/doc/sphinxman/source/bibliography.rst
+++ b/doc/sphinxman/source/bibliography.rst
@@ -833,3 +833,13 @@ Bibliography
    *J. Chem. Phys.* **152**, 184102 (2020)
    https://doi.org/10.1063/5.0004997
 
+.. [Almloef:1982:385]
+   J. Almlöf, K. Faegri Jr, and K. Korsell
+   *J. Comput. Chem.* **3**, 385 (1982).
+   https://doi.org/10.1002/jcc.540030314
+
+.. [Parrish:2016:131101]
+   R. M. Parrish, F. Liu, and T. J. Martínez
+   *J. Chem. Phys.* **144**, 131101 (2016).
+   https://doi.org/10.1063/1.4945277
+

--- a/doc/sphinxman/source/scf.rst
+++ b/doc/sphinxman/source/scf.rst
@@ -685,7 +685,7 @@ DIRECT
     up to 1500 basis functions, uses zero disk (if DF pre-iterations are
     turned off), and can obtain significant
     speedups with negligible error loss if |scf__ints_tolerance|
-    is set to 1.0E-8 or so.
+    is set to 1.0E-8 or so. See the :ref:`sec:directscf` section for more information.
 DF [:ref:`Default <table:conv_scf>`]
     A density-fitted algorithm designed for computations with thousands of
     basis functions. This algorithm is highly optimized, and is threaded
@@ -824,6 +824,55 @@ resort will be used.
 To avoid this, either set |scf__df_basis_scf| to an auxiliary
 basis set defined for all atoms in the system, or set |scf__df_scf_guess|
 to false, which disables this acceleration entirely.
+
+.. _`sec:directscf`:
+
+Integral-Direct Self-Consistent Field
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The integral-direct SCF algorithm [Almloef:1982:385]_ computes the
+exact Fock matrix by recomputing integrals on the fly at every
+iteration and contracting them with the density matrix. As the
+electron density changes very little in later iterations, the direct
+SCF method often employs incremental formation for the Fock matrix:
+since the Fock matrix is linear in the density, one does not have to
+compute the full matrix at every iteration, only the change from a
+previously computed Fock matrix.  This behavior is toggled by the
+|scf__incfock| keyword. Because the elements in the difference density
+matrix are much smaller than the elements in the density matrix, this
+makes the screening of the integrals much tighter when density-based screening is used, reducing the number
+of integrals that need to be calculated.
+
+The typical implementation of incremental Fock matrix formation
+updates the reference at every iteration. This makes the screening
+better and better as the wave function converges, because the density
+changes between SCF iterations go to zero as convergence is approached. But, since small changes can accumulate to a
+non-negligible outcome over many iterations, this procedure is
+susceptible to creeping numerical error. For this reason, a fresh Fock
+matrix needs to be rebuilt every ``N`` iterations
+(|scf__incfock_full_fock_every|, defaults to 5). In addition, due to the
+danger of the creepup of small errors, the iterative formation is
+turned off when a sufficiently tight convergence
+(|scf__incfock_convergence|, defaults to ``1e-5``) has been reached,
+so that the final iterations are performed without deleterious
+screening.
+
+Psi4 also implements a different type of algorithm, where a fixed
+reference density and Fock matrix is employed (see
+[Parrish:2016:131101]_ for inspiration). Because the reference is
+fixed, there is no danger of incremental creepup of numerical noise;
+however, the flip side is that roughly the same number of integrals
+need to be computed for every incremental step. This algorithm is used
+instead of the typical algorithm discussed above, if
+|scf__incfock_fixed_reference| is ``true``.
+
+
+It has the following options
+
+.. include:: autodir_options_c/scf__incfock.rst
+.. include:: autodir_options_c/scf__incfock_fixed_reference.rst
+.. include:: autodir_options_c/scf__incfock_full_fock_every.rst
+.. include:: autodir_options_c/scf__incfock_convergence.rst
 
 .. _`sec:scfddfj`:
 

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -142,13 +142,13 @@ void DirectJK::incfock_setup() {
 
     if (fixed_reference_) {
         // A valid, correctly-sized reference is required to build incrementally
-        if (D_reference_.size() != njk) do_incfock_iter_ = false;
+        if (D_fixed_ref_.size() != njk) do_incfock_iter_ = false;
 
         if (do_incfock_iter_) {
             // Incremental formation: build from the difference against the fixed reference
             for (size_t jki = 0; jki < njk; jki++) {
                 D_ref_[jki] = D_ao_[jki]->clone();
-                D_ref_[jki]->subtract(D_reference_[jki]);
+                D_ref_[jki]->subtract(D_fixed_ref_[jki]);
             }
         } else {
             // Full formation
@@ -183,20 +183,20 @@ void DirectJK::incfock_postiter() {
         if (do_incfock_iter_) {
             // Incremental build: add back the J, K, and wK from the fixed reference
             for (size_t jki = 0; jki < njk; jki++) {
-                if (do_J_) J_ao_[jki]->add(J_reference_[jki]);
-                if (do_K_) K_ao_[jki]->add(K_reference_[jki]);
-                if (do_wK_) wK_ao_[jki]->add(wK_reference_[jki]);
+                if (do_J_) J_ao_[jki]->add(J_fixed_ref_[jki]);
+                if (do_K_) K_ao_[jki]->add(K_fixed_ref_[jki]);
+                if (do_wK_) wK_ao_[jki]->add(wK_fixed_ref_[jki]);
             }
         } else {
             // Full build: capture the fixed reference density and its J, K, and wK
-            D_reference_.clear();
-            for (auto const& Di : D_ao_) D_reference_.push_back(Di->clone());
-            J_reference_.clear();
-            if (do_J_) for (auto const& Ji : J_ao_) J_reference_.push_back(Ji->clone());
-            K_reference_.clear();
-            if (do_K_) for (auto const& Ki : K_ao_) K_reference_.push_back(Ki->clone());
-            wK_reference_.clear();
-            if (do_wK_) for (auto const& wKi : wK_ao_) wK_reference_.push_back(wKi->clone());
+            D_fixed_ref_.clear();
+            for (auto const& Di : D_ao_) D_fixed_ref_.push_back(Di->clone());
+            J_fixed_ref_.clear();
+            if (do_J_) for (auto const& Ji : J_ao_) J_fixed_ref_.push_back(Ji->clone());
+            K_fixed_ref_.clear();
+            if (do_K_) for (auto const& Ki : K_ao_) K_fixed_ref_.push_back(Ki->clone());
+            wK_fixed_ref_.clear();
+            if (do_wK_) for (auto const& wKi : wK_ao_) wK_fixed_ref_.push_back(wKi->clone());
         }
         return;
     }

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -86,6 +86,7 @@ void DirectJK::common_init() {
 #endif
 
     incfock_ = options_.get_bool("INCFOCK");
+    fixed_reference_ = options_.get_bool("INCFOCK_FIXED_REFERENCE");
     incfock_count_ = 0;
     do_incfock_iter_ = false;
     if (options_.get_int("INCFOCK_FULL_FOCK_EVERY") <= 0) {
@@ -121,6 +122,7 @@ void DirectJK::print_header() const {
         outfile->Printf("    Screening Type:    %11s\n", screen_type.c_str());
         outfile->Printf("    Screening Cutoff:  %11.0E\n", cutoff_);
         outfile->Printf("    Incremental Fock:  %11s\n", incfock_ ? "Yes" : "No");
+        if (incfock_) outfile->Printf("    Fixed reference:   %11s\n", fixed_reference_ ? "Yes" : "No");
         outfile->Printf("\n");
     }
 }
@@ -136,9 +138,27 @@ void DirectJK::preiterations() {
 }
 
 void DirectJK::incfock_setup() {
-    if (do_incfock_iter_) {
-        size_t njk = D_ao_.size();
+    size_t njk = D_ao_.size();
 
+    if (fixed_reference_) {
+        // A valid, correctly-sized reference is required to build incrementally
+        if (D_reference_.size() != njk) do_incfock_iter_ = false;
+
+        if (do_incfock_iter_) {
+            // Incremental formation: build from the difference against the fixed reference
+            for (size_t jki = 0; jki < njk; jki++) {
+                D_ref_[jki] = D_ao_[jki]->clone();
+                D_ref_[jki]->subtract(D_reference_[jki]);
+            }
+        } else {
+            // Full formation
+            D_ref_ = D_ao_;
+            zero();
+        }
+        return;
+    }
+
+    if (do_incfock_iter_) {
         // If there is no previous pseudo-density, this iteration is normal
         if (initial_iteration_ || D_prev_.size() != njk) {
 	        initial_iteration_ = true;
@@ -158,6 +178,29 @@ void DirectJK::incfock_setup() {
 }
 
 void DirectJK::incfock_postiter() {
+    if (fixed_reference_) {
+        size_t njk = D_ao_.size();
+        if (do_incfock_iter_) {
+            // Incremental build: add back the J, K, and wK from the fixed reference
+            for (size_t jki = 0; jki < njk; jki++) {
+                if (do_J_) J_ao_[jki]->add(J_reference_[jki]);
+                if (do_K_) K_ao_[jki]->add(K_reference_[jki]);
+                if (do_wK_) wK_ao_[jki]->add(wK_reference_[jki]);
+            }
+        } else {
+            // Full build: capture the fixed reference density and its J, K, and wK
+            D_reference_.clear();
+            for (auto const& Di : D_ao_) D_reference_.push_back(Di->clone());
+            J_reference_.clear();
+            if (do_J_) for (auto const& Ji : J_ao_) J_reference_.push_back(Ji->clone());
+            K_reference_.clear();
+            if (do_K_) for (auto const& Ki : K_ao_) K_reference_.push_back(Ki->clone());
+            wK_reference_.clear();
+            if (do_wK_) for (auto const& wKi : wK_ao_) wK_reference_.push_back(wKi->clone());
+        }
+        return;
+    }
+
     // Save a copy of the density for the next iteration
     D_prev_.clear();
     for(auto const &Di : D_ao_) {
@@ -336,10 +379,16 @@ void DirectJK::compute_JK() {
         double incfock_conv = options_.get_double("INCFOCK_CONVERGENCE");
         double Dnorm = Process::environment.globals["SCF D NORM"];
         // Do IFB on this iteration?
-        do_incfock_iter_ = (Dnorm >= incfock_conv) && !initial_iteration_ && (incfock_count_ % reset != reset - 1);
-        
-        if (!initial_iteration_ && (Dnorm >= incfock_conv)) incfock_count_ += 1;
-        
+        if (fixed_reference_) {
+            // A fixed-reference incremental build is exact, so it can be used on
+            // every iteration once a reference has been captured (see incfock_setup).
+            do_incfock_iter_ = !initial_iteration_;
+        } else {
+            do_incfock_iter_ = (Dnorm >= incfock_conv) && !initial_iteration_ && (incfock_count_ % reset != reset - 1);
+
+            if (!initial_iteration_ && (Dnorm >= incfock_conv)) incfock_count_ += 1;
+        }
+
         incfock_setup();
 	
         timer_off("DirectJK: INCFOCK Preprocessing");
@@ -404,16 +453,18 @@ void DirectJK::build_JK_matrices(std::vector<std::shared_ptr<TwoBodyAOInt>>& int
     timer_on("build_JK_matrices()");
 
     // => Zeroing... <= //
-    
+
     // Ideally, this wouldnt be here at all
     // It would be better covered in incfock_setup()
     // But removing this causes a couple of tests to fail for some reason
-    
-    if (!do_incfock_iter_) {
+
+    // The fixed-reference incremental build always computes a fresh delta and adds
+    // the reference contribution back in incfock_postiter(), so it must always zero.
+    if (fixed_reference_ || !do_incfock_iter_) {
         for (auto& Jmat : J) {
             Jmat->zero();
         }
-    
+
         for (auto& Kmat : K) {
             Kmat->zero();
         }

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -750,10 +750,10 @@ class PSI_API DirectJK : public JK {
     std::vector<SharedMatrix> D_prev_;
 
     /// Fixed reference density and the J, K, and wK matrices built from it (used by the fixed-reference incremental build)
-    std::vector<SharedMatrix> D_reference_;
-    std::vector<SharedMatrix> J_reference_;
-    std::vector<SharedMatrix> K_reference_;
-    std::vector<SharedMatrix> wK_reference_;
+    std::vector<SharedMatrix> D_fixed_ref_;
+    std::vector<SharedMatrix> J_fixed_ref_;
+    std::vector<SharedMatrix> K_fixed_ref_;
+    std::vector<SharedMatrix> wK_fixed_ref_;
 
     /// Pseudo-density matrix to be used this iteration
     std::vector<SharedMatrix> D_ref_;

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -740,12 +740,20 @@ class PSI_API DirectJK : public JK {
     
     /// Perform Incremental Fock Build for J and K Matrices? (default false)
     bool incfock_;
+    /// Use a fixed reference for the incremental Fock build instead of updating it every iteration? (default false)
+    bool fixed_reference_;
     /// The number of times INCFOCK has been performed (includes resets)
     int incfock_count_;
     bool do_incfock_iter_;
 
-    /// Previous iteration pseudo-density matrix
+    /// Previous iteration pseudo-density matrix (used by the default, updated-reference incremental build)
     std::vector<SharedMatrix> D_prev_;
+
+    /// Fixed reference density and the J, K, and wK matrices built from it (used by the fixed-reference incremental build)
+    std::vector<SharedMatrix> D_reference_;
+    std::vector<SharedMatrix> J_reference_;
+    std::vector<SharedMatrix> K_reference_;
+    std::vector<SharedMatrix> wK_reference_;
 
     /// Pseudo-density matrix to be used this iteration
     std::vector<SharedMatrix> D_ref_;

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1640,7 +1640,11 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_double("SCF_INITIAL_FINISH_DIIS_TRANSITION", 1.0E-4);
         /*- Do perform incremental Fock build? -*/
         options.add_bool("INCFOCK", false);
-        /*- Frequency with which to compute the full Fock matrix if using |scf__incfock| . 
+        /*- Use a fixed reference density for the incremental Fock build instead of updating the reference
+        every iteration? Since the incremental build against a fixed reference is exact (up to screening),
+        it is used on every iteration and |scf__incfock_full_fock_every| does not apply. Only affects DirectJK. -*/
+        options.add_bool("INCFOCK_FIXED_REFERENCE", false);
+        /*- Frequency with which to compute the full Fock matrix if using |scf__incfock| .
         N means rebuild every N SCF iterations to avoid accumulating error from the incremental procedure. -*/
         options.add_int("INCFOCK_FULL_FOCK_EVERY", 5);
         /*- The density threshold at which to stop building the Fock matrix incrementally -*/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,7 +43,7 @@ foreach(test_name aediis-1
                   cisd-h2o+-2 cisd-h2o-clpse cisd-opt-fd cisd-sp cisd-sp-2
                   ci-property cubeprop cubeprop-frontier decontract dct-grad1 dct-grad2
                   dct-grad3 dct-grad4 dct1 dct2 dct3 dct4 dct5 dct6 dct7 dct8 dct9
-                  dct10 dct11 dct12 ao-dfcasscf-sp density-screen-1 density-screen-2 dfcasscf-sa-sp
+                  dct10 dct11 dct12 ao-dfcasscf-sp density-screen-1 density-screen-2 density-screen-3 dfcasscf-sa-sp
                   dfcasscf-fzc-sp dfcasscf-sp dfccd1 dfccdl1 dfccd-grad1 dfccsd1 dfccsdl1 dfccsd-grad1
                   dfccsd-t-grad1
                   dfccsdt1 dfccsdat1 dfmp2-2 dfmp2-3 dfmp2-4 dfmp2-5 dfmp2-freq1 dfmp2-freq2

--- a/tests/density-screen-3/CMakeLists.txt
+++ b/tests/density-screen-3/CMakeLists.txt
@@ -1,0 +1,4 @@
+include(TestingMacros)
+
+add_regression_test(density-screen-3 "psi;dft;scf;medlong")
+set_tests_properties(density-screen-3 PROPERTIES COST 500)

--- a/tests/density-screen-3/input.dat
+++ b/tests/density-screen-3/input.dat
@@ -1,0 +1,29 @@
+ref_energy = -155.05718342486921 # TEST (CSAM Screening)
+
+molecule {
+H         -1.94154        0.37711        0.00000
+O         -1.19295       -0.22119        0.00000
+C          0.00000        0.55670        0.00000
+C          1.17015       -0.40258        0.00000
+H          0.03989        1.20005        0.88560
+H          0.03989        1.20005       -0.88560
+H          2.11312        0.14575        0.00000
+H          1.13568       -1.03910       -0.88413
+H          1.13568       -1.03910        0.88413
+}
+
+set basis cc-pVTZ
+set df_scf_guess false
+set scf_type direct
+set incfock false
+noincfock_energy = energy('wb97x')
+psi4.compare_values(ref_energy, noincfock_energy, 9, "wB97X Total Energy, No Incremental Formation")
+
+set incfock true
+set incfock_fixed_reference true
+incfock_fixed_energy = energy('wb97x')
+psi4.compare_values(ref_energy, incfock_fixed_energy, 9, "wB97X Total Energy, Incremental Formation With Fixed Reference Density")
+
+set incfock_fixed_reference false
+incfock_update_energy = energy('wb97x')
+psi4.compare_values(ref_energy, incfock_update_energy, 9, "wB97X Total Energy, Incremental Formation With Updating Reference Density")

--- a/tests/density-screen-3/test_input.py
+++ b/tests/density-screen-3/test_input.py
@@ -1,0 +1,5 @@
+from addons import *
+
+@ctest_labeler("dft;scf;medlong")
+def test_density_screen_3():
+    ctest_runner(__file__)


### PR DESCRIPTION
Adds a fixed-reference variant to the `DirectJK` incremental Fock build, exposed through a new `INCFOCK_FIXED_REFERENCE` option.

## Background

The default incremental Fock build keeps the reference density updated every iteration: it builds J/K from `ΔD = D − D_prev` and accumulates the result in place. This tightens density-based screening as the SCF converges, but small errors accumulate over many iterations, so a full Fock matrix must be rebuilt every `INCFOCK_FULL_FOCK_EVERY` iterations, and the incremental build is switched off once `INCFOCK_CONVERGENCE` is reached.

## The fixed-reference variant

With `INCFOCK_FIXED_REFERENCE true`, the density and the J/K/wK matrices from the first full build are captured and held fixed. Each subsequent iteration:

1. builds J/K/wK from the difference against the **fixed** reference, `ΔD = D − D_ref`, and
2. adds the stored reference contributions back: `J = J[D − D_ref] + J[D_ref]`.

By linearity of the Fock build this is exact regardless of iteration count (up to screening), so it runs on **every** iteration and needs no periodic full rebuild — `INCFOCK_FULL_FOCK_EVERY` does not apply. The trade-off is that roughly the same number of integrals are computed at each incremental step, with no danger of accumulated numerical creep. See [Parrish:2016:131101] for inspiration.

## Implementation notes

- The default (updated-reference) path is **behaviorally unchanged** — the fixed-reference logic is a separate branch in `incfock_setup`, `incfock_postiter`, the per-iteration decision, and the `build_JK_matrices` zeroing (fixed reference always zeros, since it recomputes a fresh delta and adds the reference back).
- New members on `DirectJK`: `fixed_reference_` and `D_reference_ / J_reference_ / K_reference_ / wK_reference_`.
- `print_header` reports the fixed-reference setting when incfock is on.

## Testing

Adds a `density-screen-3` regression test that runs wB97X/cc-pVTZ three ways — no incfock, incremental with a fixed reference, and incremental with an updating reference — and checks all three energies agree to 1e-9. wB97X exercises J, K, and wK simultaneously, so all three reference matrices are covered.

## Notes for reviewers

- This is a clean reimplementation on current `master` of a fixed-reference variant I first prototyped ~2 years ago (branch `directjk_reference`); that branch had since been overtaken by the IncFock standardization (#2808), so it is reimplemented from scratch on top of the current incfock structure rather than rebased.
- I was not able to build/run locally in this environment, so **CI is the compile-and-test gate**. In particular the `density-screen-3` reference energy and the exact-agreement tolerance should be confirmed by CI; `output.ref` is intentionally not committed (the runner drives `input.dat`'s `compare_values` calls, not a byte comparison) and can be regenerated from a passing run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
