### PR TITLE
Speed up MBIS population analysis

### DIFF
--- a/psi4/src/psi4/libfock/cubature.h
+++ b/psi4/src/psi4/libfock/cubature.h
@@ -439,6 +439,8 @@ class BlockOPoints {
     double* w() const { return w_; }
     /// The center of the block
     Vector3 center() const { return xc_; }
+    /// The bounding radius of the block
+    double radius() const { return R_; }
 
     /// Relevant shells, local -> global
     const std::vector<int>& shells_local_to_global() const { return shells_local_to_global_; }

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1836,8 +1836,8 @@ static inline void mbis_exp_batch(const double* __restrict arg, double* __restri
  *  - N and sigma are strictly positive, and a negative sigma would make exp(-r/sigma) diverge. The
  *    mixing is therefore done on log(N), log(sigma), so every combination is positive by
  *    construction, whatever coefficients the least-squares returns.
- *  - The normal equations are Tikhonov-regularised. Nearly-parallel residual histories are the
- *    usual source of the huge coefficients that produce a wild extrapolation.
+ *  - The residual least-squares problem is Tikhonov-regularised. Nearly-parallel residual histories
+ *    are the usual source of the huge coefficients that produce a wild extrapolation.
  *  - The extrapolation is rejected outright if the mixing coefficients grow past `kMaxCoefSum`,
  *    if the least-squares is singular, or if the result is not finite. Acceleration is never
  *    allowed to be worse than doing nothing.
@@ -1845,7 +1845,7 @@ static inline void mbis_exp_batch(const double* __restrict arg, double* __restri
  *    step made it worse, which falls back to plain Picard until the history rebuilds.
  */
 class MBISAnderson {
-    static constexpr double kRidge = 1.0e-12;    // relative Tikhonov shift on the normal equations
+    static constexpr double kRidge = 1.0e-12;    // relative Tikhonov penalty on the mixing coefficients
     static constexpr double kMaxCoefSum = 20.0;  // reject extrapolations that reach this far out
 
     size_t n_;                                  // length of the parameter vector
@@ -1870,50 +1870,57 @@ class MBISAnderson {
         const size_t m = xs_.size();
         if (m < 2) return g;  // nothing to extrapolate from yet
 
-        // Minimise ||sum_i c_i f_i|| subject to sum_i c_i = 1, via the bordered normal equations.
-        const size_t dim = m + 1;
-        std::vector<double> A(dim * dim, 0.0), b(dim, 0.0);
+        // Minimise ||sum_i c_i f_i|| subject to sum_i c_i = 1. Eliminate the last coefficient,
+        // c_last = 1 - sum_i alpha_i, and solve the resulting least-squares problem directly. This
+        // avoids squaring the condition number in normal equations and delegates rank decisions to
+        // LAPACK's pivoted QR implementation.
+        const int ncols = static_cast<int>(m - 1);
+        const int nrows = static_cast<int>(n_) + static_cast<int>(m);
+        const int ldb = std::max(nrows, ncols);
         double maxdiag = 0.0;
         for (size_t i = 0; i < m; i++) {
-            for (size_t j = 0; j < m; j++) {
-                double dot = 0.0;
-                for (size_t k = 0; k < n_; k++) dot += fs_[i][k] * fs_[j][k];
-                A[i * dim + j] = dot;
-            }
-            maxdiag = std::max(maxdiag, A[i * dim + i]);
-            A[i * dim + m] = -1.0;
-            A[m * dim + i] = -1.0;
+            double diagonal = 0.0;
+            for (size_t k = 0; k < n_; k++) diagonal += fs_[i][k] * fs_[i][k];
+            maxdiag = std::max(maxdiag, diagonal);
         }
-        for (size_t i = 0; i < m; i++) A[i * dim + i] += kRidge * maxdiag;
-        b[m] = -1.0;
+        if (!(maxdiag > 0.0) || !std::isfinite(maxdiag)) return g;
 
-        // Gauss-Jordan with partial pivoting.
-        std::vector<double> c(b);
-        bool ok = true;
-        for (size_t col = 0; col < dim && ok; col++) {
-            size_t piv = col;
-            for (size_t r = col + 1; r < dim; r++)
-                if (std::fabs(A[r * dim + col]) > std::fabs(A[piv * dim + col])) piv = r;
-            if (std::fabs(A[piv * dim + col]) < 1.0e-14) {
-                ok = false;
-                break;
-            }
-            if (piv != col) {
-                for (size_t k = 0; k < dim; k++) std::swap(A[col * dim + k], A[piv * dim + k]);
-                std::swap(c[col], c[piv]);
-            }
-            const double d = A[col * dim + col];
-            for (size_t k = 0; k < dim; k++) A[col * dim + k] /= d;
-            c[col] /= d;
-            for (size_t r = 0; r < dim; r++) {
-                if (r == col) continue;
-                const double factor = A[r * dim + col];
-                if (factor == 0.0) continue;
-                for (size_t k = 0; k < dim; k++) A[r * dim + k] -= factor * A[col * dim + k];
-                c[r] -= factor * c[col];
-            }
+        // DGELSY expects column-major storage. The first n_ rows hold f_i - f_last; the remaining
+        // rows express sqrt(lambda) * ||c||, including c_last = 1 - sum_i alpha_i.
+        std::vector<double> A(static_cast<size_t>(nrows) * ncols, 0.0), rhs(ldb, 0.0);
+        const auto& f_last = fs_.back();
+        for (size_t k = 0; k < n_; k++) rhs[k] = -f_last[k];
+        for (int i = 0; i < ncols; i++) {
+            for (size_t k = 0; k < n_; k++) A[static_cast<size_t>(i) * nrows + k] = fs_[i][k] - f_last[k];
         }
-        if (!ok) return g;
+        const double sqrt_ridge = std::sqrt(kRidge * maxdiag);
+        for (int i = 0; i < ncols; i++) {
+            A[static_cast<size_t>(i) * nrows + n_ + i] = sqrt_ridge;
+            A[static_cast<size_t>(i) * nrows + n_ + ncols] = sqrt_ridge;
+        }
+        rhs[n_ + ncols] = sqrt_ridge;
+
+        std::vector<int> jpvt(ncols, 0);
+        int rank = 0;
+        double work_query = 0.0;
+        const double rcond = std::numeric_limits<double>::epsilon() * std::max(nrows, ncols);
+        int info = C_DGELSY(nrows, ncols, 1, A.data(), nrows, rhs.data(), ldb, jpvt.data(), rcond, &rank,
+                            &work_query, -1);
+        if (info != 0 || !std::isfinite(work_query)) return g;
+        const int lwork = std::max(1, static_cast<int>(work_query));
+        std::vector<double> work(lwork);
+        std::fill(jpvt.begin(), jpvt.end(), 0);
+        info = C_DGELSY(nrows, ncols, 1, A.data(), nrows, rhs.data(), ldb, jpvt.data(), rcond, &rank, work.data(),
+                        lwork);
+        if (info != 0 || rank != ncols) return g;
+
+        std::vector<double> c(m);
+        double alpha_sum = 0.0;
+        for (int i = 0; i < ncols; i++) {
+            c[i] = rhs[i];
+            alpha_sum += rhs[i];
+        }
+        c.back() = 1.0 - alpha_sum;
 
         // sum_i c_i == 1 by construction, so sum_i |c_i| measures how far outside the history the
         // extrapolation reaches. Large values are the signature of a step about to go wild.

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -30,8 +30,9 @@
 #include <omp.h>
 #endif
 
+#include <bit>
+#include <cassert>
 #include <cstdint>
-#include <cstring>
 #include <limits>
 
 #include "psi4/psifiles.h"
@@ -1786,17 +1787,22 @@ const std::vector<std::tuple<double, double>>& get_mbis_params(int atomic_num) {
  * is pure arithmetic and so vectorises under plain -O3 -march=native. Measured at 1.07 ulp against
  * libm over the argument range MBIS uses, and about 4x its throughput.
  *
- * Arguments are always <= 0 here (rate < 0, r >= 0). Anything below -700 underflows to
+ * Arguments are always finite and <= 0 here (rate < 0, r >= 0). Anything below -700 underflows to
  * ~1e-304 rather than to exactly zero; those terms are ~300 orders of magnitude below the
  * densities they are summed into, and the screening has already discarded the atoms where this
- * could arise.
+ * could arise. Building 2^k from its exponent bits requires an IEEE-754 binary64 double; state that
+ * contract explicitly instead of silently relying on it through a memcpy.
  */
 static inline void mbis_exp_batch(const double* __restrict arg, double* __restrict out, int n) {
+    static_assert(sizeof(double) == sizeof(std::uint64_t));
+    static_assert(std::numeric_limits<double>::is_iec559 && std::numeric_limits<double>::radix == 2 &&
+                  std::numeric_limits<double>::digits == 53 && std::numeric_limits<double>::max_exponent == 1024);
     constexpr double LOG2E = 1.4426950408889634074;
     constexpr double LN2_HI = 6.93147180369123816490e-01;
     constexpr double LN2_LO = 1.90821492927058770002e-10;
 #pragma omp simd
     for (int k = 0; k < n; k++) {
+        assert(std::isfinite(arg[k]) && arg[k] <= 0.0);
         const double x = arg[k] < -700.0 ? -700.0 : arg[k];
         const double kf = std::nearbyint(x * LOG2E);
         const double f = (x - kf * LN2_HI) - kf * LN2_LO;
@@ -1814,10 +1820,8 @@ static inline void mbis_exp_batch(const double* __restrict arg, double* __restri
         p = 0.5 + f * p;
         p = 1.0 + f * p;
         p = 1.0 + f * p;
-        const std::int64_t bits = (static_cast<std::int64_t>(kf) + 1023) << 52;
-        double scale;
-        std::memcpy(&scale, &bits, sizeof(double));
-        out[k] = p * scale;
+        const auto bits = static_cast<std::uint64_t>(static_cast<std::int64_t>(kf) + 1023) << 52;
+        out[k] = p * std::bit_cast<double>(bits);
     }
 }
 

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -2007,6 +2007,7 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
     // Block extents, used for the distance screening in the stockholder sweep below.
     const size_t n_blocks = blocks.size();
     std::vector<size_t> block_offset(n_blocks, 0), block_size(n_blocks, 0);
+    std::vector<double> block_cx(n_blocks), block_cy(n_blocks), block_cz(n_blocks), block_R(n_blocks);
 
     // Coordinates, weights, and rho (molecular electron density) at each grid point
     std::vector<double> x_points(total_points, 0.0);
@@ -2045,6 +2046,11 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
 
         block_offset[b] = running_points;
         block_size[b] = num_points;
+        const Vector3 block_center = block->center();
+        block_cx[b] = block_center[0];
+        block_cy[b] = block_center[1];
+        block_cz[b] = block_center[2];
+        block_R[b] = block->radius();
         running_points += num_points;
     }
     timer_off("MBIS: grid density");
@@ -2150,26 +2156,6 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
             shell_rate[s] = -1.0 / S[s];
         }
     };
-
-    // Bounding sphere per grid block. cubature.h computes one internally but does not expose it,
-    // and recomputing here is one pass over the grid, so this stays local to MBIS.
-    std::vector<double> block_cx(n_blocks), block_cy(n_blocks), block_cz(n_blocks), block_R(n_blocks, 0.0);
-    for (size_t b = 0; b < n_blocks; b++) {
-        const size_t off = block_offset[b], np = block_size[b];
-        double cx = 0.0, cy = 0.0, cz = 0.0;
-        for (size_t i = 0; i < np; i++) {
-            cx += x_points[off + i];
-            cy += y_points[off + i];
-            cz += z_points[off + i];
-        }
-        cx /= np; cy /= np; cz /= np;
-        double R2 = 0.0;
-        for (size_t i = 0; i < np; i++) {
-            const double dx = x_points[off + i] - cx, dy = y_points[off + i] - cy, dz = z_points[off + i] - cz;
-            R2 = std::max(R2, dx * dx + dy * dy + dz * dz);
-        }
-        block_cx[b] = cx; block_cy[b] = cy; block_cz[b] = cz; block_R[b] = std::sqrt(R2);
-    }
 
     // Distance screening. The pro-atom density falls off as exp(-r/sigma) with sigma ~ 0.3-1 bohr,
     // so beyond a few tens of bohr an atom's contribution to a grid point is far below any

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -2246,104 +2246,119 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
         std::fill(sum_s.begin(), sum_s.end(), 0.0);
         std::fill(delta_atom.begin(), delta_atom.end(), 0.0);
 
+        // Fixed chunks preserve dynamic load balancing without making the summation order depend on
+        // which thread finishes first. The chunk count also caps the extra reduction storage.
+        constexpr size_t kMaxReductionChunks = 64;
+        const size_t n_chunks = std::min(n_blocks, kMaxReductionChunks);
+        std::vector<double> chunk_n(n_chunks * total_shells, 0.0), chunk_s(n_chunks * total_shells, 0.0);
+        std::vector<double> chunk_d(n_chunks * num_atoms, 0.0);
+
 #pragma omp parallel
         {
-            std::vector<double> loc_n(total_shells, 0.0), loc_s(total_shells, 0.0);
-            std::vector<double> loc_d(num_atoms, 0.0);
             std::vector<double> atom_r(num_atoms);
             // Per-block flattened shell tables, so the exponentials of one grid point form a
             // single contiguous batch instead of num_atoms batches of one to five.
             std::vector<double> bcoef, brate, barg, bval;
             std::vector<int> bglob, bstart;
 
-            // Blocks vary in both point count and surviving-atom count, so hand them out dynamically.
+            // Chunks vary in surviving-atom count, so hand them out dynamically. Each chunk covers a
+            // fixed contiguous range of blocks and owns its reduction buffers.
 #pragma omp for schedule(dynamic, 1)
-            for (size_t b = 0; b < n_blocks; b++) {
-                const size_t off = block_offset[b], np = block_size[b];
-                const int* atoms = block_atoms.data() + block_atoms_off[b];
-                const int na = static_cast<int>(block_atoms_off[b + 1] - block_atoms_off[b]);
+            for (size_t chunk = 0; chunk < n_chunks; chunk++) {
+                double* loc_n = chunk_n.data() + chunk * total_shells;
+                double* loc_s = chunk_s.data() + chunk * total_shells;
+                double* loc_d = chunk_d.data() + chunk * num_atoms;
+                const size_t block_begin = n_blocks * chunk / n_chunks;
+                const size_t block_end = n_blocks * (chunk + 1) / n_chunks;
+                for (size_t b = block_begin; b < block_end; b++) {
+                    const size_t off = block_offset[b], np = block_size[b];
+                    const int* atoms = block_atoms.data() + block_atoms_off[b];
+                    const int na = static_cast<int>(block_atoms_off[b + 1] - block_atoms_off[b]);
 
-                // Atoms that left this block's list since the last sweep still hold that sweep's
-                // densities; clear them so the (point, atom) entries stay uniformly valid.
-                for (size_t k = block_drop_off[b]; k < block_drop_off[b + 1]; k++) {
-                    const int atom = block_drop[k];
-                    for (size_t p = off; p < off + np; p++) {
-                        double& stale_density = rho_a_0_points[p * num_atoms + atom];
-                        if (accumulate_delta) loc_d[atom] += weights[p] * stale_density * stale_density;
-                        stale_density = 0.0;
+                    // Atoms that left this block's list since the last sweep still hold that sweep's
+                    // densities; clear them so the (point, atom) entries stay uniformly valid.
+                    for (size_t k = block_drop_off[b]; k < block_drop_off[b + 1]; k++) {
+                        const int atom = block_drop[k];
+                        for (size_t p = off; p < off + np; p++) {
+                            double& stale_density = rho_a_0_points[p * num_atoms + atom];
+                            if (accumulate_delta) loc_d[atom] += weights[p] * stale_density * stale_density;
+                            stale_density = 0.0;
+                        }
                     }
-                }
-                if (na == 0) continue;
+                    if (na == 0) continue;
 
-                bstart.assign(na + 1, 0);
-                bcoef.clear();
-                brate.clear();
-                bglob.clear();
-                for (int ia = 0; ia < na; ia++) {
-                    const int atom = atoms[ia];
-                    for (int s = shell_off[atom]; s < shell_off[atom + 1]; s++) {
-                        bcoef.push_back(shell_coef[s]);
-                        brate.push_back(shell_rate[s]);
-                        bglob.push_back(s);
-                    }
-                    bstart[ia + 1] = static_cast<int>(bcoef.size());
-                }
-                const int ns = static_cast<int>(bcoef.size());
-                barg.resize(ns);
-                bval.resize(ns);
-
-                for (size_t point = off; point < off + np; point++) {
-                    const double xp = x_points[point], yp = y_points[point], zp = z_points[point];
-
+                    bstart.assign(na + 1, 0);
+                    bcoef.clear();
+                    brate.clear();
+                    bglob.clear();
                     for (int ia = 0; ia < na; ia++) {
                         const int atom = atoms[ia];
-                        const double dx = xp - atom_x[atom], dy = yp - atom_y[atom], dz = zp - atom_z[atom];
-                        const double r = std::sqrt(dx * dx + dy * dy + dz * dz);
-                        atom_r[atom] = r;
-                        for (int k = bstart[ia]; k < bstart[ia + 1]; k++) barg[k] = brate[k] * r;
+                        for (int s = shell_off[atom]; s < shell_off[atom + 1]; s++) {
+                            bcoef.push_back(shell_coef[s]);
+                            brate.push_back(shell_rate[s]);
+                            bglob.push_back(s);
+                        }
+                        bstart[ia + 1] = static_cast<int>(bcoef.size());
                     }
+                    const int ns = static_cast<int>(bcoef.size());
+                    barg.resize(ns);
+                    bval.resize(ns);
 
-                    mbis_exp_batch(barg.data(), bval.data(), ns);
+                    for (size_t point = off; point < off + np; point++) {
+                        const double xp = x_points[point], yp = y_points[point], zp = z_points[point];
 
-                    double rho_0 = 0.0;
+                        for (int ia = 0; ia < na; ia++) {
+                            const int atom = atoms[ia];
+                            const double dx = xp - atom_x[atom], dy = yp - atom_y[atom], dz = zp - atom_z[atom];
+                            const double r = std::sqrt(dx * dx + dy * dy + dz * dz);
+                            atom_r[atom] = r;
+                            for (int k = bstart[ia]; k < bstart[ia + 1]; k++) barg[k] = brate[k] * r;
+                        }
+
+                        mbis_exp_batch(barg.data(), bval.data(), ns);
+
+                        double rho_0 = 0.0;
 #pragma omp simd reduction(+ : rho_0)
-                    for (int k = 0; k < ns; k++) {
-                        bval[k] *= bcoef[k];
-                        rho_0 += bval[k];
-                    }
-
-                    const double w = weights[point];
-                    const double scale = w * rho[point] / rho_0;
-                    double* rho_a_0_here = &rho_a_0_points[point * num_atoms];
-
-                    for (int ia = 0; ia < na; ia++) {
-                        const int atom = atoms[ia];
-                        const double r = atom_r[atom];
-                        double rho_a_0 = 0.0;
-                        for (int k = bstart[ia]; k < bstart[ia + 1]; k++) {
-                            const double v = bval[k];
-                            loc_n[bglob[k]] += scale * v;
-                            loc_s[bglob[k]] += scale * r * v;
-                            rho_a_0 += v;
+                        for (int k = 0; k < ns; k++) {
+                            bval[k] *= bcoef[k];
+                            rho_0 += bval[k];
                         }
-                        if (accumulate_delta) {
-                            const double d = rho_a_0 - rho_a_0_here[atom];
-                            loc_d[atom] += w * d * d;
+
+                        const double w = weights[point];
+                        const double scale = w * rho[point] / rho_0;
+                        double* rho_a_0_here = &rho_a_0_points[point * num_atoms];
+
+                        for (int ia = 0; ia < na; ia++) {
+                            const int atom = atoms[ia];
+                            const double r = atom_r[atom];
+                            double rho_a_0 = 0.0;
+                            for (int k = bstart[ia]; k < bstart[ia + 1]; k++) {
+                                const double v = bval[k];
+                                loc_n[bglob[k]] += scale * v;
+                                loc_s[bglob[k]] += scale * r * v;
+                                rho_a_0 += v;
+                            }
+                            if (accumulate_delta) {
+                                const double d = rho_a_0 - rho_a_0_here[atom];
+                                loc_d[atom] += w * d * d;
+                            }
+                            rho_a_0_here[atom] = rho_a_0;
                         }
-                        rho_a_0_here[atom] = rho_a_0;
+                        rho_0_points[point] = rho_0;
                     }
-                    rho_0_points[point] = rho_0;
                 }
             }
+        }
 
-#pragma omp critical
-            {
-                for (int s = 0; s < total_shells; s++) {
-                    sum_n[s] += loc_n[s];
-                    sum_s[s] += loc_s[s];
-                }
-                for (int atom = 0; atom < num_atoms; atom++) delta_atom[atom] += loc_d[atom];
+        for (size_t chunk = 0; chunk < n_chunks; chunk++) {
+            const double* loc_n = chunk_n.data() + chunk * total_shells;
+            const double* loc_s = chunk_s.data() + chunk * total_shells;
+            const double* loc_d = chunk_d.data() + chunk * num_atoms;
+            for (int s = 0; s < total_shells; s++) {
+                sum_n[s] += loc_n[s];
+                sum_s[s] += loc_s[s];
             }
+            for (int atom = 0; atom < num_atoms; atom++) delta_atom[atom] += loc_d[atom];
         }
 
         for (int s = 0; s < total_shells; s++) {
@@ -2505,53 +2520,58 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
     const int n_acc = 20 + n_rmom;  // 1 monopole + 3 dipole + 6 quadrupole + 10 octupole + moments
 
     std::vector<double> acc(static_cast<size_t>(num_atoms) * n_acc, 0.0);
+    constexpr size_t kMaxReductionChunks = 64;
+    const size_t n_chunks = std::min(n_blocks, kMaxReductionChunks);
+    std::vector<double> chunk_acc(n_chunks * acc.size(), 0.0);
 
 #pragma omp parallel
     {
-        std::vector<double> loc(static_cast<size_t>(num_atoms) * n_acc, 0.0);
-
 #pragma omp for schedule(dynamic, 1)
-        for (size_t b = 0; b < n_blocks; b++) {
-            const size_t off = block_offset[b], np = block_size[b];
-            const int* atoms = block_atoms.data() + block_atoms_off[b];
-            const int na = static_cast<int>(block_atoms_off[b + 1] - block_atoms_off[b]);
-            if (na == 0) continue;  // no atom reaches this block; rho_0 was never formed there
+        for (size_t chunk = 0; chunk < n_chunks; chunk++) {
+            double* loc = chunk_acc.data() + chunk * acc.size();
+            const size_t block_begin = n_blocks * chunk / n_chunks;
+            const size_t block_end = n_blocks * (chunk + 1) / n_chunks;
+            for (size_t b = block_begin; b < block_end; b++) {
+                const size_t off = block_offset[b], np = block_size[b];
+                const int* atoms = block_atoms.data() + block_atoms_off[b];
+                const int na = static_cast<int>(block_atoms_off[b + 1] - block_atoms_off[b]);
+                if (na == 0) continue;  // no atom reaches this block; rho_0 was never formed there
 
-            for (size_t p = off; p < off + np; p++) {
-                const double xp = x_points[p], yp = y_points[p], zp = z_points[p];
-                const double wrho = weights[p] * rho[p] / rho_0_points[p];
-                const double* rho_a_0_here = &rho_a_0_points[p * num_atoms];
+                for (size_t p = off; p < off + np; p++) {
+                    const double xp = x_points[p], yp = y_points[p], zp = z_points[p];
+                    const double wrho = weights[p] * rho[p] / rho_0_points[p];
+                    const double* rho_a_0_here = &rho_a_0_points[p * num_atoms];
 
-                for (int ia = 0; ia < na; ia++) {
-                    const int a = atoms[ia];
-                    const double d[3] = {xp - atom_x[a], yp - atom_y[a], zp - atom_z[a]};
-                    // c = -w * rho_a; the multipoles carry the electron's negative charge, the
-                    // radial moments do not.
-                    const double c = -wrho * rho_a_0_here[a];
-                    double* la = &loc[static_cast<size_t>(a) * n_acc];
+                    for (int ia = 0; ia < na; ia++) {
+                        const int a = atoms[ia];
+                        const double d[3] = {xp - atom_x[a], yp - atom_y[a], zp - atom_z[a]};
+                        // c = -w * rho_a; the multipoles carry the electron's negative charge, the
+                        // radial moments do not.
+                        const double c = -wrho * rho_a_0_here[a];
+                        double* la = &loc[static_cast<size_t>(a) * n_acc];
 
-                    la[0] += c;
-                    for (int i = 0; i < 3; i++) la[1 + i] += c * d[i];
-                    for (int q = 0; q < 6; q++) la[4 + q] += c * d[qpole_inds[q][0]] * d[qpole_inds[q][1]];
-                    for (int o = 0; o < 10; o++)
-                        la[10 + o] += c * d[opole_inds[o][0]] * d[opole_inds[o][1]] * d[opole_inds[o][2]];
+                        la[0] += c;
+                        for (int i = 0; i < 3; i++) la[1 + i] += c * d[i];
+                        for (int q = 0; q < 6; q++) la[4 + q] += c * d[qpole_inds[q][0]] * d[qpole_inds[q][1]];
+                        for (int o = 0; o < 10; o++)
+                            la[10 + o] += c * d[opole_inds[o][0]] * d[opole_inds[o][1]] * d[opole_inds[o][2]];
 
-                    const double r2 = d[0] * d[0] + d[1] * d[1] + d[2] * d[2];
-                    const double r = std::sqrt(r2);
-                    double rn = r2;  // n = 2
-                    la[20] -= c * rn;
-                    for (int n = 3; n <= rmom_top; n++) {
-                        rn *= r;
-                        la[20 + n - 2] -= c * rn;
+                        const double r2 = d[0] * d[0] + d[1] * d[1] + d[2] * d[2];
+                        const double r = std::sqrt(r2);
+                        double rn = r2;  // n = 2
+                        la[20] -= c * rn;
+                        for (int n = 3; n <= rmom_top; n++) {
+                            rn *= r;
+                            la[20 + n - 2] -= c * rn;
+                        }
                     }
                 }
             }
         }
-
-#pragma omp critical
-        {
-            for (size_t i = 0; i < acc.size(); i++) acc[i] += loc[i];
-        }
+    }
+    for (size_t chunk = 0; chunk < n_chunks; chunk++) {
+        const double* loc = chunk_acc.data() + chunk * acc.size();
+        for (size_t i = 0; i < acc.size(); i++) acc[i] += loc[i];
     }
 
     std::vector<SharedMatrix> rmoms;

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -30,9 +30,8 @@
 #include <omp.h>
 #endif
 
-#include <bit>
-#include <cassert>
-#include <cstdint>
+#include <Eigen/Core>
+
 #include <limits>
 
 #include "psi4/psifiles.h"
@@ -1779,50 +1778,19 @@ const std::vector<std::tuple<double, double>>& get_mbis_params(int atomic_num) {
 
 /* Batched exp() for the MBIS stockholder sweep.
  *
- * The sweep spends nearly all of its time in exp(-r/sigma), and scalar libm exp is the limit:
- * glibc only vectorises exp through libmvec under -ffast-math, which Psi4 does not build with, so
- * a plain loop calling std::exp runs one element at a time however wide the machine is.
+ * The sweep spends nearly all of its time in exp(-r/sigma). A plain loop over std::exp runs one
+ * element at a time however wide the machine is, because glibc only vectorises exp through libmvec
+ * under -ffast-math, which Psi4 does not build with. Eigen ships its own vectorised exp, so this
+ * gets SIMD throughput from a dependency Psi4 already requires rather than from a hand-rolled
+ * range reduction that would have to restate the IEEE-754 contract itself.
  *
- * This is the textbook 2^k * exp(f) reduction with |f| <= ln2/2 and a degree-13 Taylor core, which
- * is pure arithmetic and so vectorises under plain -O3 -march=native. Measured at 1.07 ulp against
- * libm over the argument range MBIS uses, and about 4x its throughput.
- *
- * Arguments are always finite and <= 0 here (rate < 0, r >= 0). Anything below -700 underflows to
- * ~1e-304 rather than to exactly zero; those terms are ~300 orders of magnitude below the
- * densities they are summed into, and the screening has already discarded the atoms where this
- * could arise. Building 2^k from its exponent bits requires an IEEE-754 binary64 double; state that
- * contract explicitly instead of silently relying on it through a memcpy.
+ * Measured on 96-element batches: 526 Mexp/s against libm's 126 with -march=native, and 138
+ * against 130 without it. That second column is the reason this is a library call -- a hand-rolled
+ * polynomial kernel is about 2x *slower* than libm on a build that lost its -march flag, and
+ * nothing warns you when that happens.
  */
 static inline void mbis_exp_batch(const double* __restrict arg, double* __restrict out, int n) {
-    static_assert(sizeof(double) == sizeof(std::uint64_t));
-    static_assert(std::numeric_limits<double>::is_iec559 && std::numeric_limits<double>::radix == 2 &&
-                  std::numeric_limits<double>::digits == 53 && std::numeric_limits<double>::max_exponent == 1024);
-    constexpr double LOG2E = 1.4426950408889634074;
-    constexpr double LN2_HI = 6.93147180369123816490e-01;
-    constexpr double LN2_LO = 1.90821492927058770002e-10;
-#pragma omp simd
-    for (int k = 0; k < n; k++) {
-        assert(std::isfinite(arg[k]) && arg[k] <= 0.0);
-        const double x = arg[k] < -700.0 ? -700.0 : arg[k];
-        const double kf = std::nearbyint(x * LOG2E);
-        const double f = (x - kf * LN2_HI) - kf * LN2_LO;
-        double p = 1.0 / 6227020800.0;
-        p = 1.0 / 479001600.0 + f * p;
-        p = 1.0 / 39916800.0 + f * p;
-        p = 1.0 / 3628800.0 + f * p;
-        p = 1.0 / 362880.0 + f * p;
-        p = 1.0 / 40320.0 + f * p;
-        p = 1.0 / 5040.0 + f * p;
-        p = 1.0 / 720.0 + f * p;
-        p = 1.0 / 120.0 + f * p;
-        p = 1.0 / 24.0 + f * p;
-        p = 1.0 / 6.0 + f * p;
-        p = 0.5 + f * p;
-        p = 1.0 + f * p;
-        p = 1.0 + f * p;
-        const auto bits = static_cast<std::uint64_t>(static_cast<std::int64_t>(kf) + 1023) << 52;
-        out[k] = p * std::bit_cast<double>(bits);
-    }
+    Eigen::Map<Eigen::ArrayXd>(out, n) = Eigen::Map<const Eigen::ArrayXd>(arg, n).exp();
 }
 
 /* Anderson acceleration for the MBIS stockholder fixed point.

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -34,6 +34,10 @@
 
 #include <limits>
 
+#ifdef USING_LAPACK_MKL
+#include <mkl.h>
+#endif
+
 #include "psi4/psifiles.h"
 #include "psi4/psi4-dec.h"
 #include "psi4/physconst.h"
@@ -1872,18 +1876,32 @@ class MBISAnderson {
         }
         rhs[n_ + ncols] = sqrt_ridge;
 
+        // The problem is tall and extremely thin -- about 550 x 5 -- so threading it buys nothing
+        // and costs reproducibility: a threaded QR picks its reduction order at run time, which
+        // perturbs the mixing coefficients between otherwise identical runs. Because the iteration
+        // stops on a threshold, that perturbation lands in the converged answer (measured: 5.8e-13
+        // on the charges of a 109-atom case, against 2.7e-15 with acceleration switched off).
+        // Pinning the solve to one thread makes it deterministic and is not slower at this size.
+#ifdef USING_LAPACK_MKL
+        const int mkl_threads_on_entry = mkl_get_max_threads();
+        mkl_set_num_threads(1);
+#endif
         std::vector<int> jpvt(ncols, 0);
         int rank = 0;
         double work_query = 0.0;
         const double rcond = std::numeric_limits<double>::epsilon() * std::max(nrows, ncols);
         int info = C_DGELSY(nrows, ncols, 1, A.data(), nrows, rhs.data(), ldb, jpvt.data(), rcond, &rank,
                             &work_query, -1);
-        if (info != 0 || !std::isfinite(work_query)) return g;
         const int lwork = std::max(1, static_cast<int>(work_query));
         std::vector<double> work(lwork);
-        std::fill(jpvt.begin(), jpvt.end(), 0);
-        info = C_DGELSY(nrows, ncols, 1, A.data(), nrows, rhs.data(), ldb, jpvt.data(), rcond, &rank, work.data(),
-                        lwork);
+        if (info == 0 && std::isfinite(work_query)) {
+            std::fill(jpvt.begin(), jpvt.end(), 0);
+            info = C_DGELSY(nrows, ncols, 1, A.data(), nrows, rhs.data(), ldb, jpvt.data(), rcond, &rank, work.data(),
+                            lwork);
+        }
+#ifdef USING_LAPACK_MKL
+        mkl_set_num_threads(mkl_threads_on_entry);
+#endif
         if (info != 0 || rank != ncols) return g;
 
         std::vector<double> c(m);

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1262,7 +1262,7 @@ SharedMatrix ESPPropCalc::compute_field_over_grid_in_memory(SharedMatrix input_g
 
 void OEProp::compute_esp_at_nuclei() {
     std::shared_ptr<std::vector<double>> nesps = epc_.compute_esp_at_nuclei(true, print_ > 2);
-    for (int atom1 = 0; atom1 < nesps->size(); ++atom1) {
+    for (size_t atom1 = 0; atom1 < nesps->size(); ++atom1) {
         std::stringstream s;
         s << "ESP AT CENTER " << atom1 + 1;
         /*- Process::environment.globals["ESP AT CENTER n"] -*/
@@ -1824,26 +1824,42 @@ class MBISAnderson {
     static constexpr double kRidge = 1.0e-12;    // relative Tikhonov penalty on the mixing coefficients
     static constexpr double kMaxCoefSum = 20.0;  // reject extrapolations that reach this far out
 
-    size_t n_;                                  // length of the parameter vector
-    size_t depth_;                              // history length
-    std::vector<std::vector<double>> xs_, fs_;  // iterates and residuals, most recent last
+    size_t n_;      // length of the parameter vector
+    size_t depth_;  // history length
+    // Iterates and residuals, one column each. A ring buffer over fixed columns rather than a
+    // deque of vectors: dropping the oldest entry is an index update instead of a memmove of the
+    // whole history, and the least-squares matrix below can be filled with block writes instead of
+    // hand-rolled column-major arithmetic.
+    Eigen::MatrixXd xs_, fs_;
+    size_t count_ = 0;  // how many columns are live, capped at depth_
+    size_t head_ = 0;   // column holding the oldest live entry
 
    public:
-    MBISAnderson(size_t n, size_t depth) : n_(n), depth_(depth) {}
+    MBISAnderson(size_t n, size_t depth)
+        : n_(n),
+          depth_(depth),
+          xs_(Eigen::MatrixXd::Zero(static_cast<Eigen::Index>(n), static_cast<Eigen::Index>(depth))),
+          fs_(Eigen::MatrixXd::Zero(static_cast<Eigen::Index>(n), static_cast<Eigen::Index>(depth))) {}
+
+    /// Column of the history holding entry i, counting 0 as the oldest live entry.
+    Eigen::Index slot(size_t i) const { return static_cast<Eigen::Index>((head_ + i) % depth_); }
 
     /// Given the current iterate x and the Picard image g(x), return the next iterate.
     std::vector<double> next(const std::vector<double>& x, const std::vector<double>& g) {
-        std::vector<double> f(n_);
-        for (size_t i = 0; i < n_; i++) f[i] = g[i] - x[i];
+        const Eigen::Map<const Eigen::VectorXd> xv(x.data(), static_cast<Eigen::Index>(n_));
+        const Eigen::Map<const Eigen::VectorXd> gv(g.data(), static_cast<Eigen::Index>(n_));
 
-        xs_.push_back(g);  // store the images; the mix is over g's, Anderson type-II
-        fs_.push_back(f);
-        if (xs_.size() > depth_) {
-            xs_.erase(xs_.begin());
-            fs_.erase(fs_.begin());
+        // Store the images; the mix is over g's, Anderson type-II.
+        const Eigen::Index write = (count_ < depth_) ? slot(count_) : head_;
+        xs_.col(write) = gv;
+        fs_.col(write) = gv - xv;
+        if (count_ < depth_) {
+            count_++;
+        } else {
+            head_ = (head_ + 1) % depth_;  // overwrote the oldest; it is now the newest
         }
 
-        const size_t m = xs_.size();
+        const size_t m = count_;
         if (m < 2) return g;  // nothing to extrapolate from yet
 
         // Minimise ||sum_i c_i f_i|| subject to sum_i c_i = 1. Eliminate the last coefficient,
@@ -1854,27 +1870,26 @@ class MBISAnderson {
         const int nrows = static_cast<int>(n_) + static_cast<int>(m);
         const int ldb = std::max(nrows, ncols);
         double maxdiag = 0.0;
-        for (size_t i = 0; i < m; i++) {
-            double diagonal = 0.0;
-            for (size_t k = 0; k < n_; k++) diagonal += fs_[i][k] * fs_[i][k];
-            maxdiag = std::max(maxdiag, diagonal);
-        }
+        for (size_t i = 0; i < m; i++) maxdiag = std::max(maxdiag, fs_.col(slot(i)).squaredNorm());
         if (!(maxdiag > 0.0) || !std::isfinite(maxdiag)) return g;
 
-        // DGELSY expects column-major storage. The first n_ rows hold f_i - f_last; the remaining
-        // rows express sqrt(lambda) * ||c||, including c_last = 1 - sum_i alpha_i.
-        std::vector<double> A(static_cast<size_t>(nrows) * ncols, 0.0), rhs(ldb, 0.0);
-        const auto& f_last = fs_.back();
-        for (size_t k = 0; k < n_; k++) rhs[k] = -f_last[k];
-        for (int i = 0; i < ncols; i++) {
-            for (size_t k = 0; k < n_; k++) A[static_cast<size_t>(i) * nrows + k] = fs_[i][k] - f_last[k];
+        // Eigen is column-major, which is what DGELSY wants, so A can be handed over directly.
+        // Rows [0, n_) hold f_i - f_last. The next ncols rows penalise each alpha_i, and the final
+        // row penalises c_last = 1 - sum_i alpha_i, so the ridge acts on the whole coefficient
+        // vector rather than only the part that survived the elimination.
+        const Eigen::Index nrows_e = nrows, ncols_e = ncols, n_e = static_cast<Eigen::Index>(n_);
+        Eigen::MatrixXd A = Eigen::MatrixXd::Zero(nrows_e, ncols_e);
+        Eigen::VectorXd rhs = Eigen::VectorXd::Zero(ldb);
+
+        const auto f_last = fs_.col(slot(m - 1));
+        rhs.head(n_e) = -f_last;
+        for (Eigen::Index i = 0; i < ncols_e; i++) {
+            A.col(i).head(n_e) = fs_.col(slot(static_cast<size_t>(i))) - f_last;
         }
         const double sqrt_ridge = std::sqrt(kRidge * maxdiag);
-        for (int i = 0; i < ncols; i++) {
-            A[static_cast<size_t>(i) * nrows + n_ + i] = sqrt_ridge;
-            A[static_cast<size_t>(i) * nrows + n_ + ncols] = sqrt_ridge;
-        }
-        rhs[n_ + ncols] = sqrt_ridge;
+        A.block(n_e, 0, ncols_e, ncols_e).diagonal().setConstant(sqrt_ridge);
+        A.row(n_e + ncols_e).setConstant(sqrt_ridge);
+        rhs(n_e + ncols_e) = sqrt_ridge;
 
         // The problem is tall and extremely thin -- about 550 x 5 -- so threading it buys nothing
         // and costs reproducibility: a threaded QR picks its reduction order at run time, which
@@ -1886,30 +1901,29 @@ class MBISAnderson {
         const int mkl_threads_on_entry = mkl_get_max_threads();
         mkl_set_num_threads(1);
 #endif
+        // The ridge block is itself full column rank, so the stacked matrix always is too. That
+        // makes rank deficiency unreachable and DGELSY's rcond inert; conditioning is handled by
+        // kRidge, and a wild extrapolation by the coefficient-sum test below.
         std::vector<int> jpvt(ncols, 0);
         int rank = 0;
         double work_query = 0.0;
-        const double rcond = std::numeric_limits<double>::epsilon() * std::max(nrows, ncols);
-        int info = C_DGELSY(nrows, ncols, 1, A.data(), nrows, rhs.data(), ldb, jpvt.data(), rcond, &rank,
+        int info = C_DGELSY(nrows, ncols, 1, A.data(), nrows, rhs.data(), ldb, jpvt.data(), 0.0, &rank,
                             &work_query, -1);
         const int lwork = std::max(1, static_cast<int>(work_query));
         std::vector<double> work(lwork);
         if (info == 0 && std::isfinite(work_query)) {
             std::fill(jpvt.begin(), jpvt.end(), 0);
-            info = C_DGELSY(nrows, ncols, 1, A.data(), nrows, rhs.data(), ldb, jpvt.data(), rcond, &rank, work.data(),
+            info = C_DGELSY(nrows, ncols, 1, A.data(), nrows, rhs.data(), ldb, jpvt.data(), 0.0, &rank, work.data(),
                             lwork);
         }
 #ifdef USING_LAPACK_MKL
         mkl_set_num_threads(mkl_threads_on_entry);
 #endif
-        if (info != 0 || rank != ncols) return g;
+        if (info != 0) return g;
 
         std::vector<double> c(m);
-        double alpha_sum = 0.0;
-        for (int i = 0; i < ncols; i++) {
-            c[i] = rhs[i];
-            alpha_sum += rhs[i];
-        }
+        const double alpha_sum = rhs.head(ncols_e).sum();
+        for (int i = 0; i < ncols; i++) c[i] = rhs(i);
         c.back() = 1.0 - alpha_sum;
 
         // sum_i c_i == 1 by construction, so sum_i |c_i| measures how far outside the history the
@@ -1918,18 +1932,18 @@ class MBISAnderson {
         for (size_t i = 0; i < m; i++) coefsum += std::fabs(c[i]);
         if (!std::isfinite(coefsum) || coefsum > kMaxCoefSum) return g;
 
-        std::vector<double> out(n_, 0.0);
-        for (size_t i = 0; i < m; i++)
-            for (size_t k = 0; k < n_; k++) out[k] += c[i] * xs_[i][k];
+        std::vector<double> out(n_);
+        Eigen::Map<Eigen::VectorXd> outv(out.data(), n_e);
+        outv.setZero();
+        for (size_t i = 0; i < m; i++) outv += c[i] * xs_.col(slot(i));
 
-        for (size_t k = 0; k < n_; k++)
-            if (!std::isfinite(out[k])) return g;  // reject a bad extrapolation wholesale
+        if (!outv.allFinite()) return g;  // reject a bad extrapolation wholesale
         return out;
     }
 
     void reset() {
-        xs_.clear();
-        fs_.clear();
+        count_ = 0;
+        head_ = 0;
     }
 };
 
@@ -1988,7 +2002,7 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
     size_t max_nbf = 0;
 
     std::vector<std::shared_ptr<BlockOPoints>> blocks = grid->blocks();
-    for (int b = 0; b < blocks.size(); b++) {
+    for (size_t b = 0; b < blocks.size(); b++) {
         max_points = std::max(max_points, blocks[b]->npoints());
         max_nbf = std::max(max_nbf, blocks[b]->local_nbf());
     }
@@ -2022,7 +2036,7 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
     std::vector<double> rho(total_points, 0.0);
 
     timer_on("MBIS: grid density");
-    for (int b = 0; b < blocks.size(); b++) {
+    for (size_t b = 0; b < blocks.size(); b++) {
         std::shared_ptr<BlockOPoints> block = blocks[b];
         SharedVector rho_block;
         size_t num_points = block->npoints();
@@ -2062,7 +2076,7 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
 
     // Electron count via numerical interagration
     double grid_electrons = 0.0;
-    for (int p = 0; p < total_points; p++) {
+    for (size_t p = 0; p < total_points; p++) {
         grid_electrons += weights[p] * rho[p];
     }
 

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -30,6 +30,10 @@
 #include <omp.h>
 #endif
 
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
 #include "psi4/psifiles.h"
 #include "psi4/psi4-dec.h"
 #include "psi4/physconst.h"
@@ -1771,53 +1775,166 @@ const std::vector<std::tuple<double, double>>& get_mbis_params(int atomic_num) {
     return it->second;
 }
 
-// A Helper Method That Calculates Radial Moments using Atomic Electron Densities derived from Charge Partitioning
-std::vector<SharedMatrix> compute_radial_moments(const std::shared_ptr<DFTGrid>& grid,
-                                                 const std::vector<double>& rho_a_points,
-                                                 const std::vector<double>& distances, int num_atoms) {
-    Options& options = Process::environment.options;
-    const int max_power = std::max(4, options.get_int("MAX_RADIAL_MOMENT"));
 
-    std::vector<SharedMatrix> rmoms;
-
-    for (int n = 2; n <= max_power; n++) {
-        std::stringstream sstream;
-        sstream << "ATOMIC RADIAL MOMENTS <R^" << n << ">";
-        auto mat_name = sstream.str();
-
-        rmoms.push_back(std::make_shared<Matrix>(mat_name, num_atoms, 1));
+/* Batched exp() for the MBIS stockholder sweep.
+ *
+ * The sweep spends nearly all of its time in exp(-r/sigma), and scalar libm exp is the limit:
+ * glibc only vectorises exp through libmvec under -ffast-math, which Psi4 does not build with, so
+ * a plain loop calling std::exp runs one element at a time however wide the machine is.
+ *
+ * This is the textbook 2^k * exp(f) reduction with |f| <= ln2/2 and a degree-13 Taylor core, which
+ * is pure arithmetic and so vectorises under plain -O3 -march=native. Measured at 1.07 ulp against
+ * libm over the argument range MBIS uses, and about 4x its throughput.
+ *
+ * Arguments are always <= 0 here (rate < 0, r >= 0). Anything below -700 underflows to
+ * ~1e-304 rather than to exactly zero; those terms are ~300 orders of magnitude below the
+ * densities they are summed into, and the screening has already discarded the atoms where this
+ * could arise.
+ */
+static inline void mbis_exp_batch(const double* __restrict arg, double* __restrict out, int n) {
+    constexpr double LOG2E = 1.4426950408889634074;
+    constexpr double LN2_HI = 6.93147180369123816490e-01;
+    constexpr double LN2_LO = 1.90821492927058770002e-10;
+#pragma omp simd
+    for (int k = 0; k < n; k++) {
+        const double x = arg[k] < -700.0 ? -700.0 : arg[k];
+        const double kf = std::nearbyint(x * LOG2E);
+        const double f = (x - kf * LN2_HI) - kf * LN2_LO;
+        double p = 1.0 / 6227020800.0;
+        p = 1.0 / 479001600.0 + f * p;
+        p = 1.0 / 39916800.0 + f * p;
+        p = 1.0 / 3628800.0 + f * p;
+        p = 1.0 / 362880.0 + f * p;
+        p = 1.0 / 40320.0 + f * p;
+        p = 1.0 / 5040.0 + f * p;
+        p = 1.0 / 720.0 + f * p;
+        p = 1.0 / 120.0 + f * p;
+        p = 1.0 / 24.0 + f * p;
+        p = 1.0 / 6.0 + f * p;
+        p = 0.5 + f * p;
+        p = 1.0 + f * p;
+        p = 1.0 + f * p;
+        const std::int64_t bits = (static_cast<std::int64_t>(kf) + 1023) << 52;
+        double scale;
+        std::memcpy(&scale, &bits, sizeof(double));
+        out[k] = p * scale;
     }
-
-    auto blocks = grid->blocks();
-    size_t total_points = grid->npoints();
-
-#pragma omp parallel for
-    for (int a = 0; a < num_atoms; a++) {
-        for (int n = 2; n <= max_power; n++) {
-            size_t running_points = 0;
-            double val = 0;
-            for (int b = 0; b < blocks.size(); b++) {
-                auto block = blocks[b];
-                SharedVector rho_block;
-                size_t num_points = block->npoints();
-
-                double* x = block->x();
-                double* y = block->y();
-                double* z = block->z();
-                double* w = block->w();
-
-                for (size_t p = running_points; p < running_points + num_points; p++) {
-                    auto ap = a * total_points + p;
-                    val += w[p - running_points] * rho_a_points[ap] * pow(distances[ap], n);
-                }
-                running_points += num_points;
-            }
-            rmoms[n - 2]->set(a, 0, val);
-        }
-    }
-
-    return rmoms;
 }
+
+/* Anderson acceleration for the MBIS stockholder fixed point.
+ *
+ * The stockholder update is a plain Picard iteration x_{k+1} = g(x_k) on the shell populations and
+ * widths, and it converges linearly: 60-80 iterations to 1e-8 on the systems profiled, essentially
+ * independent of how fast a single iteration is made. Anderson mixing reuses the last few residuals
+ * to extrapolate, which typically removes most of those iterations for a few hundred flops.
+ *
+ * Anderson is not unconditionally convergent, though, and on an ionic system (NaCl was the case
+ * that caught this) an unsafeguarded version oscillates indefinitely and eventually drives a shell
+ * population to zero, which turns the whole result into NaN. Four guards, in order of how often
+ * they matter:
+ *
+ *  - N and sigma are strictly positive, and a negative sigma would make exp(-r/sigma) diverge. The
+ *    mixing is therefore done on log(N), log(sigma), so every combination is positive by
+ *    construction, whatever coefficients the least-squares returns.
+ *  - The normal equations are Tikhonov-regularised. Nearly-parallel residual histories are the
+ *    usual source of the huge coefficients that produce a wild extrapolation.
+ *  - The extrapolation is rejected outright if the mixing coefficients grow past `kMaxCoefSum`,
+ *    if the least-squares is singular, or if the result is not finite. Acceleration is never
+ *    allowed to be worse than doing nothing.
+ *  - The caller watches the residual it already computes and calls `reset()` when an accelerated
+ *    step made it worse, which falls back to plain Picard until the history rebuilds.
+ */
+class MBISAnderson {
+    static constexpr double kRidge = 1.0e-12;    // relative Tikhonov shift on the normal equations
+    static constexpr double kMaxCoefSum = 20.0;  // reject extrapolations that reach this far out
+
+    size_t n_;                                  // length of the parameter vector
+    size_t depth_;                              // history length
+    std::vector<std::vector<double>> xs_, fs_;  // iterates and residuals, most recent last
+
+   public:
+    MBISAnderson(size_t n, size_t depth) : n_(n), depth_(depth) {}
+
+    /// Given the current iterate x and the Picard image g(x), return the next iterate.
+    std::vector<double> next(const std::vector<double>& x, const std::vector<double>& g) {
+        std::vector<double> f(n_);
+        for (size_t i = 0; i < n_; i++) f[i] = g[i] - x[i];
+
+        xs_.push_back(g);  // store the images; the mix is over g's, Anderson type-II
+        fs_.push_back(f);
+        if (xs_.size() > depth_) {
+            xs_.erase(xs_.begin());
+            fs_.erase(fs_.begin());
+        }
+
+        const size_t m = xs_.size();
+        if (m < 2) return g;  // nothing to extrapolate from yet
+
+        // Minimise ||sum_i c_i f_i|| subject to sum_i c_i = 1, via the bordered normal equations.
+        const size_t dim = m + 1;
+        std::vector<double> A(dim * dim, 0.0), b(dim, 0.0);
+        double maxdiag = 0.0;
+        for (size_t i = 0; i < m; i++) {
+            for (size_t j = 0; j < m; j++) {
+                double dot = 0.0;
+                for (size_t k = 0; k < n_; k++) dot += fs_[i][k] * fs_[j][k];
+                A[i * dim + j] = dot;
+            }
+            maxdiag = std::max(maxdiag, A[i * dim + i]);
+            A[i * dim + m] = -1.0;
+            A[m * dim + i] = -1.0;
+        }
+        for (size_t i = 0; i < m; i++) A[i * dim + i] += kRidge * maxdiag;
+        b[m] = -1.0;
+
+        // Gauss-Jordan with partial pivoting.
+        std::vector<double> c(b);
+        bool ok = true;
+        for (size_t col = 0; col < dim && ok; col++) {
+            size_t piv = col;
+            for (size_t r = col + 1; r < dim; r++)
+                if (std::fabs(A[r * dim + col]) > std::fabs(A[piv * dim + col])) piv = r;
+            if (std::fabs(A[piv * dim + col]) < 1.0e-14) {
+                ok = false;
+                break;
+            }
+            if (piv != col) {
+                for (size_t k = 0; k < dim; k++) std::swap(A[col * dim + k], A[piv * dim + k]);
+                std::swap(c[col], c[piv]);
+            }
+            const double d = A[col * dim + col];
+            for (size_t k = 0; k < dim; k++) A[col * dim + k] /= d;
+            c[col] /= d;
+            for (size_t r = 0; r < dim; r++) {
+                if (r == col) continue;
+                const double factor = A[r * dim + col];
+                if (factor == 0.0) continue;
+                for (size_t k = 0; k < dim; k++) A[r * dim + k] -= factor * A[col * dim + k];
+                c[r] -= factor * c[col];
+            }
+        }
+        if (!ok) return g;
+
+        // sum_i c_i == 1 by construction, so sum_i |c_i| measures how far outside the history the
+        // extrapolation reaches. Large values are the signature of a step about to go wild.
+        double coefsum = 0.0;
+        for (size_t i = 0; i < m; i++) coefsum += std::fabs(c[i]);
+        if (!std::isfinite(coefsum) || coefsum > kMaxCoefSum) return g;
+
+        std::vector<double> out(n_, 0.0);
+        for (size_t i = 0; i < m; i++)
+            for (size_t k = 0; k < n_; k++) out[k] += c[i] * xs_[i][k];
+
+        for (size_t k = 0; k < n_; k++)
+            if (!std::isfinite(out[k])) return g;  // reject a bad extrapolation wholesale
+        return out;
+    }
+
+    void reset() {
+        xs_.clear();
+        fs_.clear();
+    }
+};
 
 // Minimal Basis Iterative Stockholder (JCTC, 2016, p. 3894-3912, Verstraelen et al.)
 std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAnalysisCalc::compute_mbis_multipoles(
@@ -1841,7 +1958,9 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
     mbis_grid_options_int["DFT_SPHERICAL_POINTS"] = options.get_int("MBIS_SPHERICAL_POINTS");
     mbis_grid_options_str["DFT_PRUNING_SCHEME"] = options.get_str("MBIS_PRUNING_SCHEME");
 
+    timer_on("MBIS: grid build");
     auto grid = std::make_shared<DFTGrid>(mol, basisset_, mbis_grid_options_int, mbis_grid_options_str, options);
+    timer_off("MBIS: grid build");
 
     if (print_output && debug >= 1) grid->print();
 
@@ -1857,6 +1976,7 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
         max_points = std::max(max_points, blocks[b]->npoints());
         max_nbf = std::max(max_nbf, blocks[b]->local_nbf());
     }
+    timer_on("MBIS: density subset");
     SharedMatrix Da = wfn_->Da_subset("AO");
     SharedMatrix Db;
     auto point_func = (std::shared_ptr<PointFunctions>)(std::make_shared<RKSFunctions>(basisset_, max_points, max_nbf));
@@ -1869,8 +1989,13 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
         point_func = (std::shared_ptr<PointFunctions>)(std::make_shared<UKSFunctions>(basisset_, max_points, max_nbf));
         point_func->set_pointers(Da, Db);
     }
+    timer_off("MBIS: density subset");
 
     size_t running_points = 0;
+
+    // Block extents, used for the distance screening in the stockholder sweep below.
+    const size_t n_blocks = blocks.size();
+    std::vector<size_t> block_offset(n_blocks, 0), block_size(n_blocks, 0);
 
     // Coordinates, weights, and rho (molecular electron density) at each grid point
     std::vector<double> x_points(total_points, 0.0);
@@ -1879,6 +2004,7 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
     std::vector<double> weights(total_points, 0.0);
     std::vector<double> rho(total_points, 0.0);
 
+    timer_on("MBIS: grid density");
     for (int b = 0; b < blocks.size(); b++) {
         std::shared_ptr<BlockOPoints> block = blocks[b];
         SharedVector rho_block;
@@ -1906,8 +2032,11 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
             rho[running_points + p] = rho_block->get(p);
         }
 
+        block_offset[b] = running_points;
+        block_size[b] = num_points;
         running_points += num_points;
     }
+    timer_off("MBIS: grid density");
 
     // Electron count via numerical interagration
     double grid_electrons = 0.0;
@@ -1943,19 +2072,13 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
             grid_electrons);
     }
 
-    // Distances and displacements between grid points and nuclei
-    std::vector<double> distances(num_atoms * total_points, 0.0);
-    std::vector<std::vector<double>> disps(3, std::vector<double>(num_atoms * total_points, 0.0));
-
-#pragma omp parallel for
+    // Nuclear coordinates, kept flat so the hot loop below does not touch Molecule.
+    std::vector<double> atom_x(num_atoms), atom_y(num_atoms), atom_z(num_atoms);
     for (int atom = 0; atom < num_atoms; atom++) {
-        for (size_t point = 0; point < total_points; point++) {
-            Vector3 dr = Vector3(x_points[point], y_points[point], z_points[point]) - mol->xyz(atom);
-            distances[atom * total_points + point] = dr.norm();
-            disps[0][atom * total_points + point] = dr[0];
-            disps[1][atom * total_points + point] = dr[1];
-            disps[2][atom * total_points + point] = dr[2];
-        }
+        Vector3 R = mol->xyz(atom);
+        atom_x[atom] = R[0];
+        atom_y[atom] = R[1];
+        atom_z[atom] = R[2];
     }
 
     // => Setup Proatom Basis Functions <= //
@@ -1968,7 +2091,7 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
         int n_valence_electrons = static_cast<int>(mol->Z(atom));
         int true_atomic_num = static_cast<int>(mol->true_atomic_number(atom));
         if (n_valence_electrons != true_atomic_num) {
-            throw PSIEXCEPTION("MBIS incompatible with ECP. ECP detected on atom " + std::to_string(atom + 1) + " (" + 
+            throw PSIEXCEPTION("MBIS incompatible with ECP. ECP detected on atom " + std::to_string(atom + 1) + " (" +
                                mol->symbol(atom) + "). Use all-electron basis or reconstruct density with denspart.");
         }
 
@@ -1976,203 +2099,472 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
         mA[atom] = static_cast<int>(get_mbis_params(atomic_num).size());
     }
 
+    // Shells are flattened to a single running index so the inner loop is a flat sweep.
+    // shell_off[a] is where atom a's shells begin; total_shells = sum_a mA[a].
+    std::vector<int> shell_off(num_atoms + 1, 0);
+    for (int atom = 0; atom < num_atoms; atom++) shell_off[atom + 1] = shell_off[atom] + mA[atom];
+    const int total_shells = shell_off[num_atoms];
+
     // Atomic shell populations (N) and widths (S), from equations 18 and 19 in Verstraelen et al.
-    // Fixed inner size of 7 (maximum across all Z=1-118); unused slots are zero and never accessed,
-    // consistent with how lighter atoms have always been handled (e.g. H uses only index 0).
-    constexpr int max_shells = 7;
-    std::vector<std::vector<double>> Nai(num_atoms, std::vector<double>(max_shells, 0.0));
-    std::vector<std::vector<double>> Sai(num_atoms, std::vector<double>(max_shells, 0.0));
+    std::vector<double> Nf(total_shells, 0.0), Sf(total_shells, 0.0);
+    std::vector<double> Nf_next(total_shells, 0.0), Sf_next(total_shells, 0.0);
 
-    // Next iteration populations and widths
-    std::vector<std::vector<double>> Nai_next(num_atoms, std::vector<double>(max_shells, 0.0));
-    std::vector<std::vector<double>> Sai_next(num_atoms, std::vector<double>(max_shells, 0.0));
-
-    // Population and width guesses, from get_mbis_params function
     for (int atom = 0; atom < num_atoms; atom++) {
-        int atomic_num = static_cast<int>(mol->Z(atom));
-        auto shells = get_mbis_params(atomic_num);
-
+        auto shells = get_mbis_params(static_cast<int>(mol->Z(atom)));
         for (int m = 0; m < mA[atom]; m++) {
-            Nai[atom][m] = std::get<0>(shells[m]);
-            Sai[atom][m] = 1.0 / std::get<1>(shells[m]);
-
+            Nf[shell_off[atom] + m] = std::get<0>(shells[m]);
+            Sf[shell_off[atom] + m] = 1.0 / std::get<1>(shells[m]);
             if (print_output && debug >= 1) {
-                outfile->Printf("  INITIAL ATOM %d, SHELL %d, POP %8.5f, WIDTH %8.5f\n", atom + 1, m + 1, Nai[atom][m],
-                                Sai[atom][m]);
+                outfile->Printf("  INITIAL ATOM %d, SHELL %d, POP %8.5f, WIDTH %8.5f\n", atom + 1, m + 1,
+                                Nf[shell_off[atom] + m], Sf[shell_off[atom] + m]);
             }
-
-            Nai_next[atom][m] = Nai[atom][m];
-            Sai_next[atom][m] = Sai[atom][m];
         }
     }
 
-    // Promolecular and proatomic densities
+    // Pro-atom densities, point-major (point * num_atoms + atom): the fused sweep below writes all
+    // atoms of one point together, so this layout keeps those writes contiguous. Only the previous
+    // iteration's values are needed (for the convergence test), so this is the single large array
+    // MBIS now holds -- distances, displacements and the per-atom density are all recomputed.
+    timer_on("MBIS: alloc");
+    std::vector<double> rho_a_0_points(static_cast<size_t>(num_atoms) * total_points, 0.0);
+    timer_off("MBIS: alloc");
     std::vector<double> rho_0_points(total_points, 0.0);
-    std::vector<double> rho_a_0_points(num_atoms * total_points, 0.0);
 
-    // Next iteration densities
-    std::vector<double> rho_0_points_next(total_points, 0.0);
-    std::vector<double> rho_a_0_points_next(num_atoms * total_points, 0.0);
-
-// Calculate initial proatom and promolecule density at all points
-#pragma omp parallel for
-    for (size_t point = 0; point < total_points; point++) {
-        rho_0_points[point] = 0.0;
-        for (int atom = 0; atom < num_atoms; atom++) {
-            rho_a_0_points[atom * total_points + point] = 0.0;
-            for (int m = 0; m < mA[atom]; m++) {
-                rho_a_0_points[atom * total_points + point] +=
-                    rho_ai_0(Nai[atom][m], Sai[atom][m], distances[atom * total_points + point]);
-            }
-            rho_0_points[point] += rho_a_0_points[atom * total_points + point];
+    // rho_ai_0 = N * exp(-r/S) / (8 pi S^3). Hoisting N/(8 pi S^3) and -1/S out of the point loop
+    // removes a pow() and a division from every one of the natom * mA * npoints evaluations.
+    std::vector<double> shell_coef(total_shells), shell_rate(total_shells);
+    auto refresh_shell_constants = [&](const std::vector<double>& N, const std::vector<double>& S) {
+        for (int s = 0; s < total_shells; s++) {
+            shell_coef[s] = N[s] / (8.0 * M_PI * S[s] * S[s] * S[s]);
+            shell_rate[s] = -1.0 / S[s];
         }
+    };
+
+    // Bounding sphere per grid block. cubature.h computes one internally but does not expose it,
+    // and recomputing here is one pass over the grid, so this stays local to MBIS.
+    std::vector<double> block_cx(n_blocks), block_cy(n_blocks), block_cz(n_blocks), block_R(n_blocks, 0.0);
+    for (size_t b = 0; b < n_blocks; b++) {
+        const size_t off = block_offset[b], np = block_size[b];
+        double cx = 0.0, cy = 0.0, cz = 0.0;
+        for (size_t i = 0; i < np; i++) {
+            cx += x_points[off + i];
+            cy += y_points[off + i];
+            cz += z_points[off + i];
+        }
+        cx /= np; cy /= np; cz /= np;
+        double R2 = 0.0;
+        for (size_t i = 0; i < np; i++) {
+            const double dx = x_points[off + i] - cx, dy = y_points[off + i] - cy, dz = z_points[off + i] - cz;
+            R2 = std::max(R2, dx * dx + dy * dy + dz * dz);
+        }
+        block_cx[b] = cx; block_cy[b] = cy; block_cz[b] = cz; block_R[b] = std::sqrt(R2);
     }
+
+    // Distance screening. The pro-atom density falls off as exp(-r/sigma) with sigma ~ 0.3-1 bohr,
+    // so beyond a few tens of bohr an atom's contribution to a grid point is far below any
+    // meaningful threshold -- yet the unscreened loop still visits every (atom, point) pair, which
+    // is what makes MBIS quadratic in system size. For each block we keep only the atoms whose
+    // largest possible contribution anywhere in that block exceeds MBIS_SCREENING_THRESHOLD.
+    //
+    // This is bounded, not heuristic: a discarded atom contributes less than the threshold to
+    // rho_0, and its own population/width sums pick up an error below (w * rho * threshold / rho_0)
+    // at that point. Where rho_0 is itself near the threshold the molecular density rho is
+    // negligible too, so the absolute error stays bounded by the threshold either way.
+    const double screen_eps = options.get_double("MBIS_SCREENING_THRESHOLD");
+    const bool do_screen = screen_eps > 0.0;
+    std::vector<int> block_atoms;  // flat concatenation of per-block atom lists, ascending within a block
+    std::vector<size_t> block_atoms_off(n_blocks + 1, 0);
+    std::vector<double> atom_cut(num_atoms, 0.0);
+
+    // rho_a_0_points is kept valid for *every* (point, atom), with a hard zero wherever the atom is
+    // screened out, so the post-processing below needs no knowledge of the screening. Maintaining
+    // that by memset-ing the array each sweep would cost more traffic than the screened sweep
+    // itself, so instead the zeros are written only when an atom actually drops out of a block's
+    // list -- which happens in the first iteration or two and then essentially never. block_drop
+    // carries those (block, atom) pairs from rebuild_screening to the next sweep.
+    std::vector<int> block_drop;
+    std::vector<size_t> block_drop_off(n_blocks + 1, 0);
+    std::vector<int> prev_atoms;
+    std::vector<size_t> prev_atoms_off(n_blocks + 1, 0);
+    bool first_screening = true;
+
+    auto rebuild_screening = [&]() {
+        for (int atom = 0; atom < num_atoms; atom++) {
+            double cut = std::numeric_limits<double>::infinity();
+            if (do_screen) {
+                cut = 0.0;
+                for (int s = shell_off[atom]; s < shell_off[atom + 1]; s++) {
+                    // shell_coef * exp(-r/S) < eps  ->  r > S * ln(shell_coef / eps)
+                    if (shell_coef[s] > screen_eps) {
+                        const double S = -1.0 / shell_rate[s];
+                        cut = std::max(cut, S * std::log(shell_coef[s] / screen_eps));
+                    }
+                }
+            }
+            atom_cut[atom] = cut;
+        }
+
+        prev_atoms.swap(block_atoms);
+        prev_atoms_off.swap(block_atoms_off);
+        block_atoms.clear();
+        block_drop.clear();
+        for (size_t b = 0; b < n_blocks; b++) {
+            block_atoms_off[b] = block_atoms.size();
+            block_drop_off[b] = block_drop.size();
+            for (int atom = 0; atom < num_atoms; atom++) {
+                const double dx = block_cx[b] - atom_x[atom], dy = block_cy[b] - atom_y[atom],
+                             dz = block_cz[b] - atom_z[atom];
+                const double d = std::sqrt(dx * dx + dy * dy + dz * dz) - block_R[b];
+                if (d < atom_cut[atom]) block_atoms.push_back(atom);
+            }
+            // Atoms present last time but not now: their stale densities must be zeroed. Both lists
+            // are ascending, so this is a merge. (The dropped values are below screen_eps by
+            // construction, so discarding them does not perturb the convergence delta.)
+            if (!first_screening) {
+                size_t i = prev_atoms_off[b], j = block_atoms_off[b];
+                const size_t iend = prev_atoms_off[b + 1], jend = block_atoms.size();
+                while (i < iend) {
+                    while (j < jend && block_atoms[j] < prev_atoms[i]) j++;
+                    if (j == jend || block_atoms[j] != prev_atoms[i]) block_drop.push_back(prev_atoms[i]);
+                    i++;
+                }
+            }
+        }
+        block_atoms_off[n_blocks] = block_atoms.size();
+        block_drop_off[n_blocks] = block_drop.size();
+        first_screening = false;
+    };
+
+    // One sweep over the grid at fixed parameters. It simultaneously
+    //   (a) rebuilds the pro-atom/promolecule densities for these parameters,
+    //   (b) accumulates the convergence delta against the previous sweep's densities, and
+    //   (c) accumulates the population/width sums that define the *next* parameters.
+    // The original code did (a)+(b) and (c) in two separate sweeps one iteration apart, evaluating
+    // the identical set of exponentials twice; fusing them halves the exponential count.
+    auto sweep = [&](std::vector<double>& sum_n, std::vector<double>& sum_s,
+                     std::vector<double>& delta_atom, bool accumulate_delta) {
+        std::fill(sum_n.begin(), sum_n.end(), 0.0);
+        std::fill(sum_s.begin(), sum_s.end(), 0.0);
+        std::fill(delta_atom.begin(), delta_atom.end(), 0.0);
+
+#pragma omp parallel
+        {
+            std::vector<double> loc_n(total_shells, 0.0), loc_s(total_shells, 0.0);
+            std::vector<double> loc_d(num_atoms, 0.0);
+            std::vector<double> atom_r(num_atoms);
+            // Per-block flattened shell tables, so the exponentials of one grid point form a
+            // single contiguous batch instead of num_atoms batches of one to five.
+            std::vector<double> bcoef, brate, barg, bval;
+            std::vector<int> bglob, bstart;
+
+            // Blocks vary in both point count and surviving-atom count, so hand them out dynamically.
+#pragma omp for schedule(dynamic, 1)
+            for (size_t b = 0; b < n_blocks; b++) {
+                const size_t off = block_offset[b], np = block_size[b];
+                const int* atoms = block_atoms.data() + block_atoms_off[b];
+                const int na = static_cast<int>(block_atoms_off[b + 1] - block_atoms_off[b]);
+
+                // Atoms that left this block's list since the last sweep still hold that sweep's
+                // densities; clear them so the (point, atom) entries stay uniformly valid.
+                for (size_t k = block_drop_off[b]; k < block_drop_off[b + 1]; k++) {
+                    const int atom = block_drop[k];
+                    for (size_t p = off; p < off + np; p++) rho_a_0_points[p * num_atoms + atom] = 0.0;
+                }
+                if (na == 0) continue;
+
+                bstart.assign(na + 1, 0);
+                bcoef.clear();
+                brate.clear();
+                bglob.clear();
+                for (int ia = 0; ia < na; ia++) {
+                    const int atom = atoms[ia];
+                    for (int s = shell_off[atom]; s < shell_off[atom + 1]; s++) {
+                        bcoef.push_back(shell_coef[s]);
+                        brate.push_back(shell_rate[s]);
+                        bglob.push_back(s);
+                    }
+                    bstart[ia + 1] = static_cast<int>(bcoef.size());
+                }
+                const int ns = static_cast<int>(bcoef.size());
+                barg.resize(ns);
+                bval.resize(ns);
+
+                for (size_t point = off; point < off + np; point++) {
+                    const double xp = x_points[point], yp = y_points[point], zp = z_points[point];
+
+                    for (int ia = 0; ia < na; ia++) {
+                        const int atom = atoms[ia];
+                        const double dx = xp - atom_x[atom], dy = yp - atom_y[atom], dz = zp - atom_z[atom];
+                        const double r = std::sqrt(dx * dx + dy * dy + dz * dz);
+                        atom_r[atom] = r;
+                        for (int k = bstart[ia]; k < bstart[ia + 1]; k++) barg[k] = brate[k] * r;
+                    }
+
+                    mbis_exp_batch(barg.data(), bval.data(), ns);
+
+                    double rho_0 = 0.0;
+#pragma omp simd reduction(+ : rho_0)
+                    for (int k = 0; k < ns; k++) {
+                        bval[k] *= bcoef[k];
+                        rho_0 += bval[k];
+                    }
+
+                    const double w = weights[point];
+                    const double scale = w * rho[point] / rho_0;
+                    double* rho_a_0_here = &rho_a_0_points[point * num_atoms];
+
+                    for (int ia = 0; ia < na; ia++) {
+                        const int atom = atoms[ia];
+                        const double r = atom_r[atom];
+                        double rho_a_0 = 0.0;
+                        for (int k = bstart[ia]; k < bstart[ia + 1]; k++) {
+                            const double v = bval[k];
+                            loc_n[bglob[k]] += scale * v;
+                            loc_s[bglob[k]] += scale * r * v;
+                            rho_a_0 += v;
+                        }
+                        if (accumulate_delta) {
+                            const double d = rho_a_0 - rho_a_0_here[atom];
+                            loc_d[atom] += w * d * d;
+                        }
+                        rho_a_0_here[atom] = rho_a_0;
+                    }
+                    rho_0_points[point] = rho_0;
+                }
+            }
+
+#pragma omp critical
+            {
+                for (int s = 0; s < total_shells; s++) {
+                    sum_n[s] += loc_n[s];
+                    sum_s[s] += loc_s[s];
+                }
+                for (int atom = 0; atom < num_atoms; atom++) delta_atom[atom] += loc_d[atom];
+            }
+        }
+
+        for (int s = 0; s < total_shells; s++) {
+            Nf_next[s] = sum_n[s];
+            Sf_next[s] = sum_s[s] / (3.0 * Nf_next[s]);
+            // A shell that has lost all of its population makes the width 0/0. There is no way to
+            // continue from that, and silently carrying the NaN through to the printed charges is
+            // the worst possible outcome, so say what happened.
+            if (!(Nf_next[s] > 0.0) || !std::isfinite(Sf_next[s])) {
+                throw PSIEXCEPTION(
+                    "MBIS: the stockholder iteration reached a shell with zero population, which "
+                    "leaves its width undefined. This usually means the pro-atom parameters have "
+                    "diverged; try MBIS_ANDERSON false, or a finer MBIS grid.");
+            }
+        }
+    };
+
+    std::vector<double> sum_n(total_shells), sum_s(total_shells), delta_rho_atoms_0(num_atoms);
+
+    // Priming sweep: builds the pro-densities for the initial guess and produces the first update.
+    // Its delta is meaningless (there is no previous density), so it is not accumulated.
+    timer_on("MBIS: stockholder");
+    refresh_shell_constants(Nf, Sf);
+    rebuild_screening();
+    sweep(sum_n, sum_s, delta_rho_atoms_0, false);
+    Nf = Nf_next;
+    Sf = Sf_next;
 
     // => Main Stockholder Loop <= //
 
     int iter = 1;
     bool is_converged = false;
-    double delta_rho_max_0;
+    double delta_rho_max_0 = 0.0;
+
+    // Anderson mixing is a pure convergence accelerator: switching it off must give the same
+    // fixed point, only more slowly. Keep that escape hatch genuinely reachable.
+    const bool anderson_enabled = options.get_bool("MBIS_ANDERSON");
+    bool accelerate = anderson_enabled;
+    MBISAnderson anderson(2 * static_cast<size_t>(total_shells), 6);
+    std::vector<double> log_x(2 * total_shells), log_g(2 * total_shells);
+
+    // Anderson steps are not monotone even when they are working, so a single uptick in the
+    // residual is normal. A large one is not: it means the extrapolation is fighting the
+    // iteration rather than helping it, and on ionic systems it can keep that up indefinitely.
+    // Dropping the history at that point falls back to plain Picard until it rebuilds.
+    constexpr double kResidualBlowup = 2.0;
+    double prev_delta = std::numeric_limits<double>::infinity();
+    bool last_step_accelerated = false;
 
     if (print_output && debug >= 1) outfile->Printf("                     Delta D\n");
     while (iter < max_iter) {
-// Self-consistent update of population and density
-#pragma omp parallel for
-        for (int atom = 0; atom < num_atoms; atom++) {
-            for (int m = 0; m < mA[atom]; m++) {
-                double sum_n = 0.0;
-                double sum_s = 0.0;
-
-                for (int point = 0; point < total_points; point++) {
-                    double rho_ai_0_point =
-                        rho_ai_0(Nai[atom][m], Sai[atom][m], distances[atom * total_points + point]);
-                    sum_n += weights[point] * rho[point] * rho_ai_0_point / rho_0_points[point];
-                    sum_s += weights[point] * distances[atom * total_points + point] * rho[point] * rho_ai_0_point /
-                             rho_0_points[point];
-                }
-
-                Nai_next[atom][m] = sum_n;
-                Sai_next[atom][m] = sum_s / (3 * Nai_next[atom][m]);
-            }
-        }
-
-        std::fill(rho_0_points_next.begin(), rho_0_points_next.end(), 0.0);
-        std::fill(rho_a_0_points_next.begin(), rho_a_0_points_next.end(), 0.0);
-
-#pragma omp parallel for
-        for (size_t point = 0; point < total_points; point++) {
-            for (int atom = 0; atom < num_atoms; atom++) {
-                for (int m = 0; m < mA[atom]; m++) {
-                    rho_a_0_points_next[atom * total_points + point] +=
-                        rho_ai_0(Nai_next[atom][m], Sai_next[atom][m], distances[atom * total_points + point]);
-                }
-                rho_0_points_next[point] += rho_a_0_points_next[atom * total_points + point];
-            }
-        }
-
-        // Convergence check (Equation 20 in Verstraelen et al.) and update of pro-densities
-        std::vector<double> delta_rho_atoms_0(num_atoms, 0.0);
-
-#pragma omp parallel for
-        for (int atom = 0; atom < num_atoms; atom++) {
-            double delta;
-            for (size_t point = 0; point < total_points; point++) {
-                delta = rho_a_0_points_next[atom * total_points + point] - rho_a_0_points[atom * total_points + point];
-                delta_rho_atoms_0[atom] += weights[point] * delta * delta;
-            }
-            delta_rho_atoms_0[atom] = sqrt(delta_rho_atoms_0[atom]);
-        }
+        refresh_shell_constants(Nf, Sf);
+        rebuild_screening();
+        sweep(sum_n, sum_s, delta_rho_atoms_0, true);
 
         delta_rho_max_0 = 0.0;
         for (int atom = 0; atom < num_atoms; atom++) {
-            if (delta_rho_atoms_0[atom] > delta_rho_max_0) delta_rho_max_0 = delta_rho_atoms_0[atom];
+            const double d = std::sqrt(delta_rho_atoms_0[atom]);
+            if (d > delta_rho_max_0) delta_rho_max_0 = d;
         }
-
-        // Update populations, widths, and densities
-        Nai = Nai_next;
-        Sai = Sai_next;
-        rho_0_points = rho_0_points_next;
-        rho_a_0_points = rho_a_0_points_next;
 
         if (print_output && debug >= 1) outfile->Printf("   @MBIS iter %3d:  %.3e\n", iter, delta_rho_max_0);
 
+        if (last_step_accelerated && delta_rho_max_0 > kResidualBlowup * prev_delta) {
+            anderson.reset();
+        }
+        prev_delta = delta_rho_max_0;
+
+        // The convergence test measures the density change between successive iterates. For a plain
+        // Picard step that change *is* the fixed-point residual, but an Anderson step is an
+        // extrapolation, so two accelerated iterates can be close together without being at the
+        // fixed point -- accepting that would silently loosen MBIS_D_CONVERGENCE (measured: errors
+        // grew from 1e-11 to 1.6e-5). So the first time the accelerated iteration looks converged,
+        // acceleration is switched off and the test must be passed again on an unaccelerated step,
+        // where step and residual coincide. That costs one or two extra sweeps and restores the
+        // original convergence semantics exactly.
         if (delta_rho_max_0 < conv) {
-            if (print_output && debug >= 1) outfile->Printf("  MBIS Atomic Density Converged\n\n");
-            is_converged = true;
-            break;
+            if (accelerate) {
+                accelerate = false;
+                anderson.reset();
+            } else {
+                if (print_output && debug >= 1) outfile->Printf("  MBIS Atomic Density Converged\n\n");
+                is_converged = true;
+                break;
+            }
+        } else if (anderson_enabled && !accelerate && delta_rho_max_0 > 100.0 * conv) {
+            // The switch-off was premature; the iterate was not as close as the step suggested.
+            accelerate = true;
         }
 
+        // rho_a_0_points/rho_0_points now describe Nf/Sf; step the parameters forward, with the
+        // Picard step handed to Anderson (log space, so positivity of N and sigma is automatic).
+        if (accelerate) {
+            for (int s = 0; s < total_shells; s++) {
+                log_x[s] = std::log(Nf[s]);
+                log_x[total_shells + s] = std::log(Sf[s]);
+                log_g[s] = std::log(Nf_next[s]);
+                log_g[total_shells + s] = std::log(Sf_next[s]);
+            }
+            const std::vector<double> log_new = anderson.next(log_x, log_g);
+            for (int s = 0; s < total_shells; s++) {
+                Nf[s] = std::exp(log_new[s]);
+                Sf[s] = std::exp(log_new[total_shells + s]);
+            }
+            last_step_accelerated = true;
+        } else {
+            Nf = Nf_next;
+            Sf = Sf_next;
+            last_step_accelerated = false;
+        }
         iter += 1;
+    }
+
+    timer_off("MBIS: stockholder");
+
+    // Repack into the per-atom form the printing and post-processing below expect.
+    std::vector<std::vector<double>> Nai(num_atoms), Sai(num_atoms);
+    for (int atom = 0; atom < num_atoms; atom++) {
+        Nai[atom].assign(Nf.begin() + shell_off[atom], Nf.begin() + shell_off[atom + 1]);
+        Sai[atom].assign(Sf.begin() + shell_off[atom], Sf.begin() + shell_off[atom + 1]);
     }
 
     if (!is_converged) throw ConvergenceError<int>("MBIS", max_iter, conv, delta_rho_max_0, __FILE__, __LINE__);
 
     // => Post-Processing <= //
 
-    // Atomic density, as defined in Equation 5 of Verstraelen et al.
-    std::vector<double> rho_a(num_atoms * total_points, 0.0);
+    // Multipoles and radial moments are integrals of the same atomic density (Equation 5 in
+    // Verstraelen et al.),
+    //     rho_a(p) = rho(p) * rho_a_0(p) / rho_0(p),
+    // against different polynomials in the point-to-nucleus displacement, so they are accumulated
+    // together in one screened pass over the grid. The previous code made num_atoms separate
+    // passes for the multipoles and num_atoms * (max_power - 1) more for the radial moments, each
+    // one streaming the whole (point, atom) pro-density array -- 12.9 GB of traffic at 48 atoms --
+    // and calling pow() once per point. Displacements are recomputed rather than stored: at 109
+    // atoms they would be another ~4 GB.
+    //
+    // Screened-out atoms hold an exact zero in rho_a_0_points, so restricting the inner loop to
+    // each block's atom list drops only terms that are identically zero.
 
-#pragma omp parallel for
-    for (int atom = 0; atom < num_atoms; atom++) {
-        for (size_t point = 0; point < total_points; point++) {
-            rho_a[atom * total_points + point] =
-                rho[point] * rho_a_0_points[atom * total_points + point] / rho_0_points[point];
-        }
-    }
-
-    // Kronecker Delta
-    std::vector<std::vector<double>> k_delta = {{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}};
-
-    // Non-redundant cartesian quadrupole components
-    std::vector<std::vector<int>> qpole_inds = {{0, 0}, {0, 1}, {0, 2}, {1, 1}, {1, 2}, {2, 2}};
-
-    // Non-redundant cartesian octupole components
-    std::vector<std::vector<int>> opole_inds = {{0, 0, 0}, {0, 0, 1}, {0, 0, 2}, {0, 1, 1}, {0, 1, 2},
-                                                {0, 2, 2}, {1, 1, 1}, {1, 1, 2}, {1, 2, 2}, {2, 2, 2}};
+    // Non-redundant cartesian quadrupole and octupole components
+    static const int qpole_inds[6][2] = {{0, 0}, {0, 1}, {0, 2}, {1, 1}, {1, 2}, {2, 2}};
+    static const int opole_inds[10][3] = {{0, 0, 0}, {0, 0, 1}, {0, 0, 2}, {0, 1, 1}, {0, 1, 2},
+                                          {0, 2, 2}, {1, 1, 1}, {1, 1, 2}, {1, 2, 2}, {2, 2, 2}};
 
     // Non-redundant cartesian multipoles, as given in the convention in the HORTON software
-    /* Commented out lines ending in _stone represent multipole conventions given in
-       "The Theory of Intermolecular Forces (2nd Edition)" by Anthony Stone (A possible future addition) */
+    /* Multipole conventions given in "The Theory of Intermolecular Forces (2nd Edition)" by
+       Anthony Stone are a possible future addition. */
     auto mpole = std::make_shared<Matrix>("MBIS Charges: (a.u.)", num_atoms, 1);
     auto dpole = std::make_shared<Matrix>("MBIS Dipoles: (a.u.)", num_atoms, 3);
     auto qpole = std::make_shared<Matrix>("MBIS Quadrupoles: (a.u.)", num_atoms, 6);
     auto opole = std::make_shared<Matrix>("MBIS Octupoles: (a.u.)", num_atoms, 10);
-// auto qpole_stone = std::make_shared<Matrix>("MBIS Quadrupoles: (a.u.)", num_atoms, 6);
-// auto opole_stone = std::make_shared<Matrix>("MBIS Octupoles: (a.u.)", num_atoms, 10);
-// Calculate atomic multipoles
-#pragma omp parallel for
-    for (int a = 0; a < num_atoms; a++) {
-        mpole->add(a, 0, mol->Z(a));
-        for (size_t p = 0; p < total_points; p++) {
-            auto ap = a * total_points + p;
 
-            // Atomic monopole
-            mpole->add(a, 0, weights[p] * -rho_a[ap]);
+    timer_on("MBIS: multipoles");
 
-            // Atomic dipole
-            for (int i = 0; i < 3; i++) {
-                dpole->add(a, i, weights[p] * -rho_a[ap] * disps[i][ap]);
-            }
+    // <r^n> for n = 2 .. rmom_top. MAX_RADIAL_MOMENT can ask for more, but <r^3> (the volume used
+    // for the free-atom volume ratios) must always be available.
+    const int rmom_top = std::max(4, options.get_int("MAX_RADIAL_MOMENT"));
+    const int n_rmom = rmom_top - 1;
+    const int n_acc = 20 + n_rmom;  // 1 monopole + 3 dipole + 6 quadrupole + 10 octupole + moments
 
-            // Atomic quadrupole
-            for (int q = 0; q < 6; q++) {
-                int i = qpole_inds[q][0], j = qpole_inds[q][1];
-                qpole->add(a, q, weights[p] * -rho_a[ap] * (disps[i][ap] * disps[j][ap]));
-                // qpole_stone->add(a, q, weights[p] * rho_a[ap] * (1.5 * disps[i][ap] * disps[j][ap] - 0.5 *
-                // pow(distances[ap], 2) * k_delta[i][j]));
-            }
+    std::vector<double> acc(static_cast<size_t>(num_atoms) * n_acc, 0.0);
 
-            // Atomic octupole
-            for (int o = 0; o < 10; o++) {
-                int i = opole_inds[o][0], j = opole_inds[o][1], k = opole_inds[o][2];
-                opole->add(a, o, weights[p] * -rho_a[ap] * (disps[i][ap] * disps[j][ap] * disps[k][ap]));
-                // opole_stone->add(a, o, weights[p] * rho_a[ap]
-                //    * (2.5 * disps[i][ap] * disps[j][ap] * disps[k][ap] - 0.5 * pow(distances[ap], 2)
-                //        * (k_delta[j][k] * disps[i][ap] + k_delta[i][k] * disps[j][ap] + k_delta[i][j] *
-                //        disps[k][ap])));
+#pragma omp parallel
+    {
+        std::vector<double> loc(static_cast<size_t>(num_atoms) * n_acc, 0.0);
+
+#pragma omp for schedule(dynamic, 1)
+        for (size_t b = 0; b < n_blocks; b++) {
+            const size_t off = block_offset[b], np = block_size[b];
+            const int* atoms = block_atoms.data() + block_atoms_off[b];
+            const int na = static_cast<int>(block_atoms_off[b + 1] - block_atoms_off[b]);
+            if (na == 0) continue;  // no atom reaches this block; rho_0 was never formed there
+
+            for (size_t p = off; p < off + np; p++) {
+                const double xp = x_points[p], yp = y_points[p], zp = z_points[p];
+                const double wrho = weights[p] * rho[p] / rho_0_points[p];
+                const double* rho_a_0_here = &rho_a_0_points[p * num_atoms];
+
+                for (int ia = 0; ia < na; ia++) {
+                    const int a = atoms[ia];
+                    const double d[3] = {xp - atom_x[a], yp - atom_y[a], zp - atom_z[a]};
+                    // c = -w * rho_a; the multipoles carry the electron's negative charge, the
+                    // radial moments do not.
+                    const double c = -wrho * rho_a_0_here[a];
+                    double* la = &loc[static_cast<size_t>(a) * n_acc];
+
+                    la[0] += c;
+                    for (int i = 0; i < 3; i++) la[1 + i] += c * d[i];
+                    for (int q = 0; q < 6; q++) la[4 + q] += c * d[qpole_inds[q][0]] * d[qpole_inds[q][1]];
+                    for (int o = 0; o < 10; o++)
+                        la[10 + o] += c * d[opole_inds[o][0]] * d[opole_inds[o][1]] * d[opole_inds[o][2]];
+
+                    const double r2 = d[0] * d[0] + d[1] * d[1] + d[2] * d[2];
+                    const double r = std::sqrt(r2);
+                    double rn = r2;  // n = 2
+                    la[20] -= c * rn;
+                    for (int n = 3; n <= rmom_top; n++) {
+                        rn *= r;
+                        la[20 + n - 2] -= c * rn;
+                    }
+                }
             }
         }
+
+#pragma omp critical
+        {
+            for (size_t i = 0; i < acc.size(); i++) acc[i] += loc[i];
+        }
     }
+
+    std::vector<SharedMatrix> rmoms;
+    for (int n = 2; n <= rmom_top; n++) {
+        rmoms.push_back(std::make_shared<Matrix>("ATOMIC RADIAL MOMENTS <R^" + std::to_string(n) + ">", num_atoms, 1));
+    }
+    for (int a = 0; a < num_atoms; a++) {
+        const double* la = &acc[static_cast<size_t>(a) * n_acc];
+        mpole->set(a, 0, mol->Z(a) + la[0]);
+        for (int i = 0; i < 3; i++) dpole->set(a, i, la[1 + i]);
+        for (int q = 0; q < 6; q++) qpole->set(a, q, la[4 + q]);
+        for (int o = 0; o < 10; o++) opole->set(a, o, la[10 + o]);
+        for (int n = 2; n <= rmom_top; n++) rmoms[n - 2]->set(a, 0, la[20 + n - 2]);
+    }
+
+    timer_off("MBIS: multipoles");
 
     if (print_output) {
         outfile->Printf("  MBIS Charges: (a.u.)\n");
@@ -2215,7 +2607,6 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
     }
 
     const int max_power = options.get_int("MAX_RADIAL_MOMENT");
-    auto rmoms = compute_radial_moments(grid, rho_a, distances, num_atoms);
 
     for (int n = 2; n <= max_power; n++) {
         std::stringstream sstream;

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -1947,6 +1947,25 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
     int num_atoms = mol->natom();
     size_t total_points = grid->npoints();
 
+    // The pro-atom density array below is one double per (grid point, atom), and it is the one
+    // allocation here large enough to fail. Both factors grow with the molecule -- the grid has
+    // more points and each point carries more atoms -- so it is quadratic in system size, and the
+    // failure would otherwise arrive as a bare std::bad_alloc from deep inside a property
+    // calculation that has already paid for an SCF. Check it against the memory the user actually
+    // gave Psi4, before the grid density evaluation rather than after, and say what to do about it.
+    const size_t mbis_doubles = (static_cast<size_t>(num_atoms) + 7) * total_points;
+    const double mbis_gib = static_cast<double>(mbis_doubles) * sizeof(double) / (1024.0 * 1024.0 * 1024.0);
+    const double avail_gib = static_cast<double>(Process::environment.get_memory()) / (1024.0 * 1024.0 * 1024.0);
+    if (print_output) outfile->Printf("  MBIS Memory: needs %.3f GiB; user supplied %.3f GiB.\n\n", mbis_gib, avail_gib);
+    if (mbis_gib > avail_gib) {
+        throw PSIEXCEPTION(
+            "MBIS needs " + std::to_string(mbis_gib) + " GiB for its grid arrays but only " +
+            std::to_string(avail_gib) +
+            " GiB is available. The cost is (natom + 7) doubles per grid point, so either raise the "
+            "memory given to Psi4, or shrink the grid with the mbis_radial_points and "
+            "mbis_spherical_points options.");
+    }
+
     size_t max_points = 0;
     size_t max_nbf = 0;
 
@@ -2110,6 +2129,7 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
     // atoms of one point together, so this layout keeps those writes contiguous. Only the previous
     // iteration's values are needed (for the convergence test), so this is the single large array
     // MBIS now holds -- distances, displacements and the per-atom density are all recomputed.
+    // (Its size was checked against the available memory above, before the grid density pass.)
     timer_on("MBIS: alloc");
     std::vector<double> rho_a_0_points(static_cast<size_t>(num_atoms) * total_points, 0.0);
     timer_off("MBIS: alloc");

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -2204,11 +2204,13 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
             double cut = std::numeric_limits<double>::infinity();
             if (do_screen) {
                 cut = 0.0;
+                const double shell_eps = screen_eps / (shell_off[atom + 1] - shell_off[atom]);
                 for (int s = shell_off[atom]; s < shell_off[atom + 1]; s++) {
-                    // shell_coef * exp(-r/S) < eps  ->  r > S * ln(shell_coef / eps)
-                    if (shell_coef[s] > screen_eps) {
+                    // Requiring every shell to be below eps / nshell guarantees that their sum,
+                    // the pro-atom density documented by MBIS_SCREENING_THRESHOLD, is below eps.
+                    if (shell_coef[s] > shell_eps) {
                         const double S = -1.0 / shell_rate[s];
-                        cut = std::max(cut, S * std::log(shell_coef[s] / screen_eps));
+                        cut = std::max(cut, S * std::log(shell_coef[s] / shell_eps));
                     }
                 }
             }
@@ -2229,8 +2231,8 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
                 if (d < atom_cut[atom]) block_atoms.push_back(atom);
             }
             // Atoms present last time but not now: their stale densities must be zeroed. Both lists
-            // are ascending, so this is a merge. (The dropped values are below screen_eps by
-            // construction, so discarding them does not perturb the convergence delta.)
+            // are ascending, so this is a merge. The sweep accounts for the small transition from
+            // the stale value to zero in the convergence delta.
             if (!first_screening) {
                 size_t i = prev_atoms_off[b], j = block_atoms_off[b];
                 const size_t iend = prev_atoms_off[b + 1], jend = block_atoms.size();
@@ -2279,7 +2281,11 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
                 // densities; clear them so the (point, atom) entries stay uniformly valid.
                 for (size_t k = block_drop_off[b]; k < block_drop_off[b + 1]; k++) {
                     const int atom = block_drop[k];
-                    for (size_t p = off; p < off + np; p++) rho_a_0_points[p * num_atoms + atom] = 0.0;
+                    for (size_t p = off; p < off + np; p++) {
+                        double& stale_density = rho_a_0_points[p * num_atoms + atom];
+                        if (accumulate_delta) loc_d[atom] += weights[p] * stale_density * stale_density;
+                        stale_density = 0.0;
+                    }
                 }
                 if (na == 0) continue;
 

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -2123,9 +2123,19 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
     std::vector<int> mA(num_atoms);
     for (int atom = 0; atom < num_atoms; atom++) {
 
-        // MBIS is incompatible with ECPs: requires all-electron density
+        // MBIS needs an all-electron density, so an atom whose nuclear charge does not match its
+        // element is out of scope. Two quite different things land here, and they need different
+        // messages: an ECP replaces some of the electrons (0 < Z < true Z), whereas a ghost atom
+        // has no nucleus and no electrons at all (Z == 0), and telling someone doing a
+        // counterpoise correction that their ghost is an ECP sends them somewhere useless.
         int n_valence_electrons = static_cast<int>(mol->Z(atom));
         int true_atomic_num = static_cast<int>(mol->true_atomic_number(atom));
+        if (n_valence_electrons == 0) {
+            throw PSIEXCEPTION("MBIS does not support ghost atoms. Atom " + std::to_string(atom + 1) + " (" +
+                               mol->symbol(atom) +
+                               ") carries basis functions but no electrons, so it has no pro-atom to fit. Run MBIS on "
+                               "the molecule without ghosts.");
+        }
         if (n_valence_electrons != true_atomic_num) {
             throw PSIEXCEPTION("MBIS incompatible with ECP. ECP detected on atom " + std::to_string(atom + 1) + " (" +
                                mol->symbol(atom) + "). Use all-electron basis or reconstruct density with denspart.");

--- a/psi4/src/psi4/libmints/oeprop.cc
+++ b/psi4/src/psi4/libmints/oeprop.cc
@@ -2228,14 +2228,21 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
             // single contiguous batch instead of num_atoms batches of one to five.
             std::vector<double> bcoef, brate, barg, bval;
             std::vector<int> bglob, bstart;
+            // Accumulate into thread-local buffers and flush into the chunk slot at the end. The
+            // arithmetic order is still fixed by the chunk, so the result stays deterministic, but
+            // the hot accumulator stays in this thread's cache instead of living in a shared array.
+            std::vector<double> tls_n(total_shells), tls_s(total_shells), tls_d(num_atoms);
 
             // Chunks vary in surviving-atom count, so hand them out dynamically. Each chunk covers a
             // fixed contiguous range of blocks and owns its reduction buffers.
 #pragma omp for schedule(dynamic, 1)
             for (size_t chunk = 0; chunk < n_chunks; chunk++) {
-                double* loc_n = chunk_n.data() + chunk * total_shells;
-                double* loc_s = chunk_s.data() + chunk * total_shells;
-                double* loc_d = chunk_d.data() + chunk * num_atoms;
+                double* loc_n = tls_n.data();
+                double* loc_s = tls_s.data();
+                double* loc_d = tls_d.data();
+                std::fill(tls_n.begin(), tls_n.end(), 0.0);
+                std::fill(tls_s.begin(), tls_s.end(), 0.0);
+                std::fill(tls_d.begin(), tls_d.end(), 0.0);
                 const size_t block_begin = n_blocks * chunk / n_chunks;
                 const size_t block_end = n_blocks * (chunk + 1) / n_chunks;
                 for (size_t b = block_begin; b < block_end; b++) {
@@ -2315,6 +2322,9 @@ std::tuple<SharedMatrix, SharedMatrix, SharedMatrix, SharedMatrix> PopulationAna
                         rho_0_points[point] = rho_0;
                     }
                 }
+                std::copy(tls_n.begin(), tls_n.end(), chunk_n.begin() + chunk * total_shells);
+                std::copy(tls_s.begin(), tls_s.end(), chunk_s.begin() + chunk * total_shells);
+                std::copy(tls_d.begin(), tls_d.end(), chunk_d.begin() + chunk * num_atoms);
             }
         }
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -328,6 +328,14 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
                     "ROBUST TREUTLER NONE FLAT P_GAUSSIAN D_GAUSSIAN P_SLATER D_SLATER LOG_GAUSSIAN LOG_SLATER NONE");
     /*- Maximum Radial Moment to Calculate -*/
     options.add_int("MAX_RADIAL_MOMENT", 4);
+    /*- Accelerate the MBIS stockholder iteration with Anderson mixing on the shell populations
+        and widths. Switching this off converges to the same fixed point, just more slowly. -*/
+    options.add_bool("MBIS_ANDERSON", true);
+    /*- Pro-atom density below which an atom is dropped from a grid block in the MBIS stockholder
+        sweep. The cost of the sweep is O(natom * npoints) unscreened, and npoints itself grows with
+        natom, so this is what keeps MBIS from being quadratic in system size. Set to 0 to disable
+        screening entirely. !expert -*/
+    options.add_double("MBIS_SCREENING_THRESHOLD", 1.0e-14);
 
     /*- PCM boolean for pcmsolver module -*/
     options.add_bool("PCM", false);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,7 +67,7 @@ foreach(test_name aediis-1
                   fd-freq-gradient-large fd-gradient freq-isotope1 freq-isotope2 fnocc1 fnocc2
                   fnocc3 fnocc4 fnocc5 fnocc6 fnocc7 frac frac-ip-fitting frac-sym frac-traverse ghosts gibbs
                   lccd-grad1 lccd-grad2 matrix1 matrix2
-                  mbis-1 mbis-2 mbis-3 mbis-4 mbis-5 mbis-6 mbis-7 mcscf1 mcscf2 mcscf3
+                  mbis-1 mbis-2 mbis-3 mbis-4 mbis-5 mbis-6 mbis-7 mbis-8 mcscf1 mcscf2 mcscf3
                   mints1 mints2 mints3 mints4 mints5 mints6 mints8 mints-benchmark mints-helper
                   mints9 mints10 mints15 molden1 molden2 mom mom-h2o-3 mom-h2o-4
                   mp2-1 mp2-grad1 mp2-grad2 mp2-grad3 mp2-h mp2p5-grad1 mp2p5-grad2 mp3-grad1 mp3-grad2

--- a/tests/mbis-8/CMakeLists.txt
+++ b/tests/mbis-8/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(mbis-8 "psi;properties")

--- a/tests/mbis-8/input.dat
+++ b/tests/mbis-8/input.dat
@@ -1,4 +1,4 @@
-#! MBIS on NaCl: Anderson acceleration must not change the fixed point
+#! MBIS guards: Anderson must not change the fixed point (NaCl), and ghosts must say so
 #
 # Anderson mixing is a convergence accelerator, so switching it off must reach the same
 # stockholder fixed point, only more slowly. NaCl is the case that proves this is not automatic:
@@ -72,3 +72,30 @@ for label in ("anderson", "picard"):                                            
                      "MBIS Charges (%s)" % label)                                          #TEST
     compare_matrices(vwidths_ref, psi4.Matrix.from_array(results[label]["vwidths"]), 5,    #TEST
                      "MBIS Valence Widths (%s)" % label)                                   #TEST
+
+
+# A ghost atom carries basis functions but no electrons, so Z == 0 while its element says
+# otherwise -- the same inequality an ECP trips. Both used to be reported as "ECP detected",
+# which sends anyone doing a counterpoise correction after an all-electron basis they do not
+# need. Pin the two apart: the ghost must be named as a ghost, and must not be called an ECP.
+ghosted = psi4.geometry("""
+0 1
+Ne 0.00 0.00 0.00
+--
+@Ne 0.00 0.00 3.00
+symmetry c1
+no_reorient
+no_com
+""")
+
+e_gh, wfn_gh = energy('hf/cc-pvdz', return_wfn=True, molecule=ghosted)
+ghost_error = ""
+try:
+    oeprop(wfn_gh, 'MBIS_CHARGES', title='ghost')
+except RuntimeError as exc:
+    ghost_error = str(exc)
+
+compare(True, "does not support ghost atoms" in ghost_error,                               #TEST
+        "ghost atom is named as a ghost")                                                  #TEST
+compare(True, "ECP" not in ghost_error,                                                    #TEST
+        "ghost atom is not misreported as an ECP")                                         #TEST

--- a/tests/mbis-8/input.dat
+++ b/tests/mbis-8/input.dat
@@ -1,0 +1,74 @@
+#! MBIS on NaCl: Anderson acceleration must not change the fixed point
+#
+# Anderson mixing is a convergence accelerator, so switching it off must reach the same
+# stockholder fixed point, only more slowly. NaCl is the case that proves this is not automatic:
+# an unsafeguarded Anderson iteration oscillates here, drives a shell population to zero, and
+# returns NaN charges -- while reporting convergence, because the density change between two
+# all-zero densities is exactly zero. This test pins both halves of that: the two paths agree
+# with each other, and neither produces a non-finite number.
+#
+# References are the mbis-4 values, so both paths are anchored to known-good results rather than
+# merely to one another.
+
+import numpy as np
+
+charges_ref = psi4.Matrix.from_list([ #TEST
+ [ 0.96523585],   #TEST
+ [-0.96523183]])  #TEST
+
+vwidths_ref = psi4.Matrix.from_list([  #TEST
+ [1.13464706],     #TEST
+ [0.56829083]])    #TEST
+
+molecule mol {
+  0 1
+  Na 0.00 0.00 0.00
+  Cl 0.00 0.00 2.36
+  symmetry c1
+  no_reorient
+  no_com
+}
+
+set {
+  scf_type df
+  d_convergence 8
+  e_convergence 9
+  mbis_radial_points 99
+  mbis_spherical_points 350
+}
+
+e, wfn = energy('hf/cc-pvdz', return_wfn=True)
+
+results = {}
+for label, accelerate in (("anderson", True), ("picard", False)):
+    psi4.set_options({"mbis_anderson": accelerate})
+    oeprop(wfn, 'MBIS_CHARGES', title='NaCl ' + label)
+    results[label] = {
+        "charges": np.array(wfn.array_variable('MBIS CHARGES')),
+        "vwidths": np.array(wfn.array_variable('MBIS VALENCE WIDTHS')),
+        "vcharges": np.array(wfn.array_variable('MBIS VALENCE CHARGES')),
+    }
+
+# The NaN regression: every MBIS quantity must be a number, on both paths.
+for label, quantities in results.items():                                                  #TEST
+    for name, value in quantities.items():                                                 #TEST
+        compare_integers(1, int(np.all(np.isfinite(value))),                               #TEST
+                         "MBIS %s %s finite" % (label, name))                              #TEST
+
+# Acceleration must not move the fixed point. MBIS_D_CONVERGENCE = 1e-8 is a tolerance on the
+# pro-atom *density*, and it does not pin every derived quantity equally: two iteration paths that
+# both satisfy it agree to ~1e-7 on the charges but only ~1e-6 on the valence widths, which are
+# sum_s / (3 N) and so divide one converged sum by another. The tolerances below are set from
+# that measured behaviour, not from an assumption that the two paths are interchangeable to
+# machine precision.
+cross_path_digits = {"charges": 6, "vcharges": 6, "vwidths": 5}                            #TEST
+for name, digits in cross_path_digits.items():                                             #TEST
+    compare_values(results["picard"][name], results["anderson"][name], digits,             #TEST
+                   "MBIS %s: Anderson matches Picard" % name)                              #TEST
+
+# ... and both must still be right.
+for label in ("anderson", "picard"):                                                       #TEST
+    compare_matrices(charges_ref, psi4.Matrix.from_array(results[label]["charges"]), 5,    #TEST
+                     "MBIS Charges (%s)" % label)                                          #TEST
+    compare_matrices(vwidths_ref, psi4.Matrix.from_array(results[label]["vwidths"]), 5,    #TEST
+                     "MBIS Valence Widths (%s)" % label)                                   #TEST

--- a/tests/mbis-8/output.ref
+++ b/tests/mbis-8/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.12a1.dev41 
+                               Psi4 1.12a1.dev45 
 
-                         Git: Rev {mbis_speed1} fcbafa8 dirty
+                         Git: Rev {mbis_speed1} 4dd891c dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -32,15 +32,15 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Friday, 11 September 2026 02:12AM
+    Psi4 started on: Friday, 11 September 2026 04:46AM
 
-    Process ID: 3449644
-    Host:       atl1-1-02-002-27-1.pace.gatech.edu
+    Process ID: 1391034
+    Host:       atl1-1-02-002-25-1.pace.gatech.edu
     PSIDATADIR: /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     Addons:     a̶d̶c̶c̶, a̶m̶b̶i̶t̶, b̶s̶e̶, c̶c̶t̶3̶, c̶f̶o̶u̶r̶, c̶h̶e̶m̶p̶s̶2̶, c̶p̶p̶e̶, d̶d̶x̶, dftd3,
-                dftd4, d̶k̶h̶, e̶c̶p̶i̶n̶t̶, e̶i̶n̶s̶u̶m̶s̶, f̶o̶r̶t̶e̶, g̶a̶u̶x̶c̶, g̶c̶p̶,
+                dftd4, d̶k̶h̶, ecpint, e̶i̶n̶s̶u̶m̶s̶, f̶o̶r̶t̶e̶, g̶a̶u̶x̶c̶, g̶c̶p̶,
                 g̶d̶m̶a̶, g̶e̶o̶m̶e̶t̶r̶i̶c̶, g̶p̶u̶_̶d̶f̶c̶c̶, i̶n̶t̶e̶g̶r̶a̶t̶o̶r̶x̶x̶,
                 i̶p̶i̶, l̶i̶b̶e̶f̶p̶, m̶d̶i̶, m̶p̶2̶d̶, m̶r̶c̶c̶, o̶o̶o̶,
                 o̶p̶e̶n̶f̶e̶r̶m̶i̶o̶n̶p̶s̶i̶4̶, p̶c̶m̶s̶o̶l̶v̶e̶r̶, p̶s̶i̶4̶f̶o̶c̶k̶c̶i̶,
@@ -50,7 +50,7 @@
   ==> Input File <==
 
 --------------------------------------------------------------------------
-#! MBIS on NaCl: Anderson acceleration must not change the fixed point
+#! MBIS guards: Anderson must not change the fixed point (NaCl), and ghosts must say so
 #
 # Anderson mixing is a convergence accelerator, so switching it off must reach the same
 # stockholder fixed point, only more slowly. NaCl is the case that proves this is not automatic:
@@ -124,6 +124,33 @@ for label in ("anderson", "picard"):                                            
                      "MBIS Charges (%s)" % label)                                          #TEST
     compare_matrices(vwidths_ref, psi4.Matrix.from_array(results[label]["vwidths"]), 5,    #TEST
                      "MBIS Valence Widths (%s)" % label)                                   #TEST
+
+
+# A ghost atom carries basis functions but no electrons, so Z == 0 while its element says
+# otherwise -- the same inequality an ECP trips. Both used to be reported as "ECP detected",
+# which sends anyone doing a counterpoise correction after an all-electron basis they do not
+# need. Pin the two apart: the ghost must be named as a ghost, and must not be called an ECP.
+ghosted = psi4.geometry("""
+0 1
+Ne 0.00 0.00 0.00
+--
+@Ne 0.00 0.00 3.00
+symmetry c1
+no_reorient
+no_com
+""")
+
+e_gh, wfn_gh = energy('hf/cc-pvdz', return_wfn=True, molecule=ghosted)
+ghost_error = ""
+try:
+    oeprop(wfn_gh, 'MBIS_CHARGES', title='ghost')
+except RuntimeError as exc:
+    ghost_error = str(exc)
+
+compare(True, "does not support ghost atoms" in ghost_error,                               #TEST
+        "ghost atom is named as a ghost")                                                  #TEST
+compare(True, "ECP" not in ghost_error,                                                    #TEST
+        "ghost atom is not misreported as an ECP")                                         #TEST
 --------------------------------------------------------------------------
 
 Scratch directory: /tmp/
@@ -134,8 +161,8 @@ Scratch directory: /tmp/
     Onebody   basis highest AM E, G, H:  -, -, -
     Solid Harmonics ordering:            Gaussian
 
-*** tstart() called on atl1-1-02-002-27-1.pace.gatech.edu
-*** at Fri Sep 11 02:12:54 2026
+*** tstart() called on atl1-1-02-002-25-1.pace.gatech.edu
+*** at Fri Sep 11 04:46:45 2026
 
    => Loading Basis Set <=
 
@@ -255,17 +282,17 @@ Scratch directory: /tmp/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -620.94148883015089   -6.20941e+02   0.00000e+00 
-   @DF-RHF iter   1:  -621.38771176646571   -4.46223e-01   6.97696e-03 ADIIS/DIIS
-   @DF-RHF iter   2:  -621.42850815199733   -4.07964e-02   2.82756e-03 ADIIS/DIIS
-   @DF-RHF iter   3:  -621.43354301212594   -5.03486e-03   1.88946e-04 ADIIS/DIIS
-   @DF-RHF iter   4:  -621.43361677227108   -7.37601e-05   5.29915e-05 DIIS
-   @DF-RHF iter   5:  -621.43362372733225   -6.95506e-06   9.59533e-06 DIIS
-   @DF-RHF iter   6:  -621.43362400393505   -2.76603e-07   3.18994e-06 DIIS
-   @DF-RHF iter   7:  -621.43362404937579   -4.54407e-08   5.22507e-07 DIIS
-   @DF-RHF iter   8:  -621.43362405031155   -9.35756e-10   7.88247e-08 DIIS
-   @DF-RHF iter   9:  -621.43362405032667   -1.51203e-11   1.12752e-08 DIIS
-   @DF-RHF iter  10:  -621.43362405032690   -2.27374e-13   1.32594e-09 DIIS
+   @DF-RHF iter SAD:  -620.94148883013065   -6.20941e+02   0.00000e+00 
+   @DF-RHF iter   1:  -621.38771176644502   -4.46223e-01   6.97696e-03 ADIIS/DIIS
+   @DF-RHF iter   2:  -621.42850815197767   -4.07964e-02   2.82756e-03 ADIIS/DIIS
+   @DF-RHF iter   3:  -621.43354301210525   -5.03486e-03   1.88946e-04 ADIIS/DIIS
+   @DF-RHF iter   4:  -621.43361677225141   -7.37601e-05   5.29915e-05 DIIS
+   @DF-RHF iter   5:  -621.43362372731133   -6.95506e-06   9.59533e-06 DIIS
+   @DF-RHF iter   6:  -621.43362400391459   -2.76603e-07   3.18994e-06 DIIS
+   @DF-RHF iter   7:  -621.43362404935579   -4.54412e-08   5.22507e-07 DIIS
+   @DF-RHF iter   8:  -621.43362405029097   -9.35188e-10   7.88247e-08 DIIS
+   @DF-RHF iter   9:  -621.43362405030621   -1.52340e-11   1.12752e-08 DIIS
+   @DF-RHF iter  10:  -621.43362405030689   -6.82121e-13   1.32594e-09 DIIS
   Energy and wave function converged.
 
 
@@ -299,14 +326,14 @@ Scratch directory: /tmp/
     NA   [    14 ]
     NB   [    14 ]
 
-  @DF-RHF Final Energy:  -621.43362405032690
+  @DF-RHF Final Energy:  -621.43362405030689
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             41.9305671166483052
-    One-Electron Energy =                -949.1924605660532279
-    Two-Electron Energy =                 285.8282693990780672
-    Total Energy =                       -621.4336240503268982
+    One-Electron Energy =                -949.1924605660614134
+    Two-Electron Energy =                 285.8282693991063184
+    Total Energy =                       -621.4336240503068893
 
 Computation Completed
 
@@ -323,21 +350,21 @@ Properties computed using the SCF density matrix
  ------------------------------------------------------------------------------------
 
  L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
- Dipole X            :         -0.0000000            0.0000000           -0.0000000
- Dipole Y            :         -0.0000000            0.0000000           -0.0000000
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
  Dipole Z            :        -79.4879772           75.8158122           -3.6721650
  Magnitude           :                                                    3.6721650
 
  ------------------------------------------------------------------------------------
 
-*** tstop() called on atl1-1-02-002-27-1.pace.gatech.edu at Fri Sep 11 02:12:56 2026
+*** tstop() called on atl1-1-02-002-25-1.pace.gatech.edu at Fri Sep 11 04:46:47 2026
 Module time:
-	user time   =       0.92 seconds =       0.02 minutes
-	system time =       0.12 seconds =       0.00 minutes
+	user time   =       0.97 seconds =       0.02 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 Total time:
-	user time   =       0.92 seconds =       0.02 minutes
-	system time =       0.12 seconds =       0.00 minutes
+	user time   =       0.97 seconds =       0.02 minutes
+	system time =       0.13 seconds =       0.00 minutes
 	total time  =          2 seconds =       0.03 minutes
 
 
@@ -359,18 +386,18 @@ Properties computed using the NaCl anderson density matrix
 
   MBIS Dipoles: [e a0]
    Center  Symbol  Z        X           Y           Z
-      1      NA   11   -0.000000   -0.000000   -0.009806
-      2      CL   17   -0.000000   -0.000000    0.642358
+      1      NA   11   -0.000000    0.000000   -0.009806
+      2      CL   17    0.000000    0.000000    0.642358
 
   MBIS Quadrupoles: [e a0^2]
    Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
       1      NA   11   -2.3499    0.0000    0.0000   -2.3499    0.0000   -2.2898
-      2      CL   17   -11.8920   -0.0000    0.0000   -11.8920    0.0000   -12.0798
+      2      CL   17   -11.8920    0.0000   -0.0000   -11.8920   -0.0000   -12.0798
 
   MBIS Octupoles: [e a0^3]
    Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
       1      NA   11   -0.0000    0.0000   -0.0256   -0.0000    0.0000   -0.0000   -0.0000   -0.0256    0.0000   -0.0592
-      2      CL   17   -0.0000   -0.0000    2.2570   -0.0000    0.0000   -0.0000   -0.0000    2.2570   -0.0000    4.5695
+      2      CL   17    0.0000    0.0000    2.2570   -0.0000    0.0000   -0.0000   -0.0000    2.2570    0.0000    4.5695
 
   MBIS Radial Moments:
    Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
@@ -407,18 +434,18 @@ Properties computed using the NaCl picard density matrix
 
   MBIS Dipoles: [e a0]
    Center  Symbol  Z        X           Y           Z
-      1      NA   11   -0.000000   -0.000000   -0.009806
-      2      CL   17   -0.000000   -0.000000    0.642357
+      1      NA   11   -0.000000    0.000000   -0.009806
+      2      CL   17    0.000000    0.000000    0.642357
 
   MBIS Quadrupoles: [e a0^2]
    Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
       1      NA   11   -2.3499    0.0000    0.0000   -2.3499    0.0000   -2.2898
-      2      CL   17   -11.8920   -0.0000    0.0000   -11.8920    0.0000   -12.0798
+      2      CL   17   -11.8920   -0.0000   -0.0000   -11.8920   -0.0000   -12.0798
 
   MBIS Octupoles: [e a0^3]
    Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
       1      NA   11   -0.0000    0.0000   -0.0256   -0.0000    0.0000   -0.0000   -0.0000   -0.0256    0.0000   -0.0592
-      2      CL   17   -0.0000   -0.0000    2.2570   -0.0000    0.0000   -0.0000   -0.0000    2.2570   -0.0000    4.5695
+      2      CL   17   -0.0000    0.0000    2.2570    0.0000    0.0000   -0.0000   -0.0000    2.2570    0.0000    4.5695
 
   MBIS Radial Moments:
    Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
@@ -449,7 +476,227 @@ Properties computed using the NaCl picard density matrix
     MBIS Charges (picard).................................................................PASSED
     MBIS Valence Widths (picard)..........................................................PASSED
 
-    Psi4 stopped on: Friday, 11 September 2026 02:12AM
-    Psi4 wall time for execution: 0:00:03.01
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on atl1-1-02-002-25-1.pace.gatech.edu
+*** at Fri Sep 11 04:46:49 2026
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry NE         line   258 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         NE           0.000000000000     0.000000000000     0.000000000000    19.992440176200
+      Gh(NE)          0.000000000000     0.000000000000     3.000000000000    19.992440176200
+
+  Running in c1 symmetry.
+
+  Rotational constants: A = ************  B =      0.09369  C =      0.09369 [cm^-1]
+  Rotational constants: A = ************  B =   2808.72283  C =   2808.72283 [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 28
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry NE         line   321 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):      18.6224
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 48
+    Number of basis functions: 140
+    Number of Cartesian functions: 162
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 1.9312724808E-01.
+  Reciprocal condition number of the overlap matrix is 1.1328320081E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         28      28 
+   -------------------------
+    Total      28      28
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -128.48879233394612   -1.28489e+02   0.00000e+00 
+   @DF-RHF iter   1:  -128.48885961916667   -6.72852e-05   6.19114e-05 DIIS
+   @DF-RHF iter   2:  -128.48886077776811   -1.15860e-06   2.13275e-05 DIIS
+   @DF-RHF iter   3:  -128.48886086910284   -9.13347e-08   3.55500e-06 DIIS
+   @DF-RHF iter   4:  -128.48886087227083   -3.16800e-09   1.07507e-07 DIIS
+   @DF-RHF iter   5:  -128.48886087227609   -5.25802e-12   1.67616e-08 DIIS
+   @DF-RHF iter   6:  -128.48886087227606    2.84217e-14   4.72146e-10 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -32.765791     2A     -1.918887     3A     -0.832199  
+       4A     -0.832199     5A     -0.832177  
+
+    Virtual:                                                              
+
+       6A      0.660586     7A      1.058968     8A      1.060670  
+       9A      1.060670    10A      1.694622    11A      1.694622  
+      12A      1.697372    13A      2.159700    14A      4.155364  
+      15A      5.197019    16A      5.197020    17A      5.197020  
+      18A      5.197022    19A      5.197022    20A      7.707040  
+      21A      7.707040    22A      7.707042    23A      7.707042  
+      24A      7.707045    25A      8.670154    26A      8.670154  
+      27A      8.670882    28A     53.244243  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+    NA   [     5 ]
+    NB   [     5 ]
+
+  @DF-RHF Final Energy:  -128.48886087227606
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -182.6152154857397534
+    Two-Electron Energy =                  54.1263546134636897
+    Total Energy =                       -128.4888608722760637
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :         -0.0005041            0.0000000           -0.0005041
+ Magnitude           :                                                    0.0005041
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on atl1-1-02-002-25-1.pace.gatech.edu at Fri Sep 11 04:46:49 2026
+Module time:
+	user time   =       0.21 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.19 seconds =       0.05 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the ghost density matrix
+
+  ==> Computing MBIS Charges <==
+
+  MBIS Memory: needs 0.003 GiB; user supplied 0.488 GiB.
+
+  Electron Count from Grid (Expected Number): 10.00000 (10.00000)
+  Difference:  0.00000
+
+    ghost atom is named as a ghost........................................................PASSED
+    ghost atom is not misreported as an ECP...............................................PASSED
+
+    Psi4 stopped on: Friday, 11 September 2026 04:46AM
+    Psi4 wall time for execution: 0:00:03.73
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/mbis-8/output.ref
+++ b/tests/mbis-8/output.ref
@@ -1,0 +1,455 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.12a1.dev41 
+
+                         Git: Rev {mbis_speed1} fcbafa8 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, D. L. Poole, T. Győri, E. C. Mitchell, J. P. Pederson,
+    and A. M. Wallace
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    https://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Friday, 11 September 2026 02:12AM
+
+    Process ID: 3449644
+    Host:       atl1-1-02-002-27-1.pace.gatech.edu
+    PSIDATADIR: /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    Addons:     a̶d̶c̶c̶, a̶m̶b̶i̶t̶, b̶s̶e̶, c̶c̶t̶3̶, c̶f̶o̶u̶r̶, c̶h̶e̶m̶p̶s̶2̶, c̶p̶p̶e̶, d̶d̶x̶, dftd3,
+                dftd4, d̶k̶h̶, e̶c̶p̶i̶n̶t̶, e̶i̶n̶s̶u̶m̶s̶, f̶o̶r̶t̶e̶, g̶a̶u̶x̶c̶, g̶c̶p̶,
+                g̶d̶m̶a̶, g̶e̶o̶m̶e̶t̶r̶i̶c̶, g̶p̶u̶_̶d̶f̶c̶c̶, i̶n̶t̶e̶g̶r̶a̶t̶o̶r̶x̶x̶,
+                i̶p̶i̶, l̶i̶b̶e̶f̶p̶, m̶d̶i̶, m̶p̶2̶d̶, m̶r̶c̶c̶, o̶o̶o̶,
+                o̶p̶e̶n̶f̶e̶r̶m̶i̶o̶n̶p̶s̶i̶4̶, p̶c̶m̶s̶o̶l̶v̶e̶r̶, p̶s̶i̶4̶f̶o̶c̶k̶c̶i̶,
+                p̶s̶i̶x̶a̶s̶, p̶y̶e̶i̶n̶s̶u̶m̶s̶, qcmanybody, r̶e̶s̶p̶, s̶i̶m̶i̶n̶t̶,
+                s̶n̶s̶m̶p̶2̶, v̶2̶r̶d̶m̶_̶c̶a̶s̶s̶c̶f̶
+
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! MBIS on NaCl: Anderson acceleration must not change the fixed point
+#
+# Anderson mixing is a convergence accelerator, so switching it off must reach the same
+# stockholder fixed point, only more slowly. NaCl is the case that proves this is not automatic:
+# an unsafeguarded Anderson iteration oscillates here, drives a shell population to zero, and
+# returns NaN charges -- while reporting convergence, because the density change between two
+# all-zero densities is exactly zero. This test pins both halves of that: the two paths agree
+# with each other, and neither produces a non-finite number.
+#
+# References are the mbis-4 values, so both paths are anchored to known-good results rather than
+# merely to one another.
+
+import numpy as np
+
+charges_ref = psi4.Matrix.from_list([ #TEST
+ [ 0.96523585],   #TEST
+ [-0.96523183]])  #TEST
+
+vwidths_ref = psi4.Matrix.from_list([  #TEST
+ [1.13464706],     #TEST
+ [0.56829083]])    #TEST
+
+molecule mol {
+  0 1
+  Na 0.00 0.00 0.00
+  Cl 0.00 0.00 2.36
+  symmetry c1
+  no_reorient
+  no_com
+}
+
+set {
+  scf_type df
+  d_convergence 8
+  e_convergence 9
+  mbis_radial_points 99
+  mbis_spherical_points 350
+}
+
+e, wfn = energy('hf/cc-pvdz', return_wfn=True)
+
+results = {}
+for label, accelerate in (("anderson", True), ("picard", False)):
+    psi4.set_options({"mbis_anderson": accelerate})
+    oeprop(wfn, 'MBIS_CHARGES', title='NaCl ' + label)
+    results[label] = {
+        "charges": np.array(wfn.array_variable('MBIS CHARGES')),
+        "vwidths": np.array(wfn.array_variable('MBIS VALENCE WIDTHS')),
+        "vcharges": np.array(wfn.array_variable('MBIS VALENCE CHARGES')),
+    }
+
+# The NaN regression: every MBIS quantity must be a number, on both paths.
+for label, quantities in results.items():                                                  #TEST
+    for name, value in quantities.items():                                                 #TEST
+        compare_integers(1, int(np.all(np.isfinite(value))),                               #TEST
+                         "MBIS %s %s finite" % (label, name))                              #TEST
+
+# Acceleration must not move the fixed point. MBIS_D_CONVERGENCE = 1e-8 is a tolerance on the
+# pro-atom *density*, and it does not pin every derived quantity equally: two iteration paths that
+# both satisfy it agree to ~1e-7 on the charges but only ~1e-6 on the valence widths, which are
+# sum_s / (3 N) and so divide one converged sum by another. The tolerances below are set from
+# that measured behaviour, not from an assumption that the two paths are interchangeable to
+# machine precision.
+cross_path_digits = {"charges": 6, "vcharges": 6, "vwidths": 5}                            #TEST
+for name, digits in cross_path_digits.items():                                             #TEST
+    compare_values(results["picard"][name], results["anderson"][name], digits,             #TEST
+                   "MBIS %s: Anderson matches Picard" % name)                              #TEST
+
+# ... and both must still be right.
+for label in ("anderson", "picard"):                                                       #TEST
+    compare_matrices(charges_ref, psi4.Matrix.from_array(results[label]["charges"]), 5,    #TEST
+                     "MBIS Charges (%s)" % label)                                          #TEST
+    compare_matrices(vwidths_ref, psi4.Matrix.from_array(results[label]["vwidths"]), 5,    #TEST
+                     "MBIS Valence Widths (%s)" % label)                                   #TEST
+--------------------------------------------------------------------------
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on atl1-1-02-002-27-1.pace.gatech.edu
+*** at Fri Sep 11 02:12:54 2026
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry NA         line   288 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2 entry CL         line   658 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         NA           0.000000000000     0.000000000000     0.000000000000    22.989769282000
+         CL           0.000000000000     0.000000000000     2.360000000000    34.968852682000
+
+  Running in c1 symmetry.
+
+  Rotational constants: A = ************  B =      0.08655  C =      0.08655 [cm^-1]
+  Rotational constants: A = ************  B =   2594.84732  C =   2594.84732 [MHz]
+  Nuclear repulsion =   41.930567116648305
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 28
+  Nalpha       = 14
+  Nbeta        = 14
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 16
+    Number of basis functions: 36
+    Number of Cartesian functions: 38
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: (CC-PVDZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry NA         line   498 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2 entry CL         line   667 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.003 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (CC-PVDZ AUX)
+    Blend: CC-PVDZ-JKFIT + DEF2-UNIVERSAL-JKFIT
+    Number of shells: 70
+    Number of basis functions: 224
+    Number of Cartesian functions: 267
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 1.0327031572E-02.
+  Reciprocal condition number of the overlap matrix is 3.7657931940E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         36      36 
+   -------------------------
+    Total      36      36
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -620.94148883015089   -6.20941e+02   0.00000e+00 
+   @DF-RHF iter   1:  -621.38771176646571   -4.46223e-01   6.97696e-03 ADIIS/DIIS
+   @DF-RHF iter   2:  -621.42850815199733   -4.07964e-02   2.82756e-03 ADIIS/DIIS
+   @DF-RHF iter   3:  -621.43354301212594   -5.03486e-03   1.88946e-04 ADIIS/DIIS
+   @DF-RHF iter   4:  -621.43361677227108   -7.37601e-05   5.29915e-05 DIIS
+   @DF-RHF iter   5:  -621.43362372733225   -6.95506e-06   9.59533e-06 DIIS
+   @DF-RHF iter   6:  -621.43362400393505   -2.76603e-07   3.18994e-06 DIIS
+   @DF-RHF iter   7:  -621.43362404937579   -4.54407e-08   5.22507e-07 DIIS
+   @DF-RHF iter   8:  -621.43362405031155   -9.35756e-10   7.88247e-08 DIIS
+   @DF-RHF iter   9:  -621.43362405032667   -1.51203e-11   1.12752e-08 DIIS
+   @DF-RHF iter  10:  -621.43362405032690   -2.27374e-13   1.32594e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A   -104.698637     2A    -40.505194     3A    -10.423282  
+       4A     -7.889706     5A     -7.888905     6A     -7.888905  
+       7A     -2.827009     8A     -1.549220     9A     -1.549210  
+      10A     -1.549210    11A     -0.937466    12A     -0.364644  
+      13A     -0.348287    14A     -0.348287  
+
+    Virtual:                                                              
+
+      15A     -0.016752    16A      0.035654    17A      0.035654  
+      18A      0.067079    19A      0.111400    20A      0.146052  
+      21A      0.146052    22A      0.204707    23A      0.244898  
+      24A      0.244898    25A      0.290988    26A      0.290988  
+      27A      0.378292    28A      0.925512    29A      0.925512  
+      30A      0.933579    31A      1.094051    32A      1.111512  
+      33A      1.111512    34A      1.152404    35A      1.152404  
+      36A      1.376553  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    14 ]
+    NA   [    14 ]
+    NB   [    14 ]
+
+  @DF-RHF Final Energy:  -621.43362405032690
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             41.9305671166483052
+    One-Electron Energy =                -949.1924605660532279
+    Two-Electron Energy =                 285.8282693990780672
+    Total Energy =                       -621.4336240503268982
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Y            :         -0.0000000            0.0000000           -0.0000000
+ Dipole Z            :        -79.4879772           75.8158122           -3.6721650
+ Magnitude           :                                                    3.6721650
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on atl1-1-02-002-27-1.pace.gatech.edu at Fri Sep 11 02:12:56 2026
+Module time:
+	user time   =       0.92 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       0.92 seconds =       0.02 minutes
+	system time =       0.12 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the NaCl anderson density matrix
+
+  ==> Computing MBIS Charges <==
+
+  MBIS Memory: needs 0.003 GiB; user supplied 0.488 GiB.
+
+  Electron Count from Grid (Expected Number): 28.00000 (28.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1      NA   11   10.034764    0.965236
+      2      CL   17   17.965232   -0.965232
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1      NA   11   -0.000000   -0.000000   -0.009806
+      2      CL   17   -0.000000   -0.000000    0.642358
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1      NA   11   -2.3499    0.0000    0.0000   -2.3499    0.0000   -2.2898
+      2      CL   17   -11.8920   -0.0000    0.0000   -11.8920    0.0000   -12.0798
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1      NA   11   -0.0000    0.0000   -0.0256   -0.0000    0.0000   -0.0000   -0.0000   -0.0256    0.0000   -0.0592
+      2      CL   17   -0.0000   -0.0000    2.2570   -0.0000    0.0000   -0.0000   -0.0000    2.2570   -0.0000    4.5695
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1      NA   11    6.989657   10.985662   33.141114
+      2      CL   17   35.863783   93.713828   296.832772
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1      NA   11    1.134648
+      2      CL   17    0.568291
+
+
+  MBIS Valence Charges: (a.u.)
+   Center  Symbol  Z     Charge
+      1      NA   11   -0.032768
+      2      CL   17   -9.231223
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the NaCl picard density matrix
+
+  ==> Computing MBIS Charges <==
+
+  MBIS Memory: needs 0.003 GiB; user supplied 0.488 GiB.
+
+  Electron Count from Grid (Expected Number): 28.00000 (28.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1      NA   11   10.034764    0.965236
+      2      CL   17   17.965232   -0.965232
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1      NA   11   -0.000000   -0.000000   -0.009806
+      2      CL   17   -0.000000   -0.000000    0.642357
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1      NA   11   -2.3499    0.0000    0.0000   -2.3499    0.0000   -2.2898
+      2      CL   17   -11.8920   -0.0000    0.0000   -11.8920    0.0000   -12.0798
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1      NA   11   -0.0000    0.0000   -0.0256   -0.0000    0.0000   -0.0000   -0.0000   -0.0256    0.0000   -0.0592
+      2      CL   17   -0.0000   -0.0000    2.2570   -0.0000    0.0000   -0.0000   -0.0000    2.2570   -0.0000    4.5695
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1      NA   11    6.989657   10.985663   33.141116
+      2      CL   17   35.863782   93.713824   296.832754
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1      NA   11    1.134647
+      2      CL   17    0.568291
+
+
+  MBIS Valence Charges: (a.u.)
+   Center  Symbol  Z     Charge
+      1      NA   11   -0.032768
+      2      CL   17   -9.231223
+    MBIS anderson charges finite..........................................................PASSED
+    MBIS anderson vwidths finite..........................................................PASSED
+    MBIS anderson vcharges finite.........................................................PASSED
+    MBIS picard charges finite............................................................PASSED
+    MBIS picard vwidths finite............................................................PASSED
+    MBIS picard vcharges finite...........................................................PASSED
+    MBIS charges: Anderson matches Picard.................................................PASSED
+    MBIS vcharges: Anderson matches Picard................................................PASSED
+    MBIS vwidths: Anderson matches Picard.................................................PASSED
+    MBIS Charges (anderson)...............................................................PASSED
+    MBIS Valence Widths (anderson)........................................................PASSED
+    MBIS Charges (picard).................................................................PASSED
+    MBIS Valence Widths (picard)..........................................................PASSED
+
+    Psi4 stopped on: Friday, 11 September 2026 02:12AM
+    Psi4 wall time for execution: 0:00:03.01
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/mbis-8/test_input.py
+++ b/tests/mbis-8/test_input.py
@@ -1,0 +1,6 @@
+from addons import *
+
+@ctest_labeler("properties")
+def test_mbis_8():
+    ctest_runner(__file__)
+

--- a/tests/mbis-ecp/input.dat
+++ b/tests/mbis-ecp/input.dat
@@ -1,6 +1,6 @@
 #! MBIS regression test catching ECPs
 
-molecule mol {
+molecule mei {
   0 1
   C 0.000000 0.000000 0.000000
   I 0.000000 0.000000 2.105000
@@ -26,7 +26,9 @@ if psi4.core.get_option("scf", "orbital_optimizer_package") != "INTERNAL":  # KP
 set scf_properties ['MBIS_CHARGES', 'MBIS_VOLUME_RATIOS']
 
 try:
-    energy("mp2/def2-svp", molecule=hi)
+    energy("mp2/def2-svp", molecule=mei)
     compare_values(0, 1, "MBIS should have raised an error for ECP-containing basis sets.")
-except Exception:
-    compare_values(1, 1, "Expected error caught: MBIS correctly rejects ECP systems.")
+except RuntimeError as e:
+    # Check the message, not just the type: an unrelated RuntimeError from the SCF would
+    # otherwise satisfy this test without the ECP path ever being reached.
+    compare(True, "MBIS incompatible with ECP" in str(e), "Expected error caught: MBIS correctly rejects ECP systems.")

--- a/tests/mbis-ecp/output.ref
+++ b/tests/mbis-ecp/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.11a1.dev62 
+                               Psi4 1.12a1.dev44 
 
-                         Git: Rev {HEAD} c6ce4dd 
+                         Git: Rev {mbis_speed1} f492046 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -32,25 +32,27 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Friday, 19 June 2026 01:04PM
+    Psi4 started on: Friday, 11 September 2026 04:20AM
 
-    Process ID: 24027
-    Host:       sjc22-bm212-893c74a7-15c4-4bdb-ab11-9de3141bd4d4-4EA9747036E0.local
-    PSIDATADIR: /Users/runner/work/psi4/psi4/install/share/psi4
+    Process ID: 3511377
+    Host:       atl1-1-02-002-27-1.pace.gatech.edu
+    PSIDATADIR: /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4
     Memory:     500.0 MiB
     Threads:    1
-    Addons:     adcc, ambit, bse, c̶c̶t̶3̶, c̶f̶o̶u̶r̶, c̶h̶e̶m̶p̶s̶2̶, cppe, ddx, dftd3, dftd4, dkh, ecpint,
-                einsums, f̶o̶r̶t̶e̶, g̶a̶u̶x̶c̶, gcp, gdma, geometric, g̶p̶u̶_̶d̶f̶c̶c̶,
-                integratorxx, ipi, libefp, mdi, m̶p̶2̶d̶, m̶r̶c̶c̶, ooo,
-                o̶p̶e̶n̶f̶e̶r̶m̶i̶o̶n̶p̶s̶i̶4̶, pcmsolver, p̶s̶i̶4̶f̶o̶c̶k̶c̶i̶, p̶s̶i̶x̶a̶s̶,
-                pyeinsums, r̶e̶s̶p̶, s̶i̶m̶i̶n̶t̶, s̶n̶s̶m̶p̶2̶, v2rdm_casscf
+    Addons:     a̶d̶c̶c̶, a̶m̶b̶i̶t̶, b̶s̶e̶, c̶c̶t̶3̶, c̶f̶o̶u̶r̶, c̶h̶e̶m̶p̶s̶2̶, c̶p̶p̶e̶, d̶d̶x̶, dftd3,
+                dftd4, d̶k̶h̶, ecpint, e̶i̶n̶s̶u̶m̶s̶, f̶o̶r̶t̶e̶, g̶a̶u̶x̶c̶, g̶c̶p̶,
+                g̶d̶m̶a̶, g̶e̶o̶m̶e̶t̶r̶i̶c̶, g̶p̶u̶_̶d̶f̶c̶c̶, i̶n̶t̶e̶g̶r̶a̶t̶o̶r̶x̶x̶,
+                i̶p̶i̶, l̶i̶b̶e̶f̶p̶, m̶d̶i̶, m̶p̶2̶d̶, m̶r̶c̶c̶, o̶o̶o̶,
+                o̶p̶e̶n̶f̶e̶r̶m̶i̶o̶n̶p̶s̶i̶4̶, p̶c̶m̶s̶o̶l̶v̶e̶r̶, p̶s̶i̶4̶f̶o̶c̶k̶c̶i̶,
+                p̶s̶i̶x̶a̶s̶, p̶y̶e̶i̶n̶s̶u̶m̶s̶, qcmanybody, r̶e̶s̶p̶, s̶i̶m̶i̶n̶t̶,
+                s̶n̶s̶m̶p̶2̶, v̶2̶r̶d̶m̶_̶c̶a̶s̶s̶c̶f̶
 
   ==> Input File <==
 
 --------------------------------------------------------------------------
 #! MBIS regression test catching ECPs
 
-molecule mol {
+molecule mei {
   0 1
   C 0.000000 0.000000 0.000000
   I 0.000000 0.000000 2.105000
@@ -76,15 +78,774 @@ if psi4.core.get_option("scf", "orbital_optimizer_package") != "INTERNAL":  # KP
 set scf_properties ['MBIS_CHARGES', 'MBIS_VOLUME_RATIOS']
 
 try:
-    energy("mp2/def2-svp", molecule=hi)
+    energy("mp2/def2-svp", molecule=mei)
     compare_values(0, 1, "MBIS should have raised an error for ECP-containing basis sets.")
-except Exception:
-    compare_values(1, 1, "Expected error caught: MBIS correctly rejects ECP systems.")
+except RuntimeError as e:
+    # Check the message, not just the type: an unrelated RuntimeError from the SCF would
+    # otherwise satisfy this test without the ECP path ever being reached.
+    compare(True, "MBIS incompatible with ECP" in str(e), "Expected error caught: MBIS correctly rejects ECP systems.")
 --------------------------------------------------------------------------
-    Expected error caught: MBIS correctly rejects ECP systems.............................PASSED
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on atl1-1-02-002-27-1.pace.gatech.edu
+*** at Fri Sep 11 04:20:57 2026
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line    90 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2   entry I          line  1687 (ECP: line  2788) file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 3-5 entry H          line    15 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/def2-svp.gbs 
+
+    !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: Cs
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000     0.000000000000     0.000000000000    12.000000000000
+         I            0.000000000000     0.000000000000     2.105000000000   126.904471900000
+         H            0.000000000000     0.937000000000    -0.297000000000     1.007825032230
+         H            0.811000000000    -0.469000000000    -0.297000000000     1.007825032230
+         H           -0.811000000000    -0.469000000000    -0.297000000000     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =      6.35193  B =      0.02989  C =      0.02989 [cm^-1]
+  Rotational constants: A = 190426.01392  B =    896.20616  C =    896.20224 [MHz]
+  Nuclear repulsion =   63.771808839065109
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 34
+  Nalpha       = 17
+  Nbeta        = 17
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 25
+    Number of basis functions: 55
+    Number of Cartesian functions: 58
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Core potential: DEF2-SVP
+    Number of shells: 4
+    Number of ECP primitives: 29
+    Number of ECP core electrons: 28
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2   entry I          line  4980 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 3-5 entry H          line    18 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.009 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (DEF2-SVP AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 89
+    Number of basis functions: 347
+    Number of Cartesian functions: 458
+    Spherical Harmonics?: true
+    Max angular momentum: 5
+
+  Minimum eigenvalue in the overlap matrix is 1.0156751460E-02.
+  Reciprocal condition number of the overlap matrix is 1.9592079190E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         55      55 
+   -------------------------
+    Total      55      55
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -332.60812754540956   -3.32608e+02   0.00000e+00 
+   @DF-RHF iter   1:  -336.08798985633473   -3.47986e+00   7.76946e-03 ADIIS/DIIS
+   @DF-RHF iter   2:  -336.19058666195849   -1.02597e-01   3.19079e-03 ADIIS/DIIS
+   @DF-RHF iter   3:  -336.20473693859412   -1.41503e-02   6.01676e-04 ADIIS/DIIS
+   @DF-RHF iter   4:  -336.20610051168262   -1.36357e-03   2.73856e-04 ADIIS/DIIS
+   @DF-RHF iter   5:  -336.20627216256185   -1.71651e-04   6.09874e-05 DIIS
+   @DF-RHF iter   6:  -336.20629371420250   -2.15516e-05   1.71415e-05 DIIS
+   @DF-RHF iter   7:  -336.20629535726653   -1.64306e-06   2.75595e-06 DIIS
+   @DF-RHF iter   8:  -336.20629539041119   -3.31447e-08   5.47454e-07 DIIS
+   @DF-RHF iter   9:  -336.20629539163843   -1.22725e-09   5.18116e-08 DIIS
+   @DF-RHF iter  10:  -336.20629539164776   -9.32232e-12   7.82058e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -11.255938     2A     -7.724920     3A     -5.581560  
+       4A     -5.569175     5A     -5.569175     6A     -2.277220  
+       7A     -2.271605     8A     -2.271604     9A     -2.258926  
+      10A     -2.258926    11A     -1.029855    12A     -0.848104  
+      13A     -0.641483    14A     -0.641230    15A     -0.469640  
+      16A     -0.359924    17A     -0.359912  
+
+    Virtual:                                                              
+
+      18A      0.117048    19A      0.206306    20A      0.255585  
+      21A      0.255628    22A      0.459199    23A      0.504237  
+      24A      0.504338    25A      0.534469    26A      0.587786  
+      27A      0.587813    28A      0.627281    29A      0.627292  
+      30A      0.696489    31A      0.775698    32A      0.776060  
+      33A      0.891716    34A      0.939445    35A      0.958849  
+      36A      0.958929    37A      1.196010    38A      1.456117  
+      39A      1.456598    40A      1.851045    41A      2.062795  
+      42A      2.063422    43A      2.068323    44A      2.390560  
+      45A      2.391003    46A      2.548809    47A      2.879152  
+      48A      2.879826    49A      3.388400    50A      3.479421  
+      51A      3.480419    52A     19.182154    53A     19.182196  
+      54A     19.447913    55A     56.448359  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [    17 ]
+    NA   [    17 ]
+    NB   [    17 ]
+
+  @DF-RHF Final Energy:  -336.20629539164776
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             63.7718088390651090
+    One-Electron Energy =                -697.1778117824585479
+    Two-Electron Energy =                 297.1997075517456892
+    Total Energy =                       -336.2062953916477568
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+  Running 3 free-atom UHF computations
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on atl1-1-02-002-27-1.pace.gatech.edu
+*** at Fri Sep 11 04:20:59 2026
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry H          line    15 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            0.000000000000     0.000000000000     0.000000000000     1.007825032230
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 1
+  Nalpha       = 1
+  Nbeta        = 0
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 3
+    Number of basis functions: 5
+    Number of Cartesian functions: 5
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry H          line    18 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.000 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (DEF2-SVP AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 6
+    Number of basis functions: 18
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Minimum eigenvalue in the overlap matrix is 3.1520017525E-01.
+  Reciprocal condition number of the overlap matrix is 1.8708464390E-01.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag         2       2 
+     B1g        0       0 
+     B2g        0       0 
+     B3g        0       0 
+     Au         0       0 
+     B1u        1       1 
+     B2u        1       1 
+     B3u        1       1 
+   -------------------------
+    Total       5       5
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:    -0.35372439564810   -3.53724e-01   0.00000e+00 
+   @DF-UHF iter   1:    -0.48993956268632   -1.36215e-01   2.99341e-02 ADIIS/DIIS
+   @DF-UHF iter   2:    -0.49802911122231   -8.08955e-03   1.10142e-02 ADIIS/DIIS
+   @DF-UHF iter   3:    -0.49927642883137   -1.24732e-03   4.38538e-04 ADIIS/DIIS
+   @DF-UHF iter   4:    -0.49927840520805   -1.97638e-06   7.01815e-06 DIIS
+   @DF-UHF iter   5:    -0.49927840571435   -5.06302e-10   0.00000e+00 DIIS
+   @DF-UHF iter   6:    -0.49927840571435    1.11022e-16   0.00000e+00 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   0.000000000E+00
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.500000000E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -0.499458  
+
+    Alpha Virtual:                                                        
+
+       2Ag     0.574321     1B1u    1.595802     1B2u    1.595802  
+       1B3u    1.595802  
+
+    Beta Occupied:                                                        
+
+    
+
+    Beta Virtual:                                                         
+
+       1Ag     0.073328     2Ag     0.754711     1B1u    1.726537  
+       1B2u    1.726537     1B3u    1.726537  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
+    SOCC [     1,    0,    0,    0,    0,    0,    0,    0 ]
+    NA   [     1,    0,    0,    0,    0,    0,    0,    0 ]
+    NB   [     0,    0,    0,    0,    0,    0,    0,    0 ]
+
+  @DF-UHF Final Energy:    -0.49927840571435
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                  -0.4992784057143471
+    Two-Electron Energy =                   0.0000000000000000
+    Total Energy =                         -0.4992784057143471
+
+  UHF NO Occupations:
+  HONO-0 :    1 Ag 1.0000000
+  LUNO+0 :    1B3u 0.0000000
+  LUNO+1 :    1B2u 0.0000000
+  LUNO+2 :    1B1u 0.0000000
+  LUNO+3 :    2 Ag -0.0000000
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+  ==> Computing MBIS Charges <==
+
+  MBIS Memory: needs 0.001 GiB; user supplied 0.488 GiB.
+
+  Electron Count from Grid (Expected Number):  1.00000 ( 1.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       H    1    1.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       H    1    0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       H    1   -0.9910    0.0000    0.0000   -0.9910   -0.0000   -0.9910
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       H    1   -0.0000   -0.0000   -0.0000   -0.0000    0.0000   -0.0000   -0.0000   -0.0000   -0.0000   -0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       H    1    2.972853    7.305452   21.191665
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       H    1    0.499037
+
+
+  MBIS Valence Charges: (a.u.)
+   Center  Symbol  Z     Charge
+      1       H    1   -1.000000
+
+*** tstop() called on atl1-1-02-002-27-1.pace.gatech.edu at Fri Sep 11 04:20:59 2026
+Module time:
+	user time   =       0.18 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.37 seconds =       0.02 minutes
+	system time =       0.07 seconds =       0.00 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the H HF/DEF2-SVP density matrix
+
+  ==> Computing MBIS Charges <==
+
+  MBIS Memory: needs 0.001 GiB; user supplied 0.488 GiB.
+
+  Electron Count from Grid (Expected Number):  1.00000 ( 1.00000)
+  Difference: -0.00000
+
+  MBIS Charges: (a.u.)
+   Center  Symbol  Z      Pop.       Charge
+      1       H    1    1.000000    0.000000
+
+  MBIS Dipoles: [e a0]
+   Center  Symbol  Z        X           Y           Z
+      1       H    1    0.000000   -0.000000    0.000000
+
+  MBIS Quadrupoles: [e a0^2]
+   Center  Symbol  Z      XX        XY        XZ        YY        YZ        ZZ
+      1       H    1   -0.9910    0.0000    0.0000   -0.9910   -0.0000   -0.9910
+
+  MBIS Octupoles: [e a0^3]
+   Center  Symbol  Z      XXX       XXY       XXZ       XYY       XYZ       XZZ       YYY       YYZ       YZZ       ZZZ
+      1       H    1   -0.0000   -0.0000   -0.0000   -0.0000    0.0000   -0.0000   -0.0000   -0.0000   -0.0000   -0.0000
+
+  MBIS Radial Moments:
+   Center  Symbol  Z      [a0^2]      [a0^3]      [a0^4]      
+      1       H    1    2.972853    7.305452   21.191665
+
+  MBIS Valence Widths: [a0]
+   Center  Symbol  Z     Width
+      1       H    1    0.499037
+
+
+  MBIS Valence Charges: (a.u.)
+   Center  Symbol  Z     Charge
+      1       H    1   -1.000000
+
+Scratch directory: /tmp/
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  7, 6, 3
+    Auxiliary basis highest AM E, G, H:  7, 7, 4
+    Onebody   basis highest AM E, G, H:  -, -, -
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on atl1-1-02-002-27-1.pace.gatech.edu
+*** at Fri Sep 11 04:20:59 2026
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1 entry I          line  1687 (ECP: line  2788) file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/def2-svp.gbs 
+
+    !!!  WARNING: ECP capability is in beta. Please check occupations closely.  !!!
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Geometry (in Angstrom), charge = 0, multiplicity = 6:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         I            0.000000000000     0.000000000000     0.000000000000   126.904471900000
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B = ************  C = ************ [cm^-1]
+  Rotational constants: A = ************  B = ************  C = ************ [MHz]
+  Nuclear repulsion =    0.000000000000000
+
+  Charge       = 0
+  Multiplicity = 6
+  Electrons    = 25
+  Nalpha       = 15
+  Nbeta        = 10
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 10
+    Number of basis functions: 26
+    Number of Cartesian functions: 28
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  Core potential: DEF2-SVP
+    Number of shells: 4
+    Number of ECP primitives: 29
+    Number of ECP core electrons: 28
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (DEF2-SVP AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1 entry I          line  4980 file /storage/project/r-cs207-0/lburns7/posthive/p4priv_collab/hrw-priv/objdir_py314_cuest02/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.002 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: (DEF2-SVP AUX)
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 46
+    Number of basis functions: 218
+    Number of Cartesian functions: 309
+    Spherical Harmonics?: true
+    Max angular momentum: 5
+
+  Minimum eigenvalue in the overlap matrix is 6.7766710353E-02.
+  Reciprocal condition number of the overlap matrix is 2.3496680926E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag         8       8 
+     B1g        2       2 
+     B2g        2       2 
+     B3g        2       2 
+     Au         0       0 
+     B1u        4       4 
+     B2u        4       4 
+     B3u        4       4 
+   -------------------------
+    Total      26      26
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:  -292.93240178917790   -2.92932e+02   0.00000e+00 
+   @DF-UHF iter   1:  -295.64917790238906   -2.71678e+00   1.55751e-02 ADIIS/DIIS
+   @DF-UHF iter   2:  -295.65871726724725   -9.53936e-03   3.16870e-03 ADIIS/DIIS
+   @DF-UHF iter   3:  -295.65912428865784   -4.07021e-04   6.38168e-04 ADIIS/DIIS
+   @DF-UHF iter   4:  -295.65925913106400   -1.34842e-04   3.18600e-04 ADIIS/DIIS
+   @DF-UHF iter   5:  -295.65932389051807   -6.47595e-05   1.37263e-04 ADIIS/DIIS
+   @DF-UHF iter   6:  -295.65933837511540   -1.44846e-05   9.12457e-06 DIIS
+   @DF-UHF iter   7:  -295.65933840251353   -2.73981e-08   7.72513e-07 DIIS
+   @DF-UHF iter   8:  -295.65933840259862   -8.50946e-11   1.06206e-07 DIIS
+   @DF-UHF iter   9:  -295.65933840260072   -2.10321e-12   1.85377e-08 DIIS
+   @DF-UHF iter  10:  -295.65933840260084   -1.13687e-13   1.04872e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.541837616E-03
+   @S^2 Expected:                8.750000000E+00
+   @S^2 Observed:                8.751541838E+00
+   @S   Expected:                2.500000000E+00
+   @S   Observed:                2.500000000E+00
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1Ag    -7.866245     1B3u   -5.710082     1B2u   -5.710082  
+       1B1u   -5.707127     1B1g   -2.408340     2Ag    -2.408340  
+       1B2g   -2.399336     1B3g   -2.399336     3Ag    -2.396458  
+       4Ag    -1.098502     2B1u   -0.563884     2B2u   -0.549263  
+       2B3u   -0.549263     5Ag     0.016726     3B1u    0.164056  
+
+    Alpha Virtual:                                                        
+
+       3B2u    0.413812     3B3u    0.413812     2B1g    0.454168  
+       6Ag     0.454168     2B3g    0.466838     2B2g    0.466838  
+       7Ag     0.471367     4B1u   18.995861     4B3u   19.005737  
+       4B2u   19.005737     8Ag    56.233207  
+
+    Beta Occupied:                                                        
+
+       1Ag    -7.819305     1B3u   -5.675478     1B2u   -5.675478  
+       1B1u   -5.653404     1B1g   -2.380877     2Ag    -2.380877  
+       1B2g   -2.363963     1B3g   -2.363963     3Ag    -2.358302  
+       4Ag    -0.762232  
+
+    Beta Virtual:                                                         
+
+       2B2u   -0.071775     2B3u   -0.071775     2B1u   -0.039108  
+       5Ag     0.403164     3B2u    0.552219     3B3u    0.552219  
+       3B1u    0.581953     2B1g    0.609129     6Ag     0.609129  
+       2B3g    0.630473     2B2g    0.630473     7Ag     0.638184  
+       4B3u   19.048120     4B2u   19.048120     4B1u   19.065657  
+       8Ag    56.253384  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     4,    1,    1,    1,    0,    1,    1,    1 ]
+    SOCC [     1,    0,    0,    0,    0,    2,    1,    1 ]
+    NA   [     5,    1,    1,    1,    0,    3,    2,    2 ]
+    NB   [     4,    1,    1,    1,    0,    1,    1,    1 ]
+
+  @DF-UHF Final Energy:  -295.65933840260084
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              0.0000000000000000
+    One-Electron Energy =                -514.2993242650218235
+    Two-Electron Energy =                 218.6399858624209287
+    Total Energy =                       -295.6593384026008948
+
+  UHF NO Occupations:
+  HONO-2 :    2B3u 1.0000000
+  HONO-1 :    2B2u 1.0000000
+  HONO-0 :    5 Ag 1.0000000
+  LUNO+0 :    6 Ag 0.0002802
+  LUNO+1 :    2B3g 0.0001322
+  LUNO+2 :    2B2g 0.0001322
+  LUNO+3 :    7 Ag 0.0001118
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+  ==> Computing MBIS Charges <==
+
+  MBIS Memory: needs 0.002 GiB; user supplied 0.488 GiB.
+
+  Electron Count from Grid (Expected Number): 25.00000 (25.00000)
+  Difference: -0.00000
+
     Expected error caught: MBIS correctly rejects ECP systems.............................PASSED
 
-    Psi4 stopped on: Friday, 19 June 2026 01:04PM
-    Psi4 wall time for execution: 0:00:00.00
+    Psi4 stopped on: Friday, 11 September 2026 04:20AM
+    Psi4 wall time for execution: 0:00:02.56
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
LAB: at the moment, I understand not a whit of this changeset. We might try it against some existing databases with usual MBIS implementation. @andyj10224 

## Summary

MBIS dominated post-SCF property runs. On a 109-atom system (steroid-like solute
+ 20 waters, DZVP, 754 bf) it took 990 s — an order of magnitude more than the
SCF it was analysing. This makes it 15x faster, and fixes several correctness
and robustness problems found along the way.

Nothing here changes what MBIS computes. Charges and derived quantities move by
far less than the tolerance the iteration is converged to.

## Result

Stock master (`f234e73af3`) and this branch, same build directory, same
`-march=native`, 4 threads, timed on one cached converged SCF density so the
measurement is MBIS and nothing else:

| | MBIS |
|---|---|
| stock master | 990 s |
| this branch | **64 s** |
| | **15.5x** |

The remaining 64 s is DFT grid construction 42 s, gau2grid collocation 8 s,
stockholder iteration 14 s. Grid construction is shared infrastructure and is
addressed in a separate, deliberately deferred PR; within MBIS proper there is
little left.

Peak MBIS memory at 109 atoms: 8.4 GB → 1.3 GB.

## What changed

### Performance

**Fuse the two hot loops.** `loopNS` at iteration k+1 was evaluating exactly the
exponentials `loopRHO` had computed at iteration k and discarded by summing over
shells. One pass with points outside and (atom, shell) inside halves the
exponential count. `distances`/`disps` are no longer materialised; seven
`natom x npts` arrays collapse to one.

**Anderson acceleration** on `log(N), log(sigma)`: 55 → 17 iterations on water
clusters. New option `MBIS_ANDERSON` (default true).

**Per-block screening**, new option `MBIS_SCREENING_THRESHOLD` (default 1e-14,
0 disables). An atom is kept for a grid block if its pro-density could exceed
the threshold anywhere inside the block's bounding sphere. Screened atoms hold
an exact zero, so nothing downstream needs to know about it.

**Eigen's vectorised `exp`.** glibc only vectorises `exp` through libmvec under
`-ffast-math`, which Psi4 does not build with, so `#pragma omp simd` over
`std::exp` changes nothing. Measured on 96-element batches:

| | no `-march` | `-march=native` |
|---|---|---|
| libm `std::exp` | 130 | 126 Mexp/s |
| a hand-rolled Taylor kernel | 66 | 585 |
| `Eigen::ArrayXd::exp()` | 138 | 526 |

The middle row is why this is a library call. A build that loses `-march=native`
runs a hand-rolled kernel at half the speed of plain libm, and nothing warns
you; Eigen gets 90% of the throughput when the flag is present and is never
worse than libm when it is not. It also underflows to exact zero like libm, so
no clamp, no `bit_cast`, and no restating IEEE-754 by hand.

**Fuse multipoles and radial moments.** `compute_radial_moments` made
`natom * (max_power - 1)` passes over the grid, each streaming the whole
pro-density array and calling `pow(dist, n)` per point — 12.9 GB of traffic at
48 atoms. Now one screened pass: 2.18 s → 0.04 s.

**Deterministic reductions**, via fixed chunks with thread-local accumulators
flushed per chunk, so the arithmetic order does not depend on thread scheduling.
See the caveat below.

### Correctness and robustness

**Anderson returned NaN charges on NaCl** — and reported *convergence* while
doing so, because the density change between two all-zero densities is exactly
zero. Unsafeguarded, it oscillated for 80 iterations and drove a shell
population to zero. Four guards: log-space mixing for positivity, Tikhonov
regularisation, rejection of extrapolations whose coefficients sum past 20, and
a history reset when an accelerated step more than doubles the residual. A shell
that does lose all its population now raises a diagnostic instead of NaN.

**The convergence test measured the step, not the residual.** Those coincide for
a Picard iteration but not for an extrapolation, so two accelerated iterates
could be close without being at the fixed point — silently loosening
`MBIS_D_CONVERGENCE` from 1e-11 to 1.6e-5. Acceleration is now switched off and
the test re-passed on an unaccelerated step before convergence is declared.

**The grid allocation is one double per (grid point, atom)** — quadratic in
system size, 1.3 GB at 109 atoms — and was unchecked, so exceeding memory
surfaced as a bare `std::bad_alloc` after an SCF had already been paid for. Now
sized against the available memory, reported alongside the other MBIS output,
before the grid density pass rather than at the allocation.

**Ghost atoms were reported as ECPs.** Both trip `Z != true_atomic_number`, so
anyone running a counterpoise correction was told to switch to an all-electron
basis. Now diagnosed separately. Message change only — ghosts are still
rejected; whether MBIS should instead exclude them from the pro-atom set is a
separate question about the physics.

**`mbis-ecp` never tested anything.** It ran `energy(..., molecule=hi)` where the
molecule was named `mol`, so it raised `NameError`, which a bare
`except Exception` swallowed as success. The committed reference output recorded
the evidence: `Psi4 wall time for execution: 0:00:00.00`. It now reaches MBIS and
asserts on the message, not just the exception type.

**Anderson's LAPACK solve was nondeterministic.** MKL's threaded QR on a
550 x 5 problem picks its reduction order at run time; pinned to one thread at
no measurable cost.

Also: LAPACK `DGELSY` replaces a hand-rolled Gauss-Jordan on the bordered normal
equations, avoiding the squared condition number; the Anderson history is an
Eigen matrix with a ring-buffer index rather than a `vector<vector<double>>`
that memmoved itself every iteration; a rank check that could never fire is
gone; and `oeprop.cc` is clean under `-Wsign-compare`.

## Risks

1. **Anderson's safeguard thresholds are empirical**, chosen against water
   clusters and NaCl rather than derived. A system outside that experience could
   still iterate badly. Failure is now a clear exception or a higher iteration
   count rather than silent NaN, and `MBIS_ANDERSON false` recovers the old
   iteration exactly — same fixed point, 55 iterations instead of 17.

2. **`MBIS_SCREENING_THRESHOLD` is a deliberate approximation**, unlike
   everything else here, argued from `0 <= rho_a/rho_0 <= 1` rather than proved
   for all cases. Set to 0 to disable; it is worth ~1.3x, so it is cheap to drop.

3. **MBIS is still not reproducible run to run**, by about 1e-11 on the charges
   of the 109-atom case. The sweep's own reductions are order-fixed and the
   LAPACK solve is pinned, but Anderson is an extrapolation and amplifies the
   ~1e-15 noise the threaded grid density evaluation feeds it, where plain
   Picard is contractive and damps it (measured: 2.7e-15 with acceleration off).
   Closing this means making gau2grid's collocation bitwise reproducible, which
   is outside MBIS.

4. **MBIS_D_CONVERGENCE does not pin every quantity equally.** It is a tolerance
   on the pro-atom density; two iteration paths that both satisfy 1e-8 agree to
   ~1e-7 on charges but only ~1e-6 on valence widths, which are `sum_s / (3 N)`
   and so divide one converged sum by another. Downstream reference data tighter
   than that needs regenerating.

5. **`rho_a_0_points` is still quadratic** — 1.3 GB at 109 atoms, down from
   8.4 GB. Compressing it per block is awkward because the convergence test
   depends on the previous iteration's densities.

6. **One line of `cubature.h`** exposes the bounding radius `BlockOPoints`
   already computes, so MBIS can stop recomputing it. Header only; the
   `cubature.cc` work is a separate PR.

## Validation

- 9 `mbis-*` ctest cases, all passing. `mbis-8` is new: it pins that
  `MBIS_ANDERSON` cannot move the fixed point, that no quantity is NaN on either
  path, and that ghosts are not misreported as ECPs.
- `mbis-8` and `mbis-ecp` were both checked with a negative control —
  substituting a string that cannot match makes them fail with exit 1 — because
  this test family has a history of passing for the wrong reason.
- 111 ctest cases matching `dft|scf|props|prop`.
- Element-by-element diff of every MBIS quantity against the pre-change code at
  12, 24, 48 and 109 atoms. On the 109-atom case charges agree to 8.3e-7; for
  scale, MBIS's own grid-integration error there is 4.1e-4 electrons, identical
  before and after.

## Not done

The `cubature.cc` grid-construction work, worth a further ~1.7x, is deliberately
held back as a separate PR: it touches every DFT calculation in Psi4 and
deserves its own review. It still applies cleanly on top of this branch.

A GPU port is not obviously worth it: MBIS is no longer the dominant cost, and
most of what remains is grid construction and collocation rather than the
elementwise work a custom kernel would target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)