### PR TITLE
cc: replace malloc'd C-string arrays with owning std::string containers

### DIFF
--- a/psi4/src/psi4/cc/cceom/MOInfo.h
+++ b/psi4/src/psi4/cc/cceom/MOInfo.h
@@ -56,8 +56,8 @@ struct MOInfo {
     Dimension frdocc;                       /* no. of frozen core orbitals per irrep */
     Dimension fruocc;                       /* no. of frozen unoccupied orbitals per irrep */
     int nvirt;                         /* total no. of (active) virtual orbitals */
-    std::vector<std::string> irr_labs; /* irrep labels */
-    char **irr_labs_lowercase;         /* irrep labels */
+    std::vector<std::string> irr_labs;           /* irrep labels */
+    std::vector<std::string> irr_labs_lowercase; /* irrep labels, lowercased */
     Dimension occpi;                        /* no. of occupied orbs. (incl. open) per irrep */
     Dimension aoccpi;                       /* no. of alpha occupied orbs. (incl. open) per irrep */
     Dimension boccpi;                       /* no. of beta occupied orbs. (incl. open) per irrep */

--- a/psi4/src/psi4/cc/cceom/amp_write.cc
+++ b/psi4/src/psi4/cc/cceom/amp_write.cc
@@ -113,8 +113,8 @@ void amp_write_RHF(dpdfile2 *RIA, dpdbuf4 *RIjAb, int namps) {
             Ga = R1_stack[m].Ga;
             i = frdocc[Gi] + R1_stack[m].i + 1;
             a = frdocc[Ga] + clsdpi[Ga] + R1_stack[m].a + 1;
-            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi]);
-            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga]);
+            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi].c_str());
+            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga].c_str());
             outfile->Printf("       %3d > %3d      :    %6s > %6s : %15.10f\n", R1_stack[m].i, R1_stack[m].a, lbli,
                             lbla, R1_stack[m].value);
         }
@@ -138,10 +138,10 @@ void amp_write_RHF(dpdfile2 *RIA, dpdbuf4 *RIjAb, int namps) {
             a = frdocc[Ga] + clsdpi[Ga] + R2_stack[m].a + 1;
             b = frdocc[Gb] + clsdpi[Gb] + R2_stack[m].b + 1;
 
-            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi]);
-            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj]);
-            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga]);
-            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb]);
+            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi].c_str());
+            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj].c_str());
+            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga].c_str());
+            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb].c_str());
             outfile->Printf("      %3d %3d > %3d %3d     : %6s %6s > %6s %6s : %15.10f\n", R2_stack[m].i, R2_stack[m].j,
                             R2_stack[m].a, R2_stack[m].b, lbli, lblj, lbla, lblb, R2_stack[m].value);
         }
@@ -169,8 +169,8 @@ void amp_write_UHF(dpdfile2 *RIA, dpdfile2 *Ria, dpdbuf4 *RIJAB, dpdbuf4 *Rijab,
             Ga = R1_stack[m].Ga;
             i = frdocc[Gi] + R1_stack[m].i + 1;
             a = frdocc[Ga] + clsdpi[Ga] + openpi[Ga] + R1_stack[m].a + 1;
-            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi]);
-            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga]);
+            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi].c_str());
+            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga].c_str());
             outfile->Printf("       %3d > %3d      :    %6s > %6s : %15.10f\n", R1_stack[m].i, R1_stack[m].a, lbli,
                             lbla, R1_stack[m].value);
         }
@@ -187,8 +187,8 @@ void amp_write_UHF(dpdfile2 *RIA, dpdfile2 *Ria, dpdbuf4 *RIJAB, dpdbuf4 *Rijab,
             Ga = R1_stack[m].Ga;
             i = frdocc[Gi] + R1_stack[m].i + 1;
             a = frdocc[Ga] + clsdpi[Ga] + R1_stack[m].a + 1;
-            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi]);
-            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga]);
+            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi].c_str());
+            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga].c_str());
             outfile->Printf("       %3d > %3d      :    %6s > %6s : %15.10f\n", R1_stack[m].i, R1_stack[m].a, lbli,
                             lbla, R1_stack[m].value);
         }
@@ -212,10 +212,10 @@ void amp_write_UHF(dpdfile2 *RIA, dpdfile2 *Ria, dpdbuf4 *RIJAB, dpdbuf4 *Rijab,
             a = frdocc[Ga] + clsdpi[Ga] + openpi[Ga] + R2_stack[m].a + 1;
             b = frdocc[Gb] + clsdpi[Gb] + R2_stack[m].b + 1;
 
-            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi]);
-            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj]);
-            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga]);
-            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb]);
+            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi].c_str());
+            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj].c_str());
+            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga].c_str());
+            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb].c_str());
             outfile->Printf("      %3d %3d > %3d %3d     : %6s %6s > %6s %6s : %15.10f\n", R2_stack[m].i, R2_stack[m].j,
                             R2_stack[m].a, R2_stack[m].b, lbli, lblj, lbla, lblb, R2_stack[m].value);
         }
@@ -238,10 +238,10 @@ void amp_write_UHF(dpdfile2 *RIA, dpdfile2 *Ria, dpdbuf4 *RIJAB, dpdbuf4 *Rijab,
             a = frdocc[Ga] + clsdpi[Ga] + openpi[Ga] + R2_stack[m].a + 1;
             b = frdocc[Gb] + clsdpi[Gb] + openpi[Gb] + R2_stack[m].b + 1;
 
-            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi]);
-            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj]);
-            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga]);
-            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb]);
+            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi].c_str());
+            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj].c_str());
+            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga].c_str());
+            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb].c_str());
             outfile->Printf("      %3d %3d > %3d %3d     : %6s %6s > %6s %6s : %15.10f\n", R2_stack[m].i, R2_stack[m].j,
                             R2_stack[m].a, R2_stack[m].b, lbli, lblj, lbla, lblb, R2_stack[m].value);
         }
