### PR TITLE
Stability improvements to integral direct JK algorithms

### DIFF
--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -278,6 +278,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
     cosx_enabled = "COSX" in core.get_option('SCF', 'SCF_TYPE')
     directjk_enabled = "DIRECT" in core.get_option('SCF', 'SCF_TYPE')
     incfock_enabled = core.get_option('SCF', 'INCFOCK')
+    var_tol_enabled = core.get_option('SCF', 'INCFOCK_VAR_INTS_TOL')
     ooo_scf = core.get_option("SCF", "ORBITAL_OPTIMIZER_PACKAGE") in ["OOO", "OPENORBITALOPTIMIZER"]
     if ooo_scf:
         pcm_enabled = core.get_option('SCF', 'PCM')
@@ -340,7 +341,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
         self.jk().set_COSX_grid("Initial")
 
     variable_screening = False
-    if directjk_enabled and incfock_enabled:
+    if directjk_enabled and incfock_enabled and var_tol_enabled:
         variable_screening = True
 
     # maximum number of scf iterations to run after early screening is disabled

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -256,9 +256,10 @@ def scf_initialize(self):
     # Print iteration header
     is_dfjk = core.get_global_option('SCF_TYPE').endswith('DF')
     diis_rms = core.get_option('SCF', 'DIIS_RMS_ERROR')
+    variable_screening = "DIRECT" in core.get_option('SCF', 'SCF_TYPE') and core.get_option('SCF', 'INCFOCK') and core.get_option('SCF', 'INCFOCK_VAR_INTS_TOL')
     core.print_out("  ==> Iterations <==\n\n")
-    core.print_out("%s                        Total Energy        Delta E     %s |[F,P]|\n\n" %
-                   ("   " if is_dfjk else "", "RMS" if diis_rms else "MAX"))
+    core.print_out("%s                        Total Energy        Delta E     %s |[F,P]|%s\n\n" %
+                   ("   " if is_dfjk else "", "RMS" if diis_rms else "MAX", "    Ints Tol" if variable_screening else ""))
 
 
 def scf_iterate(self, e_conv=None, d_conv=None):
@@ -352,6 +353,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
 
     # has early_screening changed from True to False?
     early_screening_disabled = False
+    fixed_ints_tol = core.get_option('SCF', 'INTS_TOLERANCE') if variable_screening else None
 
     # SCF iterations!
     SCFE_old = 0.0
@@ -379,14 +381,15 @@ def scf_iterate(self, e_conv=None, d_conv=None):
         SCFE = 0.0
         self.clear_external_potentials()
 
-        if variable_screening: # trying out qchem's incfock error mitigation strategy
-            # save user specified screening thresh
-            fixed_thresh = core.get_option('SCF', 'INTS_TOLERANCE')
+        ints_tol_field = ""
+        if variable_screening: # trying out qchem's incfock error mitigation strategy            
             if self.iteration_ == 1:
-                core.set_local_option("SCF", "INTS_TOLERANCE", 1e-6)
+                itr_thresh = 1.0e-6
             else:
-                itr_thresh = fixed_thresh * Dnorm
-                core.set_local_option("SCF", "INTS_TOLERANCE", itr_thresh)
+                itr_thresh = fixed_ints_tol * Dnorm
+
+            core.set_local_option("SCF", "INTS_TOLERANCE", itr_thresh)
+            ints_tol_field = f" {itr_thresh:11.3e}"
 
         # Two-electron contribution to Fock matrix from self.jk()
         core.timer_on("HF: Form G")
