### PR TITLE
Improve SparseMap infrastructure of DLPNO, require GCC-12

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -9,13 +9,13 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      gcc_11:
-        CXX_COMPILER: 'g++-11'
+      gcc_12:
+        CXX_COMPILER: 'g++-12'
         PYTHON_VER: '3.14'
-        C_COMPILER: 'gcc-11'
+        C_COMPILER: 'gcc-12'
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'
-        APT_INSTALL: 'gfortran gcc-11 g++-11'
+        APT_INSTALL: 'gfortran gcc-12 g++-12'
         vmImage: 'ubuntu-22.04'
         PYTEST_MARKER_EXPR: "quick"
         PYTEST_NAME_EXPR: 'not nonsense1'

--- a/psi4/src/psi4/dlpno/ccsd.cc
+++ b/psi4/src/psi4/dlpno/ccsd.cc
@@ -1191,7 +1191,7 @@ template<bool crude> double DLPNOCCSD::filter_pairs(const std::vector<double>& e
 
     if constexpr (crude) {
         // Clear information from old maps
-        std::vector<std::vector<int>> i_j_to_ij_new;
+        SparseMap i_j_to_ij_new;
         std::vector<std::pair<int,int>> ij_to_i_j_new;
         std::vector<int> ij_to_ji_new;
 

--- a/psi4/src/psi4/dlpno/dlpno.cc
+++ b/psi4/src/psi4/dlpno/dlpno.cc
@@ -55,6 +55,26 @@
 namespace psi {
 namespace dlpno {
 
+/* Args: SparseMap from x to y, maximum possible y value
+ * Returns: SparseMap from y to x
+ */
+[[nodiscard]] constexpr SparseMap invert_map(const SparseMap& x_to_y, int ny) {
+    std::vector<int> count(ny, 0);
+    for (const auto& ys : x_to_y)
+        for (int y : ys) {
+            if (y < 0 && y >= ny) throw PSIEXCEPTION("Cannot invert an invalid map!");
+            ++count[y];
+        }
+
+    SparseMap y_to_x(ny);
+    for (int y = 0; y < ny; ++y) y_to_x[y].reserve(count[y]);
+
+    for (int x = 0; x < std::ssize(x_to_y); ++x)  // ascending x keeps each list sorted
+        for (int y : x_to_y[x]) y_to_x[y].push_back(x);
+
+    return y_to_x;
+}
+
 DLPNO::DLPNO(SharedWavefunction ref_wfn, Options& options) : Wavefunction(options) {
     shallow_copy(ref_wfn);
     reference_wavefunction_ = ref_wfn;
@@ -1678,5 +1698,5 @@ void DLPNO::print_pao_pair_domains() {
 
 double DLPNO::compute_energy() { return 0.0; }
 
-}
-}
+}  // namespace dlpno
+}  // namespace psi

--- a/psi4/src/psi4/dlpno/dlpno.cc
+++ b/psi4/src/psi4/dlpno/dlpno.cc
@@ -47,6 +47,7 @@
 #include "psi4/libqt/qt.h"
 
 #include <algorithm>
+#include <iterator>
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/psi4/src/psi4/dlpno/dlpno.h
+++ b/psi4/src/psi4/dlpno/dlpno.h
@@ -169,7 +169,7 @@ class DLPNO : public Wavefunction {
     SparseMap lmo_to_riatoms_; ///< aux BFs on which atoms are needed for density-fitting a LMO?
     SparseMap lmo_to_paos_; ///< which PAOs span the virtual space of a LMO?
     SparseMap lmo_to_paoatoms_; ///< PAOs on which atoms span the virtual space of a LMO?
-    std::vector<std::vector<int>> i_j_to_ij_; ///< LMO indices (i, j) to significant LMO pair index (ij); insignificant (i, j) maps to -1
+    SparseMap i_j_to_ij_; ///< LMO indices (i, j) to significant LMO pair index (ij); insignificant (i, j) maps to -1
     std::vector<std::pair<int,int>> ij_to_i_j_; ///< LMO pair index (ij) to both LMO indices (i, j)
     std::vector<int> ij_to_ji_; ///< LMO pair index (ij) to LMO pair index (ji)
 
@@ -196,20 +196,20 @@ class DLPNO : public Wavefunction {
     /* Takes an atom index and a global LMO index 
     to return the sparse LMO index on that atom,
     (-1) if that LMO is not on the riatom's extended domain */
-    std::vector<std::vector<int>> riatom_to_lmos_ext_dense_;
+    SparseMap riatom_to_lmos_ext_dense_;
     /* Takes an atom index and a global PAO index 
     to return the sparse PAO index on that atom,
     (-1) if that PAO is not on the riatom's extended domain */
-    std::vector<std::vector<int>> riatom_to_paos_ext_dense_;
+    SparseMap riatom_to_paos_ext_dense_;
     std::vector<std::vector<bool>> riatom_to_atoms1_dense_;
     std::vector<std::vector<bool>> riatom_to_atoms2_dense_;
-    std::vector<std::vector<int>> lmopair_to_lmos_dense_;
+    SparseMap lmopair_to_lmos_dense_;
 
     /// Useful for generating DF integrals (TODO: Replace this with "index_list" function)
-    std::vector<std::vector<std::vector<int>>> lmopair_lmo_to_riatom_lmo_;
-    std::vector<std::vector<std::vector<int>>> lmopair_pao_to_riatom_pao_;
+    std::vector<SparseMap> lmopair_lmo_to_riatom_lmo_;
+    std::vector<SparseMap> lmopair_pao_to_riatom_pao_;
     std::vector<std::vector<std::pair<int,int>>> riatom_to_pao_pairs_; ///< Which (u,v) pao pairs belong to an riatom
-    std::vector<std::vector<std::vector<int>>> riatom_to_pao_pairs_dense_; ///< For each riatom, returns the index of the element in qab tensor
+    std::vector<SparseMap> riatom_to_pao_pairs_dense_; ///< For each riatom, returns the index of the element in qab tensor
 
     /// PSIO object (helps with reading/writing large tensors)
     std::shared_ptr<PSIO> psio_;
@@ -324,11 +324,11 @@ class PSI_API DLPNOCCSD : public DLPNO {
 
     std::vector<double> e_ij_mp2_scale_; ///< how much to scale MP2 energies for scaled approximation to PAO-LMP2
 
-    std::vector<std::vector<int>> i_j_to_ij_strong_; ///< LMO indices (i, j) to significant strong pair index (ij); insignificant (i, j) maps to -1
+    SparseMap i_j_to_ij_strong_; ///< LMO indices (i, j) to significant strong pair index (ij); insignificant (i, j) maps to -1
     std::vector<std::pair<int,int>> ij_to_i_j_strong_;  ///< LMO strong pair index (ij) to both LMO indices (i, j)
     std::vector<int> ij_to_ji_strong_; ///< LMO strong pair index (ij) to LMO pair index (ji)
 
-    std::vector<std::vector<int>> i_j_to_ij_weak_; ///< LMO indices (i, j) to significant weak pair index (ij); insignificant (i, j) maps to -1
+    SparseMap i_j_to_ij_weak_; ///< LMO indices (i, j) to significant weak pair index (ij); insignificant (i, j) maps to -1
     std::vector<std::pair<int,int>> ij_to_i_j_weak_;  ///< LMO weak pair index (ij) to both LMO indices (i, j)
     std::vector<int> ij_to_ji_weak_; ///< LMO weak pair index (ij) to LMO pair index (ji)
 

--- a/psi4/src/psi4/dlpno/sparse.cc
+++ b/psi4/src/psi4/dlpno/sparse.cc
@@ -90,7 +90,7 @@ std::vector<int> index_list(const std::vector<int> &l1, const std::vector<int> &
     return lsub;
 }
 
-std::vector<int> contract_lists(const std::vector<int> &y, const std::vector<std::vector<int>> &A_to_y) {
+std::vector<int> contract_lists(const std::vector<int> &y, const SparseMap &A_to_y) {
 
     // TODO: runtime is proportional to A_to_y size (system size, O(N))
     // could maybe reduce to &y size (domain size, O(1)), probably doesn't matter
@@ -135,10 +135,10 @@ std::vector<int> block_list(const std::vector<int> &x_list, const std::vector<in
 
 }
 
-std::vector<std::vector<int>> invert_map(const std::vector<std::vector<int>> &x_to_y, int ny) {
+SparseMap invert_map(const SparseMap &x_to_y, int ny) {
 
     int nx = x_to_y.size();
-    std::vector<std::vector<int>> y_to_x(ny);
+    SparseMap y_to_x(ny);
 
     for(int x = 0; x < nx; x++) {
         for(auto y : x_to_y[x]) {
@@ -150,10 +150,10 @@ std::vector<std::vector<int>> invert_map(const std::vector<std::vector<int>> &x_
 
 }
 
-std::vector<std::vector<int>> chain_maps(const std::vector<std::vector<int>> &x_to_y, const std::vector<std::vector<int>> &y_to_z) {
+SparseMap chain_maps(const SparseMap &x_to_y, const SparseMap &y_to_z) {
 
     int nx = x_to_y.size();
-    std::vector<std::vector<int>> x_to_z(nx);
+    SparseMap x_to_z(nx);
 
     for(int x = 0; x < nx; x++) {
         for(auto y : x_to_y[x]) {
@@ -169,10 +169,10 @@ std::vector<std::vector<int>> chain_maps(const std::vector<std::vector<int>> &x_
 
 }
 
-std::vector<std::vector<int>> extend_maps(const std::vector<std::vector<int>> &x_to_y, const std::vector<std::pair<int,int>> &xpairs) {
+SparseMap extend_maps(const SparseMap &x_to_y, const std::vector<std::pair<int,int>> &xpairs) {
 
     int nx = x_to_y.size();
-    std::vector<std::vector<int>> xext_to_y(nx);
+    SparseMap xext_to_y(nx);
 
     for(auto xpair : xpairs) {
         size_t x1, x2;

--- a/psi4/src/psi4/dlpno/sparse.cc
+++ b/psi4/src/psi4/dlpno/sparse.cc
@@ -135,23 +135,6 @@ std::vector<int> block_list(const std::vector<int> &x_list, const std::vector<in
 
 }
 
-[[nodiscard]] constexpr SparseMap invert_map(const SparseMap& x_to_y, int ny) {
-    std::vector<int> count(ny, 0);
-    for (const auto& ys : x_to_y)
-        for (int y : ys) {
-            if (y < 0 && y >= ny) throw PSIEXCEPTION("Cannot invert an invalid map!");
-            ++count[y];
-        }
-
-    SparseMap y_to_x(ny);
-    for (int y = 0; y < ny; ++y) y_to_x[y].reserve(count[y]);
-
-    for (int x = 0; x < std::ssize(x_to_y); ++x)  // ascending x keeps each list sorted
-        for (int y : x_to_y[x]) y_to_x[y].push_back(x);
-
-    return y_to_x;
-}
-
 SparseMap chain_maps(const SparseMap &x_to_y, const SparseMap &y_to_z) {
 
     int nx = x_to_y.size();

--- a/psi4/src/psi4/dlpno/sparse.cc
+++ b/psi4/src/psi4/dlpno/sparse.cc
@@ -34,6 +34,7 @@
 #include <algorithm>
 
 namespace psi {
+namespace dlpno {
 
 std::vector<int> merge_lists(const std::vector<int> &l1, const std::vector<int> &l2) {
 
@@ -223,5 +224,6 @@ SharedMatrix submatrix_rows_and_cols(const Matrix &mat, const std::vector<int> &
     return mat_new;
 }
 
+} // namespace dlpno
 } // namespace psi
 

--- a/psi4/src/psi4/dlpno/sparse.cc
+++ b/psi4/src/psi4/dlpno/sparse.cc
@@ -135,19 +135,21 @@ std::vector<int> block_list(const std::vector<int> &x_list, const std::vector<in
 
 }
 
-SparseMap invert_map(const SparseMap &x_to_y, int ny) {
-
-    int nx = x_to_y.size();
-    SparseMap y_to_x(ny);
-
-    for(int x = 0; x < nx; x++) {
-        for(auto y : x_to_y[x]) {
-            y_to_x[y].push_back(x);
+[[nodiscard]] constexpr SparseMap invert_map(const SparseMap& x_to_y, int ny) {
+    std::vector<int> count(ny, 0);
+    for (const auto& ys : x_to_y)
+        for (int y : ys) {
+            if (y < 0 && y >= ny) throw PSIEXCEPTION("Cannot invert an invalid map!");
+            ++count[y];
         }
-    }
+
+    SparseMap y_to_x(ny);
+    for (int y = 0; y < ny; ++y) y_to_x[y].reserve(count[y]);
+
+    for (int x = 0; x < std::ssize(x_to_y); ++x)  // ascending x keeps each list sorted
+        for (int y : x_to_y[x]) y_to_x[y].push_back(x);
 
     return y_to_x;
-
 }
 
 SparseMap chain_maps(const SparseMap &x_to_y, const SparseMap &y_to_z) {

--- a/psi4/src/psi4/dlpno/sparse.h
+++ b/psi4/src/psi4/dlpno/sparse.h
@@ -61,11 +61,6 @@ std::vector<int> contract_lists(const std::vector<int>& y, const SparseMap& A_to
  */
 std::vector<int> block_list(const std::vector<int> &x_list, const std::vector<int> &x_to_y_map);
 
-/* Args: SparseMap from x to y, maximum possible y value
- * Returns: SparseMap from y to x
- */
-[[nodiscard]] constexpr SparseMap invert_map(const SparseMap& x_to_y, int ny);
-
 /* Args: SparseMap from x to y, SparseMap from y to z
  * Returns: SparseMap from x to z
  */

--- a/psi4/src/psi4/dlpno/sparse.h
+++ b/psi4/src/psi4/dlpno/sparse.h
@@ -52,7 +52,7 @@ std::vector<int> PSI_API index_list(const std::vector<int> &l1, const std::vecto
 /* Args: sorted list of y, sparse map from A to another list of y (assume sorted, each possible value of y appears exactly once in entire map)
  * Returns: the union of lists in A_to_y where at least one element is in y
  */
-std::vector<int> contract_lists(const std::vector<int> &y, const std::vector<std::vector<int>> &A_to_y);
+std::vector<int> contract_lists(const std::vector<int>& y, const SparseMap& A_to_y);
 
 /* Args: x is a list of values (sorted), y is a map from values of x to values of y
  * Returns: a list of y values

--- a/psi4/src/psi4/dlpno/sparse.h
+++ b/psi4/src/psi4/dlpno/sparse.h
@@ -64,7 +64,7 @@ std::vector<int> block_list(const std::vector<int> &x_list, const std::vector<in
 /* Args: SparseMap from x to y, maximum possible y value
  * Returns: SparseMap from y to x
  */
-SparseMap invert_map(const SparseMap &x_to_y, int ny);
+[[nodiscard]] constexpr SparseMap invert_map(const SparseMap& x_to_y, int ny);
 
 /* Args: SparseMap from x to y, SparseMap from y to z
  * Returns: SparseMap from x to z

--- a/psi4/src/psi4/dlpno/sparse.h
+++ b/psi4/src/psi4/dlpno/sparse.h
@@ -30,12 +30,12 @@
 #define PSI4_SRC_DLPNO_SPARSE_H_
 
 #include "psi4/libmints/matrix.h"
-
 #include <vector>
 
-typedef std::vector<std::vector<int>> SparseMap;
+namespace psi {
+namespace dlpno {
 
-namespace psi{
+using SparseMap = std::vector<std::vector<int>>;
 
 /* Args: sorted lists l1 and l2
  * Returns: sorted union of l1 and l2
@@ -85,6 +85,7 @@ SharedMatrix submatrix_cols(const Matrix &mat, const std::vector<int> &col_inds)
 /* Args: Matrix, list of row and column indices */
 SharedMatrix submatrix_rows_and_cols(const Matrix &mat, const std::vector<int> &row_inds, const std::vector<int> &col_inds);
 
-} // namespace psi
+}  // namespace dlpno
+}  // namespace psi
 
 #endif // PSI4_SRC_DLPNO_SPARSE_H_


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
Almost all of DLPNO is nicely cordoned off in `namespace dlpno`, but sparse.h/cc is not. This PR pulls the contents of those files into `namespace dlpno`.

Currently, sparse.h is adding a `typedef std::vector<std::vector<int>> SparseMap` into global scope. This PR modernizes that to `using SparseMap = std::vector<std::vector<int>>` and pulls it into psi::dlpno.
Despite this alias being defined, the DLPNO module still uses the `std::vector<std::vector<int>>` boilerplate at some places. This PR uses the alias everywhere it is applicable in DLPNO.

`SparseMap invert_map(const SparseMap &x_to_y, int ny)` is called exactly once in the entire codebase, in dlpno.cc. This PR improves invert_map to throw on an invalid map and to reallocate its vector fewer times.
invert_map is also moved into dlpno.cc from sparse.h, so that other code including that header does not have to see and spend some compile time parsing it.

Finally, the minimum GCC version requirement will be GCC-12 after this PR, due to the use of std::ssize(std::vector) in the new invert_map implementation.

## User API & Changelog headlines
<!-- A bullet-point format description of how this PR affects the user.
     This is destined for the release notes. May be empty. -->
- [x] Psi4 now requires at least GCC 12 to compile

## Dev notes & details
<!-- A bullet-point format description of what this PR does "at a glance."
     Target audience is code reviewers and other devs skimming PRs.
     Should be more technical than user notes. Should never be empty. -->
- [x] Wrap the contents of dlpno/sparse.h and dlpno/sparse.cc in namespace dlpno {}
- [x] Modernize SparseMap typedef and pull it into psi::dlpno from global scope
- [x] Replace remaining `std::vector<std::vector<int>>` boilerplate in dlpno with SparseMap 
- [x] Improve `invert_map` to do fewer heap allocations and throw on invalid input map
- [x] Move `invert_map` from sparse.h to dlpno.cc, where its only call is
- [x] Modify the gcc_11 Azure CI lane to use GCC 12

## AI
<!-- Briefly describe where AI contributed to the PR (tests, derivation,
     bug-seeking, code generation, docs, etc.). No restrictions, but a
     person should be submitting the PR and (as usual) be ready to answer
     questions about it. -->
- [x] The new invert_map implementation is mostly LLM-generated

## Checklist
- [x] No new features
- [x] The docs dont seem to contain a minimum GCC version requirement, so no docs update
- Test running is well covered by CI. For running locally, see [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- Ready for merge -- use Draft/Open GitHub status to signal your view on merge readiness