@@ -264,10 +264,10 @@ void amp_write_UHF(dpdfile2 *RIA, dpdfile2 *Ria, dpdbuf4 *RIJAB, dpdbuf4 *Rijab,
             a = frdocc[Ga] + clsdpi[Ga] + R2_stack[m].a + 1;
             b = frdocc[Gb] + clsdpi[Gb] + R2_stack[m].b + 1;
 
-            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi]);
-            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj]);
-            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga]);
-            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb]);
+            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi].c_str());
+            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj].c_str());
+            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga].c_str());
+            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb].c_str());
             outfile->Printf("      %3d %3d > %3d %3d     : %6s %6s > %6s %6s : %15.10f\n", R2_stack[m].i, R2_stack[m].j,
                             R2_stack[m].a, R2_stack[m].b, lbli, lblj, lbla, lblb, R2_stack[m].value);
         }
@@ -296,8 +296,8 @@ void amp_write_ROHF(dpdfile2 *RIA, dpdfile2 *Ria, dpdbuf4 *RIJAB, dpdbuf4 *Rijab
             Ga = R1_stack[m].Ga;
             i = frdocc[Gi] + R1_stack[m].i + 1;
             a = frdocc[Ga] + clsdpi[Ga] + openpi[Ga] + R1_stack[m].a + 1;
-            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi]);
-            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga]);
+            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi].c_str());
+            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga].c_str());
             outfile->Printf("       %3d > %3d      :    %6s > %6s : %15.10f\n", R1_stack[m].i, R1_stack[m].a, lbli,
                             lbla, R1_stack[m].value);
         }
@@ -319,8 +319,8 @@ void amp_write_ROHF(dpdfile2 *RIA, dpdfile2 *Ria, dpdbuf4 *RIJAB, dpdbuf4 *Rijab
             else
                 a = frdocc[Ga] + clsdpi[Ga] + (R1_stack[m].a - (virtpi[Ga] - openpi[Ga])) + 1;
 
-            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi]);
-            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga]);
+            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi].c_str());
+            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga].c_str());
             outfile->Printf("       %3d > %3d      :    %6s > %6s : %15.10f\n", R1_stack[m].i, R1_stack[m].a, lbli,
                             lbla, R1_stack[m].value);
         }
@@ -347,10 +347,10 @@ void amp_write_ROHF(dpdfile2 *RIA, dpdfile2 *Ria, dpdbuf4 *RIJAB, dpdbuf4 *Rijab
             else
                 b = frdocc[Gb] + clsdpi[Gb] + (R2_stack[m].b - (virtpi[Gb] - openpi[Gb])) + 1;
 
-            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi]);
-            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj]);
-            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga]);
-            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb]);
+            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi].c_str());
+            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj].c_str());
+            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga].c_str());
+            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb].c_str());
             outfile->Printf("      %3d %3d > %3d %3d     : %6s %6s > %6s %6s : %15.10f\n", R2_stack[m].i, R2_stack[m].j,
                             R2_stack[m].a, R2_stack[m].b, lbli, lblj, lbla, lblb, R2_stack[m].value);
         }
@@ -373,10 +373,10 @@ void amp_write_ROHF(dpdfile2 *RIA, dpdfile2 *Ria, dpdbuf4 *RIJAB, dpdbuf4 *Rijab
             a = frdocc[Ga] + clsdpi[Ga] + openpi[Ga] + R2_stack[m].a + 1;
             b = frdocc[Gb] + clsdpi[Gb] + openpi[Gb] + R2_stack[m].b + 1;
 
-            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi]);
-            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj]);
-            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga]);
-            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb]);
+            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi].c_str());
+            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj].c_str());
+            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga].c_str());
+            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb].c_str());
             outfile->Printf("      %3d %3d > %3d %3d     : %6s %6s > %6s %6s : %15.10f\n", R2_stack[m].i, R2_stack[m].j,
                             R2_stack[m].a, R2_stack[m].b, lbli, lblj, lbla, lblb, R2_stack[m].value);
         }
@@ -407,10 +407,10 @@ void amp_write_ROHF(dpdfile2 *RIA, dpdfile2 *Ria, dpdbuf4 *RIJAB, dpdbuf4 *Rijab
             else
                 b = frdocc[Gb] + clsdpi[Gb] + (R2_stack[m].b - (virtpi[Gb] - openpi[Gb])) + 1;
 
-            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi]);
-            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj]);
-            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga]);
-            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb]);
+            sprintf(lbli, "%d%s", i, moinfo.irr_labs_lowercase[Gi].c_str());
+            sprintf(lblj, "%d%s", j, moinfo.irr_labs_lowercase[Gj].c_str());
+            sprintf(lbla, "%d%s", a, moinfo.irr_labs_lowercase[Ga].c_str());
+            sprintf(lblb, "%d%s", b, moinfo.irr_labs_lowercase[Gb].c_str());
             outfile->Printf("      %3d %3d > %3d %3d     : %6s %6s > %6s %6s : %15.10f\n", R2_stack[m].i, R2_stack[m].j,
                             R2_stack[m].a, R2_stack[m].b, lbli, lblj, lbla, lblb, R2_stack[m].value);
         }