@@ -574,9 +577,9 @@ def scf_iterate(self, e_conv=None, d_conv=None):
 
         # Print out the iteration
         core.print_out(
-            "   @%s%s iter %3s: %20.14f   %12.5e   %-11.5e %s\n" %
+            "   @%s%s iter %3s: %20.14f   %12.5e   %-11.5e%s %s\n" %
             ("DF-" if is_dfjk else "", reference, "SAD" if
-             ((self.iteration_ == 0) and self.sad_) else self.iteration_, SCFE, Ediff, Dnorm, '/'.join(status)))
+             ((self.iteration_ == 0) and self.sad_) else self.iteration_, SCFE, Ediff, Dnorm, ints_tol_field, '/'.join(status)))
 
         # if a an excited MOM is requested but not started, don't stop yet
         # Note that MOM_performed_ just checks initialization, and our convergence measures used the pre-MOM orbitals

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -277,6 +277,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
     efp_enabled = hasattr(self.molecule(), 'EFP')
     cosx_enabled = "COSX" in core.get_option('SCF', 'SCF_TYPE')
     directjk_enabled = "DIRECT" in core.get_option('SCF', 'SCF_TYPE')
+    incfock_enabled = core.get_option('SCF', 'INCFOCK')
     ooo_scf = core.get_option("SCF", "ORBITAL_OPTIMIZER_PACKAGE") in ["OOO", "OPENORBITALOPTIMIZER"]
     if ooo_scf:
         pcm_enabled = core.get_option('SCF', 'PCM')
@@ -339,7 +340,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
         self.jk().set_COSX_grid("Initial")
 
     variable_screening = False
-    if directjk_enabled:
+    if directjk_enabled and incfock_enabled:
         variable_screening = True
 
     # maximum number of scf iterations to run after early screening is disabled
@@ -377,10 +378,10 @@ def scf_iterate(self, e_conv=None, d_conv=None):
         SCFE = 0.0
         self.clear_external_potentials()
 
-        if(variable_screening): # trying out qchem's incfock error mitigation strategy
-            # save user specified thresh
+        if variable_screening: # trying out qchem's incfock error mitigation strategy
+            # save user specified screening thresh
             fixed_thresh = core.get_option('SCF', 'INTS_TOLERANCE')
-            if(self.iteration_ == 1):
+            if self.iteration_ == 1:
                 core.set_local_option("SCF", "INTS_TOLERANCE", 1e-6)
             else:
                 itr_thresh = fixed_thresh * Dnorm

--- a/psi4/driver/procrouting/scf_proc/scf_iterator.py
+++ b/psi4/driver/procrouting/scf_proc/scf_iterator.py
@@ -276,6 +276,7 @@ def scf_iterate(self, e_conv=None, d_conv=None):
     frac_enabled = _validate_frac()
     efp_enabled = hasattr(self.molecule(), 'EFP')
     cosx_enabled = "COSX" in core.get_option('SCF', 'SCF_TYPE')
+    directjk_enabled = "DIRECT" in core.get_option('SCF', 'SCF_TYPE')
     ooo_scf = core.get_option("SCF", "ORBITAL_OPTIMIZER_PACKAGE") in ["OOO", "OPENORBITALOPTIMIZER"]
     if ooo_scf:
         pcm_enabled = core.get_option('SCF', 'PCM')
@@ -337,6 +338,10 @@ def scf_iterate(self, e_conv=None, d_conv=None):
         early_screening = True
         self.jk().set_COSX_grid("Initial")
 
+    variable_screening = False
+    if directjk_enabled:
+        variable_screening = True
+
     # maximum number of scf iterations to run after early screening is disabled
     scf_maxiter_post_screening = core.get_option('SCF', 'COSX_MAXITER_FINAL')
 
@@ -371,6 +376,15 @@ def scf_iterate(self, e_conv=None, d_conv=None):
 
         SCFE = 0.0
         self.clear_external_potentials()
+
+        if(variable_screening): # trying out qchem's incfock error mitigation strategy
+            # save user specified thresh
+            fixed_thresh = core.get_option('SCF', 'INTS_TOLERANCE')
+            if(self.iteration_ == 1):
+                core.set_local_option("SCF", "INTS_TOLERANCE", 1e-6)
+            else:
+                itr_thresh = fixed_thresh * Dnorm
+                core.set_local_option("SCF", "INTS_TOLERANCE", itr_thresh)
 
         # Two-electron contribution to Fock matrix from self.jk()
         core.timer_on("HF: Form G")