--- a/psi4/src/psi4/cc/cceom/get_moinfo.cc
+++ b/psi4/src/psi4/cc/cceom/get_moinfo.cc
@@ -87,11 +87,10 @@ void get_moinfo(std::shared_ptr<Wavefunction> wfn) {
 
     nirreps = moinfo.nirreps;
 
-    moinfo.irr_labs_lowercase = (char **)malloc(sizeof(char *) * nirreps);
+    moinfo.irr_labs_lowercase.resize(nirreps);
     for (i = 0; i < nirreps; i++) {
-        moinfo.irr_labs_lowercase[i] = ::strdup(moinfo.irr_labs[i].c_str());
-        for (j = 0; j < ::strlen(moinfo.irr_labs_lowercase[i]); ++j)
-            moinfo.irr_labs_lowercase[i][j] = std::tolower(moinfo.irr_labs_lowercase[i][j]);
+        moinfo.irr_labs_lowercase[i] = moinfo.irr_labs[i];
+        for (auto &c : moinfo.irr_labs_lowercase[i]) c = std::tolower(static_cast<unsigned char>(c));
     }
 
     psio_read_entry(PSIF_CC_INFO, "Reference Wavefunction", (char *)&(params.ref), sizeof(int));
@@ -217,8 +216,7 @@ void cleanup() {
         free(moinfo.Cb);
     }
 
-    for (i = 0; i < moinfo.nirreps; i++) free(moinfo.irr_labs_lowercase[i]);
-    free(moinfo.irr_labs_lowercase);
+    moinfo.irr_labs_lowercase.clear();
     if (params.ref == 2) {
         free(moinfo.aocc_sym);
         free(moinfo.bocc_sym);

--- a/psi4/src/psi4/cc/ccresponse/optrot.cc
+++ b/psi4/src/psi4/cc/ccresponse/optrot.cc
@@ -67,6 +67,7 @@
 
   -TDC, 4/09, revised 3/15
 */
+#include <array>
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
@@ -99,7 +100,7 @@ void linresp(double *tensor, double A, double B, const char *pert_x, int x_irrep
 void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
     double ***tensor_rl, ***tensor_pl, ***tensor_rp, **tensor0;
     double **tensor_rl0, **tensor_rl1, **tensor_pl0, **tensor_pl1;
-    char **cartcomp, pert[32], pert_x[32], pert_y[32];
+    char pert[32], pert_x[32], pert_y[32];
     int alpha, beta, i, j, k;
     double TrG_rl, TrG_pl, M, nu, bohr2a4, m2a, hbar, prefactor;
     double *rotation_rl, *rotation_pl, *rotation_rp, *rotation_mod;
@@ -111,10 +112,7 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
     if (params.gauge == "LENGTH" || params.gauge == "BOTH") compute_rl = 1;
     if (params.gauge == "VELOCITY" || params.gauge == "BOTH") compute_pl = 1;
 
-    cartcomp = (char **)malloc(3 * sizeof(char *));
-    cartcomp[0] = strdup("X");
-    cartcomp[1] = strdup("Y");
-    cartcomp[2] = strdup("Z");
+    const std::array<std::string, 3> cartcomp{"X", "Y", "Z"};
 
     tensor_rl = (double ***)malloc(params.nomega * sizeof(double **));
     tensor_pl = (double ***)malloc(params.nomega * sizeof(double **));
@@ -150,11 +148,11 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
         sprintf(lbl1, "<<P;L>>_(%5.3f)", 0.0);
         if (!params.restart || !psio_tocscan(PSIF_CC_INFO, lbl1)) {
             for (alpha = 0; alpha < 3; alpha++) {
-                sprintf(pert, "P_%1s", cartcomp[alpha]);
+                sprintf(pert, "P_%1s", cartcomp[alpha].c_str());
                 pertbar(pert, moinfo.mu_irreps[alpha], 1);
                 compute_X(pert, moinfo.mu_irreps[alpha], 0);
 
-                sprintf(pert, "L_%1s", cartcomp[alpha]);
+                sprintf(pert, "L_%1s", cartcomp[alpha].c_str());
                 pertbar(pert, moinfo.l_irreps[alpha], 1);
                 compute_X(pert, moinfo.l_irreps[alpha], 0);
             }
@@ -162,8 +160,8 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
             outfile->Printf("\n\tComputing %s tensor.\n", lbl1);
             for (alpha = 0; alpha < 3; alpha++) {
                 for (beta = 0; beta < 3; beta++) {
-                    sprintf(pert_x, "P_%1s", cartcomp[alpha]);
-                    sprintf(pert_y, "L_%1s", cartcomp[beta]);
+                    sprintf(pert_x, "P_%1s", cartcomp[alpha].c_str());
+                    sprintf(pert_y, "L_%1s", cartcomp[beta].c_str());
                     linresp(&tensor0[alpha][beta], -1.0, 0.0, pert_x, moinfo.mu_irreps[alpha], 0.0, pert_y,
                             moinfo.l_irreps[beta], 0.0);
                 }
@@ -215,36 +213,36 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
             /* prepare the dipole-length and/or dipole-velocity integrals */
             if (compute_rl) {
                 for (alpha = 0; alpha < 3; alpha++) {
-                    sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                    sprintf(pert, "Mu_%1s", cartcomp[alpha].c_str());
                     pertbar(pert, moinfo.mu_irreps[alpha], 0);
                 }
             }
             if (compute_pl) {
                 for (alpha = 0; alpha < 3; alpha++) {
-                    sprintf(pert, "P_%1s", cartcomp[alpha]);
+                    sprintf(pert, "P_%1s", cartcomp[alpha].c_str());
                     pertbar(pert, moinfo.mu_irreps[alpha], 1);
                 }
             }
 
             /* prepare the magnetic-dipole integrals */
             for (alpha = 0; alpha < 3; alpha++) {
-                sprintf(pert, "L_%1s", cartcomp[alpha]);
+                sprintf(pert, "L_%1s", cartcomp[alpha].c_str());
                 pertbar(pert, moinfo.l_irreps[alpha], 1);
             }
 
             /* Compute the +omega magnetic-dipole and -omega electric-dipole CC wave functions */
             for (alpha = 0; alpha < 3; alpha++) {
                 if (compute_rl) {
-                    sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                    sprintf(pert, "Mu_%1s", cartcomp[alpha].c_str());
                     compute_X(pert, moinfo.mu_irreps[alpha], -params.omega[i]);
                 }
 
                 if (compute_pl) {
-                    sprintf(pert, "P_%1s", cartcomp[alpha]);
+                    sprintf(pert, "P_%1s", cartcomp[alpha].c_str());
                     compute_X(pert, moinfo.mu_irreps[alpha], -params.omega[i]);
                 }
 
-                sprintf(pert, "L_%1s", cartcomp[alpha]);
+                sprintf(pert, "L_%1s", cartcomp[alpha].c_str());
                 compute_X(pert, moinfo.l_irreps[alpha], params.omega[i]);
             }
 
@@ -253,8 +251,8 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
                 outfile->Printf("\tComputing %s tensor.\n", lbl1);
                 for (alpha = 0; alpha < 3; alpha++) {
                     for (beta = 0; beta < 3; beta++) {
-                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
-                        sprintf(pert_y, "L_%1s", cartcomp[beta]);
+                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha].c_str());
+                        sprintf(pert_y, "L_%1s", cartcomp[beta].c_str());
                         linresp(&tensor_rl0[alpha][beta], +0.5, 0.0, pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
                                 pert_y, moinfo.l_irreps[beta], params.omega[i]);
                     }
@@ -265,8 +263,8 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
                 outfile->Printf("\tComputing %s tensor.\n", lbl2);
                 for (alpha = 0; alpha < 3; alpha++) {
                     for (beta = 0; beta < 3; beta++) {
-                        sprintf(pert_x, "P_%1s", cartcomp[alpha]);
-                        sprintf(pert_y, "L_%1s", cartcomp[beta]);
+                        sprintf(pert_x, "P_%1s", cartcomp[alpha].c_str());
+                        sprintf(pert_y, "L_%1s", cartcomp[beta].c_str());
                         linresp(&tensor_pl0[alpha][beta], -0.5, 0.0, pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
                                 pert_y, moinfo.l_irreps[beta], params.omega[i]);
                     }
@@ -304,35 +302,35 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
             /* prepare the dipole-length or dipole-velocity integrals */
             if (compute_rl) {
                 for (alpha = 0; alpha < 3; alpha++) {
-                    sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                    sprintf(pert, "Mu_%1s", cartcomp[alpha].c_str());
                     pertbar(pert, moinfo.mu_irreps[alpha], 0);
                 }
             }
             if (compute_pl) {
                 for (alpha = 0; alpha < 3; alpha++) {
-                    sprintf(pert, "P*_%1s", cartcomp[alpha]);
+                    sprintf(pert, "P*_%1s", cartcomp[alpha].c_str());
                     pertbar(pert, moinfo.mu_irreps[alpha], 1);
                 }
             }
 
             /* prepare the complex-conjugate of the magnetic-dipole integrals */
             for (alpha = 0; alpha < 3; alpha++) {
-                sprintf(pert, "L*_%1s", cartcomp[alpha]);
+                sprintf(pert, "L*_%1s", cartcomp[alpha].c_str());
                 pertbar(pert, moinfo.l_irreps[alpha], 1);
             }
 
             /* Compute the -omega magnetic-dipole and +omega electric-dipole CC wave functions */
             for (alpha = 0; alpha < 3; alpha++) {
                 if (compute_rl) {
-                    sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                    sprintf(pert, "Mu_%1s", cartcomp[alpha].c_str());
                     compute_X(pert, moinfo.mu_irreps[alpha], params.omega[i]);
                 }
                 if (compute_pl) {
-                    sprintf(pert, "P*_%1s", cartcomp[alpha]);
+                    sprintf(pert, "P*_%1s", cartcomp[alpha].c_str());
                     compute_X(pert, moinfo.mu_irreps[alpha], params.omega[i]);
                 }
 
-                sprintf(pert, "L*_%1s", cartcomp[alpha]);
+                sprintf(pert, "L*_%1s", cartcomp[alpha].c_str());
                 compute_X(pert, moinfo.l_irreps[alpha], -params.omega[i]);
             }
 
@@ -341,8 +339,8 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
                 outfile->Printf("\tComputing %s tensor.\n", lbl1);
                 for (alpha = 0; alpha < 3; alpha++) {
                     for (beta = 0; beta < 3; beta++) {
-                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
-                        sprintf(pert_y, "L*_%1s", cartcomp[beta]);
+                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha].c_str());
+                        sprintf(pert_y, "L*_%1s", cartcomp[beta].c_str());
                         linresp(&tensor_rl1[alpha][beta], +0.5, 0.0, pert_x, moinfo.mu_irreps[alpha], params.omega[i],
                                 pert_y, moinfo.l_irreps[beta], -params.omega[i]);
                     }
@@ -353,8 +351,8 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
                 outfile->Printf("\tComputing %s tensor.\n", lbl2);
                 for (alpha = 0; alpha < 3; alpha++) {
                     for (beta = 0; beta < 3; beta++) {
-                        sprintf(pert_x, "P*_%1s", cartcomp[alpha]);
-                        sprintf(pert_y, "L*_%1s", cartcomp[beta]);
+                        sprintf(pert_x, "P*_%1s", cartcomp[alpha].c_str());
+                        sprintf(pert_y, "L*_%1s", cartcomp[beta].c_str());
                         linresp(&tensor_pl1[alpha][beta], -0.5, 0.0, pert_x, moinfo.mu_irreps[alpha], params.omega[i],
                                 pert_y, moinfo.l_irreps[beta], -params.omega[i]);
                     }
@@ -366,16 +364,16 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
                 outfile->Printf("\tComputing %s tensor.\n", lbl3);
                 for (alpha = 0; alpha < 3; alpha++) {
                     for (beta = 0; beta < 3; beta++) {
-                        sprintf(pert_x, "P_%1s", cartcomp[alpha]);
-                        sprintf(pert_y, "Mu_%1s", cartcomp[beta]);
+                        sprintf(pert_x, "P_%1s", cartcomp[alpha].c_str());
+                        sprintf(pert_y, "Mu_%1s", cartcomp[beta].c_str());
                         linresp(&tensor_rp[i][alpha][beta], -0.5, 0.0, pert_x, moinfo.mu_irreps[alpha],
                                 -params.omega[i], pert_y, moinfo.mu_irreps[beta], params.omega[i]);
                     }
                 }
                 for (alpha = 0; alpha < 3; alpha++) {
                     for (beta = 0; beta < 3; beta++) {
-                        sprintf(pert_x, "P*_%1s", cartcomp[alpha]);
-                        sprintf(pert_y, "Mu_%1s", cartcomp[beta]);
+                        sprintf(pert_x, "P*_%1s", cartcomp[alpha].c_str());
+                        sprintf(pert_y, "Mu_%1s", cartcomp[beta].c_str());
                         linresp(&tensor_rp[i][alpha][beta], -0.5, 1.0, pert_x, moinfo.mu_irreps[alpha], params.omega[i],
                                 pert_y, moinfo.mu_irreps[beta], -params.omega[i]);
                     }
@@ -632,11 +630,6 @@ void optrot(std::shared_ptr<Wavefunction> ref_wfn) {
     free_block(tensor_rl1);
     free_block(tensor_pl0);
     free_block(tensor_pl1);
-
-    free(cartcomp[0]);
-    free(cartcomp[1]);
-    free(cartcomp[2]);
-    free(cartcomp);
 }
 
 // for the edification of the autodoc-er. these set py-side or through oeprop calls

--- a/psi4/src/psi4/cc/ccresponse/polar.cc
+++ b/psi4/src/psi4/cc/ccresponse/polar.cc
@@ -30,6 +30,7 @@
     \ingroup ccresponse
     \brief Enter brief description of file here
 */
+#include <array>
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
@@ -59,16 +60,13 @@ void linresp(double *tensor, double A, double B, const char *pert_x, int x_irrep
 
 void polar(std::shared_ptr<Wavefunction> ref_wfn) {
     double ***tensor;
-    char **cartcomp, pert[32], pert_x[32], pert_y[32];
+    char pert[32], pert_x[32], pert_y[32];
     int alpha, beta, i;
     double omega_nm, omega_ev, omega_cm, *trace;
     char lbl[32];
     double value;
 
-    cartcomp = (char **)malloc(3 * sizeof(char *));
-    cartcomp[0] = strdup("X");
-    cartcomp[1] = strdup("Y");
-    cartcomp[2] = strdup("Z");
+    const std::array<std::string, 3> cartcomp{"X", "Y", "Z"};
 
     tensor = (double ***)malloc(params.nomega * sizeof(double **));
     for (i = 0; i < params.nomega; i++) tensor[i] = block_matrix(3, 3);
@@ -79,7 +77,7 @@ void polar(std::shared_ptr<Wavefunction> ref_wfn) {
         sprintf(lbl, "<<Mu;Mu>_(%5.3f)", params.omega[i]);
         if (!params.restart || !psio_tocscan(PSIF_CC_INFO, lbl)) {
             for (alpha = 0; alpha < 3; alpha++) {
-                sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                sprintf(pert, "Mu_%1s", cartcomp[alpha].c_str());
                 pertbar(pert, moinfo.mu_irreps[alpha], 0);
                 compute_X(pert, moinfo.mu_irreps[alpha], params.omega[i]);
                 if (params.omega[i] != 0.0) compute_X(pert, moinfo.mu_irreps[alpha], -params.omega[i]);
@@ -88,8 +86,8 @@ void polar(std::shared_ptr<Wavefunction> ref_wfn) {
             outfile->Printf("\n\tComputing %s tensor.\n", lbl);
             for (alpha = 0; alpha < 3; alpha++) {
                 for (beta = 0; beta < 3; beta++) {
-                    sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
-                    sprintf(pert_y, "Mu_%1s", cartcomp[beta]);
+                    sprintf(pert_x, "Mu_%1s", cartcomp[alpha].c_str());
+                    sprintf(pert_y, "Mu_%1s", cartcomp[beta].c_str());
                     linresp(&tensor[i][alpha][beta], -1.0, 0.0, pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
                             pert_y, moinfo.mu_irreps[beta], params.omega[i]);
                 }
@@ -181,11 +179,6 @@ void polar(std::shared_ptr<Wavefunction> ref_wfn) {
     free(tensor);
 
     free(trace);
-
-    free(cartcomp[0]);
-    free(cartcomp[1]);
-    free(cartcomp[2]);
-    free(cartcomp);
 }
 
 // for the edification of the autodoc-er. these set py-side or through oeprop calls

--- a/psi4/src/psi4/cc/ccresponse/roa.cc
+++ b/psi4/src/psi4/cc/ccresponse/roa.cc
@@ -37,6 +37,7 @@
 
   -TDC, August 2009
 */
+#include <array>
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
@@ -64,7 +65,7 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
     double ***tensor_rl, ***tensor_pl, **tensor0, ***tensor_rr;
     double ****tensor_rQ, ***tensor_rQ0, ***tensor_rQ1;
     double **tensor_rl0, **tensor_rl1, **tensor_pl0, **tensor_pl1;
-    char **cartcomp, pert[32], pert_x[32], pert_y[32];
+    char pert[32], pert_x[32], pert_y[32];
     int alpha, beta, gamma, i, j, k, l, irrep;
     double omega_nm, omega_ev, omega_cm;
     char lbl1[32], lbl2[32], lbl3[32], lbl4[32];
@@ -76,10 +77,7 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
     if (params.gauge == "LENGTH" || params.gauge == "BOTH") compute_rl = 1;
     if (params.gauge == "VELOCITY" || params.gauge == "BOTH") compute_pl = 1;
 
-    cartcomp = (char **)malloc(3 * sizeof(char *));
-    cartcomp[0] = strdup("X");
-    cartcomp[1] = strdup("Y");
-    cartcomp[2] = strdup("Z");
+    const std::array<std::string, 3> cartcomp{"X", "Y", "Z"};
 
     tensor_rQ = (double ****)malloc(params.nomega * sizeof(double ***));
     for (i = 0; i < params.nomega; i++) {
@@ -111,11 +109,11 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
         sprintf(lbl1, "<<P;L>>_(%5.3f)", 0.0);
         if (!params.restart || !psio_tocscan(PSIF_CC_INFO, lbl1)) {
             for (alpha = 0; alpha < 3; alpha++) {
-                sprintf(pert, "P_%1s", cartcomp[alpha]);
+                sprintf(pert, "P_%1s", cartcomp[alpha].c_str());
                 pertbar(pert, moinfo.mu_irreps[alpha], 1);
                 compute_X(pert, moinfo.mu_irreps[alpha], 0);
 
-                sprintf(pert, "L_%1s", cartcomp[alpha]);
+                sprintf(pert, "L_%1s", cartcomp[alpha].c_str());
                 pertbar(pert, moinfo.l_irreps[alpha], 1);
                 compute_X(pert, moinfo.l_irreps[alpha], 0);
             }
@@ -123,8 +121,8 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
             outfile->Printf("\n\tComputing %s tensor.\n", lbl1);
             for (alpha = 0; alpha < 3; alpha++) {
                 for (beta = 0; beta < 3; beta++) {
-                    sprintf(pert_x, "P_%1s", cartcomp[alpha]);
-                    sprintf(pert_y, "L_%1s", cartcomp[beta]);
+                    sprintf(pert_x, "P_%1s", cartcomp[alpha].c_str());
+                    sprintf(pert_y, "L_%1s", cartcomp[beta].c_str());
                     linresp(&tensor0[alpha][beta], -1.0, 0.0, pert_x, moinfo.mu_irreps[alpha], 0.0, pert_y,
                             moinfo.l_irreps[beta], 0.0);
                 }
@@ -183,27 +181,27 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
              !psio_tocscan(PSIF_CC_INFO, lbl3) || !psio_tocscan(PSIF_CC_INFO, lbl4))) {
             /* prepare the dipole-length and/or dipole-velocity integrals */
             for (alpha = 0; alpha < 3; alpha++) {
-                sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                sprintf(pert, "Mu_%1s", cartcomp[alpha].c_str());
                 pertbar(pert, moinfo.mu_irreps[alpha], 0);
             }
 
             if (compute_pl) {
                 for (alpha = 0; alpha < 3; alpha++) {
-                    sprintf(pert, "P_%1s", cartcomp[alpha]);
+                    sprintf(pert, "P_%1s", cartcomp[alpha].c_str());
                     pertbar(pert, moinfo.mu_irreps[alpha], 1);
                 }
             }
 
             /* prepare the magnetic-dipole integrals */
             for (alpha = 0; alpha < 3; alpha++) {
-                sprintf(pert, "L_%1s", cartcomp[alpha]);
+                sprintf(pert, "L_%1s", cartcomp[alpha].c_str());
                 pertbar(pert, moinfo.l_irreps[alpha], 1);
             }
 
             /* electric quadrupole integrals */
             for (alpha = 0; alpha < 3; alpha++) {
                 for (beta = 0; beta < 3; beta++) {
-                    sprintf(pert, "Q_%1s%1s", cartcomp[alpha], cartcomp[beta]);
+                    sprintf(pert, "Q_%1s%1s", cartcomp[alpha].c_str(), cartcomp[beta].c_str());
                     irrep = moinfo.mu_irreps[alpha] ^ moinfo.mu_irreps[beta];
                     pertbar(pert, irrep, 0);
                 }
@@ -211,28 +209,28 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
 
             for (alpha = 0; alpha < 3; alpha++) {
                 /* -omega electric-dipole CC wave functions */
-                sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                sprintf(pert, "Mu_%1s", cartcomp[alpha].c_str());
                 compute_X(pert, moinfo.mu_irreps[alpha], -params.omega[i]);
 
                 /* +omega electric-dipole CC wave functions */
-                sprintf(pert, "Mu_%1s", cartcomp[alpha]);
+                sprintf(pert, "Mu_%1s", cartcomp[alpha].c_str());
                 compute_X(pert, moinfo.mu_irreps[alpha], +params.omega[i]);
 
                 if (compute_pl) {
                     /* -omega velocity electric-dipole CC wave functions */
-                    sprintf(pert, "P_%1s", cartcomp[alpha]);
+                    sprintf(pert, "P_%1s", cartcomp[alpha].c_str());
                     compute_X(pert, moinfo.mu_irreps[alpha], -params.omega[i]);
                 }
 
                 /* +omega magnetic-dipole CC wave functions */
-                sprintf(pert, "L_%1s", cartcomp[alpha]);
+                sprintf(pert, "L_%1s", cartcomp[alpha].c_str());
                 compute_X(pert, moinfo.l_irreps[alpha], +params.omega[i]);
             }
 
             /* +omega electric-quadrupole CC wave functions */
             for (alpha = 0; alpha < 3; alpha++) {
                 for (beta = 0; beta < 3; beta++) {
-                    sprintf(pert, "Q_%1s%1s", cartcomp[alpha], cartcomp[beta]);
+                    sprintf(pert, "Q_%1s%1s", cartcomp[alpha].c_str(), cartcomp[beta].c_str());
                     irrep = moinfo.mu_irreps[alpha] ^ moinfo.mu_irreps[beta];
                     compute_X(pert, irrep, params.omega[i]);
                 }
@@ -242,8 +240,8 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
             outfile->Printf("\tComputing %s tensor.\n", lbl3);
             for (alpha = 0; alpha < 3; alpha++) {
                 for (beta = 0; beta < 3; beta++) {
-                    sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
-                    sprintf(pert_y, "Mu_%1s", cartcomp[beta]);
+                    sprintf(pert_x, "Mu_%1s", cartcomp[alpha].c_str());
+                    sprintf(pert_y, "Mu_%1s", cartcomp[beta].c_str());
                     linresp(&tensor_rr[i][alpha][beta], -1.0, 0.0, pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
                             pert_y, moinfo.mu_irreps[beta], +params.omega[i]);
                 }
@@ -254,8 +252,8 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
                 outfile->Printf("\tComputing %s tensor.\n", lbl1);
                 for (alpha = 0; alpha < 3; alpha++) {
                     for (beta = 0; beta < 3; beta++) {
-                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
-                        sprintf(pert_y, "L_%1s", cartcomp[beta]);
+                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha].c_str());
+                        sprintf(pert_y, "L_%1s", cartcomp[beta].c_str());
                         linresp(&tensor_rl0[alpha][beta], +0.5, 0.0, pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
                                 pert_y, moinfo.l_irreps[beta], params.omega[i]);
                     }
@@ -266,8 +264,8 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
                 outfile->Printf("\tComputing %s tensor.\n", lbl2);
                 for (alpha = 0; alpha < 3; alpha++) {
                     for (beta = 0; beta < 3; beta++) {
-                        sprintf(pert_x, "P_%1s", cartcomp[alpha]);
-                        sprintf(pert_y, "L_%1s", cartcomp[beta]);
+                        sprintf(pert_x, "P_%1s", cartcomp[alpha].c_str());
+                        sprintf(pert_y, "L_%1s", cartcomp[beta].c_str());
                         linresp(&tensor_pl0[alpha][beta], -0.5, 0.0, pert_x, moinfo.mu_irreps[alpha], -params.omega[i],
                                 pert_y, moinfo.l_irreps[beta], params.omega[i]);
                     }
@@ -279,8 +277,8 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
             for (alpha = 0; alpha < 3; alpha++) {
                 for (beta = 0; beta < 3; beta++) {
                     for (gamma = 0; gamma < 3; gamma++) {
-                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
-                        sprintf(pert_y, "Q_%1s%1s", cartcomp[beta], cartcomp[gamma]);
+                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha].c_str());
+                        sprintf(pert_y, "Q_%1s%1s", cartcomp[beta].c_str(), cartcomp[gamma].c_str());
                         linresp(&tensor_rQ0[alpha][beta][gamma], -0.5, 0.0, pert_x, moinfo.mu_irreps[alpha],
                                 -params.omega[i], pert_y, moinfo.mu_irreps[beta] ^ moinfo.mu_irreps[gamma],
                                 params.omega[i]);
@@ -324,32 +322,32 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
              !psio_tocscan(PSIF_CC_INFO, lbl3))) {
             if (compute_pl) {
                 for (alpha = 0; alpha < 3; alpha++) {
-                    sprintf(pert, "P*_%1s", cartcomp[alpha]);
+                    sprintf(pert, "P*_%1s", cartcomp[alpha].c_str());
                     pertbar(pert, moinfo.mu_irreps[alpha], 1);
                 }
             }
 
             /* prepare the complex-conjugate of the magnetic-dipole integrals */
             for (alpha = 0; alpha < 3; alpha++) {
-                sprintf(pert, "L*_%1s", cartcomp[alpha]);
+                sprintf(pert, "L*_%1s", cartcomp[alpha].c_str());
                 pertbar(pert, moinfo.l_irreps[alpha], 1);
             }
 
             /* +omega velocity electric-dipole CC wave functions */
             for (alpha = 0; alpha < 3; alpha++) {
                 if (compute_pl) {
-                    sprintf(pert, "P*_%1s", cartcomp[alpha]);
+                    sprintf(pert, "P*_%1s", cartcomp[alpha].c_str());
                     compute_X(pert, moinfo.mu_irreps[alpha], params.omega[i]);
                 }
 
                 /* -omega magnetic-dipole CC wave functions */
-                sprintf(pert, "L*_%1s", cartcomp[alpha]);
+                sprintf(pert, "L*_%1s", cartcomp[alpha].c_str());
                 compute_X(pert, moinfo.l_irreps[alpha], -params.omega[i]);
             }
 
             for (alpha = 0; alpha < 3; alpha++) {
                 for (beta = 0; beta < 3; beta++) {
-                    sprintf(pert, "Q_%1s%1s", cartcomp[alpha], cartcomp[beta]);
+                    sprintf(pert, "Q_%1s%1s", cartcomp[alpha].c_str(), cartcomp[beta].c_str());
                     compute_X(pert, moinfo.mu_irreps[alpha] ^ moinfo.mu_irreps[beta], -params.omega[i]);
                 }
             }
@@ -359,8 +357,8 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
                 outfile->Printf("\tComputing %s tensor.\n", lbl1);
                 for (alpha = 0; alpha < 3; alpha++) {
                     for (beta = 0; beta < 3; beta++) {
-                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
-                        sprintf(pert_y, "L*_%1s", cartcomp[beta]);
+                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha].c_str());
+                        sprintf(pert_y, "L*_%1s", cartcomp[beta].c_str());
                         linresp(&tensor_rl1[alpha][beta], +0.5, 0.0, pert_x, moinfo.mu_irreps[alpha], params.omega[i],
                                 pert_y, moinfo.l_irreps[beta], -params.omega[i]);
                     }
@@ -371,8 +369,8 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
                 outfile->Printf("\tComputing %s tensor.\n", lbl2);
                 for (alpha = 0; alpha < 3; alpha++) {
                     for (beta = 0; beta < 3; beta++) {
-                        sprintf(pert_x, "P*_%1s", cartcomp[alpha]);
-                        sprintf(pert_y, "L*_%1s", cartcomp[beta]);
+                        sprintf(pert_x, "P*_%1s", cartcomp[alpha].c_str());
+                        sprintf(pert_y, "L*_%1s", cartcomp[beta].c_str());
                         linresp(&tensor_pl1[alpha][beta], -0.5, 0.0, pert_x, moinfo.mu_irreps[alpha], params.omega[i],
                                 pert_y, moinfo.l_irreps[beta], -params.omega[i]);
                     }
@@ -384,8 +382,8 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
             for (alpha = 0; alpha < 3; alpha++) {
                 for (beta = 0; beta < 3; beta++) {
                     for (gamma = 0; gamma < 3; gamma++) {
-                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha]);
-                        sprintf(pert_y, "Q_%1s%1s", cartcomp[beta], cartcomp[gamma]);
+                        sprintf(pert_x, "Mu_%1s", cartcomp[alpha].c_str());
+                        sprintf(pert_y, "Q_%1s%1s", cartcomp[beta].c_str(), cartcomp[gamma].c_str());
                         linresp(&tensor_rQ1[alpha][beta][gamma], -0.5, 0.0, pert_x, moinfo.mu_irreps[alpha],
                                 +params.omega[i], pert_y, moinfo.mu_irreps[beta] ^ moinfo.mu_irreps[gamma],
                                 -params.omega[i]);
@@ -584,11 +582,6 @@ void roa(std::shared_ptr<Wavefunction> ref_wfn) {
     free_block(tensor_rl1);
     free_block(tensor_pl0);
     free_block(tensor_pl1);
-
-    free(cartcomp[0]);
-    free(cartcomp[1]);
-    free(cartcomp[2]);
-    free(cartcomp);
 }
 
 }  // namespace ccresponse


### PR DESCRIPTION
## Description

Modernizes a cluster of obsolete owned C-string arrays in the CC modules, replacing manual `malloc()`/`strdup()`/`free()` bookkeeping with owning `std::string` containers. This is a follow-up to the libpsio `get_filename()` modernization, found while sweeping the tree for the same antipattern.

## User API & Changelog headlines
- [ ] None — internal cleanup, no user-facing or numerical change.

## Dev notes & details
- [x] ccresponse `polar`/`roa`/`optrot`: the per-call `char **cartcomp` (a `malloc(3)` + `strdup("X"/"Y"/"Z")` + `free`) becomes a `const std::array<std::string, 3>`.
- [x] cceom: the `char **irr_labs_lowercase` MOInfo member (`malloc` + per-irrep `strdup` + manual `free` in `cleanup()`) becomes a `std::vector<std::string>`, matching the `std::vector<std::string> irr_labs` it is copied from and sits next to.
- [x] The existing `sprintf()` label-building sites are unchanged apart from a `.c_str()` on the array element.
- [x] The lower-casing loop now casts to `unsigned char` before `std::tolower()` (the previous code passed a raw `char`).
- [x] Behavior-preserving and mechanical; all six touched TUs compile clean locally.

## Questions
- [ ] None.

## AI
- [x] The antipattern survey and the mechanical conversion were done with Claude Code; the change is behavior-preserving and human-reviewed.

## Checklist
- [x] Tests added for any new features — n/a (no behavior change; exercised by existing ccresponse/cceom tests)
- [x] Docstring or narrative docs/sphinxman/source updated if needed — n/a

## Status
- [x] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