--- a/psi4/src/psi4/libfock/CompositeJK.cc
+++ b/psi4/src/psi4/libfock/CompositeJK.cc
@@ -275,17 +275,16 @@ void CompositeJK::compute_JK() {
         timer_on("CompositeJK: INCFOCK Preprocessing");
 
         auto reset = options_.get_int("INCFOCK_FULL_FOCK_EVERY");
-        auto incfock_conv = options_.get_double("INCFOCK_CONVERGENCE");
         auto Dnorm = Process::environment.globals["SCF D NORM"];
         // Do IFB on this iteration?
-        do_incfock_iter_ = (Dnorm >= incfock_conv) && !initial_iteration_ && (incfock_count_ % reset != reset - 1);
+        do_incfock_iter_ = !initial_iteration_ && (incfock_count_ % reset != reset - 1);
 
         if (k_algo_->name() == "sn-LinK") {
             auto k_algo_derived = std::dynamic_pointer_cast<snLinK>(k_algo_); 
             k_algo_derived->set_incfock_iter(do_incfock_iter_);
         }
 
-        if (!initial_iteration_ && (Dnorm >= incfock_conv)) incfock_count_ += 1;
+        if (!initial_iteration_) incfock_count_ += 1;
 
         incfock_setup();
         

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -361,12 +361,10 @@ void DirectJK::compute_JK() {
     if (incfock_) {
         timer_on("DirectJK: INCFOCK Preprocessing");
         int reset = options_.get_int("INCFOCK_FULL_FOCK_EVERY");
-        double incfock_conv = options_.get_double("INCFOCK_CONVERGENCE");
-        double Dnorm = Process::environment.globals["SCF D NORM"];
         // Do IFB on this iteration?
-        do_incfock_iter_ = (Dnorm >= incfock_conv) && !initial_iteration_ && (incfock_count_ % reset != reset - 1);
+        do_incfock_iter_ = !initial_iteration_ && (incfock_count_ % reset != reset - 1);
         
-        if (!initial_iteration_ && (Dnorm >= incfock_conv)) incfock_count_ += 1;
+        if (!initial_iteration_) incfock_count_ += 1;
         
         incfock_setup();
 	

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -125,7 +125,17 @@ void DirectJK::print_header() const {
     }
 }
 void DirectJK::preiterations() {
+    // clear, resize, and zero delta buffers here
+    J_delta_.clear();
+    K_delta_.clear();
+    wK_delta_.clear();
 
+    for(auto const &Di : D_ao_) {
+        J_delta_.push_back(Di->clone());
+        K_delta_.push_back(Di->clone());
+        wK_delta_.push_back(Di->clone());
+    }
+    
 #ifdef USING_BrianQC
     if (brianEnable) {
         double threshold = cutoff_ * (brianCPHFFlag ? 1e-3 : 1e-0); // CPHF needs higher precision
@@ -144,12 +154,16 @@ void DirectJK::incfock_setup() {
 	        initial_iteration_ = true;
 
             D_ref_ = D_ao_;
-            zero();
+            zero(); // should zero J and K as normal, delta J and K remain untouched
         } else { // Otherwise, the iteration is incremental
             for (size_t jki = 0; jki < njk; jki++) {
                 D_ref_[jki] = D_ao_[jki]->clone();
                 D_ref_[jki]->subtract(D_prev_[jki]);
             }
+            // zero delta buffers here, reference J & K are untouched unless we accumulate into them
+            J_delta_.zero();
+            K_delta_.zero();
+            wK_delta_.zero(); 
         }
     } else {
         D_ref_ = D_ao_;
@@ -159,7 +173,8 @@ void DirectJK::incfock_setup() {
 
 void DirectJK::incfock_postiter() {
     // Save a copy of the density for the next iteration
-    D_prev_.clear();
+    D_prev_.clear();   
+
     for(auto const &Di : D_ao_) {
         D_prev_.push_back(Di->clone());
     }
@@ -361,9 +376,12 @@ void DirectJK::compute_JK() {
             ints.push_back(std::shared_ptr<TwoBodyAOInt>(ints[0]->clone()));
         }
         if (do_J_) {
-            build_JK_matrices(ints, D_ref_, J_ao_, wK_ao_);
+            build_JK_matrices(ints, D_ref_, J_delta_, wK_delta_);
+            J_ao_.add(J_delta_);
+            wK_ao_.add(wK_delta_);
         } else {
-            build_JK_matrices(ints, D_ref_, temp, wK_ao_);
+            build_JK_matrices(ints, D_ref_, temp, wK_delta_);
+            wK_ao_.add(wK_delta_); 
         }
     }
 
@@ -375,11 +393,15 @@ void DirectJK::compute_JK() {
             ints.push_back(std::shared_ptr<TwoBodyAOInt>(ints[0]->clone()));
         }
         if (do_J_ && do_K_) {
-            build_JK_matrices(ints, D_ref_, J_ao_, K_ao_);
+            build_JK_matrices(ints, D_ref_, J_delta_, K_delta_);
+            J_ao_.add(J_delta_);
+            K_ao_.add(K_delta_);
         } else if (do_J_) {
-            build_JK_matrices(ints, D_ref_, J_ao_, temp);
+            build_JK_matrices(ints, D_ref_, J_delta_, temp);
+            J_ao_.add(J_delta_);
         } else {
-            build_JK_matrices(ints, D_ref_, temp, K_ao_);
+            build_JK_matrices(ints, D_ref_, temp, K_delta_);
+            K_ao_.add(K_delta_);
         }
     }
 
@@ -792,7 +814,7 @@ void DirectJK::build_JK_matrices(std::vector<std::shared_ptr<TwoBodyAOInt>>& int
             if (build_J) {
 
                 // > J_PQ < //
-
+                
                 for (int P2 = 0; P2 < nPtask; P2++) {
                     for (int Q2 = 0; Q2 < nQtask; Q2++) {
                         int P = task_shells[P2start + P2];

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -125,16 +125,10 @@ void DirectJK::print_header() const {
     }
 }
 void DirectJK::preiterations() {
-    // clear, resize, and zero delta buffers here
+    // clear delta buffers here
     J_delta_.clear();
     K_delta_.clear();
     wK_delta_.clear();
-
-    for(auto const &Di : D_ao_) {
-        J_delta_.push_back(Di->clone());
-        K_delta_.push_back(Di->clone());
-        wK_delta_.push_back(Di->clone());
-    }
     
 #ifdef USING_BrianQC
     if (brianEnable) {
@@ -160,14 +154,33 @@ void DirectJK::incfock_setup() {
                 D_ref_[jki] = D_ao_[jki]->clone();
                 D_ref_[jki]->subtract(D_prev_[jki]);
             }
-            // zero delta buffers here, reference J & K are untouched unless we accumulate into them
-            J_delta_.zero();
-            K_delta_.zero();
-            wK_delta_.zero(); 
+            // need to zero the incremental buffers each iteration
+            for (auto& Jd : J_delta_) {
+                Jd->zero();
+            }
+            for (auto& Kd : K_delta_) {
+                Kd->zero();
+            }
+            for (auto& wKd : wK_delta_) {
+                wKd->zero();
+            }
         }
     } else {
         D_ref_ = D_ao_;
         zero();
+        // probably ok to only do this here but we'll see
+        if(initial_iteration_) {
+            // resize delta buffers once in the initial iter
+            for(auto const &Ji : J_ao_) {
+                J_delta_.push_back(Ji->clone());
+            }
+            for(auto const &Ki : K_ao_) {
+                K_delta_.push_back(Ki->clone());
+            }
+            for(auto const &wKi : wK_ao_) {
+                wK_delta_.push_back(wKi->clone());
+            }
+        }
     }
 }
 
@@ -377,11 +390,17 @@ void DirectJK::compute_JK() {
         }
         if (do_J_) {
             build_JK_matrices(ints, D_ref_, J_delta_, wK_delta_);
-            J_ao_.add(J_delta_);
-            wK_ao_.add(wK_delta_);
+            for (size_t i = 0; i < J_ao_.size(); i++) {
+                J_ao_[i]->add(J_delta_[i]);
+            }
+            for (size_t i = 0; i < wK_ao_.size(); i++) {
+                wK_ao_[i]->add(wK_delta_[i]);
+            }
         } else {
             build_JK_matrices(ints, D_ref_, temp, wK_delta_);
-            wK_ao_.add(wK_delta_); 
+            for (size_t i = 0; i < wK_ao_.size(); i++) {
+                wK_ao_[i]->add(wK_delta_[i]);
+            }        
         }
     }
 
@@ -394,14 +413,22 @@ void DirectJK::compute_JK() {
         }
         if (do_J_ && do_K_) {
             build_JK_matrices(ints, D_ref_, J_delta_, K_delta_);
-            J_ao_.add(J_delta_);
-            K_ao_.add(K_delta_);
+            for (size_t i = 0; i < J_ao_.size(); i++) {
+                J_ao_[i]->add(J_delta_[i]);
+            }
+            for (size_t i = 0; i < K_ao_.size(); i++) {
+                K_ao_[i]->add(K_delta_[i]);
+            }
         } else if (do_J_) {
             build_JK_matrices(ints, D_ref_, J_delta_, temp);
-            J_ao_.add(J_delta_);
+            for (size_t i = 0; i < J_ao_.size(); i++) {
+                J_ao_[i]->add(J_delta_[i]);
+            }
         } else {
             build_JK_matrices(ints, D_ref_, temp, K_delta_);
-            K_ao_.add(K_delta_);
+            for (size_t i = 0; i < K_ao_.size(); i++) {
+                K_ao_[i]->add(K_delta_[i]);
+            }
         }
     }
 

--- a/psi4/src/psi4/libfock/DirectJK.cc
+++ b/psi4/src/psi4/libfock/DirectJK.cc
@@ -146,13 +146,29 @@ void DirectJK::incfock_setup() {
         // If there is no previous pseudo-density, this iteration is normal
         if (initial_iteration_ || D_prev_.size() != njk) {
 	        initial_iteration_ = true;
+            // this is a full build after all, so don't route through the delta buffers
+            do_incfock_iter_ = false;
 
             D_ref_ = D_ao_;
-            zero(); // should zero J and K as normal, delta J and K remain untouched
+            zero();
         } else { // Otherwise, the iteration is incremental
             for (size_t jki = 0; jki < njk; jki++) {
                 D_ref_[jki] = D_ao_[jki]->clone();
                 D_ref_[jki]->subtract(D_prev_[jki]);
+            }
+            // the delta buffers are only needed on incremental iterations, and
+            // preiterations() clears them, so (re)build them on any size mismatch
+            if (J_delta_.size() != J_ao_.size()) {
+                J_delta_.clear();
+                for (auto const &Ji : J_ao_) J_delta_.push_back(Ji->clone());
+            }
+            if (K_delta_.size() != K_ao_.size()) {
+                K_delta_.clear();
+                for (auto const &Ki : K_ao_) K_delta_.push_back(Ki->clone());
+            }
+            if (wK_delta_.size() != wK_ao_.size()) {
+                wK_delta_.clear();
+                for (auto const &wKi : wK_ao_) wK_delta_.push_back(wKi->clone());
             }
             // need to zero the incremental buffers each iteration
             for (auto& Jd : J_delta_) {
@@ -168,19 +184,6 @@ void DirectJK::incfock_setup() {
     } else {
         D_ref_ = D_ao_;
         zero();
-        // probably ok to only do this here but we'll see
-        if(initial_iteration_) {
-            // resize delta buffers once in the initial iter
-            for(auto const &Ji : J_ao_) {
-                J_delta_.push_back(Ji->clone());
-            }
-            for(auto const &Ki : K_ao_) {
-                K_delta_.push_back(Ki->clone());
-            }
-            for(auto const &wKi : wK_ao_) {
-                wK_delta_.push_back(wKi->clone());
-            }
-        }
     }
 }
 
@@ -379,6 +382,15 @@ void DirectJK::compute_JK() {
     // Passed in as a dummy when J (and/or K) is not built
     std::vector<SharedMatrix> temp;
 
+    // On incremental iterations the ERI contributions are accumulated into separate
+    // \Delta buffers and only then added to J/K, so that the (small) increment is
+    // summed at full precision instead of into the (large) running Fock matrices.
+    // On a full build there is no increment, so build straight into J/K as usual
+    // (build_JK_matrices() zeros them for us when !do_incfock_iter_).
+    auto& J_out = do_incfock_iter_ ? J_delta_ : J_ao_;
+    auto& K_out = do_incfock_iter_ ? K_delta_ : K_ao_;
+    auto& wK_out = do_incfock_iter_ ? wK_delta_ : wK_ao_;
+
     if (do_wK_) {
         std::vector<std::shared_ptr<TwoBodyAOInt>> ints;
         ints.push_back(std::shared_ptr<TwoBodyAOInt>(factory->erf_eri(omega_)));
@@ -386,20 +398,8 @@ void DirectJK::compute_JK() {
         for (int thread = 1; thread < df_ints_num_threads_; thread++) {
             ints.push_back(std::shared_ptr<TwoBodyAOInt>(ints[0]->clone()));
         }
-        if (do_J_) {
-            build_JK_matrices(ints, D_ref_, J_delta_, wK_delta_);
-            for (size_t i = 0; i < J_ao_.size(); i++) {
-                J_ao_[i]->add(J_delta_[i]);
-            }
-            for (size_t i = 0; i < wK_ao_.size(); i++) {
-                wK_ao_[i]->add(wK_delta_[i]);
-            }
-        } else {
-            build_JK_matrices(ints, D_ref_, temp, wK_delta_);
-            for (size_t i = 0; i < wK_ao_.size(); i++) {
-                wK_ao_[i]->add(wK_delta_[i]);
-            }        
-        }
+        // J never comes from the erf integrals; the do_J_ || do_K_ block below builds it
+        build_JK_matrices(ints, D_ref_, temp, wK_out);
     }
 
     if (do_J_ || do_K_) {
@@ -410,23 +410,23 @@ void DirectJK::compute_JK() {
             ints.push_back(std::shared_ptr<TwoBodyAOInt>(ints[0]->clone()));
         }
         if (do_J_ && do_K_) {
-            build_JK_matrices(ints, D_ref_, J_delta_, K_delta_);
-            for (size_t i = 0; i < J_ao_.size(); i++) {
-                J_ao_[i]->add(J_delta_[i]);
-            }
-            for (size_t i = 0; i < K_ao_.size(); i++) {
-                K_ao_[i]->add(K_delta_[i]);
-            }
+            build_JK_matrices(ints, D_ref_, J_out, K_out);
         } else if (do_J_) {
-            build_JK_matrices(ints, D_ref_, J_delta_, temp);
-            for (size_t i = 0; i < J_ao_.size(); i++) {
-                J_ao_[i]->add(J_delta_[i]);
-            }
+            build_JK_matrices(ints, D_ref_, J_out, temp);
         } else {
-            build_JK_matrices(ints, D_ref_, temp, K_delta_);
-            for (size_t i = 0; i < K_ao_.size(); i++) {
-                K_ao_[i]->add(K_delta_[i]);
-            }
+            build_JK_matrices(ints, D_ref_, temp, K_out);
+        }
+    }
+
+    if (do_incfock_iter_) {
+        if (do_J_) {
+            for (size_t i = 0; i < J_ao_.size(); i++) J_ao_[i]->add(J_delta_[i]);
+        }
+        if (do_K_) {
+            for (size_t i = 0; i < K_ao_.size(); i++) K_ao_[i]->add(K_delta_[i]);
+        }
+        if (do_wK_) {
+            for (size_t i = 0; i < wK_ao_.size(); i++) wK_ao_[i]->add(wK_delta_[i]);
         }
     }
 

--- a/psi4/src/psi4/libfock/jk.h
+++ b/psi4/src/psi4/libfock/jk.h
@@ -750,6 +750,12 @@ class PSI_API DirectJK : public JK {
     /// Pseudo-density matrix to be used this iteration
     std::vector<SharedMatrix> D_ref_;
 
+    /// \Delta J & \Delta K matricies to accumulate eri contributions into this iteration (to avoid roundoff error)
+    std::vector<SharedMatrix> J_delta_;
+    std::vector<SharedMatrix> K_delta_;
+    std::vector<SharedMatrix> wK_delta_;
+
+
     // Is the JK currently on the first SCF iteration of this SCF cycle?
     bool initial_iteration_ = true;
 

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1647,6 +1647,8 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         options.add_int("INCFOCK_FULL_FOCK_EVERY", 5);
         /*- The density threshold at which to stop building the Fock matrix incrementally -*/
         options.add_double("INCFOCK_CONVERGENCE", 1.0e-5);
+        /*- Use a variable integral tolerance while building the Fock matrix incrementally? -*/
+        options.add_bool("INCFOCK_VAR_INTS_TOL", false);
 
         /*- The screening tolerance used for ERI/Density sparsity in the LinK algorithm -*/
         options.add_double("LINK_INTS_TOLERANCE", 1.0e-12);

--- a/psi4/src/read_options.cc
+++ b/psi4/src/read_options.cc
@@ -1645,8 +1645,6 @@ int read_options(const std::string &name, Options &options, bool suppress_printi
         /*- Frequency with which to compute the full Fock matrix if using |scf__incfock| . 
         N means rebuild every N SCF iterations to avoid accumulating error from the incremental procedure. -*/
         options.add_int("INCFOCK_FULL_FOCK_EVERY", 5);
-        /*- The density threshold at which to stop building the Fock matrix incrementally -*/
-        options.add_double("INCFOCK_CONVERGENCE", 1.0e-5);
         /*- Use a variable integral tolerance while building the Fock matrix incrementally? -*/
         options.add_bool("INCFOCK_VAR_INTS_TOL", false);
 


### PR DESCRIPTION
This draft PR seeks to address the convergence problems encountered when using integral direct JK algorithms (DirectJK, DF-DirJ, LinK, COSX) with density screening + incfock enabled. As far as I can tell, the implementation of incfock (and density screening) is correct, but the small errors the procedure introduces amplifies inaccuracies inherent to approximate JK builds or reveals implementation-specific numerical instabilities.

**DirectJK**
- [x] Added zeroed buffers in which to accumulate contributions to J/K/wK. Previously, contributions were added directly to the corresponding element of J/K/wK, which introduced potential round-off error (assuming individual contributions are small). This patch has virtually eliminated all repeat-run non-determinism (see #3531) for the large system/diffuse basis cases that DirectJK previously struggled with, even when using a relatively loose integral tolerance of 1e-10.

**DF-DirJ**
- [ ] WIP

**LinK**
- [x] fixed race condition bug
- [x] fixed bug in which the incorrect shell ceiling was used
- [x] Added zero buffers into which to accumulate contributions to K, rather than directly adding them to directly to previous iterations deltaK (again to avoid round-off error) 

**COSX**
- [ ] WIP

**Misc.**
Whether or not the following end up as permanent features is contingent on whether the stability of all algorithms considered can be improved. 
- [x] Removed the option to turn off IncFock near convergence. 
- [x] Added a variable integral tolerance option that calculates the current iteration integral tolerance as ints_tol * Dnorm (inspired by the [qchem manual](https://manual.q-chem.com/5.3/sect_incfock.html))
- [x] Changed default interval for building the full fock matrix from every 5 iterations to every 15 iterations